### PR TITLE
Re-integrate detection-grade enforcement + POSIX symlink fix (HOLD: macOS CI + operator go)

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -60,6 +60,7 @@ from agenttalk import supervisor_lifecycle as supervisor_lifecycle
 # from holding a waiter forever. 30 min was picked to comfortably cover
 # long substantive review cycles without being effectively infinite.
 _COMPOSING_MAX_EXTEND_SECONDS = 1800.0
+_OPERATION_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 
 
 # --------------------------------------------------------------------- utils
@@ -96,6 +97,43 @@ def _read_body(args: argparse.Namespace) -> str:
         if data:
             return data
     return ""
+
+
+def _operation_idempotency(
+    store: Store,
+    *,
+    sender: str,
+    recipient: str,
+    body: str,
+    kind: str,
+    operation: str,
+    meta: dict,
+    nonce: str | None,
+) -> tuple[object | None, str | None]:
+    """Bind one wrapper operation nonce to one canonical semantic payload."""
+    _ = store, sender
+    if nonce is None:
+        return None, None
+    if _OPERATION_NONCE_RE.fullmatch(nonce) is None:
+        return None, "operation nonce must be exactly 32 lowercase hexadecimal characters"
+    from agenttalk.wrapper.obligations import operation_payload_digest
+
+    digest = operation_payload_digest(
+        operation=operation,
+        body=body,
+        kind=kind,
+        recipient=recipient,
+        in_reply_to=meta.get("in_reply_to"),
+        request_id=meta.get("request_id"),
+        broadcast_id=meta.get("broadcast_id"),
+        origin_request_id=meta.get("origin_request_id"),
+        origin_inbound_id=meta.get("origin_inbound_id"),
+        origin_obligation_key_digest=meta.get("origin_obligation_key_digest"),
+        expected_roster_revision=meta.get("expected_roster_revision"),
+    )
+    meta["operation_nonce"] = nonce
+    meta["operation_digest"] = digest
+    return None, None
 
 
 def _json_scrub_nonfinite(value):
@@ -1589,17 +1627,54 @@ def cmd_composing(args: argparse.Namespace) -> int:
         meta["request_id"] = rid
     else:
         recipient = _resolve_peer(args.recipient, cfg, sender)
-    msg = store.send(
+    operation_nonce = getattr(args, "operation_nonce", None)
+    existing, operation_error = _operation_idempotency(
+        store,
         sender=sender,
         recipient=recipient,
         body=body,
         kind="composing",
-        subject=args.subject or "composing",
+        operation="composing",
         meta=meta,
+        nonce=operation_nonce,
     )
+    if operation_error is not None:
+        sys.stderr.write(f"agenttalk composing: {operation_error}.\n")
+        return 2
+    if existing is not None:
+        if not args.quiet:
+            print(f"(composing operation already recorded: id={existing.id})")
+        return 0
+    try:
+        if operation_nonce is not None:
+            msg, published = store.send_operation(
+                sender=sender,
+                recipient=recipient,
+                body=body,
+                kind="composing",
+                subject=args.subject or "composing",
+                meta=meta,
+                operation_nonce=operation_nonce,
+                operation_digest=str(meta["operation_digest"]),
+            )
+        else:
+            msg = store.send(
+                sender=sender,
+                recipient=recipient,
+                body=body,
+                kind="composing",
+                subject=args.subject or "composing",
+                meta=meta,
+            )
+            published = True
+    except ValueError as exc:
+        sys.stderr.write(f"agenttalk composing: {exc}.\n")
+        return 2
     if rid:
         store.write_composing_intent(sender, rid, recipient)  # best-effort
-    if not args.quiet:
+    if not published and not args.quiet:
+        print(f"(composing operation already recorded: id={msg.id})")
+    elif not args.quiet:
         print(f"(composing ping sent: {sender} -> {recipient}; id={msg.id})")
     return 0
 
@@ -5693,6 +5768,17 @@ def cmd_escalate(args: argparse.Namespace) -> int:
         return 2
     meta = _parse_meta(args.meta)
     meta["needs_operator"] = "true"  # force-set: the bucket discriminator
+    origin_request = getattr(args, "origin_request", None)
+    origin_id = getattr(args, "origin_id", None)
+    if bool(origin_request) != bool(origin_id):
+        sys.stderr.write(
+            "agenttalk escalate: --origin-request and --origin-id must be supplied together.\n"
+        )
+        return 2
+    if origin_request:
+        meta["origin_request_id"] = origin_request
+        meta["origin_inbound_id"] = origin_id
+        meta["in_reply_to"] = origin_id
     # Typed attention enrichment (0.56.0): escalate OWNS meta.attention - build it ONLY from
     # the typed flags (a caller --meta attention=... is not a supported typed input). Strict
     # CLI validation: a malformed typed block exits 2 BEFORE any write (gate 4); the reader
@@ -5708,14 +5794,55 @@ def cmd_escalate(args: argparse.Namespace) -> int:
         meta["attention"] = att_block
     if "request_id" not in meta:
         meta["request_id"] = "esc-" + uuid.uuid4().hex[:12]
-    msg = store.send(
+    operation_nonce = getattr(args, "operation_nonce", None)
+    existing, operation_error = _operation_idempotency(
+        store,
         sender=sender,
         recipient=target,
         body=body,
         kind="question",
-        subject=args.subject or "operator input needed",
+        operation="terminal",
         meta=meta,
+        nonce=operation_nonce,
     )
+    if operation_error is not None:
+        sys.stderr.write(f"agenttalk escalate: {operation_error}.\n")
+        return 2
+    if existing is not None:
+        if not args.quiet:
+            print(f"(escalation operation already recorded: id={existing.id})")
+        print(f"request_id={(existing.meta or {}).get('request_id', meta['request_id'])}")
+        return 0
+    try:
+        if operation_nonce is not None:
+            msg, published = store.send_operation(
+                sender=sender,
+                recipient=target,
+                body=body,
+                kind="question",
+                subject=args.subject or "operator input needed",
+                meta=meta,
+                operation_nonce=operation_nonce,
+                operation_digest=str(meta["operation_digest"]),
+            )
+        else:
+            msg = store.send(
+                sender=sender,
+                recipient=target,
+                body=body,
+                kind="question",
+                subject=args.subject or "operator input needed",
+                meta=meta,
+            )
+            published = True
+    except ValueError as exc:
+        sys.stderr.write(f"agenttalk escalate: {exc}.\n")
+        return 2
+    if not published:
+        if not args.quiet:
+            print(f"(escalation operation already recorded: id={msg.id})")
+        print(f"request_id={(msg.meta or {}).get('request_id', meta['request_id'])}")
+        return 0
     if not args.quiet:
         print(render(msg, header=f"AGENTTALK :: ESCALATE  {sender} -> {target}"))
     # Always print the machine-parseable correlation line: the caller's
@@ -6333,7 +6460,9 @@ def cmd_broadcast(args: argparse.Namespace) -> int:
     resume = getattr(args, "resume", None)
     if resume:
         if (args.message or getattr(args, "file", None) or args.subject
-                or args.kind != "message" or args.meta):
+                or args.kind != "message" or args.meta
+                or getattr(args, "response_policy", None)
+                or getattr(args, "response_quorum", None) is not None):
             sys.stderr.write(
                 "agenttalk broadcast: --resume re-sends the ORIGINAL frozen "
                 "copies - it takes no body/subject/kind/meta overrides.\n")
@@ -6498,6 +6627,28 @@ def cmd_broadcast(args: argparse.Namespace) -> int:
         )
         return 2
     bid = supplied_bid or supplied_rid or ("b-" + uuid.uuid4().hex[:12])
+    response_policy = getattr(args, "response_policy", None)
+    response_quorum = getattr(args, "response_quorum", None)
+    if args.kind == "question":
+        response_policy = response_policy or "each"
+        if response_policy == "quorum":
+            if response_quorum is None or not 1 <= response_quorum <= len(recipients):
+                sys.stderr.write(
+                    "agenttalk broadcast: --response-policy quorum requires "
+                    "--response-quorum N within the frozen audience size.\n"
+                )
+                return 2
+        elif response_quorum is not None:
+            sys.stderr.write(
+                "agenttalk broadcast: --response-quorum is valid only with "
+                "--response-policy quorum.\n"
+            )
+            return 2
+    elif response_policy is not None or response_quorum is not None:
+        sys.stderr.write(
+            "agenttalk broadcast: response policy applies only to --kind question.\n"
+        )
+        return 2
     audience_label = "all" if args.all else target
     sent: list = []
     # Delivery accounting (#16, 0.15.0): every copy freezes the fan-out
@@ -6528,6 +6679,12 @@ def cmd_broadcast(args: argparse.Namespace) -> int:
             meta["audience_role"] = target
         meta["audience_resolved"] = ",".join(recipients)
         meta["batch_total"] = str(len(recipients))
+        if args.kind == "question":
+            meta["broadcast_policy_version"] = 1
+            meta["membership_snapshot"] = list(recipients)
+            meta["response_policy"] = response_policy
+            if response_policy == "quorum":
+                meta["response_quorum"] = response_quorum
         if args.kind in OPENER_KINDS:
             # one epoch for the whole batch (B3); pre-set so send() does not
             # recompute current_epoch() per copy.
@@ -7275,6 +7432,21 @@ def _print_rescinded(store: Store, rid: str, row) -> None:
             print(f"  reason: {row.rescind_reason}")
 
 
+def _print_requester_terminal(terminal: dict) -> int:
+    state = terminal.get("state")
+    if state == "delivery_failed":
+        print("AGENTTALK :: DELIVERY FAILED")
+        code = 4
+    elif state == "operator_resolved":
+        print("AGENTTALK :: OPERATOR RESOLVED")
+        code = 7
+    else:
+        print("AGENTTALK :: REQUESTER TERMINAL")
+        code = 7
+    print(json.dumps(terminal, ensure_ascii=False, sort_keys=True))
+    return code
+
+
 def _scoped_wait(store: Store, agent: str, args: argparse.Namespace, wait_token: str) -> int:
     """Block until a message on ONE thread (request_id) arrives — ignoring
     unrelated traffic — and return only that match.
@@ -7288,6 +7460,11 @@ def _scoped_wait(store: Store, agent: str, args: argparse.Namespace, wait_token:
     """
     rid = args.to_request
     kind_filter = getattr(args, "kind", None)
+    from .wrapper.obligations import requester_terminal_for
+
+    terminal = requester_terminal_for(store, rid, agent)
+    if terminal is not None:
+        return _print_requester_terminal(terminal)
     # Rescind wake (#12): a superseded request must never be waited on.
     # Checked at entry (the rescind may predate this wait entirely) and
     # re-evaluated when a rescind on this rid arrives mid-wait. Exit 3 —
@@ -7332,6 +7509,9 @@ def _scoped_wait(store: Store, agent: str, args: argparse.Namespace, wait_token:
             if _wait_was_superseded(store, agent, wait_token):
                 _print_wait_superseded(agent, rid=rid)
                 return 6
+            terminal = requester_terminal_for(store, rid, agent)
+            if terminal is not None:
+                return _print_requester_terminal(terminal)
             # Floor delivery at BOTH the per-thread seen pointer AND the
             # global cursor: a message already consumed globally (a `drain`
             # or plain `wait` advanced the cursor past it) must NOT be
@@ -7972,6 +8152,44 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_commit_gate(args: argparse.Namespace) -> int:
+    """Inspect or explicitly reset the detection-grade compliance breaker."""
+    from .wrapper.obligations import DetectionCommitGate
+
+    store = _get_store(args)
+    roster = store.load_config().get("agents") or []
+    agent = _resolve_self(args.agent, roster=roster)
+    gate = DetectionCommitGate.from_environment(
+        store,
+        agent,
+        fence="operator-cli",
+    )
+    if args.gate_action == "reset":
+        actor = _resolve_self(args.sender, roster=roster)
+        try:
+            gate.reset_compliance_breaker(actor=actor, reason=args.reason)
+        except (PermissionError, ValueError) as exc:
+            sys.stderr.write(f"agenttalk commit-gate reset: {exc}\n")
+            return 2
+    status = gate.status()
+    if args.json:
+        print(json.dumps(status, indent=2))
+    else:
+        print(f"commit-gate {agent}: {status['status']}")
+        if status.get("reason"):
+            print(f"  reason: {status['reason']}")
+        if status.get("breaker"):
+            print(f"  breaker: {json.dumps(status['breaker'], sort_keys=True)}")
+        if status.get("legacy_broadcast"):
+            legacy = status["legacy_broadcast"]
+            print(
+                "  legacy-broadcast: "
+                f"enforcement={legacy.get('enforcement')} "
+                f"unenforced_total={legacy.get('unenforced_total')}"
+            )
+    return 0
+
+
 def _render_doctor_human(report) -> None:
     # Root is the FIRST line (0.14.0, #13) — same contract as whoami: the
     # wrong-root footgun must be diagnosable from line one.
@@ -8344,6 +8562,9 @@ def cmd_reply(args: argparse.Namespace) -> int:
             sys.stderr.write("agenttalk reply: empty body (use -m TEXT, --file PATH, pipe stdin, or --allow-empty)\n")
             return 2
     meta = _parse_meta(args.meta)
+    # Exact immutable anchor for generation-safe replay.  The correlation id
+    # identifies the conversation; in_reply_to identifies this delivery.
+    meta["in_reply_to"] = anchor.id
     if na:
         meta["response"] = "not-applicable"  # the display discriminator
     # Auto-echo request_id for correlation. Explicit --meta wins.
@@ -8360,7 +8581,32 @@ def cmd_reply(args: argparse.Namespace) -> int:
         and "request_id" in (anchor.meta or {})
     ):
         meta["request_id"] = anchor.meta["request_id"]
+    if (
+        kind not in ("review-request", "proposal")
+        and "request_id" not in meta
+        and "broadcast_id" not in meta
+        and "broadcast_id" in (anchor.meta or {})
+    ):
+        meta["broadcast_id"] = anchor.meta["broadcast_id"]
     _maybe_autogen_request_id(kind, meta, quiet=args.quiet)
+    operation_nonce = getattr(args, "operation_nonce", None)
+    existing, operation_error = _operation_idempotency(
+        store,
+        sender=sender,
+        recipient=anchor.sender,
+        body=body,
+        kind=kind,
+        operation="terminal",
+        meta=meta,
+        nonce=operation_nonce,
+    )
+    if operation_error is not None:
+        sys.stderr.write(f"agenttalk reply: {operation_error}.\n")
+        return 2
+    if existing is not None:
+        if not args.quiet:
+            print(f"(reply operation already recorded: id={existing.id})")
+        return 0
     await_record = _prepare_await_reply(
         store,
         sender=sender,
@@ -8381,14 +8627,35 @@ def cmd_reply(args: argparse.Namespace) -> int:
         return 0
     gate_mod.validate_response_status(kind, meta)
     gate_mod.validate_review_result_evidence(kind, meta)
-    msg = store.send(
-        sender=sender,
-        recipient=anchor.sender,
-        body=body,
-        kind=kind,
-        subject=args.subject or "",
-        meta=meta,
-    )
+    try:
+        if operation_nonce is not None:
+            msg, published = store.send_operation(
+                sender=sender,
+                recipient=anchor.sender,
+                body=body,
+                kind=kind,
+                subject=args.subject or "",
+                meta=meta,
+                operation_nonce=operation_nonce,
+                operation_digest=str(meta["operation_digest"]),
+            )
+        else:
+            msg = store.send(
+                sender=sender,
+                recipient=anchor.sender,
+                body=body,
+                kind=kind,
+                subject=args.subject or "",
+                meta=meta,
+            )
+            published = True
+    except ValueError as exc:
+        sys.stderr.write(f"agenttalk reply: {exc}.\n")
+        return 2
+    if not published:
+        if not args.quiet:
+            print(f"(reply operation already recorded: id={msg.id})")
+        return 0
     if not args.quiet:
         print(render(msg, header=f"AGENTTALK :: REPLY  {msg.sender} -> {msg.recipient}"))
     _register_await_reply(store, await_record, quiet=args.quiet)
@@ -9614,6 +9881,13 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
 
         cadence_hook = _cadence
     try:
+        from .wrapper.obligations import DetectionCommitGate
+
+        commit_gate = DetectionCommitGate.from_environment(
+            store,
+            agent,
+            fence=wrapper_generation,
+        )
         turns = wloop.run_loop(
             store, agent, drive,
             max_turns=1 if one_shot_request_id else None,
@@ -9632,6 +9906,7 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             on_health_idle=health_writer.idle,
             capacity_refresh=capacity_refresh,
             wrapper_generation=wrapper_generation,
+            commit_gate=commit_gate,
         )
     except _LeadLoopLeaseLost:
         # LOST the lease mid-run (stolen / torn / force-released): the ownership gate /
@@ -11320,6 +11595,8 @@ def build_parser() -> argparse.ArgumentParser:
                             "reply-in-flight marker that `threads`/`sync` "
                             "show as '(reply in flight)'. Validates the id "
                             "is a live thread of yours.")
+    pcomp.add_argument("--operation-nonce", dest="operation_nonce",
+                       help=argparse.SUPPRESS)
     pcomp.add_argument("--subject",
                        help="One-line summary (default: 'composing')")
     pcomp.add_argument("--meta", action="append",
@@ -11937,6 +12214,12 @@ def build_parser() -> argparse.ArgumentParser:
     pesc.add_argument("--subject",
                       help="One-line summary (default: 'operator input needed')")
     pesc.add_argument("--meta", action="append", help="key=value (repeatable)")
+    pesc.add_argument("--origin-request",
+                      help="Original enforced request id (requires --origin-id).")
+    pesc.add_argument("--origin-id",
+                      help="Exact original inbound id (requires --origin-request).")
+    pesc.add_argument("--operation-nonce", dest="operation_nonce",
+                      help=argparse.SUPPRESS)
     pesc.add_argument("-m", "--message",
                       help="The operator question (else --file or stdin). Required.")
     pesc.add_argument("--file", help="Read body from this file path ('-' = stdin)")
@@ -12072,6 +12355,16 @@ def build_parser() -> argparse.ArgumentParser:
                      help="Broadcast kind (default: message). Use `question` "
                           "when you want everyone to respond.")
     pbc.add_argument("--subject", help="One-line summary.")
+    pbc.add_argument(
+        "--response-policy",
+        choices=["each", "any", "quorum"],
+        help="Question completion policy (default: each).",
+    )
+    pbc.add_argument(
+        "--response-quorum",
+        type=int,
+        help="Required answer count for --response-policy quorum.",
+    )
     pbc.add_argument("--meta", action="append", help="key=value (repeatable).")
     pbc.add_argument("-m", "--message", help="Body text (else --file or stdin).")
     pbc.add_argument("--file", help="Read body from this file path ('-' = stdin).")
@@ -12290,6 +12583,22 @@ def build_parser() -> argparse.ArgumentParser:
                      help="Second operator-facing acknowledgement required before a "
                           "freshly heartbeating protected agent is killed.")
     prr.set_defaults(func=cmd_request_restart)
+
+    pcg = sub.add_parser(
+        "commit-gate",
+        help="Inspect detection-grade commit enforcement or audit-reset its breaker.",
+    )
+    pcg.add_argument("--for", dest="agent", required=True, help="Wrapped agent name.")
+    pcg.add_argument("--json", action="store_true")
+    pcg_sub = pcg.add_subparsers(dest="gate_action")
+    pcg_status = pcg_sub.add_parser("status", help="Show activation and breaker state.")
+    pcg_status.set_defaults(func=cmd_commit_gate)
+    pcg_reset = pcg_sub.add_parser("reset", help="Authenticated, audited breaker reset.")
+    pcg_reset.add_argument("--from", dest="sender", required=True,
+                           help="Operator-facing liaison or sole lead.")
+    pcg_reset.add_argument("--reason", required=True, help="Audit reason for reset.")
+    pcg_reset.set_defaults(func=cmd_commit_gate)
+    pcg.set_defaults(func=cmd_commit_gate, gate_action="status")
 
     prl = sub.add_parser(
         "request-launch",
@@ -12666,6 +12975,8 @@ def build_parser() -> argparse.ArgumentParser:
                       help="key=value (repeatable); request_id is auto-echoed if not set")
     prpl.add_argument("-m", "--message", help="Body text (else --file or stdin)")
     prpl.add_argument("--file", help="Read body from this file path ('-' = stdin)")
+    prpl.add_argument("--operation-nonce", dest="operation_nonce",
+                      help=argparse.SUPPRESS)
     prpl.add_argument("--allow-empty", action="store_true")
     prpl.add_argument(
         "--await-reply",

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -151,6 +151,7 @@ def run(project_root: Path | None = None) -> Report:
         holds = _check_config_blocked_holds(store)
         if holds is not None:  # additive: absent unless a valid config-blocked hold exists
             report.checks.append(holds)
+        report.checks.append(_check_detection_commit_gate(store))
         kn_check = _check_knowledge(store)
         if kn_check is not None:  # additive: absent unless a knowledge store exists
             report.checks.append(kn_check)
@@ -167,6 +168,84 @@ def run(project_root: Path | None = None) -> Report:
         if lead_check is not None:  # additive: absent unless a lead-loop concern exists
             report.checks.append(lead_check)
     return report
+
+
+def _check_detection_commit_gate(store: Store) -> Check:
+    """Report the operator launch-policy snapshot and durable breaker state."""
+    from agenttalk.wrapper.obligations import (
+        POLICY_ENV,
+        DetectionCommitGate,
+        PolicySnapshot,
+        ResolverState,
+    )
+
+    roster = store.load_config().get("agents", []) or []
+    supervisor_paths: dict[str, str] = {}
+    supervisor_path = store.dir / "supervisor.json"
+    if supervisor_path.exists():
+        try:
+            supervisor = json.loads(supervisor_path.read_text(encoding="utf-8-sig"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            supervisor = None
+        entries = supervisor.get("agents") if isinstance(supervisor, dict) else None
+        if isinstance(entries, dict):
+            for name, entry in entries.items():
+                env = entry.get("env") if isinstance(entry, dict) else None
+                value = env.get(POLICY_ENV) if isinstance(env, dict) else None
+                if isinstance(value, str) and value:
+                    supervisor_paths[str(name)] = value
+    process_path = os.environ.get(POLICY_ENV)
+    rows: list[dict] = []
+    has_error = False
+    has_warn = False
+    has_legacy_broadcast = False
+    for agent in roster:
+        configured = process_path or supervisor_paths.get(agent)
+        policy = (
+            PolicySnapshot.from_path(Path(configured).expanduser().resolve(), agent)
+            if configured
+            else PolicySnapshot.inactive()
+        )
+        gate = DetectionCommitGate(store, agent, policy, fence="doctor-read-only")
+        status = gate.status()
+        status["policy_path"] = configured
+        rows.append(status)
+        has_error = has_error or policy.status == ResolverState.BLOCKED_POLICY
+        has_warn = has_warn or status.get("breaker", {}).get("tripped") is True
+        legacy = status.get("legacy_broadcast", {})
+        has_legacy_broadcast = has_legacy_broadcast or int(
+            legacy.get("unenforced_total", 0)
+        ) > 0
+    has_warn = has_warn or has_legacy_broadcast
+    details = "; ".join(
+        f"{row['agent']}={row['status']}"
+        + (
+            f" legacy_unenforced={row['legacy_broadcast']['unenforced_total']}"
+            if int(row.get("legacy_broadcast", {}).get("unenforced_total", 0)) > 0
+            else ""
+        )
+        for row in rows
+    )
+    return Check(
+        name="wrapped_commit_gate",
+        status="error" if has_error else ("warn" if has_warn else "ok"),
+        details=details or "no active agents",
+        fix=(
+            f"repair the operator-owned {POLICY_ENV} snapshot before dispatch"
+            if has_error else (
+                "audit and reset the tripped compliance breaker before paid dispatch"
+                if any(
+                    row.get("breaker", {}).get("tripped") is True for row in rows
+                )
+                else (
+                    "audit legacy broadcast records; they were logged without "
+                    "owed-action enforcement"
+                    if has_legacy_broadcast else ""
+                )
+            )
+        ),
+        data={"agents": rows, "security_grade": False},
+    )
 
 
 def _check_powershell_host(store: Store) -> Check:

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -78,6 +78,7 @@ _LOCK_PID_PREFIX_RE = re.compile(rb'"pid"\s*:\s*([0-9]+)')
 _LOCK_GENERATION_RE = re.compile(r"\A[0-9a-f]{32}\Z")
 
 _AWAIT_SCHEMA_VERSION = 1
+_MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION = 1
 _AWAIT_ID_RE = re.compile(r"\A[A-Za-z0-9_.:-]{1,128}\Z")
 _AWAIT_PATH_TOKEN_RE = re.compile(r"\A[A-Za-z0-9_-]{1,128}\Z")
 _AWAIT_SOURCES = frozenset({"send", "reply"})
@@ -1482,6 +1483,174 @@ class Store:
             what="retirement/message publication",
         )
 
+    def _message_publication_lock(
+        self,
+        *,
+        timeout: float = 10.0,
+        poll: float = 0.005,
+    ):
+        """Linearize every canonical message publication with dispatch replay."""
+        return self._lock_generation_guard(
+            self.dir / "message-publication",
+            deadline=time.monotonic() + timeout,
+            poll=poll,
+            what="message publication",
+        )
+
+    @property
+    def _message_publication_order_path(self) -> Path:
+        return self.state_dir / "message-publication-order.json"
+
+    @property
+    def _message_publication_order_anchor_path(self) -> Path:
+        return self.state_dir / "message-publication-order.anchor.json"
+
+    @staticmethod
+    def _message_publication_order_chain(
+        messages: dict[str, int],
+        *,
+        through: int | None = None,
+    ) -> str:
+        limit = len(messages) if through is None else through
+        by_sequence = {sequence: message_id for message_id, sequence in messages.items()}
+        digest = hashlib.sha256(b"agenttalk-message-publication-order-v1").hexdigest()
+        for sequence in range(1, limit + 1):
+            message_id = by_sequence.get(sequence)
+            if not isinstance(message_id, str):
+                raise ValueError("message publication order sequence is incomplete")
+            digest = hashlib.sha256(
+                f"{digest}:{sequence}:{message_id}".encode("utf-8")
+            ).hexdigest()
+        return digest
+
+    @classmethod
+    def _validate_message_publication_order(cls, raw: object) -> dict:
+        if (
+            not isinstance(raw, dict)
+            or raw.get("schema_version") != _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION
+            or not isinstance(raw.get("append_sequence"), int)
+            or isinstance(raw.get("append_sequence"), bool)
+            or int(raw["append_sequence"]) < 0
+            or not isinstance(raw.get("messages"), dict)
+        ):
+            raise ValueError("message publication order sidecar is invalid")
+        append_sequence = int(raw["append_sequence"])
+        messages = raw["messages"]
+        if any(
+            not isinstance(message_id, str)
+            or _ID_RE.fullmatch(message_id) is None
+            or not isinstance(sequence, int)
+            or isinstance(sequence, bool)
+            or sequence < 1
+            for message_id, sequence in messages.items()
+        ):
+            raise ValueError("message publication order entry is invalid")
+        sequences = set(messages.values())
+        if (
+            len(messages) != append_sequence
+            or sequences != set(range(1, append_sequence + 1))
+        ):
+            raise ValueError("message publication order sequence is non-contiguous")
+        return raw
+
+    @staticmethod
+    def _validate_message_publication_order_anchor(raw: object) -> dict:
+        if (
+            not isinstance(raw, dict)
+            or raw.get("schema_version") != _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION
+            or not isinstance(raw.get("append_sequence"), int)
+            or isinstance(raw.get("append_sequence"), bool)
+            or int(raw["append_sequence"]) < 0
+            or re.fullmatch(r"[0-9a-f]{64}", str(raw.get("chain_digest", "")))
+            is None
+        ):
+            raise ValueError("message publication order anchor is invalid")
+        return raw
+
+    def _read_message_publication_order(self) -> dict | None:
+        order_path = self._message_publication_order_path
+        anchor_path = self._message_publication_order_anchor_path
+        if not order_path.exists():
+            if anchor_path.exists():
+                raise ValueError(
+                    "message publication order sidecar is missing while its anchor exists"
+                )
+            return None
+        try:
+            raw_order = json.loads(order_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError("message publication order sidecar is unreadable") from exc
+        order = self._validate_message_publication_order(raw_order)
+        if not anchor_path.exists():
+            return order
+        try:
+            raw_anchor = json.loads(anchor_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError("message publication order anchor is unreadable") from exc
+        anchor = self._validate_message_publication_order_anchor(raw_anchor)
+        anchor_sequence = int(anchor["append_sequence"])
+        if anchor_sequence > int(order["append_sequence"]):
+            raise ValueError("message publication order sidecar rolled back")
+        prefix_digest = self._message_publication_order_chain(
+            order["messages"],
+            through=anchor_sequence,
+        )
+        if prefix_digest != anchor["chain_digest"]:
+            raise ValueError("message publication order sidecar changed below its anchor")
+        return order
+
+    def _reserve_message_publication_sequence(
+        self,
+        message_id: str,
+        existing_messages: list[Message],
+    ) -> int:
+        """Durably reserve physical append order before publishing message bytes."""
+        order = self._read_message_publication_order()
+        if order is None:
+            ordered_legacy = sorted(existing_messages, key=lambda message: message.id)
+            messages = {
+                message.id: sequence
+                for sequence, message in enumerate(ordered_legacy, start=1)
+            }
+            order = {
+                "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
+                "append_sequence": len(messages),
+                "messages": messages,
+            }
+        else:
+            messages = dict(order["messages"])
+            missing = [
+                message.id for message in existing_messages if message.id not in messages
+            ]
+            if missing:
+                raise ValueError(
+                    "validated message is missing durable publication order: "
+                    f"{missing[0]}"
+                )
+        if message_id in messages:
+            raise ValueError("message id already has a durable publication order")
+        sequence = int(order["append_sequence"]) + 1
+        messages[message_id] = sequence
+        updated = {
+            "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
+            "append_sequence": sequence,
+            "messages": messages,
+        }
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(
+            self._message_publication_order_path,
+            json.dumps(updated, indent=2, ensure_ascii=False),
+        )
+        _atomic_write_text(
+            self._message_publication_order_anchor_path,
+            json.dumps({
+                "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
+                "append_sequence": sequence,
+                "chain_digest": self._message_publication_order_chain(messages),
+            }, indent=2, ensure_ascii=False),
+        )
+        return sequence
+
     @staticmethod
     def _cfg_dict(cfg: dict, key: str) -> dict:
         """Return cfg[key] as a dict, coercing absent/null to a fresh {}.
@@ -2495,6 +2664,24 @@ class Store:
     ) -> Message:
         if not self.initialized():
             raise FileNotFoundError("agenttalk not initialized; run `agenttalk init`.")
+        supplied_meta = dict(meta or {})
+        authority_sensitive = bool(
+            supplied_meta.get("origin_request_id")
+            and supplied_meta.get("origin_inbound_id")
+        )
+        if authority_sensitive and not _config_locked:
+            with self._config_lock():
+                return self.send(
+                    sender=sender,
+                    recipient=recipient,
+                    body=body,
+                    kind=kind,
+                    subject=subject,
+                    meta=supplied_meta,
+                    sign=sign,
+                    _allow_reserved_sender=_allow_reserved_sender,
+                    _config_locked=True,
+                )
         config_before = os.stat(self.config_path)
         cfg = self.load_config()
         config_after = os.stat(self.config_path)
@@ -2523,7 +2710,46 @@ class Store:
         # yet); a pre-0.16.0 client never ran this code, so the key is absent.
         # A caller that already supplied `epoch_at_send` wins (broadcast
         # snapshots one epoch for the whole fan-out — B3).
-        meta = dict(meta or {})
+        meta = supplied_meta
+        if authority_sensitive:
+            roster = list(cfg.get("agents") or [])
+            roles = cfg.get("roles") if isinstance(cfg.get("roles"), dict) else {}
+            authorized = {
+                name for name in roster
+                if isinstance(roles.get(name), str)
+                and roles[name].casefold() == "lead"
+            }
+            liaison = cfg.get("operator_facing")
+            if isinstance(liaison, str) and liaison in roster:
+                authorized.add(liaison)
+            roster_payload = {
+                "agents": roster,
+                "roles": {name: roles[name] for name in sorted(roles)},
+                "operator_facing": liaison if isinstance(liaison, str) else None,
+            }
+            roster_revision = hashlib.sha256(
+                json.dumps(
+                    roster_payload,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            expected_revision = meta.get("expected_roster_revision")
+            if not isinstance(expected_revision, str) or not expected_revision:
+                raise ValueError(
+                    "origin-correlated authorized transition requires an expected "
+                    "roster revision"
+                )
+            if expected_revision != roster_revision:
+                raise ValueError("roster revision changed before authorized transition append")
+            if recipient not in authorized:
+                raise ValueError(
+                    "origin-correlated escalation target is not an event-time "
+                    "authorized liaison or lead"
+                )
+            meta["roster_revision"] = roster_revision
+            meta["authorized_liaisons"] = sorted(authorized)
         _gates.validate_response_status(kind, meta)
         if kind in OPENER_KINDS and "epoch_at_send" not in meta:
             meta["epoch_at_send"] = self.current_epoch()
@@ -2563,11 +2789,12 @@ class Store:
                 if _config_locked
                 else self._retirement_lock()
             )
-            with lock:
+            with lock, self._message_publication_lock():
                 # Durable payload preparation is deliberately OUTSIDE this lock,
                 # so unrelated sends do not serialize their write+fsync cost.
-                # Retirement and final publication share only this persistent,
-                # narrow mutex. Revalidate immediately before the O(1) commit.
+                # Retirement and dispatch replay share persistent, narrow
+                # mutexes with final publication. Revalidate immediately before
+                # the O(1) commit.
                 current_revision = _file_revision(os.stat(self.config_path))
                 if config_revision is None or current_revision != config_revision:
                     cfg = self.load_config()
@@ -2577,6 +2804,10 @@ class Store:
                     recipient=recipient,
                     allow_reserved_sender=_allow_reserved_sender,
                 )
+                self._reserve_message_publication_sequence(
+                    msg.id,
+                    self.valid_messages(),
+                )
                 try:
                     os.replace(pending, path)
                     _fsync_directory(path.parent)
@@ -2585,6 +2816,17 @@ class Store:
                     # that block rename. Preserve the established direct-write
                     # fallback there; ordinary Windows/POSIX stays pre-staged.
                     _atomic_write_text(path, payload)
+                # Keep publication order and the monotonic owed-action projection
+                # under one ordering mutex.  A delayed eager hook must not let a
+                # later canonical message acquire an earlier reducer sequence.
+                try:
+                    from agenttalk.wrapper.obligations import note_bus_message
+
+                    note_bus_message(self, msg)
+                except (OSError, ValueError, RuntimeError):
+                    # The immutable message is authoritative. A later replay repairs
+                    # a missed projection in canonical publication order.
+                    pass
         finally:
             try:
                 _unlink_if_same_file(pending, pending_identity)
@@ -2602,6 +2844,253 @@ class Store:
             except Exception as exc:  # noqa: BLE001 - observational cleanup only
                 _ = exc
         return msg
+
+    def _operation_intent_path(self, sender: str, operation_nonce: str) -> Path:
+        name = validate_agent_name(sender)
+        if re.fullmatch(r"[0-9a-f]{32}", operation_nonce) is None:
+            raise ValueError("operation nonce must be exactly 32 lowercase hexadecimal characters")
+        return self.state_dir / "operation-intents" / f"{name}.{operation_nonce}.json"
+
+    @staticmethod
+    def _operation_intent_identity(
+        *,
+        operation: str,
+        kind: str,
+        recipient: str,
+        meta: dict,
+    ) -> dict:
+        identity = {
+            "operation": operation,
+            "kind": kind,
+            "recipient": recipient,
+            "in_reply_to": meta.get("in_reply_to"),
+            "request_id": meta.get("request_id"),
+            "broadcast_id": meta.get("broadcast_id"),
+            "origin_request_id": meta.get("origin_request_id"),
+            "origin_inbound_id": meta.get("origin_inbound_id"),
+        }
+        origin_key = meta.get("origin_obligation_key_digest")
+        roster_revision = meta.get("expected_roster_revision")
+        if origin_key is not None:
+            identity["origin_obligation_key_digest"] = origin_key
+        if roster_revision is not None:
+            identity["expected_roster_revision"] = roster_revision
+        return identity
+
+    @staticmethod
+    def _operation_intent_digest(intent: dict) -> str:
+        canonical = json.dumps(
+            intent,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _operation_digest_for_intent(cls, intent: dict, body: str) -> str:
+        return cls._operation_intent_digest({**intent, "body": body})
+
+    def read_operation_intent(self, sender: str, operation_nonce: str) -> dict | None:
+        """Read one atomically prepared wrapper-operation identity."""
+        path = self._operation_intent_path(sender, operation_nonce)
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            return None
+        if (
+            not isinstance(value, dict)
+            or value.get("sender") != sender
+            or value.get("operation_nonce") != operation_nonce
+            or re.fullmatch(r"[0-9a-f]{64}", str(value.get("operation_digest", "")))
+            is None
+            or re.fullmatch(r"[0-9a-f]{64}", str(value.get("payload_sha256", "")))
+            is None
+            or (
+                "intent_digest" in value
+                and re.fullmatch(
+                    r"[0-9a-f]{64}",
+                    str(value.get("intent_digest", "")),
+                )
+                is None
+            )
+            or not isinstance(value.get("payload_size"), int)
+            or value.get("state") not in {"prepared", "published"}
+        ):
+            return None
+        return value
+
+    def _record_operation_intent_locked(
+        self,
+        *,
+        sender: str,
+        operation_nonce: str,
+        operation_digest: str,
+        body: str,
+        intent_digest: str | None = None,
+    ) -> tuple[Path, dict]:
+        if re.fullmatch(r"[0-9a-f]{64}", operation_digest) is None:
+            raise ValueError(
+                "operation digest must be exactly 64 lowercase hexadecimal characters"
+            )
+        path = self._operation_intent_path(sender, operation_nonce)
+        payload = body.encode("utf-8")
+        identity = {
+            "sender": sender,
+            "operation_nonce": operation_nonce,
+            "operation_digest": operation_digest,
+            "payload_sha256": hashlib.sha256(payload).hexdigest(),
+            "payload_size": len(payload),
+        }
+        if intent_digest is not None:
+            if re.fullmatch(r"[0-9a-f]{64}", intent_digest) is None:
+                raise ValueError(
+                    "operation intent digest must be exactly 64 lowercase hexadecimal characters"
+                )
+            identity["intent_digest"] = intent_digest
+        existing = self.read_operation_intent(sender, operation_nonce)
+        if isinstance(existing, dict):
+            base_identity = {
+                name: value
+                for name, value in identity.items()
+                if name != "intent_digest"
+            }
+            if any(existing.get(name) != value for name, value in base_identity.items()):
+                raise ValueError("operation nonce was already used with a different payload")
+            if intent_digest is not None:
+                existing_intent = existing.get("intent_digest")
+                if existing_intent not in {None, intent_digest}:
+                    raise ValueError(
+                        "operation nonce was already used with a different intent"
+                    )
+                if existing_intent is None:
+                    existing["intent_digest"] = intent_digest
+                    _atomic_write_text(
+                        path,
+                        json.dumps(existing, indent=2, ensure_ascii=False),
+                    )
+            return path, existing
+        if path.exists():
+            raise ValueError("operation intent marker is unreadable")
+        intent = {**identity, "state": "prepared", "prepared_at": _now_iso()}
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(path, json.dumps(intent, indent=2, ensure_ascii=False))
+        return path, intent
+
+    def record_operation_intent(
+        self,
+        *,
+        sender: str,
+        operation_nonce: str,
+        operation_digest: str,
+        body: str,
+        operation_intent: dict | None = None,
+    ) -> dict:
+        """Durably mark a complete captured payload before canonical append."""
+        intent_digest = None
+        if operation_intent is not None:
+            if not isinstance(operation_intent, dict):
+                raise ValueError("operation intent must be a mapping")
+            if self._operation_digest_for_intent(operation_intent, body) != operation_digest:
+                raise ValueError("operation intent does not match the operation digest")
+            intent_digest = self._operation_intent_digest(operation_intent)
+        lock = self.state_dir / "operation-publication.lock"
+        with self._exclusive_lock(
+            lock,
+            timeout=10.0,
+            what="wrapper operation publication",
+        ):
+            _path, intent = self._record_operation_intent_locked(
+                sender=sender,
+                operation_nonce=operation_nonce,
+                operation_digest=operation_digest,
+                body=body,
+                intent_digest=intent_digest,
+            )
+            return dict(intent)
+
+    def send_operation(
+        self,
+        *,
+        sender: str,
+        recipient: str,
+        body: str,
+        kind: str,
+        subject: str = "",
+        meta: dict,
+        operation_nonce: str,
+        operation_digest: str,
+    ) -> tuple[Message, bool]:
+        """Atomically dedupe one canonical wrapper operation publication."""
+        if re.fullmatch(r"[0-9a-f]{32}", operation_nonce) is None:
+            raise ValueError("operation nonce must be exactly 32 lowercase hexadecimal characters")
+        if re.fullmatch(r"[0-9a-f]{64}", operation_digest) is None:
+            raise ValueError("operation digest must be exactly 64 lowercase hexadecimal characters")
+        supplied = dict(meta)
+        if supplied.get("operation_nonce") not in {None, operation_nonce}:
+            raise ValueError("operation nonce metadata conflicts with publication request")
+        if supplied.get("operation_digest") not in {None, operation_digest}:
+            raise ValueError("operation digest metadata conflicts with publication request")
+        supplied["operation_nonce"] = operation_nonce
+        supplied["operation_digest"] = operation_digest
+        operation_intent = self._operation_intent_identity(
+            operation="composing" if kind == "composing" else "terminal",
+            kind=kind,
+            recipient=recipient,
+            meta=supplied,
+        )
+        if self._operation_digest_for_intent(operation_intent, body) != operation_digest:
+            raise ValueError("operation intent does not match the operation digest")
+        intent_digest = self._operation_intent_digest(operation_intent)
+        lock = self.state_dir / "operation-publication.lock"
+        with self._exclusive_lock(
+            lock,
+            timeout=10.0,
+            what="wrapper operation publication",
+        ):
+            intent_path, intent = self._record_operation_intent_locked(
+                sender=sender,
+                operation_nonce=operation_nonce,
+                operation_digest=operation_digest,
+                body=body,
+                intent_digest=intent_digest,
+            )
+            for existing in self.valid_messages():
+                existing_meta = existing.meta or {}
+                if (
+                    existing.sender != sender
+                    or existing_meta.get("operation_nonce") != operation_nonce
+                ):
+                    continue
+                if existing_meta.get("operation_digest") == operation_digest:
+                    if intent.get("state") != "published" or intent.get(
+                        "message_id"
+                    ) != existing.id:
+                        intent["state"] = "published"
+                        intent["message_id"] = existing.id
+                        intent["published_at"] = _now_iso()
+                        _atomic_write_text(
+                            intent_path,
+                            json.dumps(intent, indent=2, ensure_ascii=False),
+                        )
+                    return existing, False
+                raise ValueError("operation nonce was already used with a different payload")
+            message = self.send(
+                sender=sender,
+                recipient=recipient,
+                body=body,
+                kind=kind,
+                subject=subject,
+                meta=supplied,
+            )
+            intent["state"] = "published"
+            intent["message_id"] = message.id
+            intent["published_at"] = _now_iso()
+            _atomic_write_text(
+                intent_path,
+                json.dumps(intent, indent=2, ensure_ascii=False),
+            )
+            return message, True
 
     def send_operator_answer_atomic(
         self,
@@ -3260,6 +3749,29 @@ class Store:
         it. Sorted by id (chronological).
         """
         return self._validated_messages()
+
+    def publication_ordered_messages(
+        self,
+        messages: list[Message] | None = None,
+    ) -> list[Message]:
+        """Return validated messages in the durable physical publication order.
+
+        Legacy stores have no sidecar, so their established id order is the only
+        available bootstrap authority. The first subsequent send freezes that
+        order under the publication lock before reserving its own sequence.
+        """
+        messages = self.valid_messages() if messages is None else list(messages)
+        order = self._read_message_publication_order()
+        if order is None:
+            return messages
+        sequences = order["messages"]
+        missing = [message.id for message in messages if message.id not in sequences]
+        if missing:
+            raise ValueError(
+                "validated message is missing durable publication order: "
+                f"{missing[0]}"
+            )
+        return sorted(messages, key=lambda message: sequences[message.id])
 
     def _validated_messages(self, *, since_id: str | None = None) -> list[Message]:
         """Shared trust gate behind ``messages_for`` and ``valid_messages``.
@@ -5742,6 +6254,12 @@ class Store:
         entry["closed_reason"] = reason
         data[request_id] = entry
         self._write_threadstate(agent, data)
+        try:
+            from agenttalk.wrapper.obligations import note_manual_close
+
+            note_manual_close(self, agent, request_id)
+        except (OSError, ValueError, RuntimeError):
+            pass
 
     def thread_closed(self, agent: str, request_id: str) -> bool:
         """True iff ``agent`` has explicitly closed this thread.

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -47,6 +47,9 @@ class DriveOutcome:
     failure_class: str | None = None
     summary: str = ""
     child_output_tail: dict | None = None
+    bus_action_attempted: bool = False
+    bus_action_infra: bool = False
+    bus_action_rejected: bool = False
 
 
 def _as_outcome(ret: object) -> DriveOutcome:
@@ -215,6 +218,7 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
              capacity_refresh: Callable[[], None] | None = None,
              capacity_interval_seconds: float = 60.0,
              wrapper_generation: str | None = None,
+             commit_gate=None,
              now_iso: Callable[[], str] = _iso_now) -> int:
     """Run the wrapper listen loop. ``drive(record)`` handles ONE turn (injected).
     Returns the number of turns driven. ``max_turns`` / ``max_polls`` / ``max_wall``
@@ -254,7 +258,10 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
     interval-gated and failure-isolated; exceptions are swallowed so capacity
     cannot undo the just-completed liveness/cursor boundary."""
     stamp = heartbeat if heartbeat is not None else (lambda: store.write_heartbeat(agent))
-    wait_token = (wrapper_generation or uuid.uuid4().hex) if manage_waiting else None
+    gate_generation = getattr(commit_gate, "fence", None)
+    wait_token = (
+        wrapper_generation or gate_generation or uuid.uuid4().hex
+    ) if manage_waiting else None
     try:
         if wait_token is not None:
             store.write_waiting(agent, {
@@ -273,7 +280,8 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
                 idle_interval=idle_interval, max_idle_interval=max_idle_interval,
                 heartbeat_interval=heartbeat_interval, clock=clock, sleep=sleep,
                 max_turns=max_turns, max_polls=max_polls, max_wall=max_wall,
-                stamp=stamp, on_health_idle=on_health_idle)
+                stamp=stamp, on_health_idle=on_health_idle,
+                commit_gate=commit_gate)
         return _run_continuous(
             store, agent, drive, idle_interval=idle_interval,
             max_idle_interval=max_idle_interval, heartbeat_interval=heartbeat_interval,
@@ -286,6 +294,7 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
             pre_commit=pre_commit, cadence=cadence, on_health_idle=on_health_idle,
             capacity_refresh=capacity_refresh,
             capacity_interval_seconds=capacity_interval_seconds,
+            commit_gate=commit_gate,
             now_iso=now_iso)
     finally:
         if wait_token is not None:
@@ -309,6 +318,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     on_health_idle: Callable[[], None] | None,
                     capacity_refresh: Callable[[], None] | None,
                     capacity_interval_seconds: float,
+                    commit_gate,
                     now_iso: Callable[[], str]) -> int:
     turns = 0
 
@@ -322,9 +332,21 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         if pre_commit is not None:
             pre_commit()
 
-    def _commit(rec: dict) -> None:
+    def _commit(rec: dict, gate_resolution=None) -> bool:
         _guard_advance()
+        if (
+            commit_gate is not None
+            and gate_resolution is not None
+            and gate_resolution.ledger_revision is not None
+        ):
+            finalized = commit_gate.finalize(
+                rec,
+                gate_resolution,
+                expected_revision=gate_resolution.ledger_revision,
+            )
+            return finalized.allows_legacy_commit or finalized.terminal
         recv_api.commit(store, agent, rec)
+        return True
 
     polls = 0
     last_hb: float | None = None
@@ -379,8 +401,36 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         _guard_advance()                      # dead-letter ADVANCES the cursor - verify
         #                                       lease ownership first (lead-loop), else a
         #                                       lost-lease controller could dispose unguarded
-        store.dead_letter(agent, record, reason=reason, failure_class=failure_class,
-                          at=now_iso(), child_output_tail=child_output_tail)
+        if commit_gate is not None and legacy_gate_resolution is not None:
+            authority = commit_gate.validate_no_admission_authority(
+                record,
+                legacy_gate_resolution,
+                side_effect=lambda: store.dead_letter(
+                    agent,
+                    record,
+                    reason=reason,
+                    failure_class=failure_class,
+                    at=now_iso(),
+                    child_output_tail=child_output_tail,
+                ),
+            )
+            if not authority.allows_legacy_commit:
+                stamp()
+                if on_health_idle is not None:
+                    on_health_idle()
+                last_hb = clock()
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                return
+        else:
+            store.dead_letter(
+                agent,
+                record,
+                reason=reason,
+                failure_class=failure_class,
+                at=now_iso(),
+                child_output_tail=child_output_tail,
+            )
         stamp()                               # DL is progress (bypasses drive's stamp)
         if on_health_idle is not None:
             on_health_idle()
@@ -475,6 +525,334 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             _commit(record)
             continue
 
+        legacy_gate_resolution = None
+        if commit_gate is not None:
+            from .obligations import GateError, ResolverState
+
+            resolution = commit_gate.admit_or_finalize(record)
+            if resolution.allows_legacy_commit:
+                legacy_gate_resolution = resolution
+            if not resolution.allows_legacy_commit:
+                if resolution.state in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    ResolverState.INDETERMINATE,
+                    ResolverState.IN_PROGRESS,
+                    ResolverState.DEFERRED,
+                }:
+                    stamp()
+                    if on_health_idle is not None:
+                        on_health_idle()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                if resolution.terminal:
+                    _guard_advance()
+                    finalized = commit_gate.finalize(
+                        record,
+                        resolution,
+                        expected_revision=resolution.ledger_revision,
+                    )
+                    if finalized.state == ResolverState.INDETERMINATE:
+                        if (
+                            resolution.key is not None
+                            and finalized.reason == "finalization CAS contention exhausted"
+                        ):
+                            commit_gate.settle_retry_exhaustion(
+                                record,
+                                resolution.key,
+                                category="finalization",
+                                reason="finalization CAS contention exhausted",
+                            )
+                        sleep(fail_sleep)
+                        fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                        continue
+                    if resolution.key is not None and resolution.compliance_success:
+                        commit_gate.mark_satisfied(resolution.key)
+                    stamp()
+                    last_hb = clock()
+                    fail_sleep = idle_interval
+                    continue
+                if resolution.state != ResolverState.OWED_UNSATISFIED:
+                    stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+
+                key = resolution.key
+                if key is None:
+                    stamp()
+                    sleep(fail_sleep)
+                    continue
+                captured = commit_gate.captured_operation(key)
+                if captured is not None:
+                    may_retry = commit_gate.record_retry_barrier(
+                        key,
+                        category="operation_infra",
+                        expected_revision=resolution.scoped_revision,
+                    )
+                    if may_retry:
+                        if commit_gate.retry_captured_operation(captured, record):
+                            commit_gate.mark_captured_operation_succeeded(captured)
+                        else:
+                            commit_gate.complete_retry_barrier(
+                                key, category="operation_infra")
+                    else:
+                        latest = commit_gate.resolve(record)
+                        should_settle = latest.terminal or latest.state in {
+                            ResolverState.BLOCKED,
+                            ResolverState.BLOCKED_POLICY,
+                            ResolverState.BLOCKED_COMPLIANCE,
+                        } or commit_gate.retry_bound_exhausted(
+                            key,
+                            category="operation_infra",
+                        )
+                        if not should_settle:
+                            stamp()
+                            sleep(fail_sleep)
+                            fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                            continue
+                        _guard_advance()
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            key,
+                            category="operation_infra",
+                            reason="captured bus operation exhausted its durable retry bound",
+                            permit=captured,
+                        )
+                        commit_gate.cleanup_permit(captured)
+                        stamp()
+                        continue
+                    resolution = commit_gate.resolve(record)
+                    if resolution.terminal:
+                        _guard_advance()
+                        finalized = commit_gate.finalize(record, resolution)
+                        if finalized.state != ResolverState.INDETERMINATE:
+                            if resolution.compliance_success:
+                                commit_gate.mark_satisfied(key)
+                            commit_gate.cleanup_permit(captured)
+                            stamp()
+                            turns += 1
+                            if max_turns is not None and turns >= max_turns:
+                                return turns
+                        else:
+                            if finalized.reason == "finalization CAS contention exhausted":
+                                commit_gate.settle_retry_exhaustion(
+                                    record,
+                                    key,
+                                    category="finalization",
+                                    reason="finalization CAS contention exhausted",
+                                )
+                    else:
+                        sleep(fail_sleep)
+                        fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+
+                purpose = commit_gate.next_dispatch_purpose(key)
+                if purpose is None:
+                    if commit_gate.dispatch_exhausted(key):
+                        _guard_advance()
+                        commit_gate.fail_delivery_or_block(
+                            record,
+                            key,
+                            reason=(
+                                "agent computed but did not emit the owed reply "
+                                "(model/prompt-compliance gap)"
+                            ),
+                            expected_revision=resolution.scoped_revision,
+                        )
+                        stamp()
+                        fail_sleep = idle_interval
+                    else:
+                        stamp()
+                        sleep(fail_sleep)
+                        fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                try:
+                    permit = commit_gate.reserve_dispatch(resolution, purpose=purpose)
+                except GateError:
+                    stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                try:
+                    dispatch_record = commit_gate.dispatch_record(record, permit)
+                except GateError:
+                    stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                outcome = _as_outcome(drive(dispatch_record))
+                action_infra = (
+                    outcome.bus_action_infra or outcome.failure_class == CLASS_INFRA
+                )
+                resolution = commit_gate.resolve(record)
+                post_budget_composing = resolution.reason == "post_budget_composing"
+                action_rejected = outcome.bus_action_rejected or (
+                    resolution.state == ResolverState.OWED_UNSATISFIED
+                    and outcome.bus_action_attempted
+                    and not action_infra
+                )
+                commit_gate.mark_dispatch_result(
+                    permit,
+                    action_attempted=outcome.bus_action_attempted,
+                    action_rejected=action_rejected,
+                    action_infra=action_infra,
+                )
+                if post_budget_composing:
+                    resolution = commit_gate.resolve(record)
+                    action_infra = commit_gate.captured_operation(key) is not None
+                if (
+                    resolution.state == ResolverState.OWED_UNSATISFIED
+                    and outcome.bus_action_attempted
+                    and not action_infra
+                ):
+                    commit_gate.mark_unsatisfied_attempt(
+                        permit,
+                        reason="attempted action did not legally terminate this obligation",
+                    )
+                if resolution.terminal:
+                    _guard_advance()
+                    finalized = commit_gate.finalize(record, resolution)
+                    if finalized.state != ResolverState.INDETERMINATE:
+                        if resolution.compliance_success:
+                            commit_gate.mark_satisfied(key)
+                        commit_gate.cleanup_permit(permit)
+                        stamp()
+                        last_hb = clock()
+                        fail_sleep = idle_interval
+                        turns += 1
+                        if max_turns is not None and turns >= max_turns:
+                            return turns
+                        continue
+                    if finalized.reason == "finalization CAS contention exhausted":
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            key,
+                            category="finalization",
+                            reason="finalization CAS contention exhausted",
+                        )
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                if action_infra:
+                    may_retry = commit_gate.record_retry_barrier(
+                        key,
+                        category="operation_infra",
+                        expected_revision=resolution.scoped_revision,
+                    )
+                    if may_retry:
+                        if commit_gate.retry_captured_operation(permit, record):
+                            commit_gate.mark_captured_operation_succeeded(permit)
+                            resolution = commit_gate.resolve(record)
+                            if resolution.terminal:
+                                _guard_advance()
+                                finalized = commit_gate.finalize(record, resolution)
+                                if finalized.state != ResolverState.INDETERMINATE:
+                                    if resolution.compliance_success:
+                                        commit_gate.mark_satisfied(key)
+                                    commit_gate.cleanup_permit(permit)
+                                    stamp()
+                                    turns += 1
+                                    if max_turns is not None and turns >= max_turns:
+                                        return turns
+                                    continue
+                                if (
+                                    finalized.reason
+                                    == "finalization CAS contention exhausted"
+                                ):
+                                    settled = commit_gate.settle_retry_exhaustion(
+                                        record,
+                                        key,
+                                        category="finalization",
+                                        reason="finalization CAS contention exhausted",
+                                    )
+                                    if settled.terminal:
+                                        commit_gate.cleanup_permit(permit)
+                                sleep(fail_sleep)
+                                fail_sleep = min(
+                                    max_idle_interval,
+                                    fail_sleep * 2.0,
+                                )
+                                continue
+                        else:
+                            commit_gate.complete_retry_barrier(
+                                key, category="operation_infra")
+                    else:
+                        latest = commit_gate.resolve(record)
+                        should_settle = latest.terminal or latest.state in {
+                            ResolverState.BLOCKED,
+                            ResolverState.BLOCKED_POLICY,
+                            ResolverState.BLOCKED_COMPLIANCE,
+                        } or commit_gate.retry_bound_exhausted(
+                            key,
+                            category="operation_infra",
+                        )
+                        if not should_settle:
+                            stamp()
+                            sleep(fail_sleep)
+                            fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                            continue
+                        _guard_advance()
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            key,
+                            category="operation_infra",
+                            reason="captured bus operation exhausted its durable retry bound",
+                            permit=permit,
+                        )
+                        commit_gate.cleanup_permit(permit)
+                        stamp()
+                        continue
+                if commit_gate.dispatch_exhausted(key) and not action_infra:
+                    _guard_advance()
+                    commit_gate.fail_delivery_or_block(
+                        record,
+                        key,
+                        reason=(
+                            "agent computed but did not emit the owed reply "
+                            "(model/prompt-compliance gap)"
+                        ),
+                        expected_revision=resolution.scoped_revision,
+                    )
+                    commit_gate.cleanup_permit(permit)
+                    stamp()
+                    fail_sleep = idle_interval
+                    continue
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+
+        if (
+            commit_gate is not None
+            and legacy_gate_resolution is not None
+            and legacy_gate_resolution.reason in {
+                "no_admission_finalization_pending",
+                "no_admission_disposition_pending",
+            }
+        ):
+            _guard_advance()
+            finalized = commit_gate.finalize(
+                record,
+                legacy_gate_resolution,
+                expected_revision=legacy_gate_resolution.ledger_revision,
+            )
+            if finalized.allows_legacy_commit:
+                store.clear_attempt(agent, record.get("id"))
+                store.gc_attempts_below(agent, store.cursor(agent))
+                stamp()
+                last_hb = clock()
+                fail_sleep = idle_interval
+                turns += 1
+                if max_turns is not None and turns >= max_turns:
+                    return turns
+                continue
+            stamp()
+            sleep(fail_sleep)
+            fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+            continue
+
         # ---- dead-letter: bound the at-least-once retry of a POISON head message ----
         head_id = record.get("id")
         # A stale in_progress on this head means the process crashed mid-turn last run ->
@@ -524,13 +902,88 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 # auto-dead-letter and NEVER freeze - fall through to drive AGAIN (a real outage,
                 # incl. a stale-kill mid-outage, must keep retrying until it clears).
 
+        if commit_gate is not None and legacy_gate_resolution is not None:
+            authorized = commit_gate.authorize_no_admission_drive(
+                record,
+                legacy_gate_resolution,
+            )
+            if authorized.terminal:
+                _guard_advance()
+                finalized = commit_gate.finalize(
+                    record,
+                    authorized,
+                    expected_revision=authorized.ledger_revision,
+                )
+                if finalized.terminal:
+                    store.clear_attempt(agent, record.get("id"))
+                    store.gc_attempts_below(agent, store.cursor(agent))
+                    stamp()
+                    fail_sleep = idle_interval
+                    continue
+                stamp()
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+            if not authorized.allows_legacy_commit:
+                stamp()
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+            legacy_gate_resolution = authorized
+
         # WRITE-AHEAD: count + mark in_progress BEFORE drive() so a crash mid-turn
         # still costs a durable attempt on relaunch. EXACTLY one attempt per drive().
         store.record_attempt_start(agent, record, attempt_id=uuid.uuid4().hex[:12],
                                    at=now_iso())
         outcome = _as_outcome(drive(record))
         if outcome.ok:
-            _commit(record)                             # guards lease ownership first
+            finalization_resolution = legacy_gate_resolution
+            retained_success = False
+            if (
+                commit_gate is not None
+                and legacy_gate_resolution is not None
+                and legacy_gate_resolution.ledger_revision is not None
+            ):
+                finalization_resolution = commit_gate.record_no_admission_success(
+                    record,
+                    legacy_gate_resolution,
+                )
+                retained_success = (
+                    finalization_resolution.reason
+                    == "no_admission_finalization_pending"
+                )
+                if not (
+                    finalization_resolution.allows_legacy_commit
+                    or finalization_resolution.terminal
+                ):
+                    store.record_attempt_result(
+                        agent,
+                        head_id,
+                        failure_class=CLASS_AMBIGUOUS,
+                        summary="commit-gate no-admission success retention miss",
+                        at=now_iso(),
+                    )
+                    stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+            if not _commit(record, finalization_resolution):
+                if retained_success:
+                    store.clear_attempt(agent, head_id)
+                    stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                store.record_attempt_result(
+                    agent,
+                    head_id,
+                    failure_class=CLASS_AMBIGUOUS,
+                    summary="commit-gate no-admission CAS miss",
+                    at=now_iso(),
+                )
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
             store.clear_attempt(agent, head_id)
             store.gc_attempts_below(agent, store.cursor(agent))
             last_hb = clock()                           # drive already stamped on success
@@ -592,7 +1045,8 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
                   sleep: Callable[[float], None], max_turns: int | None,
                   max_polls: int | None, max_wall: float | None,
                   stamp: Callable[[], None] | None = None,
-                  on_health_idle: Callable[[], None] | None = None) -> int:
+                  on_health_idle: Callable[[], None] | None = None,
+                  commit_gate=None) -> int:
     """SCOPED one-shot loop for an ephemeral reviewer (see run_loop). Receives only
     messages on ``rid`` so unrelated traffic neither starves it nor is consumed from
     the global inbox; bounded so it always terminates."""
@@ -631,18 +1085,273 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
             cur_sleep = min(max_idle_interval, cur_sleep * 2.0)
             continue
         cur_sleep = idle_interval
-        if is_terminal_control(record):
+        if is_terminal_control(record) and commit_gate is None:
             # scoped record on a rescinded/closed thread: consume + stop (terminal).
             recv_api.commit(store, agent, record)
             return turns
+        legacy_gate_resolution = None
+        if commit_gate is not None:
+            from .obligations import GateError, ResolverState
+
+            resolution = commit_gate.admit_or_finalize(record)
+            if resolution.allows_legacy_commit:
+                legacy_gate_resolution = resolution
+            if not resolution.allows_legacy_commit:
+                if resolution.terminal:
+                    finalized = commit_gate.finalize(
+                        record,
+                        resolution,
+                        expected_revision=resolution.ledger_revision,
+                    )
+                    if finalized.state != ResolverState.INDETERMINATE:
+                        if resolution.key is not None and resolution.compliance_success:
+                            commit_gate.mark_satisfied(resolution.key)
+                        return turns
+                    if (
+                        resolution.key is not None
+                        and finalized.reason == "finalization CAS contention exhausted"
+                    ):
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            resolution.key,
+                            category="finalization",
+                            reason="finalization CAS contention exhausted",
+                        )
+                if resolution.state != ResolverState.OWED_UNSATISFIED:
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                key = resolution.key
+                if key is None:
+                    _stamp()
+                    sleep(fail_sleep)
+                    continue
+                captured = commit_gate.captured_operation(key)
+                if captured is not None:
+                    may_retry = commit_gate.record_retry_barrier(
+                        key,
+                        category="operation_infra",
+                        expected_revision=resolution.scoped_revision,
+                    )
+                    if not may_retry:
+                        latest = commit_gate.resolve(record)
+                        should_settle = latest.terminal or latest.state in {
+                            ResolverState.BLOCKED,
+                            ResolverState.BLOCKED_POLICY,
+                            ResolverState.BLOCKED_COMPLIANCE,
+                        } or commit_gate.retry_bound_exhausted(
+                            key,
+                            category="operation_infra",
+                        )
+                        if not should_settle:
+                            _stamp()
+                            sleep(fail_sleep)
+                            fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                            continue
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            key,
+                            category="operation_infra",
+                            reason="captured bus operation exhausted its durable retry bound",
+                            permit=captured,
+                        )
+                        commit_gate.cleanup_permit(captured)
+                        return turns
+                    if commit_gate.retry_captured_operation(captured, record):
+                        commit_gate.mark_captured_operation_succeeded(captured)
+                    else:
+                        commit_gate.complete_retry_barrier(
+                            key, category="operation_infra")
+                    resolved = commit_gate.resolve(record)
+                    if resolved.terminal:
+                        finalized = commit_gate.finalize(record, resolved)
+                        if finalized.state != ResolverState.INDETERMINATE:
+                            if resolved.compliance_success:
+                                commit_gate.mark_satisfied(key)
+                            commit_gate.cleanup_permit(captured)
+                            turns += 1
+                            return turns
+                        if finalized.reason == "finalization CAS contention exhausted":
+                            commit_gate.settle_retry_exhaustion(
+                                record,
+                                key,
+                                category="finalization",
+                                reason="finalization CAS contention exhausted",
+                            )
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                purpose = commit_gate.next_dispatch_purpose(key)
+                if purpose is None:
+                    if commit_gate.dispatch_exhausted(key):
+                        commit_gate.fail_delivery_or_block(
+                            record,
+                            key,
+                            reason=(
+                                "agent computed but did not emit the owed reply "
+                                "(model/prompt-compliance gap)"
+                            ),
+                            expected_revision=resolution.scoped_revision,
+                        )
+                        return turns
+                    _stamp()
+                    sleep(fail_sleep)
+                    continue
+                try:
+                    permit = commit_gate.reserve_dispatch(resolution, purpose=purpose)
+                except GateError:
+                    _stamp()
+                    sleep(fail_sleep)
+                    continue
+                try:
+                    dispatch_record = commit_gate.dispatch_record(record, permit)
+                except GateError:
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                outcome = _as_outcome(drive(dispatch_record))
+                action_infra = (
+                    outcome.bus_action_infra or outcome.failure_class == CLASS_INFRA
+                )
+                resolved = commit_gate.resolve(record)
+                post_budget_composing = resolved.reason == "post_budget_composing"
+                action_rejected = outcome.bus_action_rejected or (
+                    resolved.state == ResolverState.OWED_UNSATISFIED
+                    and outcome.bus_action_attempted
+                    and not action_infra
+                )
+                commit_gate.mark_dispatch_result(
+                    permit,
+                    action_attempted=outcome.bus_action_attempted,
+                    action_rejected=action_rejected,
+                    action_infra=action_infra,
+                )
+                if post_budget_composing:
+                    resolved = commit_gate.resolve(record)
+                    action_infra = commit_gate.captured_operation(key) is not None
+                if (
+                    resolved.state == ResolverState.OWED_UNSATISFIED
+                    and outcome.bus_action_attempted
+                    and not action_infra
+                ):
+                    commit_gate.mark_unsatisfied_attempt(
+                        permit,
+                        reason="attempted action did not legally terminate this obligation",
+                    )
+                if resolved.terminal:
+                    finalized = commit_gate.finalize(record, resolved)
+                    if finalized.state != ResolverState.INDETERMINATE:
+                        if resolved.compliance_success:
+                            commit_gate.mark_satisfied(key)
+                        commit_gate.cleanup_permit(permit)
+                        turns += 1
+                        return turns
+                    if finalized.reason == "finalization CAS contention exhausted":
+                        commit_gate.settle_retry_exhaustion(
+                            record,
+                            key,
+                            category="finalization",
+                            reason="finalization CAS contention exhausted",
+                        )
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                if action_infra:
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                if commit_gate.dispatch_exhausted(key) and not action_infra:
+                    commit_gate.fail_delivery_or_block(
+                        record,
+                        key,
+                        reason=(
+                            "agent computed but did not emit the owed reply "
+                            "(model/prompt-compliance gap)"
+                        ),
+                        expected_revision=resolved.scoped_revision,
+                    )
+                    commit_gate.cleanup_permit(permit)
+                    return turns
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+        if (
+            commit_gate is not None
+            and legacy_gate_resolution is not None
+            and legacy_gate_resolution.reason in {
+                "no_admission_finalization_pending",
+                "no_admission_disposition_pending",
+            }
+        ):
+            finalized = commit_gate.finalize(
+                record,
+                legacy_gate_resolution,
+                expected_revision=legacy_gate_resolution.ledger_revision,
+            )
+            if finalized.allows_legacy_commit:
+                turns += 1
+                return turns
+            _stamp()
+            sleep(fail_sleep)
+            fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+            continue
         # A scoped record carries ``rid`` by construction - it is the work this ephemeral
         # reviewer was spawned for. Normalize ONCE, then commit/thread-seen/turns++ ONLY when
         # ok - drive() returns a DriveOutcome (frozen dataclass, no __bool__ -> always truthy),
         # so a bare ``if drive(record):`` would treat a FAILED turn as success and mark the
         # scoped request seen (lead 4th-verify P1 #1; mirrors _run_continuous's _as_outcome).
+        if commit_gate is not None and legacy_gate_resolution is not None:
+            authorized = commit_gate.authorize_no_admission_drive(
+                record,
+                legacy_gate_resolution,
+            )
+            if authorized.terminal:
+                finalized = commit_gate.finalize(
+                    record,
+                    authorized,
+                    expected_revision=authorized.ledger_revision,
+                )
+                if finalized.terminal:
+                    return turns
+                _stamp()
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+            if not authorized.allows_legacy_commit:
+                _stamp()
+                sleep(fail_sleep)
+                fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                continue
+            legacy_gate_resolution = authorized
         outcome = _as_outcome(drive(record))
         if outcome.ok:
-            recv_api.commit(store, agent, record)       # SCOPED: thread-seen only
+            if legacy_gate_resolution is not None and legacy_gate_resolution.ledger_revision is not None:
+                retained = commit_gate.record_no_admission_success(
+                    record,
+                    legacy_gate_resolution,
+                )
+                if not (retained.allows_legacy_commit or retained.terminal):
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+                finalized = commit_gate.finalize(
+                    record,
+                    retained,
+                    expected_revision=retained.ledger_revision,
+                )
+                if not (finalized.allows_legacy_commit or finalized.terminal):
+                    _stamp()
+                    sleep(fail_sleep)
+                    fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+                    continue
+            else:
+                recv_api.commit(store, agent, record)   # SCOPED: thread-seen only
             last_hb = clock()
             fail_sleep = idle_interval
             turns += 1

--- a/src/agenttalk/wrapper/obligations.py
+++ b/src/agenttalk/wrapper/obligations.py
@@ -4235,10 +4235,12 @@ class DetectionCommitGate:
             raise DispatchRefused("AGENTTALK_PY must name an absolute executable")
         try:
             resolved = executable.resolve(strict=True)
-        except OSError as exc:
+        except (OSError, RuntimeError) as exc:
             raise DispatchRefused("AGENTTALK_PY executable is unavailable") from exc
-        if executable.is_symlink() or not resolved.is_file():
-            raise DispatchRefused("AGENTTALK_PY must name a regular non-symlink file")
+        # POSIX Python launchers are commonly symlinks. Returning the canonical
+        # regular-file path keeps dispatch argv stable if the launcher is retargeted.
+        if not resolved.is_file():
+            raise DispatchRefused("AGENTTALK_PY must resolve to a regular file")
         return str(resolved)
 
     def dispatch_exhausted(self, key: ObligationKey) -> bool:

--- a/src/agenttalk/wrapper/obligations.py
+++ b/src/agenttalk/wrapper/obligations.py
@@ -1,0 +1,8159 @@
+"""Detection-grade wrapped-turn commit enforcement.
+
+This module deliberately provides a detection boundary, not a same-user security
+boundary.  The parent wrapper snapshots operator launch policy, records canonical
+transitions in a durable store-owned journal, and refuses to advance an eligible
+head unless replay proves its delivery assignment terminal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+# Dispatch argv uses a pinned interpreter and never invokes a shell.
+import subprocess  # nosec B404
+import uuid
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from agenttalk import threads
+from agenttalk._atomic import write_text as _atomic_write_text
+from agenttalk.store import CONTROL_KINDS, PROC_DEAD, Message, _process_liveness
+
+POLICY_ENV = "AGENTTALK_COMMIT_GATE_POLICY"
+POLICY_SCHEMA_VERSION = 1
+LEDGER_SCHEMA_VERSION = 1
+REDUCER_VERSION = "question-replay-v1"
+DETECTION_GRADE = "detection"
+SECURITY_GRADE = "security"
+PARTICIPANT_CAPABILITIES = (
+    "answer",
+    "broadcast_policy_satisfied",
+    "composing",
+    "delivery_failed",
+    "human_escalation",
+    "manual_close",
+    "operator_resolution",
+    "rescind",
+    "transfer",
+)
+PARTICIPANT_CAPABILITIES_DIGEST = hashlib.sha256(
+    json.dumps(PARTICIPANT_CAPABILITIES, separators=(",", ":")).encode("utf-8")
+).hexdigest()
+MAX_PAID_DISPATCHES_TOTAL = 2
+COMPLIANCE_BREAKER_TRIP = 3
+MAX_DISPATCH_TOKEN_CEILING = 262_144
+MAX_DISPATCH_WALL_TIME_SECONDS = 3_600.0
+MAX_DISPATCH_RESERVED_COST = 100.0
+MAX_CONCURRENT_PAID_DISPATCHES = 1
+MAX_OPERATION_INFRA_ATTEMPTS = 16
+MAX_OPERATION_INFRA_SECONDS = 900.0
+MAX_FINALIZATION_MISSES = 12
+MAX_FINALIZATION_SECONDS = 900.0
+MAX_DEFERRAL_SECONDS = 3600.0
+PROOF_UNREADABLE_SECONDS = 900.0
+
+
+class ResolverState(str, Enum):
+    NOT_OWED = "not_owed"
+    CLASSIFICATION_UNKNOWN = "classification_unknown"
+    INACTIVE = "inactive"
+    ACTIVE = "active"
+    BLOCKED = "blocked"
+    BLOCKED_POLICY = "blocked_policy"
+    BLOCKED_COMPLIANCE = "blocked_compliance"
+    OWED_UNSATISFIED = "owed_unsatisfied"
+    SATISFIED = "satisfied"
+    SUPERSEDED = "superseded"
+    TRANSFERRED = "transferred"
+    OPERATOR_RESOLVED = "operator_resolved"
+    BROADCAST_POLICY_SATISFIED = "broadcast_policy_satisfied"
+    IN_PROGRESS = "in_progress"
+    DEFERRED = "deferred"
+    ACTION_ATTEMPT_INFRA = "action_attempt_infra"
+    ACTION_REJECTED = "action_rejected"
+    INDETERMINATE = "indeterminate"
+    DELIVERY_EXHAUSTED = "delivery_exhausted"
+
+
+TERMINAL_STATES = frozenset({
+    ResolverState.SATISFIED,
+    ResolverState.SUPERSEDED,
+    ResolverState.TRANSFERRED,
+    ResolverState.OPERATOR_RESOLVED,
+    ResolverState.BROADCAST_POLICY_SATISFIED,
+    ResolverState.DELIVERY_EXHAUSTED,
+})
+CLOSED_ADMISSION_STATES = frozenset({
+    "blocked",
+    "broadcast_policy_satisfied",
+    "delivery_failed",
+    "finalized",
+    "operator_resolved",
+    "transferred",
+})
+
+
+class GateError(RuntimeError):
+    """Base class for authoritative commit-gate failures."""
+
+
+class LedgerUnreadable(GateError):
+    """The canonical journal cannot be read safely."""
+
+
+class StaleRevision(GateError):
+    """A scoped compare-and-swap lost a race."""
+
+
+class DispatchRefused(GateError):
+    """A paid dispatch did not satisfy every reservation precondition."""
+
+
+@dataclass(frozen=True)
+class PolicySnapshot:
+    status: ResolverState
+    generation: str
+    grade: str | None = None
+    reason: str = ""
+    agent: str | None = None
+
+    @classmethod
+    def inactive(
+        cls,
+        reason: str = "no policy configured",
+        *,
+        agent: str | None = None,
+    ) -> "PolicySnapshot":
+        return cls(ResolverState.NOT_OWED, "inactive", reason=reason, agent=agent)
+
+    @classmethod
+    def from_mapping(cls, raw: object, agent: str) -> "PolicySnapshot":
+        if not isinstance(raw, dict) or raw.get("schema_version") != POLICY_SCHEMA_VERSION:
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                "unreadable",
+                reason="policy schema invalid",
+                agent=agent,
+            )
+        agents = raw.get("agents")
+        if not isinstance(agents, dict):
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                "unreadable",
+                reason="policy agents invalid",
+                agent=agent,
+            )
+        canonical = json.dumps(raw, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        generation = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        entry = agents.get(agent)
+        if entry is None:
+            return cls(
+                ResolverState.NOT_OWED,
+                generation,
+                reason="agent has no configured grade",
+                agent=agent,
+            )
+        if not isinstance(entry, dict) or not isinstance(entry.get("grade"), str):
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                generation,
+                reason="configured grade is invalid",
+                agent=agent,
+            )
+        grade = entry.get("grade")
+        if grade not in {DETECTION_GRADE, SECURITY_GRADE}:
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                generation,
+                reason="configured grade is unsupported",
+                agent=agent,
+            )
+        enabled = entry.get("enabled", True)
+        if enabled is not True and enabled is not False:
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                generation,
+                reason="configured enabled flag is invalid",
+                agent=agent,
+            )
+        if enabled is False:
+            return cls(
+                ResolverState.INACTIVE,
+                generation,
+                grade,
+                "operator disabled gate",
+                agent,
+            )
+        if grade == SECURITY_GRADE:
+            return cls(
+                ResolverState.BLOCKED,
+                generation,
+                SECURITY_GRADE,
+                "security-grade prerequisites are not available in this build",
+                agent,
+            )
+        return cls(
+            ResolverState.ACTIVE,
+            generation,
+            DETECTION_GRADE,
+            "policy ready",
+            agent,
+        )
+
+    @classmethod
+    def from_path(cls, path: Path, agent: str) -> "PolicySnapshot":
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            return cls(
+                ResolverState.BLOCKED_POLICY,
+                "unreadable",
+                reason=f"operator policy unreadable: {type(exc).__name__}",
+                agent=agent,
+            )
+        return cls.from_mapping(raw, agent)
+
+    @classmethod
+    def from_environment(cls, agent: str) -> "PolicySnapshot":
+        configured = os.environ.get(POLICY_ENV)
+        if not configured:
+            return cls.inactive(agent=agent)
+        return cls.from_path(Path(configured).expanduser().resolve(), agent)
+
+
+@dataclass(frozen=True)
+class ObligationKey:
+    store_epoch: str
+    inbound_id: str
+    correlation_id: str
+    requester: str
+    responder: str
+    question_generation: int
+    delivery_generation: int
+    obligation_class: str
+    reducer_version: str = REDUCER_VERSION
+    participant_capabilities_digest: str = PARTICIPANT_CAPABILITIES_DIGEST
+
+    def to_dict(self) -> dict:
+        return {
+            "store_epoch": self.store_epoch,
+            "inbound_id": self.inbound_id,
+            "correlation_id": self.correlation_id,
+            "requester": self.requester,
+            "responder": self.responder,
+            "question_generation": self.question_generation,
+            "delivery_generation": self.delivery_generation,
+            "obligation_class": self.obligation_class,
+            "reducer_version": self.reducer_version,
+            "participant_capabilities_digest": self.participant_capabilities_digest,
+        }
+
+    @property
+    def digest(self) -> str:
+        raw = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Resolution:
+    state: ResolverState
+    reason: str
+    key: ObligationKey | None = None
+    evidence_id: str | None = None
+    scoped_revision: int = 0
+    ledger_revision: int | None = None
+    compliance_success: bool = False
+    activation_generation: str | None = None
+    readiness_generation: str | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    @property
+    def allows_legacy_commit(self) -> bool:
+        return self.state in {
+            ResolverState.NOT_OWED,
+            ResolverState.CLASSIFICATION_UNKNOWN,
+            ResolverState.INACTIVE,
+        }
+
+
+@dataclass(frozen=True)
+class DispatchPermit:
+    key_digest: str
+    nonce: str
+    composing_nonce: str
+    purpose: str
+    paid_dispatches_total: int
+    draft_path: Path
+    budgets_digest: str = ""
+
+
+DEFAULT_DISPATCH_BUDGETS = {
+    "token_ceiling": MAX_DISPATCH_TOKEN_CEILING,
+    "wall_time_seconds": MAX_DISPATCH_WALL_TIME_SECONDS,
+    "reserved_cost": MAX_DISPATCH_RESERVED_COST,
+    "concurrency": MAX_CONCURRENT_PAID_DISPATCHES,
+}
+
+
+def _dispatch_budgets(raw: object) -> dict:
+    value = DEFAULT_DISPATCH_BUDGETS if raw is None else raw
+    if not isinstance(value, dict) or set(value) != set(DEFAULT_DISPATCH_BUDGETS):
+        raise DispatchRefused("dispatch budgets are incomplete")
+    token_ceiling = value.get("token_ceiling")
+    wall_time_seconds = value.get("wall_time_seconds")
+    reserved_cost = value.get("reserved_cost")
+    concurrency = value.get("concurrency")
+    if (
+        not isinstance(token_ceiling, int)
+        or isinstance(token_ceiling, bool)
+        or token_ceiling < 1
+        or token_ceiling > MAX_DISPATCH_TOKEN_CEILING
+    ):
+        raise DispatchRefused("dispatch token ceiling exceeds the v1 budget")
+    if (
+        not isinstance(wall_time_seconds, (int, float))
+        or isinstance(wall_time_seconds, bool)
+        or not math.isfinite(float(wall_time_seconds))
+        or float(wall_time_seconds) <= 0
+        or float(wall_time_seconds) > MAX_DISPATCH_WALL_TIME_SECONDS
+    ):
+        raise DispatchRefused("dispatch wall-time ceiling exceeds the v1 budget")
+    if (
+        not isinstance(reserved_cost, (int, float))
+        or isinstance(reserved_cost, bool)
+        or not math.isfinite(float(reserved_cost))
+        or float(reserved_cost) < 0
+        or float(reserved_cost) > MAX_DISPATCH_RESERVED_COST
+    ):
+        raise DispatchRefused("dispatch reserved-cost ceiling exceeds the v1 budget")
+    if concurrency != MAX_CONCURRENT_PAID_DISPATCHES:
+        raise DispatchRefused("dispatch concurrency budget exhausted")
+    return {
+        "token_ceiling": token_ceiling,
+        "wall_time_seconds": float(wall_time_seconds),
+        "reserved_cost": float(reserved_cost),
+        "concurrency": concurrency,
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _epoch(value: object) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _correlation(meta: object) -> str | None:
+    if not isinstance(meta, dict):
+        return None
+    for name in ("request_id", "broadcast_id"):
+        value = meta.get(name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _true(meta: dict, name: str) -> bool | None:
+    if name not in meta:
+        return False
+    value = meta.get(name)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        value = value.strip().casefold()
+        if value in {"true", "1", "yes"}:
+            return True
+        if value in {"false", "0", "no"}:
+            return False
+    return None
+
+
+def _broadcast_descriptor(meta: object, *, requester: object = None) -> dict | None:
+    if not isinstance(meta, dict) or not isinstance(meta.get("broadcast_id"), str):
+        return None
+    broadcast_id = meta["broadcast_id"]
+    members = meta.get("membership_snapshot")
+    policy = meta.get("response_policy")
+    quorum = meta.get("response_quorum")
+    if (
+        not isinstance(members, list)
+        or not members
+        or any(not isinstance(member, str) or not member for member in members)
+        or len(set(members)) != len(members)
+        or not isinstance(requester, str)
+        or not requester
+        or meta.get("request_id") != broadcast_id
+        or policy not in {"each", "any", "quorum"}
+        or meta.get("broadcast_policy_version") != 1
+        or (
+            policy == "quorum"
+            and (
+                not isinstance(quorum, int)
+                or isinstance(quorum, bool)
+                or quorum < 1
+                or quorum > len(members)
+            )
+        )
+    ):
+        return None
+    return {
+        "broadcast_id": broadcast_id,
+        "requester": requester,
+        "membership_snapshot": list(members),
+        "response_policy": policy,
+        "response_quorum": quorum if policy == "quorum" else None,
+        "broadcast_policy_version": 1,
+    }
+
+
+def _broadcast_descriptor_digest(descriptor: dict) -> str:
+    return hashlib.sha256(_canonical(descriptor).encode("utf-8")).hexdigest()
+
+
+def _valid_hex_digest(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 64 or value != value.lower():
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def operation_payload_digest(
+    *,
+    operation: str,
+    body: str,
+    kind: str,
+    recipient: str,
+    in_reply_to: str | None = None,
+    request_id: str | None = None,
+    broadcast_id: str | None = None,
+    origin_request_id: str | None = None,
+    origin_inbound_id: str | None = None,
+    origin_obligation_key_digest: str | None = None,
+    expected_roster_revision: str | None = None,
+) -> str:
+    payload = {
+        "operation": operation,
+        "body": body,
+        "kind": kind,
+        "recipient": recipient,
+        "in_reply_to": in_reply_to,
+        "request_id": request_id,
+        "broadcast_id": broadcast_id,
+        "origin_request_id": origin_request_id,
+        "origin_inbound_id": origin_inbound_id,
+    }
+    if origin_obligation_key_digest is not None:
+        payload["origin_obligation_key_digest"] = origin_obligation_key_digest
+    if expected_roster_revision is not None:
+        payload["expected_roster_revision"] = expected_roster_revision
+    return hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
+
+
+def _message_operation_valid(message: Message, *, operation: str, nonce: str) -> bool:
+    meta = message.meta or {}
+    if meta.get("operation_nonce") != nonce:
+        return False
+    expected = operation_payload_digest(
+        operation=operation,
+        body=message.body,
+        kind=message.kind,
+        recipient=message.recipient,
+        in_reply_to=meta.get("in_reply_to"),
+        request_id=meta.get("request_id"),
+        broadcast_id=meta.get("broadcast_id"),
+        origin_request_id=meta.get("origin_request_id"),
+        origin_inbound_id=meta.get("origin_inbound_id"),
+        origin_obligation_key_digest=meta.get("origin_obligation_key_digest"),
+        expected_roster_revision=meta.get("expected_roster_revision"),
+    )
+    return meta.get("operation_digest") == expected
+
+
+def _roster_snapshot(cfg: dict) -> dict:
+    roster = list(cfg.get("agents") or [])
+    roles = cfg.get("roles") if isinstance(cfg.get("roles"), dict) else {}
+    liaison = cfg.get("operator_facing")
+    authorized = {
+        name for name in roster
+        if isinstance(roles.get(name), str) and roles[name].casefold() == "lead"
+    }
+    if isinstance(liaison, str) and liaison in roster:
+        authorized.add(liaison)
+    payload = {
+        "agents": roster,
+        "roles": {name: roles[name] for name in sorted(roles)},
+        "operator_facing": liaison if isinstance(liaison, str) else None,
+    }
+    return {
+        "revision": hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest(),
+        "authorized_liaisons": sorted(authorized),
+    }
+
+
+def _new_ledger() -> dict:
+    return {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "store_epoch": uuid.uuid4().hex,
+        "append_sequence": 0,
+        "revision": 0,
+        "messages": {},
+        "transitions": [],
+        "scoped_revisions": {},
+        "obligations": {},
+        "inbound_index": {},
+        "no_admission_claims": {},
+        "dispatch_nonces": {},
+        "breakers": {},
+        "delivery_index": {},
+        "broadcasts": {},
+        "cursor_dispositions": {},
+        "telemetry": {},
+    }
+
+
+def _validate_ledger(raw: object) -> dict:
+    if not isinstance(raw, dict) or raw.get("schema_version") != LEDGER_SCHEMA_VERSION:
+        raise LedgerUnreadable("obligation ledger schema invalid")
+    raw.setdefault("dispatch_nonces", {})
+    raw.setdefault("broadcasts", {})
+    required = (
+        "store_epoch", "append_sequence", "revision", "messages", "transitions",
+        "scoped_revisions", "obligations", "inbound_index", "breakers",
+        "no_admission_claims", "dispatch_nonces", "delivery_index", "broadcasts",
+        "telemetry",
+        "cursor_dispositions",
+    )
+    if not isinstance(raw.get("store_epoch"), str):
+        raise LedgerUnreadable("obligation ledger epoch invalid")
+    if not all(name in raw for name in required):
+        raise LedgerUnreadable("obligation ledger fields missing")
+    if not all(isinstance(raw.get(name), dict) for name in (
+        "messages", "scoped_revisions", "obligations", "inbound_index",
+        "no_admission_claims", "dispatch_nonces", "breakers", "delivery_index",
+        "broadcasts", "telemetry",
+        "cursor_dispositions",
+    )):
+        raise LedgerUnreadable("obligation ledger maps invalid")
+    if not isinstance(raw.get("transitions"), list):
+        raise LedgerUnreadable("obligation transitions invalid")
+    sequence = raw.get("append_sequence")
+    revision = raw.get("revision")
+    if (
+        not isinstance(sequence, int)
+        or isinstance(sequence, bool)
+        or sequence < 0
+        or not isinstance(revision, int)
+        or isinstance(revision, bool)
+        or revision < 0
+    ):
+        raise LedgerUnreadable("obligation ledger counters invalid")
+    transition_sequences = [
+        row.get("sequence") if isinstance(row, dict) else None
+        for row in raw["transitions"]
+    ]
+    if transition_sequences != list(range(1, sequence + 1)):
+        raise LedgerUnreadable("obligation append sequence is non-contiguous")
+    if any(
+        not isinstance(row, dict)
+        or not isinstance(row.get("sequence"), int)
+        or row["sequence"] < 1
+        or row["sequence"] > sequence
+        for row in raw["messages"].values()
+    ):
+        raise LedgerUnreadable("obligation message sequence invalid")
+    return raw
+
+
+class DetectionCommitGate:
+    """One wrapper-process view of the detection-grade commit authority."""
+
+    def __init__(
+        self,
+        store,
+        agent: str,
+        policy: PolicySnapshot,
+        *,
+        fence: str,
+        now: Callable[[], str] = _now_iso,
+        producer_alive: Callable[[str], bool] | None = None,
+        policy_loader: Callable[[], PolicySnapshot] | None = None,
+        dispatch_budgets: dict | None = None,
+    ) -> None:
+        self.store = store
+        self.agent = agent
+        self.policy = policy
+        self.fence = fence
+        self.now = now
+        self.producer_alive = producer_alive or (lambda _token: False)
+        self.policy_loader = policy_loader
+        self.dispatch_budgets = _dispatch_budgets(dispatch_budgets)
+        self.path = store.state_dir / "owed-action" / "ledger.json"
+        self.checkpoint_path = store.state_dir / "owed-action" / "ledger.checkpoint.json"
+        self.epoch_anchor_path = store.state_dir / "owed-action" / "epoch-anchor.json"
+        self.proof_health_path = store.state_dir / "owed-action" / "proof-health.json"
+        self.drafts = store.state_dir / "owed-action" / "drafts" / agent
+
+    @classmethod
+    def from_environment(cls, store, agent: str, *, fence: str) -> "DetectionCommitGate":
+        return cls(
+            store,
+            agent,
+            PolicySnapshot.from_environment(agent),
+            fence=fence,
+            policy_loader=lambda: PolicySnapshot.from_environment(agent),
+        )
+
+    def _current_policy(self) -> PolicySnapshot:
+        return self.policy_loader() if self.policy_loader is not None else self.policy
+
+    def _revalidate_admission_policy(
+        self,
+        observed: PolicySnapshot,
+    ) -> Resolution | None:
+        """Fail closed if policy changed after admission classification."""
+        current = self._current_policy()
+        if (
+            current.status == observed.status
+            and current.generation == observed.generation
+            and current.grade == observed.grade
+            and current.agent == observed.agent
+        ):
+            return None
+        if current.status in {
+            ResolverState.BLOCKED,
+            ResolverState.BLOCKED_POLICY,
+            ResolverState.BLOCKED_COMPLIANCE,
+        }:
+            return Resolution(current.status, current.reason)
+        return Resolution(
+            ResolverState.BLOCKED_POLICY,
+            "operator policy changed during admission; retry classification",
+        )
+
+    @staticmethod
+    def _claim_matches_policy(claim: dict, policy: PolicySnapshot) -> bool:
+        return (
+            claim.get("policy_status") == policy.status.value
+            and claim.get("policy_generation") == policy.generation
+        )
+
+    @staticmethod
+    def _claim_is_untouched(claim: dict) -> bool:
+        return (
+            claim.get("state") == "open"
+            and not claim.get("drive_started_at")
+            and not claim.get("drive_succeeded_at")
+        )
+
+    @staticmethod
+    def _claim_has_no_legacy_work(claim: dict) -> bool:
+        return not claim.get("drive_started_at") and not claim.get(
+            "drive_succeeded_at"
+        )
+
+    @staticmethod
+    def _policy_blocks_durable_terminal_projection(policy: PolicySnapshot) -> bool:
+        return policy.status in {
+            ResolverState.BLOCKED_POLICY,
+            ResolverState.BLOCKED_COMPLIANCE,
+        } or (
+            policy.status == ResolverState.BLOCKED
+            and policy.grade != SECURITY_GRADE
+        )
+
+    @staticmethod
+    def _exact_no_admission_disposition_matches(
+        claim: dict,
+        disposition: object,
+        record: dict,
+        resolution: Resolution,
+    ) -> bool:
+        disposition_state = (
+            "delivery_failed"
+            if resolution.state == ResolverState.DELIVERY_EXHAUSTED
+            else resolution.state.value
+        )
+        return (
+            claim.get("state") == "finalized"
+            and claim.get("resolution") == resolution.state.value
+            and claim.get("terminal_evidence_id") == resolution.evidence_id
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == record.get("id")
+            and disposition.get("mode") == record.get("mode", "global")
+            and disposition.get("state") == disposition_state
+        )
+
+    @classmethod
+    def _durable_no_admission_disposition_matches(
+        cls,
+        claim: dict,
+        disposition: object,
+        record: dict,
+        resolution: Resolution,
+    ) -> bool:
+        return (
+            cls._claim_has_no_legacy_work(claim)
+            and cls._exact_no_admission_disposition_matches(
+                claim,
+                disposition,
+                record,
+                resolution,
+            )
+        )
+
+    def _replay_pinned_terminal_transition(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        *,
+        transition: str,
+        state: ResolverState,
+        evidence_id: object,
+    ) -> Resolution:
+        """Replay the immutable prefix that established an exact terminal winner."""
+        inbound_id = record.get("id")
+        candidates = [
+            event
+            for event in ledger["transitions"]
+            if isinstance(event, dict)
+            and event.get("transition") == transition
+            and isinstance(event.get("data"), dict)
+            and event["data"].get("inbound_id") == inbound_id
+            and event["data"].get("state") == state.value
+            and (evidence_id is None or event.get("source_id") == evidence_id)
+        ]
+        if len(candidates) != 1:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "pinned terminal authority is ambiguous",
+            )
+        authority = candidates[0]
+        cutoff = int(authority.get("sequence", 0))
+        prefix_rows = {
+            message_id: row
+            for message_id, row in ledger["messages"].items()
+            if int(row.get("sequence", 0)) < cutoff
+        }
+        prefix_ledger = {
+            **ledger,
+            "messages": prefix_rows,
+            "transitions": [
+                event
+                for event in ledger["transitions"]
+                if int(event.get("sequence", 0)) < cutoff
+            ],
+        }
+        prefix_messages = [
+            message for message in messages if message.id in prefix_rows
+        ]
+        replayed = self._resolve_replay(
+            record,
+            prefix_messages,
+            prefix_ledger,
+            admission=None,
+        )
+        if (
+            replayed.state != state
+            or not isinstance(replayed.evidence_id, str)
+            or authority.get("source_id") != replayed.evidence_id
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "pinned terminal authority conflicts with replay",
+            )
+        return replayed
+
+    def _recognized_zero_work_terminal_authority(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        claim: object,
+    ) -> Resolution | None:
+        """Return exact authority for a durably recognized zero-work terminal.
+
+        Policy controls whether new work may start.  It cannot revoke a terminal
+        that canonical replay and the no-admission journal have already agreed
+        upon.  This predicate intentionally excludes ordinary semantic claims
+        and every claim that has authorized or retained legacy work.
+        """
+        if not isinstance(claim, dict) or not self._claim_has_no_legacy_work(claim):
+            return None
+        try:
+            state = ResolverState(str(claim.get("resolution")))
+        except ValueError:
+            return (
+                Resolution(
+                    ResolverState.INDETERMINATE,
+                    "zero-work terminal authority resolution is invalid",
+                )
+                if claim.get("claim_kind") in {
+                    "pre_admission_terminal",
+                    "transfer_target_abort",
+                }
+                else None
+            )
+        inbound_id = record.get("id")
+        claim_kind: str
+        if state in TERMINAL_STATES:
+            persisted_evidence = claim.get("terminal_evidence_id")
+            replayed = self._replay_pinned_terminal_transition(
+                record,
+                messages,
+                ledger,
+                transition="PRE_ADMISSION_TERMINAL_NORMALIZED",
+                state=state,
+                evidence_id=persisted_evidence,
+            )
+            if replayed.state == ResolverState.INDETERMINATE:
+                return replayed
+            recognized = True
+            claim_kind = "pre_admission_terminal"
+        elif state == ResolverState.NOT_OWED:
+            inbound_message = next(
+                (message for message in messages if message.id == inbound_id),
+                None,
+            )
+            inbound_meta = (
+                inbound_message.meta
+                if isinstance(inbound_message, Message)
+                and isinstance(inbound_message.meta, dict)
+                else {}
+            )
+            transfer_digest = claim.get("transfer_from_key_digest")
+            transfer_events = [
+                event
+                for event in ledger["transitions"]
+                if isinstance(event, dict)
+                and event.get("transition") == "TRANSFER_TARGET_ABORTED"
+                and event.get("source_id") == inbound_id
+            ]
+            if not (
+                claim.get("claim_kind") == "transfer_target_abort"
+                or _valid_hex_digest(transfer_digest)
+                or transfer_events
+            ):
+                return None
+            recognized = bool(
+                _valid_hex_digest(transfer_digest)
+                and inbound_meta.get("transfer_from_key_digest") == transfer_digest
+                and any(
+                    isinstance(event.get("data"), dict)
+                    and event["data"].get("inbound_id") == inbound_id
+                    and event["data"].get("transfer_from_key_digest")
+                    == transfer_digest
+                    for event in transfer_events
+                )
+            )
+            replayed = Resolution(
+                ResolverState.NOT_OWED,
+                "transfer_target_abort_authority",
+            )
+            claim_kind = "transfer_target_abort"
+        else:
+            return None
+        if claim.get("state") not in {"open", "finalized"}:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "zero-work terminal authority has an invalid state",
+            )
+        persisted_evidence = claim.get("terminal_evidence_id")
+        if persisted_evidence is not None and persisted_evidence != replayed.evidence_id:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "zero-work terminal authority evidence is torn",
+            )
+        if claim.get("claim_kind") not in {None, claim_kind} or not recognized:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "zero-work terminal lacks durable recognition authority",
+            )
+        legacy_transition = any(
+            isinstance(event, dict)
+            and event.get("transition") in {
+                "PRE_ADMISSION_DRIVE_AUTHORIZED",
+                "PRE_ADMISSION_SUCCESS_RETAINED",
+            }
+            and event.get("source_id") == inbound_id
+            for event in ledger["transitions"]
+        )
+        if legacy_transition:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "zero-work terminal conflicts with legacy authority",
+            )
+        if claim.get("state") == "finalized" and not (
+            self._exact_no_admission_disposition_matches(
+                claim,
+                ledger["cursor_dispositions"].get(self.agent),
+                record,
+                replayed,
+            )
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized no-admission disposition is torn",
+            )
+        return replayed
+
+    def _rebind_zero_work_terminal_authority_locked(
+        self,
+        ledger: dict,
+        claim: dict,
+        record: dict,
+        resolution: Resolution,
+        policy: PolicySnapshot,
+    ) -> bool:
+        """Bind exact terminal authority to current readable policy and owner."""
+        previous = {
+            "policy_status": claim.get("policy_status"),
+            "policy_generation": claim.get("policy_generation"),
+            "fence": claim.get("fence"),
+            "claim_kind": claim.get("claim_kind"),
+            "terminal_evidence_id": claim.get("terminal_evidence_id"),
+        }
+        claim["policy_status"] = policy.status.value
+        claim["policy_generation"] = policy.generation
+        claim["claim_kind"] = (
+            "pre_admission_terminal"
+            if resolution.state in TERMINAL_STATES
+            else "transfer_target_abort"
+        )
+        claim["terminal_evidence_id"] = resolution.evidence_id
+        if claim.get("state") == "open":
+            claim["fence"] = self.fence
+            claim["owner_pid"] = os.getpid()
+        current = {
+            "policy_status": claim.get("policy_status"),
+            "policy_generation": claim.get("policy_generation"),
+            "fence": claim.get("fence"),
+            "claim_kind": claim.get("claim_kind"),
+            "terminal_evidence_id": claim.get("terminal_evidence_id"),
+        }
+        if current == previous:
+            return False
+        self._append(
+            ledger,
+            "ZERO_WORK_TERMINAL_AUTHORITY_REBOUND",
+            scope=str(record.get("id")),
+            source_id=resolution.evidence_id,
+            data={
+                "previous_policy_status": previous["policy_status"],
+                "previous_policy_generation": previous["policy_generation"],
+                "policy_status": policy.status.value,
+                "policy_generation": policy.generation,
+                "previous_fence": previous["fence"],
+                "fence": claim.get("fence"),
+            },
+        )
+        return True
+
+    def _authorized_legacy_terminal_replay(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        claim: object,
+        policy: PolicySnapshot,
+    ) -> Resolution | None:
+        """Recognize an exact terminal landed after durable legacy authorization."""
+        if not isinstance(claim, dict) or not (
+            claim.get("state") == "open"
+            and claim.get("drive_started_at")
+            and not claim.get("drive_succeeded_at")
+            and claim.get("claim_kind") is None
+        ):
+            return None
+        try:
+            claim_state = ResolverState(str(claim.get("resolution")))
+        except ValueError:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy claim resolution is invalid",
+            )
+        if not Resolution(claim_state, "").allows_legacy_commit:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy claim is not a no-admission claim",
+            )
+        try:
+            attempts = int(claim.get("drive_attempts", 0))
+        except (TypeError, ValueError):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy drive attempt count is invalid",
+            )
+        authorizations = [
+            event
+            for event in ledger["transitions"]
+            if isinstance(event, dict)
+            and event.get("transition") == "PRE_ADMISSION_DRIVE_AUTHORIZED"
+            and event.get("source_id") == record.get("id")
+            and isinstance(event.get("data"), dict)
+        ]
+        try:
+            authorized_attempts = {
+                int(event["data"].get("attempt", 0)) for event in authorizations
+            }
+        except (TypeError, ValueError):
+            authorized_attempts = set()
+        if (
+            attempts < 1
+            or len(authorizations) != attempts
+            or authorized_attempts != set(range(1, attempts + 1))
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy terminal lacks exact drive authority",
+            )
+        if any(
+            event["data"].get("policy_generation") != claim.get("policy_generation")
+            for event in authorizations
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy drive policy authority is torn",
+            )
+        replayed = self._resolve_replay(record, messages, ledger, admission=None)
+        if replayed.state not in TERMINAL_STATES:
+            return None
+        if not self._claim_matches_policy(claim, policy):
+            return self._policy_authority_failure(
+                policy,
+                reason="legacy terminal policy changed after work started",
+            )
+        if not isinstance(replayed.evidence_id, str):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy terminal evidence is invalid",
+            )
+        return replayed
+
+    def _retain_same_generation_legacy_terminal_locked(
+        self,
+        ledger: dict,
+        claim: dict,
+        record: dict,
+        replayed: Resolution,
+        policy: PolicySnapshot,
+    ) -> None:
+        """Linearize an exact same-policy terminal before cursor finalization."""
+        claim["state"] = "finalization_pending"
+        claim["drive_succeeded_at"] = self.now()
+        claim["resolution"] = replayed.state.value
+        claim["claim_kind"] = "same_generation_legacy_terminal"
+        claim["terminal_evidence_id"] = replayed.evidence_id
+        self._append(
+            ledger,
+            "LEGACY_DRIVE_TERMINAL_RETAINED",
+            scope=str(record.get("id")),
+            source_id=replayed.evidence_id,
+            data={
+                "inbound_id": record.get("id"),
+                "state": replayed.state.value,
+                "policy_generation": policy.generation,
+                "authorization_attempt": int(claim.get("drive_attempts", 0)),
+            },
+        )
+
+    def _recover_authorized_legacy_terminal(
+        self,
+        record: dict,
+    ) -> Resolution | None:
+        """Recover a terminal landed after authorization but before retention."""
+        inbound_id = record.get("id")
+        if not isinstance(inbound_id, str):
+            return None
+        with ExitStack() as locks:
+            locks.enter_context(self.store._message_publication_lock())
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+            observed_policy = self._current_policy()
+            if self._policy_blocks_durable_terminal_projection(observed_policy):
+                return Resolution(observed_policy.status, observed_policy.reason)
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"), timeout=10.0,
+                )
+            )
+            policy_block = self._revalidate_admission_policy(observed_policy)
+            if policy_block is not None:
+                return policy_block
+            ledger = self._load()
+            claim = ledger["no_admission_claims"].get(inbound_id)
+            replayed = self._authorized_legacy_terminal_replay(
+                record,
+                messages,
+                ledger,
+                claim,
+                observed_policy,
+            )
+            if replayed is None or replayed.state not in TERMINAL_STATES:
+                return replayed
+            if not isinstance(claim, dict):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "authorized legacy terminal claim disappeared",
+                )
+            if claim.get("fence") != self.fence:
+                if not self._can_reassign_no_admission_claim(claim):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "prior authorized legacy owner is still authoritative",
+                    )
+                previous_fence = claim.get("fence")
+                claim["fence"] = self.fence
+                claim["owner_pid"] = os.getpid()
+                self._append(
+                    ledger,
+                    "NO_ADMISSION_CLAIM_REASSIGNED",
+                    scope=inbound_id,
+                    source_id=replayed.evidence_id,
+                    data={
+                        "previous_fence": previous_fence,
+                        "fence": self.fence,
+                        "reason": "authorized_legacy_terminal",
+                    },
+                )
+            self._retain_same_generation_legacy_terminal_locked(
+                ledger,
+                claim,
+                record,
+                replayed,
+                observed_policy,
+            )
+            self._write(ledger)
+            policy_block = self._revalidate_admission_policy(observed_policy)
+            if policy_block is not None:
+                return policy_block
+            revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+        return Resolution(
+            replayed.state,
+            "no_admission_finalization_pending",
+            evidence_id=replayed.evidence_id,
+            scoped_revision=revision,
+            ledger_revision=revision,
+            activation_generation=observed_policy.generation,
+            readiness_generation=observed_policy.generation,
+        )
+
+    def _recognized_same_generation_legacy_terminal(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        claim: object,
+        policy: PolicySnapshot,
+    ) -> Resolution | None:
+        """Recover a terminal produced by already-authorized same-policy work."""
+        if not isinstance(claim, dict) or claim.get("claim_kind") != (
+            "same_generation_legacy_terminal"
+        ):
+            return None
+        if not self._claim_matches_policy(claim, policy):
+            return self._policy_authority_failure(
+                policy,
+                reason="legacy terminal policy changed after work started",
+            )
+        if claim.get("state") not in {"finalization_pending", "finalized"} or not (
+            claim.get("drive_started_at") and claim.get("drive_succeeded_at")
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "legacy terminal retention state is torn",
+            )
+        try:
+            state = ResolverState(str(claim.get("resolution")))
+        except ValueError:
+            state = ResolverState.INDETERMINATE
+        evidence_id = claim.get("terminal_evidence_id")
+        if state not in TERMINAL_STATES or not isinstance(evidence_id, str):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "legacy terminal retention evidence is invalid",
+            )
+        retained = [
+            event
+            for event in ledger["transitions"]
+            if isinstance(event, dict)
+            and event.get("transition") == "LEGACY_DRIVE_TERMINAL_RETAINED"
+            and event.get("source_id") == evidence_id
+            and isinstance(event.get("data"), dict)
+            and event["data"].get("inbound_id") == record.get("id")
+            and event["data"].get("state") == state.value
+            and event["data"].get("policy_generation") == policy.generation
+        ]
+        if len(retained) != 1:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "legacy terminal retention authority is ambiguous",
+            )
+        replayed = self._replay_pinned_terminal_transition(
+            record,
+            messages,
+            ledger,
+            transition="LEGACY_DRIVE_TERMINAL_RETAINED",
+            state=state,
+            evidence_id=evidence_id,
+        )
+        if replayed.state == ResolverState.INDETERMINATE:
+            return replayed
+        if claim.get("state") == "finalized" and not (
+            self._exact_no_admission_disposition_matches(
+                claim,
+                ledger["cursor_dispositions"].get(self.agent),
+                record,
+                replayed,
+            )
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized legacy terminal disposition is torn",
+            )
+        return replayed
+
+    def _recover_durable_no_admission_disposition(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        policy: PolicySnapshot,
+    ) -> Resolution | None:
+        """Replay a zero-work terminal whose durable disposition already won."""
+        if self._policy_blocks_durable_terminal_projection(policy):
+            return Resolution(policy.status, policy.reason)
+        inbound_id = record.get("id")
+        claim = ledger["no_admission_claims"].get(inbound_id)
+        recognized = self._recognized_zero_work_terminal_authority(
+            record,
+            messages,
+            ledger,
+            claim,
+        )
+        if recognized is not None:
+            if recognized.state == ResolverState.INDETERMINATE:
+                return recognized
+            replay_revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                current_policy = self._current_policy()
+                if self._policy_blocks_durable_terminal_projection(current_policy):
+                    return Resolution(current_policy.status, current_policy.reason)
+                current = self._load()
+                if int(current["scoped_revisions"].get(inbound_id, 0)) != (
+                    replay_revision
+                ):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "zero-work terminal authority CAS miss",
+                    )
+                current_claim = current["no_admission_claims"].get(inbound_id)
+                current_authority = self._recognized_zero_work_terminal_authority(
+                    record,
+                    messages,
+                    current,
+                    current_claim,
+                )
+                if current_authority is None or (
+                    current_authority.state == ResolverState.INDETERMINATE
+                ):
+                    return current_authority or Resolution(
+                        ResolverState.INDETERMINATE,
+                        "zero-work terminal authority disappeared",
+                    )
+                if (
+                    isinstance(current_claim, dict)
+                    and current_claim.get("state") == "open"
+                    and current_claim.get("fence") != self.fence
+                    and not self._can_reassign_no_admission_claim(current_claim)
+                ):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "prior no-admission claim owner is still authoritative",
+                    )
+                if not isinstance(current_claim, dict):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "zero-work terminal authority claim disappeared",
+                    )
+                if self._rebind_zero_work_terminal_authority_locked(
+                    current,
+                    current_claim,
+                    record,
+                    current_authority,
+                    current_policy,
+                ):
+                    self._write(current)
+                revision = int(current["scoped_revisions"].get(inbound_id, 0))
+            return Resolution(
+                current_authority.state,
+                (
+                    "no_admission_disposition_pending"
+                    if current_claim.get("state") == "finalized"
+                    else "no_admission_finalization_pending"
+                    if current_authority.state == ResolverState.NOT_OWED
+                    else current_authority.reason
+                ),
+                evidence_id=current_authority.evidence_id,
+                scoped_revision=revision,
+                ledger_revision=revision,
+                activation_generation=current_policy.generation,
+                readiness_generation=current_policy.generation,
+            )
+        authorized_terminal = self._authorized_legacy_terminal_replay(
+            record,
+            messages,
+            ledger,
+            claim,
+            policy,
+        )
+        if authorized_terminal is not None:
+            if authorized_terminal.state not in TERMINAL_STATES:
+                return authorized_terminal
+            recovered_terminal = self._recover_authorized_legacy_terminal(record)
+            if recovered_terminal is not None:
+                return recovered_terminal
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "authorized legacy terminal disappeared during recovery",
+            )
+        legacy_terminal = self._recognized_same_generation_legacy_terminal(
+            record,
+            messages,
+            ledger,
+            claim,
+            policy,
+        )
+        if legacy_terminal is not None:
+            if legacy_terminal.state not in TERMINAL_STATES:
+                return legacy_terminal
+            replay_revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                current_policy = self._current_policy()
+                if self._policy_blocks_durable_terminal_projection(current_policy):
+                    return Resolution(current_policy.status, current_policy.reason)
+                current = self._load()
+                if int(current["scoped_revisions"].get(inbound_id, 0)) != (
+                    replay_revision
+                ):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "legacy terminal recovery CAS miss",
+                    )
+                current_claim = current["no_admission_claims"].get(inbound_id)
+                current_terminal = self._recognized_same_generation_legacy_terminal(
+                    record,
+                    messages,
+                    current,
+                    current_claim,
+                    current_policy,
+                )
+                if current_terminal is None or current_terminal.state not in (
+                    TERMINAL_STATES
+                ):
+                    return current_terminal or Resolution(
+                        ResolverState.INDETERMINATE,
+                        "legacy terminal retention disappeared",
+                    )
+                if not isinstance(current_claim, dict):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "legacy terminal claim disappeared",
+                    )
+                if (
+                    current_claim.get("state") == "finalization_pending"
+                    and current_claim.get("fence") != self.fence
+                ):
+                    if not self._can_reassign_no_admission_claim(current_claim):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "prior legacy terminal owner is still authoritative",
+                        )
+                    previous_fence = current_claim.get("fence")
+                    current_claim["fence"] = self.fence
+                    current_claim["owner_pid"] = os.getpid()
+                    self._append(
+                        current,
+                        "NO_ADMISSION_CLAIM_REASSIGNED",
+                        scope=str(inbound_id),
+                        source_id=current_terminal.evidence_id,
+                        data={
+                            "previous_fence": previous_fence,
+                            "fence": self.fence,
+                            "reason": "same_generation_legacy_terminal",
+                        },
+                    )
+                    self._write(current)
+                revision = int(current["scoped_revisions"].get(inbound_id, 0))
+            return Resolution(
+                current_terminal.state,
+                (
+                    "no_admission_disposition_pending"
+                    if current_claim.get("state") == "finalized"
+                    else "no_admission_finalization_pending"
+                ),
+                evidence_id=current_terminal.evidence_id,
+                scoped_revision=revision,
+                ledger_revision=revision,
+                activation_generation=current_policy.generation,
+                readiness_generation=current_policy.generation,
+            )
+        if not isinstance(claim, dict) or claim.get("state") != "finalized":
+            return None
+        if not self._claim_has_no_legacy_work(claim):
+            return None
+        try:
+            state = ResolverState(str(claim.get("resolution")))
+        except ValueError:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized no-admission resolution is invalid",
+            )
+        evidence_id = claim.get("terminal_evidence_id")
+        if evidence_id is not None and not isinstance(evidence_id, str):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized no-admission evidence is invalid",
+            )
+        resolution: Resolution
+        if state in TERMINAL_STATES:
+            replayed = self._resolve_replay(record, messages, ledger, admission=None)
+            if replayed.state != state or replayed.evidence_id != evidence_id:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "finalized no-admission terminal conflicts with replay",
+                )
+            resolution = replayed
+        elif state in {
+            ResolverState.NOT_OWED,
+            ResolverState.CLASSIFICATION_UNKNOWN,
+            ResolverState.INACTIVE,
+        }:
+            inbound_message = next(
+                (message for message in messages if message.id == inbound_id),
+                None,
+            )
+            inbound_meta = (
+                inbound_message.meta
+                if isinstance(inbound_message, Message)
+                and isinstance(inbound_message.meta, dict)
+                else {}
+            )
+            transfer_digest = claim.get("transfer_from_key_digest")
+            if not (
+                state == ResolverState.NOT_OWED
+                and _valid_hex_digest(transfer_digest)
+                and inbound_meta.get("transfer_from_key_digest") == transfer_digest
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "finalized no-admission legacy claim lacks zero-work authority",
+                )
+            resolution = Resolution(
+                state,
+                "no_admission_disposition_pending",
+                evidence_id=evidence_id,
+            )
+        else:
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized no-admission state is not terminal",
+            )
+        if not self._durable_no_admission_disposition_matches(
+            claim,
+            ledger["cursor_dispositions"].get(self.agent),
+            record,
+            resolution,
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "finalized no-admission disposition is torn",
+            )
+        revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+        return Resolution(
+            resolution.state,
+            resolution.reason,
+            evidence_id=resolution.evidence_id,
+            scoped_revision=revision,
+            ledger_revision=revision,
+            activation_generation=policy.generation,
+            readiness_generation=policy.generation,
+        )
+
+    def _policy_authority_failure(
+        self,
+        policy: PolicySnapshot,
+        *,
+        reason: str,
+    ) -> Resolution:
+        if policy.status in {
+            ResolverState.BLOCKED,
+            ResolverState.BLOCKED_POLICY,
+            ResolverState.BLOCKED_COMPLIANCE,
+        }:
+            return Resolution(policy.status, policy.reason)
+        return Resolution(ResolverState.BLOCKED_POLICY, reason)
+
+    def _load(self, *, create: bool = True) -> dict:
+        if not self.path.exists():
+            if self.epoch_anchor_path.exists():
+                raise LedgerUnreadable("obligation ledger missing while epoch anchor exists")
+            if not create:
+                raise LedgerUnreadable("obligation ledger missing")
+            return _new_ledger()
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise LedgerUnreadable(f"obligation ledger unreadable: {type(exc).__name__}") from exc
+        ledger = _validate_ledger(raw)
+        if self.epoch_anchor_path.exists():
+            try:
+                anchor = json.loads(self.epoch_anchor_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                raise LedgerUnreadable("obligation epoch anchor unreadable") from exc
+            if not isinstance(anchor, dict) or anchor.get("store_epoch") != ledger["store_epoch"]:
+                raise LedgerUnreadable("obligation store epoch mismatch")
+            if int(anchor.get("append_sequence", -1)) > int(ledger["append_sequence"]):
+                raise LedgerUnreadable("obligation append sequence rolled back")
+            if int(anchor.get("revision", -1)) > int(ledger["revision"]):
+                raise LedgerUnreadable("obligation ledger revision rolled back")
+        return ledger
+
+    def _write(self, ledger: dict) -> None:
+        ledger["revision"] = int(ledger.get("revision", 0)) + 1
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(self.path, json.dumps(ledger, indent=2, ensure_ascii=False))
+        _atomic_write_text(
+            self.epoch_anchor_path,
+            json.dumps({
+                "store_epoch": ledger["store_epoch"],
+                "append_sequence": ledger["append_sequence"],
+                "revision": ledger["revision"],
+            }, indent=2),
+        )
+        try:
+            _atomic_write_text(
+                self.checkpoint_path,
+                json.dumps(ledger, indent=2, ensure_ascii=False),
+            )
+        except OSError:
+            # The primary journal and epoch anchor are authoritative. A failed
+            # recovery checkpoint must not turn a committed transaction into an
+            # apparent failure.
+            pass
+
+    def _record_projection_rebuild(
+        self,
+        *,
+        success: bool,
+        detail: str,
+        observed_at: str,
+    ) -> None:
+        now_text = observed_at
+        lock = self.proof_health_path.with_suffix(".lock")
+        with self.store._exclusive_lock(lock, timeout=10.0):
+            try:
+                health = json.loads(self.proof_health_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError, json.JSONDecodeError):
+                health = {}
+            if not isinstance(health, dict):
+                health = {}
+            health.setdefault("state", "blocked")
+            health.setdefault("first_failure_at", now_text)
+            health["rebuild_attempts"] = int(health.get("rebuild_attempts", 0)) + 1
+            health["last_rebuild_at"] = now_text
+            health["last_rebuild_succeeded"] = success
+            health["last_rebuild_detail"] = detail[:512]
+            self.proof_health_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(
+                self.proof_health_path,
+                json.dumps(health, indent=2, ensure_ascii=False),
+            )
+
+    def _try_rebuild_projection(self, *, observed_at: str) -> bool:
+        """Restore a byte-corrupt projection only from an epoch-matched checkpoint."""
+        try:
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                checkpoint = _validate_ledger(json.loads(
+                    self.checkpoint_path.read_text(encoding="utf-8")
+                ))
+                anchor = json.loads(self.epoch_anchor_path.read_text(encoding="utf-8"))
+                if not isinstance(anchor, dict) or any((
+                    anchor.get("store_epoch") != checkpoint["store_epoch"],
+                    int(anchor.get("append_sequence", -1))
+                    != checkpoint["append_sequence"],
+                    int(anchor.get("revision", -1)) != checkpoint["revision"],
+                )):
+                    raise LedgerUnreadable("checkpoint does not match epoch anchor")
+                _atomic_write_text(
+                    self.path,
+                    json.dumps(checkpoint, indent=2, ensure_ascii=False),
+                )
+        except (OSError, ValueError, json.JSONDecodeError, LedgerUnreadable) as exc:
+            self._record_projection_rebuild(
+                success=False,
+                detail=str(exc),
+                observed_at=observed_at,
+            )
+            return False
+        self._record_projection_rebuild(
+            success=True,
+            detail="checkpoint restored",
+            observed_at=observed_at,
+        )
+        return True
+
+    def _append(self, ledger: dict, transition: str, *, scope: str | None = None,
+                source_id: str | None = None, key_digest: str | None = None,
+                data: dict | None = None) -> dict:
+        sequence = int(ledger["append_sequence"]) + 1
+        ledger["append_sequence"] = sequence
+        event = {
+            "sequence": sequence,
+            "transition": transition,
+            "at": self.now(),
+            "source_id": source_id,
+            "key_digest": key_digest,
+            "data": data or {},
+        }
+        ledger["transitions"].append(event)
+        if scope:
+            revisions = ledger["scoped_revisions"]
+            revisions[scope] = int(revisions.get(scope, 0)) + 1
+        return event
+
+    def _index_messages(
+        self,
+        messages: list[Message],
+        *,
+        invalid_records: list[tuple[str, str]] | None = None,
+    ) -> dict:
+        """Normalize validated bus records into the monotonic canonical journal."""
+        messages = self.store.publication_ordered_messages(messages)
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            changed = False
+            for message in messages:
+                if message.id in ledger["messages"]:
+                    continue
+                rid = _correlation(message.meta)
+                meta = message.meta or {}
+                related_inbounds = [
+                    mid for mid, row in ledger["messages"].items()
+                    if isinstance(row, dict)
+                    and row.get("kind") == "question"
+                    and row.get("correlation_id") == rid
+                ]
+                if message.kind == "question" and rid:
+                    related_inbounds.append(message.id)
+                anchor = meta.get("in_reply_to")
+                if isinstance(anchor, str) and anchor:
+                    related_inbounds.append(anchor)
+                event = self._append(
+                    ledger,
+                    "BUS_RECORD_APPENDED",
+                    scope=rid,
+                    source_id=message.id,
+                    data={
+                        "kind": message.kind,
+                        "sender": message.sender,
+                        "recipient": message.recipient,
+                        "correlation_id": rid,
+                        "timestamp": message.ts,
+                    },
+                )
+                operation_nonce = meta.get("operation_nonce")
+                operation_digest = meta.get("operation_digest")
+                operation_payload_valid = bool(
+                    isinstance(operation_nonce, str)
+                    and isinstance(operation_digest, str)
+                    and operation_digest == operation_payload_digest(
+                        operation=(
+                            "composing" if message.kind == "composing" else "terminal"
+                        ),
+                        body=message.body,
+                        kind=message.kind,
+                        recipient=message.recipient,
+                        in_reply_to=meta.get("in_reply_to"),
+                        request_id=meta.get("request_id"),
+                        broadcast_id=meta.get("broadcast_id"),
+                        origin_request_id=meta.get("origin_request_id"),
+                        origin_inbound_id=meta.get("origin_inbound_id"),
+                        origin_obligation_key_digest=meta.get(
+                            "origin_obligation_key_digest"
+                        ),
+                        expected_roster_revision=meta.get(
+                            "expected_roster_revision"
+                        ),
+                    )
+                )
+                message_row = {
+                    "sequence": event["sequence"],
+                    "correlation_id": rid,
+                    "kind": message.kind,
+                    "sender": message.sender,
+                    "recipient": message.recipient,
+                    "in_reply_to": meta.get("in_reply_to"),
+                    "request_id": meta.get("request_id"),
+                    "broadcast_id": meta.get("broadcast_id"),
+                    "membership_snapshot": meta.get("membership_snapshot"),
+                    "response_policy": meta.get("response_policy"),
+                    "response_quorum": meta.get("response_quorum"),
+                    "broadcast_policy_version": meta.get("broadcast_policy_version"),
+                    "roster_revision": meta.get("roster_revision"),
+                    "authorized_liaisons": meta.get("authorized_liaisons"),
+                    "operation_nonce": operation_nonce,
+                    "operation_payload_valid": operation_payload_valid,
+                }
+                ledger["messages"][message.id] = message_row
+                revisions = ledger["scoped_revisions"]
+                for inbound_id in set(related_inbounds):
+                    revisions[inbound_id] = int(revisions.get(inbound_id, 0)) + 1
+
+                descriptor = (
+                    _broadcast_descriptor(meta, requester=message.sender)
+                    if message.kind == "question" and meta.get("broadcast_id")
+                    else None
+                )
+                if descriptor is not None:
+                    bid = descriptor["broadcast_id"]
+                    digest = _broadcast_descriptor_digest(descriptor)
+                    aggregate = ledger["broadcasts"].get(bid)
+                    if not isinstance(aggregate, dict):
+                        aggregate = {
+                            "state": "open",
+                            "generation": 1,
+                            "descriptor": descriptor,
+                            "descriptor_digest": digest,
+                            "member_inbounds": {},
+                            "winning_ids": [],
+                            "affected_member_keys": [],
+                            "history": [],
+                        }
+                        ledger["broadcasts"][bid] = aggregate
+                    if aggregate.get("descriptor_digest") != digest:
+                        if aggregate.get("state") != "blocked":
+                            aggregate["state"] = "blocked"
+                            aggregate["blocked_reason"] = (
+                                "immutable broadcast policy copies conflict"
+                            )
+                            self._append(
+                                ledger,
+                                "BROADCAST_POLICY_CONFLICT",
+                                scope=message.id,
+                                source_id=message.id,
+                                data={
+                                    "broadcast_id": bid,
+                                    "expected_descriptor_digest": aggregate.get(
+                                        "descriptor_digest"
+                                    ),
+                                    "observed_descriptor_digest": digest,
+                                },
+                            )
+                    else:
+                        prior_for_member = aggregate.get("member_inbounds", {}).get(
+                            message.recipient,
+                        )
+                        if (
+                            aggregate.get("state") == "policy_satisfied"
+                            and isinstance(prior_for_member, list)
+                            and prior_for_member
+                        ):
+                            history = list(aggregate.get("history") or [])
+                            history.append({
+                                name: value
+                                for name, value in aggregate.items()
+                                if name != "history"
+                            })
+                            aggregate = {
+                                "state": "open",
+                                "generation": int(
+                                    aggregate.get("generation", 1)
+                                ) + 1,
+                                "descriptor": descriptor,
+                                "descriptor_digest": digest,
+                                "member_inbounds": {},
+                                "winning_ids": [],
+                                "affected_member_keys": [],
+                                "history": history,
+                            }
+                            ledger["broadcasts"][bid] = aggregate
+                        member_inbounds = aggregate.setdefault("member_inbounds", {})
+                        member_inbounds.setdefault(message.recipient, []).append(message.id)
+                        message_row["broadcast_generation"] = int(
+                            aggregate.get("generation", 1)
+                        )
+                        if aggregate.get("state") == "policy_satisfied":
+                            self._append(
+                                ledger,
+                                "BROADCAST_POLICY_SATISFIED",
+                                scope=message.id,
+                                source_id=(aggregate.get("winning_ids") or [None])[-1],
+                                data={
+                                    "aggregate": False,
+                                    "broadcast_id": bid,
+                                    "inbound_id": message.id,
+                                    "winning_ids": list(
+                                        aggregate.get("winning_ids") or []
+                                    ),
+                                    "winning_classes": list(
+                                        aggregate.get("winning_classes") or []
+                                    ),
+                                    "policy": descriptor["response_policy"],
+                                    "broadcast_policy_version": 1,
+                                    "broadcast_generation": aggregate.get(
+                                        "generation", 1
+                                    ),
+                                    "transaction_id": aggregate.get("transaction_id"),
+                                    "prospective": True,
+                                },
+                            )
+                if isinstance(anchor, str) and anchor:
+                    anchor_row = ledger["messages"].get(anchor)
+                    key_id = ledger["inbound_index"].get(anchor)
+                    admission = ledger["obligations"].get(key_id) if key_id else None
+                    anchor_descriptor = (
+                        _broadcast_descriptor(
+                            anchor_row,
+                            requester=anchor_row.get("sender"),
+                        )
+                        if isinstance(anchor_row, dict)
+                        else None
+                    )
+                    current_aggregate = (
+                        ledger["broadcasts"].get(anchor_descriptor["broadcast_id"])
+                        if anchor_descriptor is not None
+                        else None
+                    )
+                    anchor_generation = anchor_row.get("broadcast_generation") if isinstance(
+                        anchor_row, dict
+                    ) else None
+                    aggregate_candidates = (
+                        [current_aggregate]
+                        + list(current_aggregate.get("history") or [])
+                        if isinstance(current_aggregate, dict)
+                        else []
+                    )
+                    aggregate = next((
+                        candidate for candidate in aggregate_candidates
+                        if isinstance(candidate, dict)
+                        and int(candidate.get("generation", 1))
+                        == int(anchor_generation or 1)
+                    ), None)
+                    prospective_policy_close = any(
+                        candidate.get("transition") == "BROADCAST_POLICY_SATISFIED"
+                        and isinstance(candidate.get("data"), dict)
+                        and candidate["data"].get("aggregate") is False
+                        and candidate["data"].get("inbound_id") == anchor
+                        and int(candidate.get("sequence", 0)) < int(event["sequence"])
+                        for candidate in ledger["transitions"]
+                    )
+                    closed_by_policy = bool(
+                        isinstance(aggregate, dict)
+                        and aggregate.get("state") == "policy_satisfied"
+                        and int(event["sequence"])
+                        > int(aggregate.get("aggregate_sequence", 0))
+                        and (
+                            isinstance(admission, dict)
+                            and admission.get("state") == "broadcast_policy_satisfied"
+                            or not isinstance(admission, dict)
+                            and prospective_policy_close
+                        )
+                    )
+                    exact_late_response = bool(
+                        anchor_descriptor is not None
+                        and _correlation(meta) == anchor_descriptor["broadcast_id"]
+                        and message.kind not in CONTROL_KINDS
+                        and message.sender == anchor_row.get("recipient")
+                        and message.recipient == anchor_row.get("sender")
+                        and closed_by_policy
+                        and message.id not in (aggregate.get("winning_ids") or [])
+                    )
+                    if exact_late_response:
+                        self._append(
+                            ledger,
+                            "LATE_RESPONSE",
+                            scope=anchor,
+                            source_id=message.id,
+                            key_digest=key_id,
+                            data={
+                                "broadcast_id": anchor_descriptor["broadcast_id"],
+                                "closed_state": (
+                                    admission.get("state")
+                                    if isinstance(admission, dict)
+                                    else "prospective_policy_satisfied"
+                                ),
+                                "transaction_id": aggregate.get("transaction_id"),
+                            },
+                        )
+                if (
+                    message.kind == "question"
+                    and meta.get("broadcast_id")
+                    and descriptor is None
+                ):
+                    telemetry = ledger["telemetry"]
+                    telemetry["legacy_broadcast_unenforced_total"] = int(
+                        telemetry.get("legacy_broadcast_unenforced_total", 0)
+                    ) + 1
+                changed = True
+            seen_invalid = ledger["telemetry"].setdefault("invalid_records", {})
+            for ident, reason in invalid_records or []:
+                fingerprint = hashlib.sha256(
+                    f"{ident}\0{reason}".encode("utf-8", errors="replace")
+                ).hexdigest()
+                if fingerprint in seen_invalid:
+                    continue
+                seen_invalid[fingerprint] = {
+                    "id": str(ident),
+                    "reason": str(reason)[:512],
+                    "first_seen_at": self.now(),
+                }
+                self._append(
+                    ledger,
+                    "INVALID_RECORD_IGNORED",
+                    data={"fingerprint": fingerprint, "id": str(ident)},
+                )
+                changed = True
+            if changed or not self.path.exists():
+                self._write(ledger)
+            return ledger
+
+    def _validated_messages(self) -> tuple[list[Message], dict]:
+        try:
+            messages = self.store.publication_ordered_messages()
+            invalid_records = self.store.list_invalid_messages()
+        except (OSError, ValueError, TimeoutError, RuntimeError) as exc:
+            observed_at = self.now()
+            failure = LedgerUnreadable("validated bus replay unavailable")
+            self.record_proof_failure(
+                error_class=type(failure).__name__,
+                path=str(self.path),
+                observed_at=observed_at,
+            )
+            raise failure from exc
+        try:
+            ledger = self._index_messages(messages, invalid_records=invalid_records)
+        except (OSError, ValueError, TimeoutError, RuntimeError) as exc:
+            observed_at = self.now()
+            if isinstance(exc, LedgerUnreadable):
+                if self._try_rebuild_projection(observed_at=observed_at):
+                    failure = LedgerUnreadable(
+                        "canonical projection rebuilt; fail-closed replay required"
+                    )
+                else:
+                    failure = exc
+            else:
+                failure = LedgerUnreadable("canonical append service unavailable")
+            self.record_proof_failure(
+                error_class=type(failure).__name__,
+                path=str(self.path),
+                observed_at=observed_at,
+            )
+            if failure is exc:
+                raise
+            raise failure from exc
+        self.clear_proof_failure()
+        return messages, ledger
+
+    def record_proof_failure(
+        self,
+        *,
+        error_class: str,
+        path: str,
+        observed_at: str | None = None,
+    ) -> dict:
+        """Persist continuous unreadability; elapsed time alone exhausts it."""
+        now_text = observed_at or self.now()
+        lock = self.proof_health_path.with_suffix(".lock")
+        with self.store._exclusive_lock(lock, timeout=10.0):
+            try:
+                health = json.loads(self.proof_health_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError, json.JSONDecodeError):
+                health = {}
+            if not isinstance(health, dict) or health.get("state") != "blocked":
+                health = {
+                    "state": "blocked",
+                    "first_failure_at": now_text,
+                    "failures": 0,
+                    "alerted": False,
+                }
+            health["failures"] = int(health.get("failures", 0)) + 1
+            health["last_failure_at"] = now_text
+            health["fingerprint"] = {
+                "error_class": str(error_class),
+                "path": str(path),
+            }
+            first = _epoch(health.get("first_failure_at"))
+            now = _epoch(now_text)
+            elapsed = 0.0 if first is None or now is None else max(0.0, now - first)
+            health["elapsed_seconds"] = elapsed
+            if elapsed >= PROOF_UNREADABLE_SECONDS:
+                health["exhausted"] = True
+                health["alerted"] = True
+                health.setdefault("alerted_at", now_text)
+                incident_id = health.setdefault("incident_id", uuid.uuid4().hex)
+                health.setdefault("incident", {
+                    "kind": "PROOF_REPLAY_INCIDENT",
+                    "incident_id": incident_id,
+                    "first_failure_at": health.get("first_failure_at"),
+                    "exhausted_at": now_text,
+                    "authority": "elapsed_time",
+                })
+            self.proof_health_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(
+                self.proof_health_path,
+                json.dumps(health, indent=2, ensure_ascii=False),
+            )
+            return health
+
+    def clear_proof_failure(self) -> None:
+        try:
+            health = json.loads(self.proof_health_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            health = None
+        if isinstance(health, dict) and health.get("disposition_block") is True:
+            return
+        try:
+            self.proof_health_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def _eligibility(
+        self,
+        record: dict,
+        *,
+        policy: PolicySnapshot | None = None,
+    ) -> tuple[ResolverState, str, str | None]:
+        policy = policy or self._current_policy()
+        try:
+            health = json.loads(self.proof_health_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            health = None
+        if isinstance(health, dict) and health.get("disposition_block") is True:
+            return (
+                ResolverState.BLOCKED,
+                str(health.get("reason") or "failed-delivery disposition unavailable"),
+                _correlation(record.get("meta")),
+            )
+        if policy.status in {
+            ResolverState.BLOCKED,
+            ResolverState.BLOCKED_POLICY,
+            ResolverState.BLOCKED_COMPLIANCE,
+        }:
+            return policy.status, policy.reason, None
+        if policy.status == ResolverState.INACTIVE:
+            return ResolverState.INACTIVE, policy.reason, None
+        if policy.status != ResolverState.ACTIVE:
+            return ResolverState.NOT_OWED, policy.reason, None
+        if record.get("kind") != "question":
+            return ResolverState.NOT_OWED, "kind is detection log-only", None
+        meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
+        consult = _true(meta, "consult")
+        if consult is None:
+            return ResolverState.CLASSIFICATION_UNKNOWN, "consult flag unsupported", None
+        if consult:
+            return ResolverState.NOT_OWED, "consult excluded", None
+        rid = _correlation(meta)
+        if not rid:
+            return ResolverState.CLASSIFICATION_UNKNOWN, "tracked correlation missing", None
+        if record.get("to") != self.agent:
+            return ResolverState.NOT_OWED, "not addressed to this wrapper", rid
+        bid = meta.get("broadcast_id")
+        if bid:
+            descriptor = _broadcast_descriptor(meta, requester=record.get("from"))
+            if descriptor is None:
+                return (
+                    ResolverState.CLASSIFICATION_UNKNOWN,
+                    "legacy broadcast is not enforcement-eligible",
+                    rid,
+                )
+            if self.agent not in descriptor["membership_snapshot"]:
+                return (
+                    ResolverState.CLASSIFICATION_UNKNOWN,
+                    "broadcast recipient is absent from frozen membership",
+                    rid,
+                )
+        transfer_from = meta.get("transfer_from_key_digest")
+        transfer_generation = meta.get("transfer_policy_generation")
+        if transfer_from is not None or transfer_generation is not None:
+            if not _valid_hex_digest(transfer_from) or not _valid_hex_digest(
+                transfer_generation
+            ):
+                return (
+                    ResolverState.CLASSIFICATION_UNKNOWN,
+                    "transfer destination marker is invalid",
+                    rid,
+                )
+        obligation_class = (
+            "human_escalation" if _true(meta, "escalation_required") is True else "answer"
+        )
+        return ResolverState.ACTIVE, obligation_class, rid
+
+    def _record_message(self, record: dict, messages: list[Message]) -> Message | None:
+        mid = record.get("id")
+        return next((message for message in messages if message.id == mid), None)
+
+    def _key_from(self, raw: dict) -> ObligationKey:
+        return ObligationKey(**raw)
+
+    def _resolve_replay(
+        self,
+        record: dict,
+        messages: list[Message],
+        ledger: dict,
+        *,
+        admission: dict | None,
+    ) -> Resolution:
+        inbound = self._record_message(record, messages)
+        rid = _correlation(record.get("meta"))
+        if inbound is None or rid is None:
+            return Resolution(ResolverState.INDETERMINATE, "exact inbound missing")
+        if (
+            inbound.kind != "question"
+            or inbound.sender != record.get("from")
+            or inbound.recipient != self.agent
+            or _correlation(inbound.meta) != rid
+        ):
+            return Resolution(ResolverState.CLASSIFICATION_UNKNOWN, "validated inbound mismatch")
+        key = self._key_from(admission["key"]) if admission is not None else None
+        inbound_descriptor = _broadcast_descriptor(
+            inbound.meta,
+            requester=inbound.sender,
+        )
+        aggregate_blocked_reason: str | None = None
+        if inbound_descriptor is not None:
+            aggregate = ledger["broadcasts"].get(
+                inbound_descriptor["broadcast_id"],
+            )
+            if isinstance(aggregate, dict) and aggregate.get("state") == "blocked":
+                aggregate_blocked_reason = str(
+                    aggregate.get("blocked_reason")
+                    or "immutable broadcast policy is blocked"
+                )
+        obligation_class = (
+            str(admission.get("obligation_class"))
+            if admission is not None
+            else (
+                "human_escalation"
+                if _true(inbound.meta or {}, "escalation_required") is True
+                else "answer"
+            )
+        )
+        if key is not None and (
+            key.reducer_version != REDUCER_VERSION
+            or key.participant_capabilities_digest != PARTICIPANT_CAPABILITIES_DIGEST
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "admission-pinned replay rules are unavailable",
+                key,
+            )
+        if admission is not None and admission.get("cursor_projection_blocked") is True:
+            return Resolution(
+                ResolverState.BLOCKED,
+                str(
+                    admission.get("cursor_projection_blocked_reason")
+                    or "cursor projection retry bound exhausted"
+                ),
+                key,
+            )
+        transfer_blocked_state = (
+            admission.get("transfer_blocked_state")
+            if admission is not None
+            else None
+        )
+        if (
+            admission is not None
+            and admission.get("state") == "open"
+            and isinstance(admission.get("broadcast_policy_close_pending"), dict)
+        ):
+            return Resolution(
+                ResolverState.OWED_UNSATISFIED,
+                "reserved dispatch owns pending broadcast policy close",
+                key,
+                scoped_revision=int(
+                    ledger["scoped_revisions"].get(inbound.id, 0)
+                ),
+            )
+        inbound_sequence = int(ledger["messages"].get(inbound.id, {}).get("sequence", 0))
+        watermark = int(admission.get("watermark_sequence", 0)) if admission else inbound_sequence
+        scope_revision = int(ledger["scoped_revisions"].get(inbound.id, 0))
+        transition_states = {
+            "MANUAL_CLOSE": ResolverState.SATISFIED,
+            "TRANSFERRED": ResolverState.TRANSFERRED,
+            "OPERATOR_RESOLUTION": ResolverState.OPERATOR_RESOLVED,
+            "BROADCAST_POLICY_SATISFIED": ResolverState.BROADCAST_POLICY_SATISFIED,
+            "DELIVERY_FAILED": ResolverState.DELIVERY_EXHAUSTED,
+        }
+        blocked_event: dict | None = None
+        for event in ledger["transitions"]:
+            if int(event.get("sequence", 0)) <= inbound_sequence:
+                continue
+            data = event.get("data") if isinstance(event.get("data"), dict) else {}
+            exact_key = key is not None and event.get("key_digest") == key.digest
+            prospective = key is None and data.get("inbound_id") == inbound.id
+            if not (exact_key or prospective):
+                continue
+            transition = event.get("transition")
+            if key is None and transition == "DELIVERY_FAILED":
+                continue
+            if (
+                transition == "DELIVERY_FAILED"
+                and admission is not None
+                and admission.get("state") == "blocked"
+            ):
+                continue
+            if transition == "OBLIGATION_BLOCKED":
+                blocked_event = event
+                continue
+            state = transition_states.get(transition)
+            if state is not None:
+                return Resolution(
+                    state,
+                    str(event.get("transition", "terminal")).casefold(),
+                    key,
+                    event.get("source_id"),
+                    scope_revision,
+                )
+        candidates = [
+            message for message in messages
+            if (
+                _correlation(message.meta) == rid
+                or (message.meta or {}).get("origin_request_id") == rid
+            )
+            and message.id != inbound.id
+        ]
+        candidates.sort(key=lambda message: int(
+            ledger["messages"].get(message.id, {}).get("sequence", 0)))
+        composing: Message | None = None
+        for message in candidates:
+            sequence = int(ledger["messages"].get(message.id, {}).get("sequence", 0))
+            if sequence <= inbound_sequence:
+                continue
+            meta = message.meta or {}
+            # Existing requester rescinds are intentionally rid-scoped and close every
+            # open generation existing when the rescind is appended.
+            if (
+                message.kind == "rescind"
+                and message.sender == inbound.sender
+                and _correlation(meta) == rid
+            ):
+                supersedes = meta.get("supersedes")
+                if supersedes is not None:
+                    try:
+                        superseded_key = self._key_from(supersedes)
+                    except (TypeError, ValueError):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "authorized exact-key supersession is uninterpretable",
+                            key,
+                            message.id,
+                            scope_revision,
+                        )
+                    if key is None or superseded_key != key:
+                        continue
+                return Resolution(
+                    ResolverState.SUPERSEDED,
+                    (
+                        "requester superseded exact generation"
+                        if supersedes is not None
+                        else "requester rescinded all visible generations"
+                    ),
+                    key,
+                    message.id,
+                    scope_revision,
+                )
+            if admission is not None and sequence <= watermark:
+                continue
+            exact = meta.get("in_reply_to") == inbound.id
+            exact_correlation = _correlation(meta) == rid
+            terminal_nonce = meta.get("operation_nonce")
+            reservations = admission.get("reservations", {}) if admission else {}
+            terminal_token_valid = bool(
+                admission is None
+                or isinstance(terminal_nonce, str)
+                and isinstance(reservations.get(terminal_nonce), dict)
+                and _message_operation_valid(
+                    message,
+                    operation="terminal",
+                    nonce=terminal_nonce,
+                )
+            )
+            if (
+                message.kind == "composing"
+                and message.sender == self.agent
+                and exact
+                and exact_correlation
+            ):
+                composing_token = meta.get("operation_nonce")
+                composing_token_valid = any(
+                    isinstance(row, dict)
+                    and row.get("composing_nonce") == composing_token
+                    for row in reservations.values()
+                ) and isinstance(composing_token, str) and _message_operation_valid(
+                    message,
+                    operation="composing",
+                    nonce=composing_token,
+                )
+                if composing_token_valid:
+                    composing = message
+                continue
+            if obligation_class == "human_escalation":
+                if (
+                    message.kind == "question"
+                    and message.sender == self.agent
+                    and meta.get("origin_request_id") == rid
+                    and meta.get("origin_inbound_id") == inbound.id
+                    and isinstance(meta.get("roster_revision"), str)
+                    and message.recipient in (meta.get("authorized_liaisons") or [])
+                    and terminal_token_valid
+                ):
+                    return Resolution(
+                        ResolverState.SATISFIED,
+                        "human escalation landed",
+                        key,
+                        message.id,
+                        scope_revision,
+                        compliance_success=True,
+                    )
+                continue
+            if not exact or not exact_correlation:
+                continue
+            if not terminal_token_valid:
+                continue
+            event = threads._classify_event(  # noqa: SLF001 - normative reducer authority
+                "question", message, inbound.sender, self.agent, self.agent,
+            )
+            if event and event[0] == "terminal":
+                return Resolution(
+                    ResolverState.SATISFIED,
+                    "thread replay closed assignment",
+                    key,
+                    message.id,
+                    scope_revision,
+                    compliance_success=True,
+                )
+        # A canonical terminal published for the exact assignment must never be
+        # masked by a locally synthesized BLOCKED transition.  Internal BLOCKED
+        # remains authoritative only when replay found no qualifying terminal.
+        if blocked_event is not None:
+            return Resolution(
+                ResolverState.BLOCKED,
+                "obligation_blocked",
+                key,
+                blocked_event.get("source_id"),
+                scope_revision,
+            )
+        if aggregate_blocked_reason is not None:
+            return Resolution(
+                ResolverState.BLOCKED,
+                aggregate_blocked_reason,
+                key,
+                scoped_revision=scope_revision,
+            )
+        if isinstance(transfer_blocked_state, str):
+            try:
+                transfer_state = ResolverState(transfer_blocked_state)
+            except ValueError:
+                transfer_state = ResolverState.BLOCKED
+            return Resolution(
+                transfer_state,
+                str(
+                    admission.get("transfer_blocked_reason")
+                    or "transfer destination validation is blocked"
+                ),
+                key,
+                scoped_revision=scope_revision,
+            )
+        if composing is not None and admission is not None:
+            first = _epoch(admission.get("first_deferred_at"))
+            now = _epoch(self.now())
+            continuation = admission.get("durable_continuation")
+            owner = admission.get("producer_token")
+            live = isinstance(owner, str) and self.producer_alive(owner)
+            if first is not None and now is not None:
+                if now - first <= MAX_DEFERRAL_SECONDS:
+                    if live or isinstance(continuation, dict):
+                        return Resolution(
+                            ResolverState.IN_PROGRESS,
+                            "authenticated producer active or continuation scheduled",
+                            key,
+                            composing.id,
+                            scope_revision,
+                        )
+                else:
+                    return Resolution(
+                        ResolverState.OWED_UNSATISFIED,
+                        "post_budget_composing",
+                        key,
+                        composing.id,
+                        scope_revision,
+                        activation_generation=(
+                            str(admission.get("activation_generation"))
+                            if admission.get("activation_generation") is not None
+                            else None
+                        ),
+                        readiness_generation=(
+                            str(admission.get("readiness_generation"))
+                            if admission.get("readiness_generation") is not None
+                            else None
+                        ),
+                    )
+        return Resolution(
+            ResolverState.OWED_UNSATISFIED,
+            "replay leaves next move with responder",
+            key,
+            scoped_revision=scope_revision,
+            activation_generation=(
+                str(admission.get("activation_generation")) if admission else None
+            ),
+            readiness_generation=(
+                str(admission.get("readiness_generation")) if admission else None
+            ),
+        )
+
+    def _persist_post_budget_composing(self, resolution: Resolution) -> Resolution:
+        """Durably classify an expired composing marker before another dispatch."""
+        if (
+            resolution.state != ResolverState.OWED_UNSATISFIED
+            or resolution.reason != "post_budget_composing"
+            or resolution.key is None
+            or not isinstance(resolution.evidence_id, str)
+        ):
+            return resolution
+        key = resolution.key
+        with ExitStack() as locks:
+            # Canonical publication and this projection/classification share an
+            # ordering domain. If a bus record already landed but its eager
+            # projection hook failed or is waiting, replay it before the CAS.
+            locks.enter_context(self.store._message_publication_lock())
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc), key)
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"),
+                    timeout=10.0,
+                ),
+            )
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if (
+                not isinstance(admission, dict)
+                or admission.get("state") != "open"
+                or admission.get("fence") != self.fence
+                or not self._live_dispatch_fence_owned()
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "post-budget composing owner changed before classification",
+                    key,
+                )
+            breaker = ledger["breakers"].get(self.agent, {})
+            if breaker.get("tripped") is True or breaker.get("config_blocked") is True:
+                return Resolution(
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    "compliance breaker tripped",
+                    key,
+                )
+            if (
+                int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+                != resolution.scoped_revision
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "post-budget composing classification CAS miss",
+                    key,
+                )
+            evidence_id = admission.get("post_budget_composing_evidence_id")
+            if evidence_id is not None and not isinstance(evidence_id, str):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "post-budget composing evidence is invalid",
+                    key,
+                )
+            changed = False
+            if evidence_id is None:
+                evidence_id = resolution.evidence_id
+                admission["post_budget_composing_evidence_id"] = evidence_id
+                self._append(
+                    ledger,
+                    "OWED_ACTION_MISSING",
+                    source_id=evidence_id,
+                    key_digest=key.digest,
+                    data={"evidence": "post_budget_composing"},
+                )
+                changed = True
+            else:
+                evidence = [
+                    event
+                    for event in ledger["transitions"]
+                    if event.get("transition") == "OWED_ACTION_MISSING"
+                    and event.get("source_id") == evidence_id
+                    and event.get("key_digest") == key.digest
+                    and isinstance(event.get("data"), dict)
+                    and event["data"].get("evidence") == "post_budget_composing"
+                ]
+                if len(evidence) != 1:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "post-budget composing evidence transition is invalid",
+                        key,
+                    )
+            captured_rows = [
+                (nonce, row)
+                for nonce, row in admission.get("reservations", {}).items()
+                if isinstance(row, dict) and row.get("state") == "action_infra"
+            ]
+            if any(
+                not self._historical_capture_valid(key, admission, nonce, row)
+                for nonce, row in captured_rows
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "captured infrastructure evidence is invalid",
+                    key,
+                )
+            captured_infra = bool(captured_rows)
+            required = {
+                "owed_action_missing_seen": True,
+                "first_dispatch_classified": True,
+                "last_exhaustion_class": (
+                    "infrastructure" if captured_infra else "compliance"
+                ),
+            }
+            for field, value in required.items():
+                if admission.get(field) != value:
+                    admission[field] = value
+                    changed = True
+            if changed:
+                self._write(ledger)
+            return Resolution(
+                ResolverState.OWED_UNSATISFIED,
+                "post_budget_composing",
+                key,
+                evidence_id,
+                int(ledger["scoped_revisions"].get(key.inbound_id, 0)),
+                ledger_revision=int(ledger["revision"]),
+                activation_generation=(
+                    str(admission.get("activation_generation"))
+                    if admission.get("activation_generation") is not None
+                    else None
+                ),
+                readiness_generation=(
+                    str(admission.get("readiness_generation"))
+                    if admission.get("readiness_generation") is not None
+                    else None
+                ),
+            )
+
+    def _historical_capture_valid(
+        self,
+        key: ObligationKey,
+        admission: dict,
+        nonce: str,
+        row: dict,
+    ) -> bool:
+        """Validate durable capture identity without requiring the mutable draft."""
+        digest = row.get("operation_payload_digest")
+        intent = row.get("operation_intent")
+        if (
+            not self._valid_dispatch_nonce(nonce)
+            or not isinstance(digest, str)
+            or len(digest) != 64
+            or digest != digest.lower()
+            or not isinstance(intent, dict)
+        ):
+            return False
+        try:
+            int(digest, 16)
+        except ValueError:
+            return False
+        marker = self.store.read_operation_intent(self.agent, nonce)
+        if (
+            not isinstance(marker, dict)
+            or marker.get("operation_digest") != digest
+            or marker.get("intent_digest")
+            != self.store._operation_intent_digest(intent)
+        ):
+            return False
+        if intent.get("operation") != "terminal" or intent.get(
+            "in_reply_to",
+        ) != key.inbound_id:
+            return False
+        if admission.get("obligation_class") == "human_escalation":
+            return bool(
+                intent.get("kind") == "question"
+                and isinstance(intent.get("recipient"), str)
+                and intent.get("recipient") not in {"", self.agent}
+                and intent.get("request_id") == f"esc-{nonce[:12]}"
+                and intent.get("broadcast_id") is None
+                and intent.get("origin_request_id") == key.correlation_id
+                and intent.get("origin_inbound_id") == key.inbound_id
+                and intent.get("origin_obligation_key_digest") == key.digest
+                and _valid_hex_digest(intent.get("expected_roster_revision"))
+            )
+        broadcast_id = admission.get("broadcast_id")
+        return bool(
+            intent.get("kind") == "message"
+            and intent.get("recipient") == key.requester
+            and intent.get("request_id")
+            == (None if isinstance(broadcast_id, str) else key.correlation_id)
+            and intent.get("broadcast_id")
+            == (broadcast_id if isinstance(broadcast_id, str) else None)
+            and intent.get("origin_request_id") is None
+            and intent.get("origin_inbound_id") is None
+        )
+
+    def _persist_unsatisfied_attempts(self, resolution: Resolution) -> Resolution:
+        """Recover split result/classification writes before a corrected retry."""
+        if resolution.state != ResolverState.OWED_UNSATISFIED or resolution.key is None:
+            return resolution
+        key = resolution.key
+        with ExitStack() as locks:
+            locks.enter_context(self.store._message_publication_lock())
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc), key)
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"),
+                    timeout=10.0,
+                ),
+            )
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if (
+                not isinstance(admission, dict)
+                or admission.get("state") != "open"
+                or admission.get("fence") != self.fence
+                or not self._live_dispatch_fence_owned()
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "unsatisfied attempt owner changed before classification",
+                    key,
+                )
+            breaker = ledger["breakers"].get(self.agent, {})
+            if breaker.get("tripped") is True or breaker.get("config_blocked") is True:
+                return Resolution(
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    "compliance breaker tripped",
+                    key,
+                )
+            if (
+                int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+                != resolution.scoped_revision
+            ):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "unsatisfied attempt classification CAS miss",
+                    key,
+                )
+            pending = [
+                (nonce, row)
+                for nonce, row in admission.get("reservations", {}).items()
+                if isinstance(row, dict)
+                and row.get("state") == "completed"
+                and row.get("action_attempted") is True
+            ]
+            if not pending:
+                return resolution
+            reason = "replay remained unsatisfied after attempted action"
+            for nonce, row in pending:
+                row["state"] = "action_rejected"
+                row["rejection_reason"] = reason
+                self._append(
+                    ledger,
+                    "ACTION_REJECTED",
+                    key_digest=key.digest,
+                    data={"nonce": nonce, "reason": reason},
+                )
+            admission["owed_action_missing_seen"] = True
+            admission["first_dispatch_classified"] = True
+            admission["last_exhaustion_class"] = "compliance"
+            self._write(ledger)
+            return Resolution(
+                resolution.state,
+                resolution.reason,
+                key,
+                resolution.evidence_id,
+                int(ledger["scoped_revisions"].get(key.inbound_id, 0)),
+                ledger_revision=int(ledger["revision"]),
+                compliance_success=resolution.compliance_success,
+                activation_generation=resolution.activation_generation,
+                readiness_generation=resolution.readiness_generation,
+            )
+
+    def _can_reassign_fenced_owner(self, owner: dict) -> bool:
+        """Require current wrapper ownership and a stale prior owner before takeover."""
+        if self.store.wrapper_wait_generation(self.agent) != self.fence:
+            return False
+        if self.store.is_managed_lead_loop(self.agent):
+            lease = self.store.read_lead_loop_lease(self.agent)
+            return bool(
+                isinstance(lease, dict)
+                and lease.get("wrapper_generation") == self.fence
+            )
+        return _process_liveness(owner.get("owner_pid")) == PROC_DEAD
+
+    def _can_reassign_no_admission_claim(self, claim: dict) -> bool:
+        return self._can_reassign_fenced_owner(claim)
+
+    def _reconcile_closed_dispatch_slots_locked(self, ledger: dict) -> bool:
+        """Release only terminal slots whose dispatch can no longer be authoritative."""
+        changed = False
+        for key_digest, admission in ledger["obligations"].items():
+            if (
+                not isinstance(admission, dict)
+                or admission.get("state") not in CLOSED_ADMISSION_STATES
+                or self._key_from(admission.get("key")).responder != self.agent
+            ):
+                continue
+            for nonce, row in admission.get("reservations", {}).items():
+                if not isinstance(row, dict):
+                    continue
+                prior_state = row.get("state")
+                if prior_state == "reserved":
+                    # No external model side effect was armed. A concurrent
+                    # dispatch_record will revalidate the now-closed admission
+                    # and fail, so this intent cannot consume capacity forever.
+                    pass
+                elif prior_state == "dispatching":
+                    dispatch_fence = row.get("dispatch_fence")
+                    if (
+                        not isinstance(dispatch_fence, str)
+                        or dispatch_fence == self.fence
+                        or _process_liveness(row.get("dispatch_owner_pid"))
+                        != PROC_DEAD
+                        or not self._can_reassign_fenced_owner(admission)
+                    ):
+                        # A live or unprovably-dead owner remains fail-closed and
+                        # continues to consume the agent-wide concurrency slot.
+                        continue
+                else:
+                    continue
+                row["state"] = "cancelled_terminal"
+                row["cancelled_at"] = self.now()
+                self._append(
+                    ledger,
+                    "TERMINAL_DISPATCH_RECONCILED",
+                    key_digest=str(key_digest),
+                    data={
+                        "nonce": nonce,
+                        "prior_state": prior_state,
+                        "terminal_state": admission.get("terminal_state"),
+                    },
+                )
+                changed = True
+        return changed
+
+    def _captured_payload_digest(self, row: dict, nonce: str) -> str | None:
+        intent = row.get("operation_intent")
+        draft = Path(str(row.get("draft_path", "")))
+        if not isinstance(intent, dict):
+            return None
+        try:
+            resolved = draft.resolve(strict=True)
+            root = self.drafts.resolve(strict=True)
+            resolved.relative_to(root)
+            if draft.is_symlink() or resolved.stat().st_size > 1024 * 1024:
+                return None
+            body = resolved.read_text(encoding="utf-8")
+        except (OSError, UnicodeError, ValueError):
+            return None
+        if not body:
+            return None
+        digest = operation_payload_digest(
+            operation=str(intent.get("operation", "")),
+            body=body,
+            kind=str(intent.get("kind", "")),
+            recipient=str(intent.get("recipient", "")),
+            in_reply_to=intent.get("in_reply_to"),
+            request_id=intent.get("request_id"),
+            broadcast_id=intent.get("broadcast_id"),
+            origin_request_id=intent.get("origin_request_id"),
+            origin_inbound_id=intent.get("origin_inbound_id"),
+            origin_obligation_key_digest=intent.get(
+                "origin_obligation_key_digest"
+            ),
+            expected_roster_revision=intent.get("expected_roster_revision"),
+        )
+        marker = self.store.read_operation_intent(self.agent, nonce)
+        payload = body.encode("utf-8")
+        if (
+            not isinstance(marker, dict)
+            or marker.get("operation_digest") != digest
+            or marker.get("intent_digest")
+            != self.store._operation_intent_digest(intent)
+            or marker.get("payload_sha256") != hashlib.sha256(payload).hexdigest()
+            or marker.get("payload_size") != len(payload)
+        ):
+            return None
+        return digest
+
+    def _recover_captured_dispatches_locked(
+        self,
+        ledger: dict,
+        admission: dict,
+        key: ObligationKey,
+        *,
+        previous_fence: str,
+    ) -> None:
+        """Recover a durable draft only after the prior wrapper is proven dead."""
+        for nonce, row in admission.get("reservations", {}).items():
+            if (
+                not isinstance(row, dict)
+                or row.get("state") != "dispatching"
+                or row.get("dispatch_fence") != previous_fence
+            ):
+                continue
+            digest = self._captured_payload_digest(row, str(nonce))
+            if digest is None:
+                continue
+            recovered_at = self.now()
+            row["state"] = "action_infra"
+            row["operation_payload_digest"] = digest
+            row["captured_at"] = recovered_at
+            admission["first_dispatch_classified"] = True
+            admission["last_exhaustion_class"] = "infrastructure"
+            admission["operation_infra_attempts"] = max(
+                1,
+                int(admission.get("operation_infra_attempts", 0)),
+            )
+            admission["operation_infra_first_at"] = (
+                admission.get("operation_infra_first_at") or recovered_at
+            )
+            self._append(
+                ledger,
+                "OPERATION_INTENT_RECOVERED",
+                key_digest=key.digest,
+                data={"nonce": nonce, "payload_digest": digest},
+            )
+
+    def _claim_open_admission(
+        self,
+        key_digest: str,
+        inbound_id: str,
+    ) -> tuple[dict, dict] | Resolution:
+        """Fence an open admission to this live wrapper or fail closed."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key_digest)
+            if not isinstance(admission, dict):
+                return Resolution(ResolverState.INDETERMINATE, "admission disappeared")
+            if admission.get("state") != "open":
+                return ledger, admission
+            key = self._key_from(admission["key"])
+            if key.inbound_id != inbound_id or key.responder != self.agent:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "admission ownership does not match exact inbound",
+                    key,
+                )
+            previous_fence = admission.get("fence")
+            if previous_fence == self.fence:
+                return ledger, admission
+            if self.store.wrapper_wait_generation(self.agent) != self.fence:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "replacement wrapper does not own the waiting generation",
+                    key,
+                )
+            if previous_fence == "unclaimed":
+                policy = self._current_policy()
+                if (
+                    policy.status != ResolverState.ACTIVE
+                    or admission.get("activation_generation") != policy.generation
+                    or admission.get("readiness_generation") != policy.generation
+                ):
+                    return Resolution(
+                        ResolverState.BLOCKED_POLICY,
+                        "transfer policy generation changed before claim",
+                        key,
+                    )
+                transition = "DELIVERY_CLAIMED"
+            else:
+                if not isinstance(previous_fence, str) or not self._can_reassign_fenced_owner(
+                    admission,
+                ):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "prior admission owner is still authoritative",
+                        key,
+                    )
+                transition = "DELIVERY_CLAIM_REASSIGNED"
+            admission["fence"] = self.fence
+            admission["owner_pid"] = os.getpid()
+            self._recover_captured_dispatches_locked(
+                ledger,
+                admission,
+                key,
+                previous_fence=str(previous_fence),
+            )
+            self._append(
+                ledger,
+                transition,
+                scope=inbound_id,
+                key_digest=key.digest,
+                data={"previous_fence": previous_fence, "fence": self.fence},
+            )
+            self._write(ledger)
+            return ledger, admission
+
+    def _normalize_pre_admission_terminal(
+        self,
+        record: dict,
+        inbound: Message,
+        replayed: Resolution,
+        observed_policy: PolicySnapshot,
+    ) -> Resolution:
+        """Durably recognize exact zero-work terminal authority before projection."""
+        if replayed.state not in TERMINAL_STATES or not isinstance(
+            replayed.evidence_id,
+            str,
+        ):
+            return Resolution(
+                ResolverState.INDETERMINATE,
+                "pre-admission terminal replay is invalid",
+            )
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            policy_block = self._revalidate_admission_policy(observed_policy)
+            if policy_block is not None:
+                return policy_block
+            current = self._load()
+            if int(current["scoped_revisions"].get(inbound.id, 0)) != (
+                replayed.scoped_revision
+            ):
+                return Resolution(ResolverState.INDETERMINATE, "normalization CAS miss")
+            if inbound.id in current["inbound_index"]:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "concurrent admission won before terminal normalization",
+                )
+            claim = current["no_admission_claims"].get(inbound.id)
+            if isinstance(claim, dict):
+                if claim.get("state") == "blocked":
+                    return Resolution(
+                        ResolverState.BLOCKED,
+                        str(claim.get("blocked_reason") or "finalization blocked"),
+                    )
+                semantic_claim = bool(
+                    self._claim_is_untouched(claim)
+                    and claim.get("claim_kind") is None
+                )
+                if semantic_claim:
+                    if claim.get("fence") != self.fence:
+                        if not self._can_reassign_no_admission_claim(claim):
+                            return Resolution(
+                                ResolverState.INDETERMINATE,
+                                "prior no-admission claim owner is still authoritative",
+                            )
+                        previous_fence = claim.get("fence")
+                        claim["fence"] = self.fence
+                        claim["owner_pid"] = os.getpid()
+                        self._append(
+                            current,
+                            "NO_ADMISSION_CLAIM_REASSIGNED",
+                            scope=inbound.id,
+                            source_id=replayed.evidence_id,
+                            data={
+                                "previous_fence": previous_fence,
+                                "fence": self.fence,
+                                "reason": "terminal_normalization",
+                            },
+                        )
+                    claim["resolution"] = replayed.state.value
+                    claim["claim_kind"] = "pre_admission_terminal"
+                    claim["terminal_evidence_id"] = replayed.evidence_id
+                    claim["policy_status"] = observed_policy.status.value
+                    claim["policy_generation"] = observed_policy.generation
+                    self._append(
+                        current,
+                        "PRE_ADMISSION_TERMINAL_NORMALIZED",
+                        scope=inbound.id,
+                        source_id=replayed.evidence_id,
+                        data={"inbound_id": inbound.id, "state": replayed.state.value},
+                    )
+                    self._write(current)
+                elif not self._claim_matches_policy(claim, observed_policy):
+                    return self._policy_authority_failure(
+                        observed_policy,
+                        reason="terminal normalization policy changed",
+                    )
+                if claim.get("resolution") != replayed.state.value or claim.get(
+                    "state"
+                ) not in {"open", "finalized"}:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "no-admission claim conflicts with terminal replay",
+                    )
+                if claim.get("state") == "open" and claim.get("fence") != self.fence:
+                    if not self._can_reassign_no_admission_claim(claim):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "prior no-admission claim owner is still authoritative",
+                        )
+                    previous_fence = claim.get("fence")
+                    claim["fence"] = self.fence
+                    claim["owner_pid"] = os.getpid()
+                    self._append(
+                        current,
+                        "NO_ADMISSION_CLAIM_REASSIGNED",
+                        scope=inbound.id,
+                        source_id=replayed.evidence_id,
+                        data={
+                            "previous_fence": previous_fence,
+                            "fence": self.fence,
+                        },
+                    )
+                    self._write(current)
+            else:
+                current["no_admission_claims"][inbound.id] = {
+                    "fence": self.fence,
+                    "owner_pid": os.getpid(),
+                    "state": "open",
+                    "resolution": replayed.state.value,
+                    "claim_kind": "pre_admission_terminal",
+                    "terminal_evidence_id": replayed.evidence_id,
+                    "policy_status": observed_policy.status.value,
+                    "policy_generation": observed_policy.generation,
+                    "finalization_misses": 0,
+                    "finalization_first_at": None,
+                    "cursor_projection_misses": 0,
+                    "cursor_projection_first_at": None,
+                    "cursor_projection_inflight": False,
+                    "cursor_projection_reserved_at": None,
+                }
+                self._append(
+                    current,
+                    "PRE_ADMISSION_TERMINAL_NORMALIZED",
+                    scope=inbound.id,
+                    source_id=replayed.evidence_id,
+                    data={"inbound_id": inbound.id, "state": replayed.state.value},
+                )
+                self._write(current)
+            scoped_revision = int(current["scoped_revisions"].get(inbound.id, 0))
+        return Resolution(
+            replayed.state,
+            replayed.reason,
+            evidence_id=replayed.evidence_id,
+            scoped_revision=scoped_revision,
+            ledger_revision=scoped_revision,
+            activation_generation=observed_policy.generation,
+            readiness_generation=observed_policy.generation,
+        )
+
+    def admit_or_finalize(self, record: dict) -> Resolution:
+        observed_policy = self._current_policy()
+        eligibility, detail, rid = self._eligibility(
+            record,
+            policy=observed_policy,
+        )
+        if eligibility != ResolverState.ACTIVE:
+            blocked_states = {
+                ResolverState.BLOCKED,
+                ResolverState.BLOCKED_POLICY,
+                ResolverState.BLOCKED_COMPLIANCE,
+            }
+            readable_policy_block = (
+                eligibility == ResolverState.BLOCKED
+                and observed_policy.status == ResolverState.BLOCKED
+                and detail == observed_policy.reason
+                and rid is None
+                and not self._policy_blocks_durable_terminal_projection(
+                    observed_policy
+                )
+            )
+            if (
+                eligibility in blocked_states
+                and not readable_policy_block
+            ):
+                return Resolution(
+                    eligibility,
+                    detail,
+                    activation_generation=observed_policy.generation,
+                    readiness_generation=observed_policy.generation,
+                )
+            try:
+                messages, ledger = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+            inbound = self._record_message(record, messages)
+            if inbound is None:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "non-admission head absent from validated replay",
+                )
+            recovered = self._recover_durable_no_admission_disposition(
+                record,
+                messages,
+                ledger,
+                observed_policy,
+            )
+            if recovered is not None:
+                return recovered
+            replayed_terminal = self._resolve_replay(
+                record,
+                messages,
+                ledger,
+                admission=None,
+            )
+            if replayed_terminal.state in TERMINAL_STATES:
+                return self._normalize_pre_admission_terminal(
+                    record,
+                    inbound,
+                    replayed_terminal,
+                    observed_policy,
+                )
+            if eligibility in blocked_states:
+                return Resolution(
+                    eligibility,
+                    detail,
+                    activation_generation=observed_policy.generation,
+                    readiness_generation=observed_policy.generation,
+                )
+            if observed_policy.generation == "inactive":
+                return Resolution(
+                    eligibility,
+                    detail,
+                    activation_generation=observed_policy.generation,
+                    readiness_generation=observed_policy.generation,
+                )
+            replay_revision = int(ledger["scoped_revisions"].get(inbound.id, 0))
+            if eligibility == ResolverState.CLASSIFICATION_UNKNOWN:
+                name = "classification_unknown_heads"
+                transition = "CLASSIFICATION_UNKNOWN"
+            elif eligibility == ResolverState.INACTIVE:
+                name = "inactive_policy_heads"
+                transition = "POLICY_INACTIVE"
+            else:
+                name = "semantic_noneligible_heads"
+                transition = "SEMANTICALLY_NOT_OWED"
+            with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+                policy_block = self._revalidate_admission_policy(observed_policy)
+                if policy_block is not None:
+                    return policy_block
+                current = self._load()
+                if int(current["scoped_revisions"].get(inbound.id, 0)) != replay_revision:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "no-admission claim CAS miss",
+                    )
+                if inbound.id in current["inbound_index"]:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "concurrent admission won before no-admission claim",
+                    )
+                claim = current["no_admission_claims"].get(inbound.id)
+                if isinstance(claim, dict):
+                    if not self._claim_matches_policy(claim, observed_policy):
+                        if not self._claim_is_untouched(claim):
+                            return self._policy_authority_failure(
+                                observed_policy,
+                                reason=(
+                                    "no-admission claim policy changed after legacy "
+                                    "work started"
+                                ),
+                            )
+                        previous_generation = claim.get("policy_generation")
+                        del current["no_admission_claims"][inbound.id]
+                        self._append(
+                            current,
+                            "NO_ADMISSION_CLAIM_POLICY_SUPERSEDED",
+                            scope=inbound.id,
+                            source_id=inbound.id,
+                            data={
+                                "previous_generation": previous_generation,
+                                "policy_generation": observed_policy.generation,
+                            },
+                        )
+                        claim = None
+                if isinstance(claim, dict):
+                    if claim.get("state") == "blocked":
+                        return Resolution(
+                            ResolverState.BLOCKED,
+                            str(claim.get("blocked_reason") or "finalization blocked"),
+                        )
+                    if claim.get("resolution") != eligibility.value or claim.get(
+                        "state"
+                    ) not in {"open", "finalization_pending", "finalized"}:
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission claim conflicts with replay",
+                        )
+                    if claim.get("state") in {"open", "finalization_pending"} and claim.get(
+                        "fence"
+                    ) != self.fence:
+                        if not self._can_reassign_no_admission_claim(claim):
+                            return Resolution(
+                                ResolverState.INDETERMINATE,
+                                "prior no-admission claim owner is still authoritative",
+                            )
+                        previous_fence = claim.get("fence")
+                        claim["fence"] = self.fence
+                        claim["owner_pid"] = os.getpid()
+                        self._append(
+                            current,
+                            "NO_ADMISSION_CLAIM_REASSIGNED",
+                            scope=inbound.id,
+                            source_id=inbound.id,
+                            data={
+                                "previous_fence": previous_fence,
+                                "fence": self.fence,
+                            },
+                        )
+                        self._write(current)
+                if not isinstance(claim, dict):
+                    current_telemetry = current["telemetry"]
+                    current_telemetry[name] = int(current_telemetry.get(name, 0)) + 1
+                    self._append(
+                        current,
+                        transition,
+                        scope=inbound.id,
+                        source_id=inbound.id,
+                        data={"reason": detail},
+                    )
+                    claim = {
+                        "fence": self.fence,
+                        "owner_pid": os.getpid(),
+                        "state": "open",
+                        "resolution": eligibility.value,
+                        "policy_status": observed_policy.status.value,
+                        "policy_generation": observed_policy.generation,
+                        "finalization_misses": 0,
+                        "finalization_first_at": None,
+                        "cursor_projection_misses": 0,
+                        "cursor_projection_first_at": None,
+                        "cursor_projection_inflight": False,
+                        "cursor_projection_reserved_at": None,
+                    }
+                    current["no_admission_claims"][inbound.id] = claim
+                    self._write(current)
+                policy_block = self._revalidate_admission_policy(observed_policy)
+                if policy_block is not None:
+                    if self._claim_is_untouched(claim) and self._claim_matches_policy(
+                        claim,
+                        observed_policy,
+                    ):
+                        del current["no_admission_claims"][inbound.id]
+                        self._append(
+                            current,
+                            "NO_ADMISSION_CLAIM_POLICY_INVALIDATED",
+                            scope=inbound.id,
+                            source_id=inbound.id,
+                            data={"policy_generation": observed_policy.generation},
+                        )
+                        self._write(current)
+                    return policy_block
+                scope_revision = int(current["scoped_revisions"].get(inbound.id, 0))
+            return Resolution(
+                eligibility,
+                (
+                    "no_admission_finalization_pending"
+                    if isinstance(claim, dict)
+                    and claim.get("state") == "finalization_pending"
+                    else "no_admission_disposition_pending"
+                    if isinstance(claim, dict)
+                    and claim.get("state") == "finalized"
+                    else detail
+                ),
+                scoped_revision=scope_revision,
+                ledger_revision=scope_revision,
+                activation_generation=observed_policy.generation,
+                readiness_generation=observed_policy.generation,
+            )
+        try:
+            messages, ledger = self._validated_messages()
+        except LedgerUnreadable as exc:
+            return Resolution(ResolverState.BLOCKED, str(exc))
+        inbound = self._record_message(record, messages)
+        if inbound is None:
+            return Resolution(ResolverState.INDETERMINATE, "inbound absent from validated replay")
+        recovered = self._recover_durable_no_admission_disposition(
+            record,
+            messages,
+            ledger,
+            observed_policy,
+        )
+        if recovered is not None:
+            return recovered
+        existing_id = ledger["inbound_index"].get(inbound.id)
+        if existing_id:
+            admission = ledger["obligations"].get(existing_id)
+            if not isinstance(admission, dict):
+                return Resolution(ResolverState.INDETERMINATE, "admission index torn")
+            existing_key = self._key_from(admission["key"])
+            if self._reconcile_landed_pending_broadcast_close(existing_key):
+                ledger = self._load()
+                admission = ledger["obligations"].get(existing_id)
+                if not isinstance(admission, dict):
+                    return Resolution(ResolverState.INDETERMINATE, "admission index torn")
+            replayed = self._resolve_replay(record, messages, ledger, admission=admission)
+            if replayed.terminal:
+                breaker = ledger["breakers"].get(self.agent, {})
+                if isinstance(breaker, dict) and breaker.get("tripped") is True:
+                    self._project_compliance_breaker_hold()
+                    self._reconcile_compliance_breaker_alert()
+                return replayed
+            if admission.get("state") == "open" and admission.get("fence") != self.fence:
+                claimed = self._claim_open_admission(existing_id, inbound.id)
+                if isinstance(claimed, Resolution):
+                    return claimed
+                ledger, admission = claimed
+                replayed = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=admission,
+                )
+            classified = self._persist_post_budget_composing(replayed)
+            if any(
+                isinstance(row, dict)
+                and row.get("state") == "completed"
+                and row.get("action_attempted") is True
+                for row in admission.get("reservations", {}).values()
+            ):
+                return self._persist_unsatisfied_attempts(classified)
+            return classified
+        inbound_meta = inbound.meta if isinstance(inbound.meta, dict) else {}
+        if _valid_hex_digest(inbound_meta.get("transfer_from_key_digest")):
+            # Publishing the immutable target and committing the source transfer are
+            # separate operations.  The first ledger CAS wins: either the source has
+            # already admitted this target, or this wrapper aborts the orphan target
+            # without invoking the model.  A crash-before-transfer therefore cannot
+            # leave the destination queue parked on an INDETERMINATE head forever.
+            replay_revision = int(
+                ledger["scoped_revisions"].get(inbound.id, 0)
+            )
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                policy_block = self._revalidate_admission_policy(observed_policy)
+                if policy_block is not None:
+                    return policy_block
+                current = self._load()
+                if int(current["scoped_revisions"].get(inbound.id, 0)) != (
+                    replay_revision
+                ):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "transfer-target abort CAS miss",
+                    )
+                if inbound.id in current["inbound_index"]:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "atomic source transfer won before target abort",
+                    )
+                claim = current["no_admission_claims"].get(inbound.id)
+                if isinstance(claim, dict):
+                    if not self._claim_matches_policy(claim, observed_policy):
+                        return self._policy_authority_failure(
+                            observed_policy,
+                            reason="transfer-target claim policy changed",
+                        )
+                    if claim.get("state") == "blocked":
+                        return Resolution(
+                            ResolverState.BLOCKED,
+                            str(
+                                claim.get("blocked_reason")
+                                or "transfer-target finalization blocked"
+                            ),
+                        )
+                    if (
+                        claim.get("resolution") != ResolverState.NOT_OWED.value
+                        or claim.get("state")
+                        not in {"open", "finalization_pending", "finalized"}
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "transfer-target abort conflicts with prior claim",
+                        )
+                    if (
+                        claim.get("state") in {"open", "finalization_pending"}
+                        and claim.get("fence") != self.fence
+                    ):
+                        if not self._can_reassign_no_admission_claim(claim):
+                            return Resolution(
+                                ResolverState.INDETERMINATE,
+                                "prior transfer-target abort owner is still authoritative",
+                            )
+                        previous_fence = claim.get("fence")
+                        claim["fence"] = self.fence
+                        claim["owner_pid"] = os.getpid()
+                        self._append(
+                            current,
+                            "NO_ADMISSION_CLAIM_REASSIGNED",
+                            scope=inbound.id,
+                            source_id=inbound.id,
+                            data={
+                                "previous_fence": previous_fence,
+                                "fence": self.fence,
+                                "reason": "transfer_target_abort",
+                            },
+                        )
+                        self._write(current)
+                else:
+                    claim = {
+                        "fence": self.fence,
+                        "owner_pid": os.getpid(),
+                        "state": "open",
+                        "resolution": ResolverState.NOT_OWED.value,
+                        "claim_kind": "transfer_target_abort",
+                        "policy_status": observed_policy.status.value,
+                        "policy_generation": observed_policy.generation,
+                        "finalization_misses": 0,
+                        "finalization_first_at": None,
+                        "cursor_projection_misses": 0,
+                        "cursor_projection_first_at": None,
+                        "cursor_projection_inflight": False,
+                        "cursor_projection_reserved_at": None,
+                        "transfer_from_key_digest": inbound_meta.get(
+                            "transfer_from_key_digest"
+                        ),
+                    }
+                    current["no_admission_claims"][inbound.id] = claim
+                    self._append(
+                        current,
+                        "TRANSFER_TARGET_ABORTED",
+                        scope=inbound.id,
+                        source_id=inbound.id,
+                        data={
+                            "inbound_id": inbound.id,
+                            "transfer_from_key_digest": inbound_meta.get(
+                                "transfer_from_key_digest"
+                            ),
+                            "transfer_policy_generation": inbound_meta.get(
+                                "transfer_policy_generation"
+                            ),
+                        },
+                    )
+                    self._write(current)
+                scoped_revision = int(
+                    current["scoped_revisions"].get(inbound.id, 0)
+                )
+            return Resolution(
+                ResolverState.NOT_OWED,
+                (
+                    "no_admission_disposition_pending"
+                    if claim.get("state") == "finalized"
+                    else "no_admission_finalization_pending"
+                ),
+                scoped_revision=scoped_revision,
+                ledger_revision=scoped_revision,
+                activation_generation=observed_policy.generation,
+                readiness_generation=observed_policy.generation,
+            )
+        before = self._resolve_replay(record, messages, ledger, admission=None)
+        if before.state in TERMINAL_STATES:
+            return self._normalize_pre_admission_terminal(
+                record,
+                inbound,
+                before,
+                observed_policy,
+            )
+        if before.state not in {ResolverState.OWED_UNSATISFIED}:
+            return before
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            policy_block = self._revalidate_admission_policy(observed_policy)
+            if policy_block is not None:
+                return policy_block
+            current = self._load()
+            if int(current["scoped_revisions"].get(inbound.id, 0)) != before.scoped_revision:
+                return Resolution(ResolverState.INDETERMINATE, "admission CAS miss")
+            if inbound.id in current["inbound_index"]:
+                return Resolution(ResolverState.INDETERMINATE, "concurrent admission won")
+            claim = current["no_admission_claims"].get(inbound.id)
+            if isinstance(claim, dict):
+                previous_generation = claim.get("policy_generation")
+                if (
+                    isinstance(previous_generation, str)
+                    and not self._claim_matches_policy(claim, observed_policy)
+                    and self._claim_is_untouched(claim)
+                ):
+                    del current["no_admission_claims"][inbound.id]
+                    self._append(
+                        current,
+                        "NO_ADMISSION_CLAIM_POLICY_SUPERSEDED",
+                        scope=inbound.id,
+                        source_id=inbound.id,
+                        data={
+                            "previous_generation": previous_generation,
+                            "policy_generation": observed_policy.generation,
+                        },
+                    )
+                elif not self._claim_matches_policy(claim, observed_policy):
+                    return self._policy_authority_failure(
+                        observed_policy,
+                        reason=(
+                            "no-admission claim policy changed after legacy work started"
+                        ),
+                    )
+                else:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "concurrent no-admission finalizer won",
+                    )
+            breaker = current["breakers"].get(self.agent, {})
+            if breaker.get("tripped") is True or breaker.get("config_blocked") is True:
+                return Resolution(
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    "compliance breaker tripped",
+                )
+            question_generation = 1 + sum(
+                1 for value in current["obligations"].values()
+                if isinstance(value, dict) and value.get("correlation_id") == rid
+            )
+            key = ObligationKey(
+                store_epoch=current["store_epoch"],
+                inbound_id=inbound.id,
+                correlation_id=rid,
+                requester=inbound.sender,
+                responder=self.agent,
+                question_generation=question_generation,
+                delivery_generation=1,
+                obligation_class=detail,
+            )
+            admission = {
+                "key": key.to_dict(),
+                "correlation_id": rid,
+                "obligation_class": detail,
+                "state": "open",
+                "watermark_sequence": current["append_sequence"],
+                "scoped_revision": int(current["scoped_revisions"].get(inbound.id, 0)),
+                "activation_generation": observed_policy.generation,
+                "readiness_generation": observed_policy.generation,
+                "fence": self.fence,
+                "owner_pid": os.getpid(),
+                "delivery_mode": record.get("mode", "global"),
+                "scoped_request_id": (
+                    record.get("scoped", {}).get("request_id")
+                    if isinstance(record.get("scoped"), dict)
+                    else None
+                ),
+                "paid_dispatches_total": 0,
+                "paid_initial_dispatches_total": 0,
+                "paid_recoveries_total": 0,
+                "paid_continuations_total": 0,
+                "continuation_used": False,
+                "recovery_used": False,
+                "first_dispatch_classified": False,
+                "last_exhaustion_class": None,
+                "reservations": {},
+                "operation_infra_attempts": 0,
+                "operation_infra_first_at": None,
+                "operation_infra_retry_inflight": False,
+                "finalization_misses": 0,
+                "finalization_first_at": None,
+                "finalization_retry_inflight": False,
+                "cursor_projection_misses": 0,
+                "cursor_projection_first_at": None,
+                "cursor_projection_inflight": False,
+                "cursor_projection_reserved_at": None,
+                "owed_action_missing_seen": False,
+                "created_at": self.now(),
+                "broadcast_id": (inbound.meta or {}).get("broadcast_id"),
+                "membership_snapshot": (inbound.meta or {}).get("membership_snapshot"),
+                "response_policy": (inbound.meta or {}).get("response_policy"),
+                "response_quorum": (inbound.meta or {}).get("response_quorum"),
+                "broadcast_policy_version": (inbound.meta or {}).get(
+                    "broadcast_policy_version"
+                ),
+                "broadcast_generation": current["messages"].get(
+                    inbound.id,
+                    {},
+                ).get("broadcast_generation"),
+            }
+            current["obligations"][key.digest] = admission
+            current["inbound_index"][inbound.id] = key.digest
+            self._append(
+                current,
+                "OBLIGATION_ADMITTED",
+                scope=inbound.id,
+                source_id=inbound.id,
+                key_digest=key.digest,
+                data={"key": key.to_dict()},
+            )
+            self._write(current)
+        return Resolution(
+            ResolverState.OWED_UNSATISFIED,
+            "obligation admitted",
+            key,
+            scoped_revision=int(current["scoped_revisions"].get(inbound.id, 0)),
+            activation_generation=observed_policy.generation,
+            readiness_generation=observed_policy.generation,
+        )
+
+    def resolve(self, record: dict) -> Resolution:
+        try:
+            messages, ledger = self._validated_messages()
+        except LedgerUnreadable as exc:
+            return Resolution(ResolverState.BLOCKED, str(exc))
+        key_id = ledger["inbound_index"].get(record.get("id"))
+        if not key_id:
+            return self.admit_or_finalize(record)
+        admission = ledger["obligations"].get(key_id)
+        if not isinstance(admission, dict):
+            return Resolution(ResolverState.INDETERMINATE, "admission missing")
+        key = self._key_from(admission["key"])
+        if self._reconcile_landed_pending_broadcast_close(key):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key_id)
+            if not isinstance(admission, dict):
+                return Resolution(ResolverState.INDETERMINATE, "admission missing")
+        replayed = self._resolve_replay(record, messages, ledger, admission=admission)
+        if replayed.terminal:
+            breaker = ledger["breakers"].get(self.agent, {})
+            if isinstance(breaker, dict) and breaker.get("tripped") is True:
+                self._project_compliance_breaker_hold()
+                self._reconcile_compliance_breaker_alert()
+            return replayed
+        if admission.get("state") == "open" and admission.get("fence") != self.fence:
+            claimed = self._claim_open_admission(key_id, str(record.get("id", "")))
+            if isinstance(claimed, Resolution):
+                return claimed
+            ledger, admission = claimed
+            replayed = self._resolve_replay(record, messages, ledger, admission=admission)
+            if replayed.terminal:
+                return replayed
+        if admission.get("state") == "blocked":
+            return Resolution(
+                ResolverState.BLOCKED,
+                str(admission.get("blocked_reason") or "obligation retry path blocked"),
+                self._key_from(admission["key"]),
+            )
+        breaker = ledger["breakers"].get(self.agent, {})
+        if breaker.get("tripped") is True:
+            self._project_compliance_breaker_hold()
+            self._reconcile_compliance_breaker_alert()
+            return Resolution(
+                ResolverState.BLOCKED_COMPLIANCE,
+                "compliance breaker tripped",
+                self._key_from(admission["key"]),
+            )
+        classified = self._persist_post_budget_composing(replayed)
+        if any(
+            isinstance(row, dict)
+            and row.get("state") == "completed"
+            and row.get("action_attempted") is True
+            for row in admission.get("reservations", {}).values()
+        ):
+            return self._persist_unsatisfied_attempts(classified)
+        return classified
+
+    def _live_dispatch_fence_owned(self) -> bool:
+        generation = self.store.wrapper_wait_generation(self.agent)
+        if generation != self.fence:
+            return False
+        if self.store.is_managed_lead_loop(self.agent):
+            lease = self.store.read_lead_loop_lease(self.agent)
+            return bool(
+                isinstance(lease, dict)
+                and lease.get("wrapper_generation") == self.fence
+            )
+        marker = self.store.read_waiting(self.agent)
+        return bool(
+            isinstance(marker, dict)
+            and marker.get("mode") == "wrapper-loop"
+            and marker.get("pid") == os.getpid()
+        )
+
+    def _dispatch_head_is_current(self, admission: dict, key: ObligationKey) -> bool:
+        from agenttalk.wrapper import recv_api
+
+        scoped_request_id = (
+            admission.get("scoped_request_id")
+            if admission.get("delivery_mode") == "scoped"
+            else None
+        )
+        head = recv_api.next_record(
+            self.store,
+            self.agent,
+            scoped_request_id=scoped_request_id,
+        )
+        return bool(isinstance(head, dict) and head.get("id") == key.inbound_id)
+
+    def _validate_dispatch_authority(
+        self,
+        ledger: dict,
+        admission: dict | None,
+        key: ObligationKey,
+        resolution: Resolution,
+    ) -> dict:
+        if not isinstance(admission, dict) or admission.get("state") != "open":
+            raise DispatchRefused("obligation is no longer open")
+        if admission.get("fence") != self.fence or not self._live_dispatch_fence_owned():
+            raise DispatchRefused("wrapper fence changed")
+        if isinstance(admission.get("transfer_blocked_state"), str):
+            raise DispatchRefused("transfer destination validation is blocked")
+        current_policy = self._current_policy()
+        activation = admission.get("activation_generation")
+        readiness = admission.get("readiness_generation")
+        if (
+            current_policy.status != ResolverState.ACTIVE
+            or activation != current_policy.generation
+            or readiness != current_policy.generation
+            or resolution.activation_generation not in {None, activation}
+            or resolution.readiness_generation not in {None, readiness}
+        ):
+            raise DispatchRefused("activation or readiness generation changed")
+        if not self._dispatch_head_is_current(admission, key):
+            raise DispatchRefused("wrapper no longer owns the exact cursor head")
+        breaker = ledger["breakers"].get(self.agent, {})
+        if breaker.get("tripped") is True or breaker.get("config_blocked") is True:
+            raise DispatchRefused("compliance breaker is tripped")
+        return admission
+
+    @staticmethod
+    def _dispatch_request_digest(
+        key: ObligationKey,
+        purpose: str,
+        budgets: dict,
+        activation_generation: object,
+        readiness_generation: object,
+    ) -> str:
+        return hashlib.sha256(_canonical({
+            "key_digest": key.digest,
+            "purpose": purpose,
+            "budgets": budgets,
+            "activation_generation": activation_generation,
+            "readiness_generation": readiness_generation,
+        }).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _valid_dispatch_nonce(value: object) -> bool:
+        if not isinstance(value, str) or len(value) != 32:
+            return False
+        try:
+            int(value, 16)
+        except ValueError:
+            return False
+        return value == value.lower()
+
+    @staticmethod
+    def _permit_from_reservation(
+        key_digest: str,
+        nonce: str,
+        row: dict,
+    ) -> DispatchPermit:
+        return DispatchPermit(
+            key_digest,
+            nonce,
+            str(row.get("composing_nonce", "")),
+            str(row.get("purpose", "")),
+            int(row.get("paid_dispatches_total", 0)),
+            Path(str(row.get("draft_path", ""))),
+            str(row.get("budgets_digest", "")),
+        )
+
+    def reserve_dispatch(
+        self,
+        resolution: Resolution,
+        *,
+        purpose: str,
+        nonce: str | None = None,
+        budgets: dict | None = None,
+    ) -> DispatchPermit:
+        if resolution.key is None or resolution.state != ResolverState.OWED_UNSATISFIED:
+            raise DispatchRefused("dispatch requires an open unsatisfied obligation")
+        if purpose not in {"initial", "recovery", "continuation"}:
+            raise ValueError("invalid dispatch purpose")
+        requested_budgets = _dispatch_budgets(
+            self.dispatch_budgets if budgets is None else budgets,
+        )
+        key = resolution.key
+        permit: DispatchPermit
+        with ExitStack() as locks:
+            # Hold final message publication across replay synchronization and
+            # reservation CAS. A canonically published terminal can never be
+            # hidden merely because its eager projection hook failed or waited.
+            locks.enter_context(self.store._message_publication_lock())
+            self._validated_messages()
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"),
+                    timeout=10.0,
+                ),
+            )
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            admission = self._validate_dispatch_authority(
+                ledger,
+                admission,
+                key,
+                resolution,
+            )
+            total = int(admission.get("paid_dispatches_total", 0))
+            if nonce is None:
+                pending = [
+                    (stored_nonce, row)
+                    for stored_nonce, row in admission.get("reservations", {}).items()
+                    if isinstance(row, dict)
+                    and row.get("purpose") == purpose
+                    and row.get("state") == "reserved"
+                ]
+                if len(pending) == 1:
+                    nonce = pending[0][0]
+                else:
+                    nonce = hashlib.sha256(
+                        f"{key.digest}:{purpose}:{total + 1}".encode("utf-8"),
+                    ).hexdigest()[:32]
+            if not self._valid_dispatch_nonce(nonce):
+                raise DispatchRefused("dispatch nonce is invalid")
+            request_digest = self._dispatch_request_digest(
+                key,
+                purpose,
+                requested_budgets,
+                admission.get("activation_generation"),
+                admission.get("readiness_generation"),
+            )
+            nonce_index = ledger["dispatch_nonces"].get(nonce)
+            if isinstance(nonce_index, dict):
+                if nonce_index.get("request_digest") != request_digest:
+                    self._append(
+                        ledger,
+                        "ACTION_REJECTED",
+                        key_digest=key.digest,
+                        data={"reason": "dispatch_nonce_reused_for_different_request"},
+                    )
+                    self._write(ledger)
+                    raise DispatchRefused("dispatch nonce was reused for another request")
+                existing = admission.get("reservations", {}).get(nonce)
+                if not isinstance(existing, dict):
+                    raise DispatchRefused("dispatch nonce index is torn")
+                permit = self._permit_from_reservation(key.digest, nonce, existing)
+            else:
+                if isinstance(admission.get("broadcast_policy_close_pending"), dict):
+                    raise DispatchRefused(
+                        "broadcast policy is satisfied; only the reserved call may finish"
+                    )
+                if (
+                    int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+                    != resolution.scoped_revision
+                ):
+                    raise StaleRevision("scoped replay revision changed before dispatch")
+                if self._reconcile_closed_dispatch_slots_locked(ledger):
+                    # Persist capacity recovery before any subsequent refusal or
+                    # new reservation. A crash cannot resurrect a leaked slot.
+                    self._write(ledger)
+                active = 0
+                for candidate in ledger["obligations"].values():
+                    if not isinstance(candidate, dict):
+                        continue
+                    candidate_key = self._key_from(candidate.get("key"))
+                    if candidate_key.responder != self.agent:
+                        continue
+                    active += sum(
+                        1
+                        for row in candidate.get("reservations", {}).values()
+                        if isinstance(row, dict)
+                        and row.get("state") in {"reserved", "dispatching"}
+                    )
+                if active >= requested_budgets["concurrency"]:
+                    raise DispatchRefused("dispatch concurrency budget exhausted")
+                if total >= MAX_PAID_DISPATCHES_TOTAL:
+                    raise DispatchRefused("paid dispatch budget exhausted")
+                if purpose == "initial" and total != 0:
+                    raise DispatchRefused("initial dispatch already reserved")
+                if purpose != "initial":
+                    if total != 1 or admission.get("first_dispatch_classified") is not True:
+                        raise DispatchRefused(
+                            "extra dispatch requires one durably classified first attempt",
+                        )
+                    if any(
+                        isinstance(row, dict)
+                        and row.get("state") == "completed"
+                        and row.get("action_attempted") is True
+                        for row in admission.get("reservations", {}).values()
+                    ):
+                        raise DispatchRefused(
+                            "corrected retry requires durable rejection classification",
+                        )
+                scheduled = admission.get("durable_continuation")
+                if purpose == "recovery" and (
+                    admission.get("continuation_used")
+                    or isinstance(scheduled, dict) and scheduled.get("state") == "scheduled"
+                ):
+                    raise DispatchRefused("second dispatch is assigned to continuation")
+                if purpose == "continuation" and (
+                    admission.get("recovery_used")
+                    or not isinstance(scheduled, dict)
+                    or scheduled.get("state") != "scheduled"
+                ):
+                    raise DispatchRefused("second dispatch is not a scheduled continuation")
+                composing_nonce = hashlib.sha256(
+                    f"{nonce}:composing".encode("utf-8"),
+                ).hexdigest()[:32]
+                draft = self.drafts / f"{key.inbound_id}.{nonce}.txt"
+                admission["paid_dispatches_total"] = total + 1
+                subtype = {
+                    "initial": "paid_initial_dispatches_total",
+                    "recovery": "paid_recoveries_total",
+                    "continuation": "paid_continuations_total",
+                }[purpose]
+                admission[subtype] = int(admission.get(subtype, 0)) + 1
+                if purpose != "initial":
+                    admission[f"{purpose}_used"] = True
+                if purpose == "continuation":
+                    scheduled["state"] = "reserved"
+                    scheduled["dispatch_nonce"] = nonce
+                budgets_digest = hashlib.sha256(
+                    _canonical(requested_budgets).encode("utf-8"),
+                ).hexdigest()
+                reservation = {
+                    "purpose": purpose,
+                    "state": "reserved",
+                    "at": self.now(),
+                    "scoped_revision": resolution.scoped_revision,
+                    "draft_path": str(draft),
+                    "composing_nonce": composing_nonce,
+                    "paid_dispatches_total": total + 1,
+                    "budgets": requested_budgets,
+                    "budgets_digest": budgets_digest,
+                    "request_digest": request_digest,
+                    "reserved_fence": self.fence,
+                }
+                admission["reservations"][nonce] = reservation
+                ledger["dispatch_nonces"][nonce] = {
+                    "key_digest": key.digest,
+                    "request_digest": request_digest,
+                }
+                self._append(
+                    ledger,
+                    "DISPATCH_RESERVED",
+                    scope=key.inbound_id,
+                    key_digest=key.digest,
+                    data={
+                        "nonce": nonce,
+                        "purpose": purpose,
+                        "total": total + 1,
+                        "budgets_digest": budgets_digest,
+                    },
+                )
+                self._write(ledger)
+                permit = self._permit_from_reservation(key.digest, nonce, reservation)
+        permit.draft_path.parent.mkdir(parents=True, exist_ok=True)
+        return permit
+
+    def next_dispatch_purpose(self, key: ObligationKey) -> str | None:
+        try:
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"),
+                timeout=10.0,
+            ):
+                ledger = self._load(create=False)
+                admission = ledger["obligations"].get(key.digest)
+                if not isinstance(admission, dict) or admission.get("state") != "open":
+                    return None
+                if admission.get("fence") != self.fence or not self._live_dispatch_fence_owned():
+                    return None
+                reservations = admission.get("reservations", {})
+                pending = [
+                    row
+                    for row in reservations.values()
+                    if isinstance(row, dict) and row.get("state") == "reserved"
+                ]
+                if len(pending) == 1:
+                    return str(pending[0].get("purpose"))
+                changed = False
+                for nonce, row in reservations.items():
+                    if not isinstance(row, dict) or row.get("state") != "dispatching":
+                        continue
+                    if row.get("dispatch_fence") == self.fence:
+                        continue
+                    if not isinstance(row.get("dispatch_fence"), str):
+                        return None
+                    row["state"] = "dispatch_result_missing"
+                    row["result_missing_at"] = self.now()
+                    admission["first_dispatch_classified"] = True
+                    admission["owed_action_missing_seen"] = True
+                    admission["last_exhaustion_class"] = "infrastructure"
+                    self._append(
+                        ledger,
+                        "DISPATCH_RESULT_MISSING",
+                        key_digest=key.digest,
+                        data={"nonce": nonce, "purpose": row.get("purpose")},
+                    )
+                    changed = True
+                if changed:
+                    self._write(ledger)
+                if any(
+                    isinstance(row, dict) and row.get("state") == "dispatching"
+                    for row in reservations.values()
+                ):
+                    return None
+                if isinstance(admission.get("broadcast_policy_close_pending"), dict):
+                    self._complete_pending_broadcast_close_locked(
+                        ledger,
+                        admission,
+                        key,
+                    )
+                    self._write(ledger)
+                    return None
+                if any(
+                    isinstance(row, dict) and row.get("state") == "action_infra"
+                    for row in reservations.values()
+                ):
+                    return None
+                total = int(admission.get("paid_dispatches_total", 0))
+                if total == 0:
+                    return "initial"
+                if total != 1 or admission.get("first_dispatch_classified") is not True:
+                    return None
+                if any(
+                    isinstance(row, dict)
+                    and row.get("state") == "completed"
+                    and row.get("action_attempted") is True
+                    for row in reservations.values()
+                ):
+                    return None
+                continuation = admission.get("durable_continuation")
+                if (
+                    isinstance(continuation, dict)
+                    and continuation.get("state") == "scheduled"
+                ):
+                    return "continuation"
+                if not admission.get("continuation_used") and not admission.get(
+                    "recovery_used",
+                ):
+                    return "recovery"
+                return None
+        except LedgerUnreadable:
+            return None
+
+    def dispatch_record(self, record: dict, permit: DispatchPermit) -> dict:
+        """Durably arm one permit, then add wrapper-owned transport facts."""
+        decorated = dict(record)
+        executable = self._pinned_executable()
+        with self.store._config_lock(timeout=10.0):
+            cfg = self.store.load_config()
+            roster = _roster_snapshot(cfg)
+            recipient = cfg.get("operator_facing")
+            if not isinstance(recipient, str) or recipient not in roster[
+                "authorized_liaisons"
+            ]:
+                candidates = [
+                    candidate for candidate in roster["authorized_liaisons"]
+                    if candidate != self.agent
+                ]
+                recipient = candidates[0] if len(candidates) == 1 else None
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0
+            ):
+                ledger = self._load(create=False)
+                admission = ledger["obligations"].get(permit.key_digest)
+                if not isinstance(admission, dict):
+                    raise DispatchRefused("dispatch admission disappeared")
+                key = self._key_from(admission["key"])
+                current_revision = int(
+                    ledger["scoped_revisions"].get(key.inbound_id, 0),
+                )
+                self._validate_dispatch_authority(
+                    ledger,
+                    admission,
+                    key,
+                    Resolution(
+                        ResolverState.OWED_UNSATISFIED,
+                        "dispatch permit revalidation",
+                        key,
+                        scoped_revision=current_revision,
+                        activation_generation=str(admission.get("activation_generation")),
+                        readiness_generation=str(admission.get("readiness_generation")),
+                    ),
+                )
+                reservation = admission.get("reservations", {}).get(permit.nonce)
+                if (
+                    not isinstance(reservation, dict)
+                    or reservation.get("state") != "reserved"
+                    or reservation.get("purpose") != permit.purpose
+                    or reservation.get("composing_nonce") != permit.composing_nonce
+                    or reservation.get("budgets_digest") != permit.budgets_digest
+                    or Path(str(reservation.get("draft_path", ""))) != permit.draft_path
+                    or int(reservation.get("paid_dispatches_total", 0))
+                    != permit.paid_dispatches_total
+                ):
+                    raise DispatchRefused(
+                        "dispatch permit draft path or authority does not match its reservation",
+                    )
+                obligation_class = admission.get("obligation_class")
+                record_meta = (
+                    record.get("meta") if isinstance(record.get("meta"), dict) else {}
+                )
+                if obligation_class == "human_escalation":
+                    if not isinstance(recipient, str) or recipient == self.agent:
+                        raise DispatchRefused(
+                            "human escalation has no external operator target"
+                        )
+                    operation_intent = {
+                        "operation": "terminal",
+                        "kind": "question",
+                        "recipient": recipient,
+                        "in_reply_to": record.get("id"),
+                        "request_id": f"esc-{permit.nonce[:12]}",
+                        "broadcast_id": None,
+                        "origin_request_id": record.get("correlation_id"),
+                        "origin_inbound_id": record.get("id"),
+                        "origin_obligation_key_digest": key.digest,
+                        "expected_roster_revision": roster["revision"],
+                    }
+                else:
+                    operation_intent = {
+                        "operation": "terminal",
+                        "kind": "message",
+                        "recipient": key.requester,
+                        "in_reply_to": record.get("id"),
+                        "request_id": record_meta.get("request_id"),
+                        "broadcast_id": record_meta.get("broadcast_id"),
+                        "origin_request_id": None,
+                        "origin_inbound_id": None,
+                    }
+                reservation["state"] = "dispatching"
+                reservation["dispatch_started_at"] = self.now()
+                reservation["dispatch_fence"] = self.fence
+                reservation["dispatch_owner_pid"] = os.getpid()
+                reservation["operation_intent"] = operation_intent
+                self._append(
+                    ledger,
+                    "DISPATCH_ATTEMPT_STARTED",
+                    key_digest=permit.key_digest,
+                    data={"nonce": permit.nonce, "purpose": permit.purpose},
+                )
+                self._write(ledger)
+                requested_budgets = dict(reservation["budgets"])
+        if obligation_class == "human_escalation":
+            argv = [
+                executable,
+                "-m",
+                "agenttalk",
+                "escalate",
+                "--from",
+                self.agent,
+                "--to",
+                str(operation_intent["recipient"]),
+                "--origin-request",
+                str(record.get("correlation_id")),
+                "--origin-id",
+                str(record.get("id")),
+                "--meta",
+                f"request_id={operation_intent['request_id']}",
+                "--meta",
+                (
+                    "expected_roster_revision="
+                    f"{operation_intent['expected_roster_revision']}"
+                ),
+                "--meta",
+                (
+                    "origin_obligation_key_digest="
+                    f"{operation_intent['origin_obligation_key_digest']}"
+                ),
+                "--operation-nonce",
+                permit.nonce,
+                "--file",
+                str(permit.draft_path),
+            ]
+        else:
+            argv = [
+                executable,
+                "-m",
+                "agenttalk",
+                "reply",
+                "--from",
+                self.agent,
+                "--to-id",
+                str(record.get("id")),
+                "--operation-nonce",
+                permit.nonce,
+                "--file",
+                str(permit.draft_path),
+            ]
+        decorated["owed_action"] = {
+            "grade": "detection",
+            "obligation_key_digest": permit.key_digest,
+            "dispatch_nonce": permit.nonce,
+            "terminal_operation_nonce": permit.nonce,
+            "composing_operation_nonce": permit.composing_nonce,
+            "purpose": permit.purpose,
+            "budgets": requested_budgets,
+            "exact_inbound_id": record.get("id"),
+            "draft_path": str(permit.draft_path),
+            "argv": argv,
+            "composing_argv": [
+                executable,
+                "-m",
+                "agenttalk",
+                "composing",
+                "--from",
+                self.agent,
+                "--to-request",
+                str(record.get("correlation_id")),
+                "--meta",
+                f"in_reply_to={record.get('id')}",
+                "--operation-nonce",
+                permit.composing_nonce,
+            ],
+            "body_transport": "structured-write-then-file",
+        }
+        return decorated
+
+    @staticmethod
+    def _pinned_executable() -> str:
+        executable = Path(os.environ.get("AGENTTALK_PY") or os.sys.executable).expanduser()
+        if not executable.is_absolute():
+            raise DispatchRefused("AGENTTALK_PY must name an absolute executable")
+        try:
+            resolved = executable.resolve(strict=True)
+        except OSError as exc:
+            raise DispatchRefused("AGENTTALK_PY executable is unavailable") from exc
+        if executable.is_symlink() or not resolved.is_file():
+            raise DispatchRefused("AGENTTALK_PY must name a regular non-symlink file")
+        return str(resolved)
+
+    def dispatch_exhausted(self, key: ObligationKey) -> bool:
+        try:
+            ledger = self._load(create=False)
+        except LedgerUnreadable:
+            return False
+        admission = ledger["obligations"].get(key.digest)
+        return bool(
+            isinstance(admission, dict)
+            and int(admission.get("paid_dispatches_total", 0))
+            >= MAX_PAID_DISPATCHES_TOTAL
+        )
+
+    def _breaker_state(self, ledger: dict) -> dict:
+        breaker = ledger["breakers"].setdefault(self.agent, {
+            "generation": 0,
+            "owed_action_cap_exhaustions_consecutive": 0,
+            "proof_infra_exhaustions_consecutive": 0,
+            "compliance_exhaustion_references": [],
+            "tripped": False,
+            "config_blocked": False,
+            "config_blocked_reason": None,
+            "alerted_generation": None,
+            "alerts": {},
+        })
+        breaker.setdefault("alerts", {})
+        return breaker
+
+    def _project_compliance_breaker_hold(self) -> None:
+        self.store.write_config_blocked_hold(
+            self.agent,
+            summary="owed_action_compliance_breaker",
+        )
+
+    def _clear_compliance_breaker_hold(self) -> None:
+        hold = self.store.read_config_blocked_hold(self.agent)
+        if (
+            isinstance(hold, dict)
+            and hold.get("summary") == "owed_action_compliance_breaker"
+        ):
+            self.store.clear_config_blocked_hold(self.agent)
+
+    def _reconcile_compliance_breaker_alert(self) -> bool:
+        """Publish and acknowledge one durable alert outbox row idempotently."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load(create=False)
+            breaker = ledger["breakers"].get(self.agent)
+            if not isinstance(breaker, dict) or breaker.get("tripped") is not True:
+                return False
+            generation = int(breaker.get("generation", 0))
+            alerts = breaker.get("alerts")
+            alert = alerts.get(str(generation)) if isinstance(alerts, dict) else None
+            if not isinstance(alert, dict):
+                return False
+            if alert.get("state") == "delivered":
+                return True
+            nonce = str(alert.get("nonce", ""))
+            body = str(alert.get("body", ""))
+            request_id = str(alert.get("request_id", ""))
+            pinned_target = alert.get("recipient")
+        candidate = None
+        if not isinstance(pinned_target, str) or not pinned_target:
+            candidate = self.store.operator_facing() or self.store.sole_lead()
+
+        # Route the outbox row once, before publication. A crash after the bus
+        # append must retry the same nonce *and* the same operation identity,
+        # even if liaison routing changes before the next wrapper generation.
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load(create=False)
+            breaker = ledger["breakers"].get(self.agent)
+            if not isinstance(breaker, dict) or breaker.get("tripped") is not True:
+                return False
+            alerts = breaker.get("alerts")
+            current = alerts.get(str(generation)) if isinstance(alerts, dict) else None
+            if not isinstance(current, dict) or current.get("nonce") != nonce:
+                return False
+            if current.get("state") == "delivered":
+                return True
+            target = current.get("recipient")
+            if not isinstance(target, str) or not target:
+                target = candidate
+            if not isinstance(target, str) or not target or target == self.agent:
+                return False
+            digest = operation_payload_digest(
+                operation="terminal",
+                body=body,
+                kind="question",
+                recipient=target,
+                request_id=request_id,
+            )
+            stored_digest = current.get("operation_digest")
+            if isinstance(stored_digest, str) and stored_digest != digest:
+                return False
+            if current.get("recipient") != target or stored_digest != digest:
+                current["recipient"] = target
+                current["operation_digest"] = digest
+                self._append(
+                    ledger,
+                    "COMPLIANCE_BREAKER_ALERT_ROUTED",
+                    data={
+                        "agent": self.agent,
+                        "generation": generation,
+                        "recipient": target,
+                        "operation_digest": digest,
+                    },
+                )
+                self._write(ledger)
+        meta = {
+            "needs_operator": "true",
+            "request_id": request_id,
+            "compliance_breaker_alert_generation": generation,
+            "compliance_breaker_agent": self.agent,
+        }
+        try:
+            message, _published = self.store.send_operation(
+                sender=self.agent,
+                recipient=target,
+                body=body,
+                kind="question",
+                subject=f"owed-action compliance breaker: {self.agent}",
+                meta=meta,
+                operation_nonce=nonce,
+                operation_digest=digest,
+            )
+        except (OSError, TimeoutError, ValueError):
+            return False
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load(create=False)
+            breaker = ledger["breakers"].get(self.agent)
+            alerts = breaker.get("alerts") if isinstance(breaker, dict) else None
+            current = alerts.get(str(generation)) if isinstance(alerts, dict) else None
+            if not isinstance(current, dict) or current.get("nonce") != nonce:
+                return False
+            if current.get("state") != "delivered":
+                current["state"] = "delivered"
+                current["message_id"] = message.id
+                current["delivered_at"] = self.now()
+                current["recipient"] = target
+                current["operation_digest"] = digest
+                breaker["alerted_generation"] = generation
+                self._append(
+                    ledger,
+                    "COMPLIANCE_BREAKER_ALERT",
+                    data={
+                        "agent": self.agent,
+                        "generation": generation,
+                        "message_id": message.id,
+                    },
+                )
+                self._write(ledger)
+            return True
+
+    def _reset_compliance_streak_locked(
+        self,
+        ledger: dict,
+        key: ObligationKey,
+    ) -> bool:
+        breaker = ledger["breakers"].get(self.agent)
+        if not isinstance(breaker, dict) or breaker.get("tripped") is True:
+            return False
+        if (
+            int(breaker.get("owed_action_cap_exhaustions_consecutive", 0)) == 0
+            and not breaker.get("compliance_exhaustion_references")
+        ):
+            return False
+        breaker["owed_action_cap_exhaustions_consecutive"] = 0
+        breaker["compliance_exhaustion_references"] = []
+        self._append(
+            ledger,
+            "COMPLIANCE_STREAK_RESET",
+            key_digest=key.digest,
+        )
+        return True
+
+    def mark_satisfied(self, key: ObligationKey) -> None:
+        """A successful delivery resets only the compliance-dominant streak."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            if self._reset_compliance_streak_locked(ledger, key):
+                self._write(ledger)
+
+    def reset_compliance_breaker(self, *, actor: str, reason: str) -> None:
+        if actor not in {self.store.operator_facing(), self.store.sole_lead()}:
+            raise PermissionError("breaker reset requires the liaison or lead")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("breaker reset requires an audit reason")
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            breaker = self._breaker_state(ledger)
+            breaker["generation"] = int(breaker.get("generation", 0)) + 1
+            breaker["tripped"] = False
+            breaker["config_blocked"] = False
+            breaker["config_blocked_reason"] = None
+            breaker["owed_action_cap_exhaustions_consecutive"] = 0
+            breaker["compliance_exhaustion_references"] = []
+            breaker["reset_at"] = self.now()
+            breaker["reset_by"] = actor
+            self._append(
+                ledger,
+                "COMPLIANCE_BREAKER_RESET",
+                data={
+                    "agent": self.agent,
+                    "actor": actor,
+                    "reason": reason.strip(),
+                    "generation": breaker["generation"],
+                },
+            )
+            self._write(ledger)
+        self._clear_compliance_breaker_hold()
+
+    def mark_dispatch_result(
+        self,
+        permit: DispatchPermit,
+        *,
+        action_attempted: bool,
+        action_rejected: bool = False,
+        action_infra: bool = False,
+    ) -> None:
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(permit.key_digest)
+            if not isinstance(admission, dict):
+                raise GateError("dispatch admission disappeared")
+            reservation = admission["reservations"].get(permit.nonce)
+            if not isinstance(reservation, dict):
+                raise GateError("dispatch reservation disappeared")
+            if reservation.get("state") != "dispatching":
+                raise GateError("dispatch result has no durable attempt barrier")
+            reservation["state"] = "completed"
+            reservation["action_attempted"] = action_attempted
+            admission["first_dispatch_classified"] = True
+            if action_infra:
+                transition = "ACTION_ATTEMPT_INFRA"
+                admission["last_exhaustion_class"] = "infrastructure"
+                payload_digest = self._captured_payload_digest(reservation, permit.nonce)
+                if payload_digest is not None:
+                    reservation["state"] = "action_infra"
+                    reservation["operation_payload_digest"] = payload_digest
+                    admission["operation_infra_attempts"] = max(
+                        1,
+                        int(admission.get("operation_infra_attempts", 0)),
+                    )
+                    admission["operation_infra_first_at"] = (
+                        admission.get("operation_infra_first_at") or self.now()
+                    )
+                else:
+                    reservation["state"] = "uncaptured_infra"
+            elif action_rejected:
+                transition = "ACTION_REJECTED"
+                reservation["state"] = "action_rejected"
+                admission["owed_action_missing_seen"] = True
+                admission["last_exhaustion_class"] = "compliance"
+            else:
+                transition = "ACTION_ATTEMPTED" if action_attempted else "OWED_ACTION_MISSING"
+                admission["last_exhaustion_class"] = "compliance"
+                if not action_attempted:
+                    admission["owed_action_missing_seen"] = True
+            self._append(ledger, transition, key_digest=permit.key_digest)
+            if isinstance(admission.get("broadcast_policy_close_pending"), dict):
+                key = self._key_from(admission["key"])
+                self._complete_pending_broadcast_close_locked(
+                    ledger,
+                    admission,
+                    key,
+                )
+            self._write(ledger)
+
+    def mark_unsatisfied_attempt(self, permit: DispatchPermit, *, reason: str) -> None:
+        """Classify an attempted operation that could not legally close this obligation."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(permit.key_digest)
+            row = admission.get("reservations", {}).get(permit.nonce) if isinstance(
+                admission, dict
+            ) else None
+            if not isinstance(admission, dict) or not isinstance(row, dict):
+                raise GateError("dispatch reservation disappeared")
+            if row.get("state") == "action_rejected":
+                return
+            if row.get("state") != "completed":
+                raise GateError("unsatisfied action is not durably classified")
+            admission["owed_action_missing_seen"] = True
+            admission["last_exhaustion_class"] = "compliance"
+            row["state"] = "action_rejected"
+            row["rejection_reason"] = reason
+            self._append(
+                ledger,
+                "ACTION_REJECTED",
+                key_digest=permit.key_digest,
+                data={"reason": reason},
+            )
+            self._write(ledger)
+
+    def captured_operation(self, key: ObligationKey) -> DispatchPermit | None:
+        try:
+            ledger = self._load(create=False)
+        except LedgerUnreadable:
+            return None
+        admission = ledger["obligations"].get(key.digest)
+        if not isinstance(admission, dict) or admission.get("state") != "open":
+            return None
+        for nonce, row in admission.get("reservations", {}).items():
+            if (
+                not isinstance(row, dict)
+                or row.get("state") != "action_infra"
+                or not isinstance(row.get("operation_payload_digest"), str)
+            ):
+                continue
+            return DispatchPermit(
+                key.digest,
+                nonce,
+                str(row.get("composing_nonce", "")),
+                row.get("purpose", "recovery"),
+                int(admission.get("paid_dispatches_total", 0)),
+                Path(row["draft_path"]),
+                str(row.get("budgets_digest", "")),
+            )
+        return None
+
+    def mark_captured_operation_succeeded(self, permit: DispatchPermit) -> None:
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(permit.key_digest)
+            row = admission.get("reservations", {}).get(permit.nonce) if isinstance(admission, dict) else None
+            if (
+                not isinstance(row, dict)
+                or row.get("state") != "action_infra"
+                or admission.get("operation_infra_retry_inflight") is not True
+            ):
+                raise GateError("captured operation disappeared")
+            row["state"] = "completed"
+            admission["operation_infra_retry_inflight"] = False
+            self._append(ledger, "CAPTURED_OPERATION_LANDED", key_digest=permit.key_digest)
+            self._write(ledger)
+
+    @staticmethod
+    def cleanup_permit(permit: DispatchPermit) -> None:
+        try:
+            permit.draft_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def retry_captured_operation(self, permit: DispatchPermit, record: dict) -> bool:
+        """Retry the fixed file-based reply operation without another model call."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load(create=False)
+            admission = ledger["obligations"].get(permit.key_digest)
+            if not isinstance(admission, dict):
+                raise DispatchRefused("captured operation admission disappeared")
+            key = self._key_from(admission["key"])
+            self._validate_dispatch_authority(
+                ledger,
+                admission,
+                key,
+                Resolution(
+                    ResolverState.OWED_UNSATISFIED,
+                    "captured operation revalidation",
+                    key,
+                    activation_generation=str(admission.get("activation_generation")),
+                    readiness_generation=str(admission.get("readiness_generation")),
+                ),
+            )
+            row = admission.get("reservations", {}).get(permit.nonce)
+            if (
+                not isinstance(row, dict)
+                or row.get("state") != "action_infra"
+                or row.get("budgets_digest") != permit.budgets_digest
+                or admission.get("operation_infra_retry_inflight") is not True
+                or not isinstance(row.get("operation_payload_digest"), str)
+                or Path(str(row.get("draft_path", ""))) != permit.draft_path
+                or not isinstance(row.get("operation_intent"), dict)
+            ):
+                raise DispatchRefused("captured operation retry is not durably reserved")
+            expected_payload_digest = row["operation_payload_digest"]
+            operation_intent = dict(row["operation_intent"])
+            obligation_class = admission.get("obligation_class")
+        draft = Path(str(row["draft_path"]))
+        try:
+            resolved = draft.resolve(strict=True)
+            root = self.drafts.resolve(strict=True)
+            resolved.relative_to(root)
+            if draft.is_symlink() or resolved.stat().st_size > 1024 * 1024:
+                return False
+            resolved.read_text(encoding="utf-8")
+        except (OSError, UnicodeError, ValueError):
+            return False
+        if self._captured_payload_digest(row, permit.nonce) != expected_payload_digest:
+            return False
+        executable = self._pinned_executable()
+        if obligation_class == "human_escalation":
+            argv = [
+                executable,
+                "-m",
+                "agenttalk",
+                "escalate",
+                "--from",
+                self.agent,
+                "--to",
+                str(operation_intent["recipient"]),
+                "--origin-request",
+                str(operation_intent["origin_request_id"]),
+                "--origin-id",
+                str(operation_intent["origin_inbound_id"]),
+                "--meta",
+                f"request_id={operation_intent['request_id']}",
+                "--meta",
+                (
+                    "expected_roster_revision="
+                    f"{operation_intent['expected_roster_revision']}"
+                ),
+                "--meta",
+                (
+                    "origin_obligation_key_digest="
+                    f"{operation_intent['origin_obligation_key_digest']}"
+                ),
+                "--operation-nonce",
+                permit.nonce,
+                "--file",
+                str(resolved),
+            ]
+        else:
+            argv = [
+                executable,
+                "-m",
+                "agenttalk",
+                "reply",
+                "--from",
+                self.agent,
+                "--to-id",
+                str(operation_intent["in_reply_to"]),
+                "--operation-nonce",
+                permit.nonce,
+                "--file",
+                str(resolved),
+            ]
+        completed = subprocess.run(  # noqa: S603  # nosec B603
+            argv,
+            cwd=self.store.root,
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30.0,
+            check=False,
+            shell=False,
+        )
+        return completed.returncode == 0
+
+    def record_retry_barrier(
+        self,
+        key: ObligationKey,
+        *,
+        category: str,
+        expected_revision: int,
+        completed_attempt: bool = False,
+    ) -> bool:
+        """Durably count a non-paid retry before allowing it to occur."""
+        if category not in {"operation_infra", "finalization"}:
+            raise ValueError("unknown retry category")
+        # Store.send() holds this same publication lock through its eager ledger
+        # hook.  Taking it before replay closes the terminal-append versus retry
+        # reservation window without inverting the publication -> ledger order.
+        with self.store._message_publication_lock():
+            try:
+                self._validated_messages()
+            except LedgerUnreadable:
+                return False
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                ledger = self._load()
+                admission = ledger["obligations"].get(key.digest)
+                if not isinstance(admission, dict):
+                    raise GateError("retry admission missing")
+                if any((
+                    admission.get("state") != "open",
+                    admission.get("fence") != self.fence,
+                    not self._live_dispatch_fence_owned(),
+                    not self._dispatch_head_is_current(admission, key),
+                    int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+                    != expected_revision,
+                )):
+                    return False
+                count_name = (
+                    f"{category}_attempts"
+                    if category == "operation_infra"
+                    else "finalization_misses"
+                )
+                first_name = f"{category}_first_at"
+                inflight_name = f"{category}_retry_inflight"
+                count = int(admission.get(count_name, 0))
+                now_text = self.now()
+                first = _epoch(admission.get(first_name))
+                now = _epoch(now_text)
+                elapsed = 0.0 if first is None or now is None else max(0.0, now - first)
+                limit = (
+                    MAX_OPERATION_INFRA_ATTEMPTS
+                    if category == "operation_infra"
+                    else MAX_FINALIZATION_MISSES
+                )
+                elapsed_limit = (
+                    MAX_OPERATION_INFRA_SECONDS
+                    if category == "operation_infra"
+                    else MAX_FINALIZATION_SECONDS
+                )
+                changed = False
+                if admission.get(inflight_name):
+                    if not completed_attempt:
+                        self._append(
+                            ledger,
+                            "OPERATION_RETRY_OUTCOME_MISSING"
+                            if category == "operation_infra"
+                            else "FINALIZATION_RETRY_OUTCOME_MISSING",
+                            key_digest=key.digest,
+                            data={"prior_count": count},
+                        )
+                    admission[inflight_name] = False
+                    changed = True
+                if count >= limit or elapsed >= elapsed_limit:
+                    if changed:
+                        self._write(ledger)
+                    return False
+                admission[count_name] = count + 1
+                admission[first_name] = admission.get(first_name) or now_text
+                admission[inflight_name] = True
+                self._append(
+                    ledger,
+                    "OPERATION_RETRY_RECORDED"
+                    if category == "operation_infra"
+                    else "FINALIZATION_MISS_RECORDED",
+                    key_digest=key.digest,
+                    data={"count": admission[count_name]},
+                )
+                self._write(ledger)
+                return True
+
+    def complete_retry_barrier(self, key: ObligationKey, *, category: str) -> None:
+        if category not in {"operation_infra", "finalization"}:
+            raise ValueError("unknown retry category")
+        inflight_name = f"{category}_retry_inflight"
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if not isinstance(admission, dict):
+                raise GateError("retry admission missing")
+            if admission.get(inflight_name):
+                admission[inflight_name] = False
+                self._append(
+                    ledger,
+                    "RETRY_ATTEMPT_COMPLETED",
+                    key_digest=key.digest,
+                    data={"category": category},
+                )
+                self._write(ledger)
+
+    def retry_bound_exhausted(self, key: ObligationKey, *, category: str) -> bool:
+        """Distinguish a spent durable bound from a stale retry reservation."""
+        if category not in {"operation_infra", "finalization"}:
+            raise ValueError("unknown retry category")
+        count_name = (
+            f"{category}_attempts"
+            if category == "operation_infra"
+            else "finalization_misses"
+        )
+        first_name = f"{category}_first_at"
+        limit = (
+            MAX_OPERATION_INFRA_ATTEMPTS
+            if category == "operation_infra"
+            else MAX_FINALIZATION_MISSES
+        )
+        elapsed_limit = (
+            MAX_OPERATION_INFRA_SECONDS
+            if category == "operation_infra"
+            else MAX_FINALIZATION_SECONDS
+        )
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            admission = self._load()["obligations"].get(key.digest)
+            if not isinstance(admission, dict):
+                return False
+            first = _epoch(admission.get(first_name))
+            now = _epoch(self.now())
+            elapsed = 0.0 if first is None or now is None else max(0.0, now - first)
+            return int(admission.get(count_name, 0)) >= limit or elapsed >= elapsed_limit
+
+    def mark_blocked(self, key: ObligationKey, *, reason: str) -> Resolution:
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if not isinstance(admission, dict):
+                raise GateError("blocked obligation admission missing")
+            if admission.get("state") == "blocked":
+                return Resolution(
+                    ResolverState.BLOCKED,
+                    str(admission.get("blocked_reason") or reason),
+                    key,
+                )
+            if admission.get("state") != "open":
+                raise GateError("blocked obligation is no longer open")
+            admission["state"] = "blocked"
+            admission["blocked_reason"] = reason
+            self._append(
+                ledger,
+                "OBLIGATION_BLOCKED",
+                scope=key.inbound_id,
+                key_digest=key.digest,
+                data={"reason": reason},
+            )
+            self._write(ledger)
+        return Resolution(ResolverState.BLOCKED, reason, key)
+
+    def _record_disposition_block(self, *, reason: str) -> None:
+        now_text = self.now()
+        lock = self.proof_health_path.with_suffix(".lock")
+        with self.store._exclusive_lock(lock, timeout=10.0):
+            try:
+                health = json.loads(
+                    self.proof_health_path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError, json.JSONDecodeError):
+                health = {}
+            if not isinstance(health, dict):
+                health = {}
+            health.update({
+                "state": "blocked",
+                "disposition_block": True,
+                "reason": reason,
+                "last_failure_at": now_text,
+                "alerted": True,
+            })
+            health.setdefault("first_failure_at", now_text)
+            self.proof_health_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(
+                self.proof_health_path,
+                json.dumps(health, indent=2, ensure_ascii=False),
+            )
+
+    def _block_retry_exhaustion(
+        self,
+        key: ObligationKey,
+        *,
+        reason: str,
+    ) -> Resolution:
+        try:
+            return self.mark_blocked(key, reason=reason)
+        except (GateError, OSError, TimeoutError):
+            self._record_disposition_block(reason=reason)
+            return Resolution(ResolverState.BLOCKED, reason, key)
+
+    def fail_delivery_or_block(
+        self,
+        record: dict,
+        key: ObligationKey,
+        *,
+        reason: str,
+        expected_revision: int,
+    ) -> Resolution:
+        """Commit exact-head failed delivery, or make inability to do so visible."""
+        try:
+            return self.delivery_failed(
+                record,
+                key,
+                reason=reason,
+                expected_revision=expected_revision,
+            )
+        except (GateError, OSError, TimeoutError, ValueError, RuntimeError) as exc:
+            failure = exc
+        try:
+            replayed = self.resolve(record)
+        except (GateError, OSError, TimeoutError, ValueError, RuntimeError) as exc:
+            return self._block_retry_exhaustion(
+                key,
+                reason=f"failed-delivery disposition unavailable: {type(exc).__name__}",
+            )
+        if replayed.terminal:
+            try:
+                finalized = self.finalize(
+                    record,
+                    replayed,
+                    expected_revision=replayed.scoped_revision,
+                )
+            except (GateError, OSError, TimeoutError, ValueError, RuntimeError):
+                return replayed
+            return replayed if finalized.state == ResolverState.INDETERMINATE else finalized
+        if replayed.state == ResolverState.OWED_UNSATISFIED and replayed.key == key:
+            try:
+                # A benign correlated append may have invalidated only the caller's
+                # revision.  Retry the exact-head disposition once at the freshly
+                # replayed revision; publication locking inside delivery_failed()
+                # still gives a concurrently published terminal precedence.
+                return self.delivery_failed(
+                    record,
+                    key,
+                    reason=reason,
+                    expected_revision=replayed.scoped_revision,
+                )
+            except (GateError, OSError, TimeoutError, ValueError, RuntimeError) as exc:
+                failure = exc
+        return self._block_retry_exhaustion(
+            key,
+            reason=f"failed-delivery disposition unavailable: {type(failure).__name__}",
+        )
+
+    def fail_head_local_corruption_or_block(
+        self,
+        record: dict,
+        key: ObligationKey,
+        permit: DispatchPermit,
+        *,
+        reason: str,
+        expected_revision: int,
+    ) -> Resolution:
+        """Dispose only a demonstrably corrupt, exact-head captured artifact.
+
+        A missing/unreadable artifact is ambiguous infrastructure and therefore
+        blocks.  Head-local failed delivery is allowed only when canonical replay
+        is healthy and readable bytes bound to this reservation disagree with the
+        durable operation proof.
+        """
+        proof: dict | None = None
+        with ExitStack() as locks:
+            locks.enter_context(self.store._message_publication_lock())
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return self._block_retry_exhaustion(
+                    key,
+                    reason=f"head-local proof unavailable: {exc}",
+                )
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"), timeout=10.0,
+                )
+            )
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if isinstance(admission, dict):
+                replayed = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=admission,
+                )
+                if replayed.terminal or replayed.state in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                }:
+                    return replayed
+
+            def block_locked(block_reason: str) -> Resolution:
+                if isinstance(admission, dict) and admission.get("state") == "open":
+                    admission["state"] = "blocked"
+                    admission["blocked_reason"] = block_reason
+                    self._append(
+                        ledger,
+                        "OBLIGATION_BLOCKED",
+                        scope=key.inbound_id,
+                        key_digest=key.digest,
+                        data={"reason": block_reason},
+                    )
+                    self._write(ledger)
+                else:
+                    self._record_disposition_block(reason=block_reason)
+                return Resolution(ResolverState.BLOCKED, block_reason, key)
+
+            row = (
+                admission.get("reservations", {}).get(permit.nonce)
+                if isinstance(admission, dict)
+                else None
+            )
+            if (
+                not isinstance(admission, dict)
+                or admission.get("state") != "open"
+                or admission.get("fence") != self.fence
+                or not self._live_dispatch_fence_owned()
+                or not self._dispatch_head_is_current(admission, key)
+                or int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+                != expected_revision
+                or not isinstance(row, dict)
+                or row.get("state") != "action_infra"
+                or permit.key_digest != key.digest
+                or row.get("purpose") != permit.purpose
+                or row.get("composing_nonce") != permit.composing_nonce
+                or row.get("budgets_digest") != permit.budgets_digest
+                or int(row.get("paid_dispatches_total", 0))
+                != permit.paid_dispatches_total
+                or Path(str(row.get("draft_path", ""))) != permit.draft_path
+                or not isinstance(row.get("operation_intent"), dict)
+                or not isinstance(row.get("operation_payload_digest"), str)
+            ):
+                return block_locked(
+                    "head-local corruption authority is stale or incomplete",
+                )
+            marker = self.store.read_operation_intent(self.agent, permit.nonce)
+            try:
+                resolved = permit.draft_path.resolve(strict=True)
+                resolved.relative_to(self.drafts.resolve(strict=True))
+                if permit.draft_path.is_symlink() or resolved.stat().st_size > 1024 * 1024:
+                    raise ValueError("captured draft identity is unsafe")
+                payload = resolved.read_bytes()
+                body = payload.decode("utf-8")
+            except (OSError, UnicodeError, ValueError):
+                return block_locked(
+                    "head-local artifact is unreadable; corruption is unproven",
+                )
+            intent = row["operation_intent"]
+            observed_payload_sha256 = hashlib.sha256(payload).hexdigest()
+            observed_operation_digest = operation_payload_digest(
+                operation=str(intent.get("operation", "")),
+                body=body,
+                kind=str(intent.get("kind", "")),
+                recipient=str(intent.get("recipient", "")),
+                in_reply_to=intent.get("in_reply_to"),
+                request_id=intent.get("request_id"),
+                broadcast_id=intent.get("broadcast_id"),
+                origin_request_id=intent.get("origin_request_id"),
+                origin_inbound_id=intent.get("origin_inbound_id"),
+                origin_obligation_key_digest=intent.get(
+                    "origin_obligation_key_digest"
+                ),
+                expected_roster_revision=intent.get("expected_roster_revision"),
+            )
+            if not isinstance(marker, dict):
+                return block_locked(
+                    "head-local durable operation proof is unavailable",
+                )
+            stable_operation_digest = row["operation_payload_digest"]
+            durable_proofs_agree = all((
+                marker.get("operation_digest") == stable_operation_digest,
+                marker.get("intent_digest")
+                == self.store._operation_intent_digest(intent),
+            ))
+            artifact_disagrees = all((
+                observed_operation_digest != stable_operation_digest,
+                observed_payload_sha256 != marker.get("payload_sha256"),
+            ))
+            if not durable_proofs_agree:
+                return block_locked(
+                    "head-local durable operation proofs disagree",
+                )
+            if not artifact_disagrees:
+                return block_locked(
+                    "head-local artifact corruption is not proven",
+                )
+            proof = {
+                "kind": "HEAD_LOCAL_PROOF_FAILURE",
+                "inbound_id": key.inbound_id,
+                "key_digest": key.digest,
+                "operation_nonce": permit.nonce,
+                "draft_path": str(permit.draft_path),
+                "expected_payload_sha256": marker.get("payload_sha256"),
+                "observed_payload_sha256": observed_payload_sha256,
+                "expected_operation_digest": row.get("operation_payload_digest"),
+                "observed_operation_digest": observed_operation_digest,
+            }
+            admission["head_local_proof_failure"] = proof
+            self._append(
+                ledger,
+                "HEAD_LOCAL_PROOF_FAILURE",
+                scope=key.inbound_id,
+                key_digest=key.digest,
+                data=proof,
+            )
+            self._write(ledger)
+            revision = int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+        return self.fail_delivery_or_block(
+            record,
+            key,
+            reason=reason,
+            expected_revision=revision,
+        )
+
+    def settle_retry_exhaustion(
+        self,
+        record: dict,
+        key: ObligationKey,
+        *,
+        category: str,
+        reason: str,
+        permit: DispatchPermit | None = None,
+    ) -> Resolution:
+        """Replay once at the bound, then choose terminal, local failure, or BLOCKED."""
+        if category not in {"operation_infra", "finalization"}:
+            raise ValueError("unknown retry category")
+        latest = self.resolve(record)
+        if latest.terminal:
+            finalized = self.finalize(
+                record,
+                latest,
+                expected_revision=latest.ledger_revision,
+            )
+            if finalized.state != ResolverState.INDETERMINATE:
+                return finalized
+            raced = self.resolve(record)
+            if raced.terminal:
+                # Keep the canonical terminal authoritative.  The next poll can
+                # retry only its cursor CAS; synthesizing BLOCKED here would mask
+                # the very terminal the exhaustion replay was required to honor.
+                return raced
+            return self._block_retry_exhaustion(
+                key,
+                reason=f"{category} exhaustion raced its final replay",
+            )
+        if latest.state in {
+            ResolverState.BLOCKED,
+            ResolverState.BLOCKED_POLICY,
+            ResolverState.BLOCKED_COMPLIANCE,
+            ResolverState.INDETERMINATE,
+        }:
+            return self._block_retry_exhaustion(
+                key,
+                reason=f"{category} exhaustion: {latest.reason}",
+            )
+        if category == "operation_infra":
+            if permit is None:
+                return self._block_retry_exhaustion(
+                    key,
+                    reason="operation exhaustion locality proof is unavailable",
+                )
+            return self.fail_head_local_corruption_or_block(
+                record,
+                key,
+                permit,
+                reason=reason,
+                expected_revision=latest.scoped_revision,
+            )
+        return self.fail_delivery_or_block(
+            record,
+            key,
+            reason=reason,
+            expected_revision=latest.scoped_revision,
+        )
+
+    def _record_finalization_miss_locked(
+        self,
+        ledger: dict,
+        owner: dict,
+        *,
+        inbound_id: str,
+        key_digest: str | None,
+    ) -> bool:
+        """Persist an observed CAS miss before returning control to the loop."""
+        now_text = self.now()
+        owner["finalization_misses"] = int(owner.get("finalization_misses", 0)) + 1
+        owner["finalization_first_at"] = owner.get("finalization_first_at") or now_text
+        owner["finalization_retry_inflight"] = False
+        first = _epoch(owner.get("finalization_first_at"))
+        now = _epoch(now_text)
+        elapsed = 0.0 if first is None or now is None else max(0.0, now - first)
+        exhausted = (
+            int(owner["finalization_misses"]) >= MAX_FINALIZATION_MISSES
+            or elapsed >= MAX_FINALIZATION_SECONDS
+        )
+        self._append(
+            ledger,
+            "FINALIZATION_MISS_RECORDED",
+            scope=inbound_id,
+            key_digest=key_digest,
+            data={
+                "count": owner["finalization_misses"],
+                "elapsed_seconds": elapsed,
+                "exhausted": exhausted,
+            },
+        )
+        return exhausted
+
+    def _advance_record_cursor(self, record: dict) -> None:
+        if record.get("mode") == "scoped":
+            self.store.mark_thread_seen(
+                self.agent,
+                record["scoped"]["request_id"],
+                record["id"],
+            )
+        else:
+            self.store.advance_cursor(self.agent, record["id"])
+
+    def _cursor_projection_is_complete(self, record: dict) -> bool:
+        inbound_id = record.get("id")
+        if not isinstance(inbound_id, str):
+            return False
+        if record.get("mode") == "scoped":
+            scoped = record.get("scoped")
+            if not isinstance(scoped, dict) or not isinstance(
+                scoped.get("request_id"), str,
+            ):
+                return False
+            return max(
+                self.store.cursor(self.agent),
+                self.store.thread_seen(self.agent, scoped["request_id"]),
+            ) >= inbound_id
+        return self.store.cursor(self.agent) >= inbound_id
+
+    def _cursor_projection_exhausted(self, owner: dict) -> tuple[bool, float]:
+        first = _epoch(owner.get("cursor_projection_first_at"))
+        now = _epoch(self.now())
+        elapsed = 0.0 if first is None or now is None else max(0.0, now - first)
+        return (
+            int(owner.get("cursor_projection_misses", 0))
+            >= MAX_FINALIZATION_MISSES
+            or elapsed >= MAX_FINALIZATION_SECONDS,
+            elapsed,
+        )
+
+    def _record_cursor_projection_miss_locked(
+        self,
+        ledger: dict,
+        owner: dict,
+        *,
+        inbound_id: str,
+        key_digest: str | None,
+        reason: str,
+    ) -> bool:
+        """Persist a projection miss before another projection may be tried."""
+        now_text = self.now()
+        owner["cursor_projection_misses"] = int(
+            owner.get("cursor_projection_misses", 0)
+        ) + 1
+        owner["cursor_projection_first_at"] = (
+            owner.get("cursor_projection_first_at")
+            or owner.get("cursor_projection_reserved_at")
+            or now_text
+        )
+        owner["cursor_projection_inflight"] = False
+        owner["cursor_projection_reserved_at"] = None
+        exhausted, elapsed = self._cursor_projection_exhausted(owner)
+        self._append(
+            ledger,
+            "CURSOR_PROJECTION_MISS_RECORDED",
+            scope=inbound_id,
+            key_digest=key_digest,
+            data={
+                "count": owner["cursor_projection_misses"],
+                "elapsed_seconds": elapsed,
+                "exhausted": exhausted,
+                "reason": reason,
+            },
+        )
+        return exhausted
+
+    def _block_cursor_projection_locked(
+        self,
+        ledger: dict,
+        owner: dict,
+        *,
+        inbound_id: str,
+        key_digest: str | None,
+    ) -> str:
+        reason = "cursor projection retry bound exhausted"
+        owner["cursor_projection_blocked"] = True
+        owner["cursor_projection_blocked_reason"] = reason
+        owner["cursor_projection_inflight"] = False
+        owner["cursor_projection_reserved_at"] = None
+        if not any(
+            event.get("transition") == "CURSOR_PROJECTION_BLOCKED"
+            and event.get("key_digest") == key_digest
+            and event.get("scope") == inbound_id
+            for event in ledger["transitions"]
+        ):
+            self._append(
+                ledger,
+                "CURSOR_PROJECTION_BLOCKED",
+                scope=inbound_id,
+                key_digest=key_digest,
+                data={"reason": reason},
+            )
+        return reason
+
+    def _reserve_cursor_projection_locked(
+        self,
+        ledger: dict,
+        owner: dict,
+        *,
+        inbound_id: str,
+        key_digest: str | None,
+    ) -> str | None:
+        """Reserve the physical cursor side effect, reconciling a crashed attempt."""
+        if owner.get("cursor_projection_blocked") is True:
+            return str(
+                owner.get("cursor_projection_blocked_reason")
+                or "cursor projection retry bound exhausted"
+            )
+        if owner.get("cursor_projection_inflight") is True:
+            exhausted = self._record_cursor_projection_miss_locked(
+                ledger,
+                owner,
+                inbound_id=inbound_id,
+                key_digest=key_digest,
+                reason="previous cursor projection outcome is missing",
+            )
+            if exhausted:
+                return self._block_cursor_projection_locked(
+                    ledger,
+                    owner,
+                    inbound_id=inbound_id,
+                    key_digest=key_digest,
+                )
+        exhausted, _elapsed = self._cursor_projection_exhausted(owner)
+        if exhausted:
+            return self._block_cursor_projection_locked(
+                ledger,
+                owner,
+                inbound_id=inbound_id,
+                key_digest=key_digest,
+            )
+        owner["cursor_projection_inflight"] = True
+        owner["cursor_projection_reserved_at"] = self.now()
+        self._append(
+            ledger,
+            "CURSOR_PROJECTION_RESERVED",
+            scope=inbound_id,
+            key_digest=key_digest,
+            data={"attempt": int(owner.get("cursor_projection_misses", 0)) + 1},
+        )
+        return None
+
+    @staticmethod
+    def _clear_cursor_projection_reservation_locked(owner: dict) -> None:
+        owner["cursor_projection_inflight"] = False
+        owner["cursor_projection_reserved_at"] = None
+
+    def _revalidate_no_admission_projection_policy(
+        self,
+        observed: PolicySnapshot,
+        claim: dict,
+    ) -> Resolution | None:
+        """Gate pending projection, without un-winning a zero-work terminal."""
+        current = self._current_policy()
+        if self._policy_blocks_durable_terminal_projection(current):
+            return Resolution(current.status, current.reason)
+        if claim.get("state") == "finalized" and self._claim_has_no_legacy_work(claim):
+            return None
+        if (
+            current.status == observed.status
+            and current.generation == observed.generation
+            and current.grade == observed.grade
+            and current.agent == observed.agent
+        ):
+            return None
+        return Resolution(
+            ResolverState.BLOCKED_POLICY,
+            "operator policy changed before legacy cursor projection",
+        )
+
+    def _defer_cursor_projection_for_policy(
+        self,
+        record: dict,
+        *,
+        key_digest: str | None,
+        reserved_at: object,
+    ) -> None:
+        """Cancel our reservation when policy, rather than the cursor write, blocks."""
+        if not isinstance(reserved_at, str):
+            return
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            owner = (
+                ledger["obligations"].get(key_digest)
+                if key_digest is not None
+                else ledger["no_admission_claims"].get(record.get("id"))
+            )
+            if (
+                isinstance(owner, dict)
+                and owner.get("cursor_projection_inflight") is True
+                and owner.get("cursor_projection_reserved_at") == reserved_at
+            ):
+                self._clear_cursor_projection_reservation_locked(owner)
+                self._write(ledger)
+
+    def validate_no_admission_authority(
+        self,
+        record: dict,
+        resolution: Resolution,
+        *,
+        side_effect: Callable[[], None] | None = None,
+    ) -> Resolution:
+        """Confirm authority and optionally linearize its side effect with replay."""
+        if not resolution.allows_legacy_commit:
+            raise GateError("only no-admission resolutions have legacy authority")
+        inbound_id = record.get("id")
+        if not isinstance(inbound_id, str):
+            raise GateError("no-admission authority requires an exact inbound")
+        terminal_replay: Resolution | None = None
+        terminal_has_started_work = False
+        with self.store._message_publication_lock():
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+            inbound = self._record_message(record, messages)
+            if inbound is None:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission authority inbound is absent from validated replay",
+                )
+            current_policy = self._current_policy()
+            if self._policy_blocks_durable_terminal_projection(current_policy):
+                return Resolution(current_policy.status, current_policy.reason)
+            eligibility, detail, _ = self._eligibility(
+                record,
+                policy=current_policy,
+            )
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                policy_block = self._revalidate_admission_policy(current_policy)
+                if policy_block is not None:
+                    return policy_block
+                ledger = self._load()
+                replayed = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=None,
+                )
+                if replayed.state in TERMINAL_STATES:
+                    terminal_replay = replayed
+                    terminal_claim = ledger["no_admission_claims"].get(inbound_id)
+                    terminal_has_started_work = bool(
+                        isinstance(terminal_claim, dict)
+                        and terminal_claim.get("drive_started_at")
+                    )
+                else:
+                    if eligibility in {
+                        ResolverState.BLOCKED,
+                        ResolverState.BLOCKED_POLICY,
+                        ResolverState.BLOCKED_COMPLIANCE,
+                    }:
+                        return Resolution(eligibility, detail)
+                    if (
+                        eligibility != resolution.state
+                        or current_policy.generation
+                        != resolution.activation_generation
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason=(
+                                "no-admission policy changed before legacy side effect"
+                            ),
+                        )
+                    if resolution.ledger_revision is None:
+                        policy_block = self._revalidate_admission_policy(
+                            current_policy,
+                        )
+                        if policy_block is not None:
+                            return policy_block
+                        if side_effect is not None:
+                            side_effect()
+                        return Resolution(
+                            resolution.state,
+                            resolution.reason,
+                            scoped_revision=resolution.scoped_revision,
+                            activation_generation=current_policy.generation,
+                            readiness_generation=current_policy.generation,
+                        )
+                    claim = ledger["no_admission_claims"].get(inbound_id)
+                    if not isinstance(claim, dict):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission authority claim missing",
+                        )
+                    if (
+                        not self._claim_matches_policy(claim, current_policy)
+                        or claim.get("policy_generation")
+                        != resolution.activation_generation
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason="no-admission side-effect policy changed",
+                        )
+                    if claim.get("resolution") != resolution.state.value:
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission authority conflicts with replay",
+                        )
+                    if (
+                        claim.get("state") != "open"
+                        or claim.get("fence") != self.fence
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission authority is not open for this fence",
+                        )
+                    if int(ledger["scoped_revisions"].get(inbound_id, 0)) != (
+                        resolution.ledger_revision
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission authority scoped CAS miss",
+                        )
+                    policy_block = self._revalidate_admission_policy(current_policy)
+                    if policy_block is not None:
+                        return policy_block
+                    revision = int(
+                        ledger["scoped_revisions"].get(inbound_id, 0)
+                    )
+                    if side_effect is not None:
+                        side_effect()
+            if terminal_replay is not None and not terminal_has_started_work:
+                return self._normalize_pre_admission_terminal(
+                    record,
+                    inbound,
+                    terminal_replay,
+                    current_policy,
+                )
+        if terminal_replay is not None:
+            return self.admit_or_finalize(record)
+        return Resolution(
+            resolution.state,
+            resolution.reason,
+            scoped_revision=revision,
+            ledger_revision=revision,
+            activation_generation=current_policy.generation,
+            readiness_generation=current_policy.generation,
+        )
+
+    def authorize_no_admission_drive(
+        self,
+        record: dict,
+        resolution: Resolution,
+    ) -> Resolution:
+        """Replay, then durably pin policy authority immediately before legacy work."""
+        if not resolution.allows_legacy_commit:
+            raise GateError("only no-admission resolutions authorize legacy work")
+        inbound_id = record.get("id")
+        if not isinstance(inbound_id, str):
+            raise GateError("no-admission drive requires an exact inbound")
+        terminal_replay: Resolution | None = None
+        terminal_has_started_work = False
+        with self.store._message_publication_lock():
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+            inbound = self._record_message(record, messages)
+            if inbound is None:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission drive inbound is absent from validated replay",
+                )
+            current_policy = self._current_policy()
+            if self._policy_blocks_durable_terminal_projection(current_policy):
+                return Resolution(current_policy.status, current_policy.reason)
+            eligibility, detail, _ = self._eligibility(
+                record,
+                policy=current_policy,
+            )
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                policy_block = self._revalidate_admission_policy(current_policy)
+                if policy_block is not None:
+                    return policy_block
+                ledger = self._load()
+                replayed = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=None,
+                )
+                if replayed.state in TERMINAL_STATES:
+                    terminal_replay = replayed
+                    terminal_claim = ledger["no_admission_claims"].get(inbound_id)
+                    terminal_has_started_work = bool(
+                        isinstance(terminal_claim, dict)
+                        and terminal_claim.get("drive_started_at")
+                    )
+                else:
+                    if eligibility in {
+                        ResolverState.BLOCKED,
+                        ResolverState.BLOCKED_POLICY,
+                        ResolverState.BLOCKED_COMPLIANCE,
+                    }:
+                        return Resolution(eligibility, detail)
+                    if (
+                        eligibility != resolution.state
+                        or current_policy.generation
+                        != resolution.activation_generation
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason="no-admission policy changed before legacy drive",
+                        )
+                    if resolution.ledger_revision is None:
+                        policy_block = self._revalidate_admission_policy(
+                            current_policy,
+                        )
+                        if policy_block is not None:
+                            return policy_block
+                        return Resolution(
+                            resolution.state,
+                            resolution.reason,
+                            scoped_revision=resolution.scoped_revision,
+                            activation_generation=current_policy.generation,
+                            readiness_generation=current_policy.generation,
+                        )
+                    claim = ledger["no_admission_claims"].get(inbound_id)
+                    if not isinstance(claim, dict):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission drive claim missing",
+                        )
+                    if (
+                        not self._claim_matches_policy(claim, current_policy)
+                        or claim.get("policy_generation")
+                        != resolution.activation_generation
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason="no-admission drive claim policy changed",
+                        )
+                    if claim.get("resolution") != resolution.state.value:
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission drive claim conflicts with replay",
+                        )
+                    if (
+                        claim.get("state") != "open"
+                        or claim.get("fence") != self.fence
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission drive claim is not open for this fence",
+                        )
+                    if int(ledger["scoped_revisions"].get(inbound_id, 0)) != (
+                        resolution.ledger_revision
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission drive scoped CAS miss",
+                        )
+                    claim["drive_started_at"] = (
+                        claim.get("drive_started_at") or self.now()
+                    )
+                    claim["drive_attempts"] = int(
+                        claim.get("drive_attempts", 0)
+                    ) + 1
+                    self._append(
+                        ledger,
+                        "PRE_ADMISSION_DRIVE_AUTHORIZED",
+                        scope=inbound_id,
+                        source_id=inbound_id,
+                        data={
+                            "attempt": claim["drive_attempts"],
+                            "policy_generation": current_policy.generation,
+                        },
+                    )
+                    self._write(ledger)
+                    policy_block = self._revalidate_admission_policy(current_policy)
+                    if policy_block is not None:
+                        return policy_block
+                    revision = int(
+                        ledger["scoped_revisions"].get(inbound_id, 0)
+                    )
+            if terminal_replay is not None and not terminal_has_started_work:
+                return self._normalize_pre_admission_terminal(
+                    record,
+                    inbound,
+                    terminal_replay,
+                    current_policy,
+                )
+        if terminal_replay is not None:
+            return self.admit_or_finalize(record)
+        return Resolution(
+            resolution.state,
+            resolution.reason,
+            scoped_revision=revision,
+            ledger_revision=revision,
+            activation_generation=current_policy.generation,
+            readiness_generation=current_policy.generation,
+        )
+
+    def record_no_admission_success(
+        self,
+        record: dict,
+        resolution: Resolution,
+    ) -> Resolution:
+        """Durably retain a successful legacy turn before its cursor CAS.
+
+        A finalization CAS miss must retry only the cursor disposition.  Without
+        this write-ahead marker the next poll would invoke the model again even
+        though the preceding turn already completed successfully.
+        """
+        if not resolution.allows_legacy_commit:
+            raise GateError("only no-admission resolutions can retain legacy success")
+        inbound_id = record.get("id")
+        if not isinstance(inbound_id, str):
+            raise GateError("no-admission success requires an exact inbound")
+        with ExitStack() as locks:
+            locks.enter_context(self.store._message_publication_lock())
+            try:
+                messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+            current_policy = self._current_policy()
+            current_eligibility, detail, _ = self._eligibility(
+                record,
+                policy=current_policy,
+            )
+            if current_policy.generation != resolution.activation_generation:
+                return self._policy_authority_failure(
+                    current_policy,
+                    reason="no-admission policy changed during legacy drive",
+                )
+            if current_eligibility != resolution.state:
+                if current_eligibility in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                }:
+                    return Resolution(current_eligibility, detail)
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission success classification changed during drive",
+                )
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"), timeout=10.0,
+                )
+            )
+            ledger = self._load()
+            claim = ledger["no_admission_claims"].get(inbound_id)
+            if not isinstance(claim, dict):
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission success claim missing",
+                )
+            if (
+                not self._claim_matches_policy(claim, current_policy)
+                or claim.get("policy_generation") != resolution.activation_generation
+            ):
+                return self._policy_authority_failure(
+                    current_policy,
+                    reason="no-admission claim policy changed during legacy drive",
+                )
+            if claim.get("resolution") != resolution.state.value:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission success replay mismatch",
+                )
+            if claim.get("state") == "finalized":
+                return resolution
+            if claim.get("state") == "blocked":
+                return Resolution(
+                    ResolverState.BLOCKED,
+                    str(claim.get("blocked_reason") or "finalization blocked"),
+                )
+            if claim.get("state") == "finalization_pending":
+                return Resolution(
+                    resolution.state,
+                    "no_admission_finalization_pending",
+                    scoped_revision=int(
+                        ledger["scoped_revisions"].get(inbound_id, 0)
+                    ),
+                    ledger_revision=int(
+                        ledger["scoped_revisions"].get(inbound_id, 0)
+                    ),
+                    activation_generation=current_policy.generation,
+                    readiness_generation=current_policy.generation,
+                )
+            replayed = self._resolve_replay(
+                record,
+                messages,
+                ledger,
+                admission=None,
+            )
+            if replayed.terminal:
+                if claim.get("state") != "open" or claim.get("fence") != self.fence:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "legacy terminal retention fence mismatch",
+                    )
+                self._retain_same_generation_legacy_terminal_locked(
+                    ledger,
+                    claim,
+                    record,
+                    replayed,
+                    current_policy,
+                )
+                self._write(ledger)
+                policy_block = self._revalidate_admission_policy(current_policy)
+                if policy_block is not None:
+                    return policy_block
+                revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+                return Resolution(
+                    replayed.state,
+                    "no_admission_finalization_pending",
+                    evidence_id=replayed.evidence_id,
+                    scoped_revision=revision,
+                    ledger_revision=revision,
+                    activation_generation=current_policy.generation,
+                    readiness_generation=current_policy.generation,
+                )
+            if claim.get("state") != "open" or claim.get("fence") != self.fence:
+                return Resolution(
+                    ResolverState.INDETERMINATE,
+                    "no-admission success fence mismatch",
+                )
+            claim["state"] = "finalization_pending"
+            claim["drive_succeeded_at"] = self.now()
+            self._append(
+                ledger,
+                "PRE_ADMISSION_SUCCESS_RETAINED",
+                scope=inbound_id,
+                source_id=inbound_id,
+                data={"state": resolution.state.value},
+            )
+            self._write(ledger)
+            policy_block = self._revalidate_admission_policy(current_policy)
+            if policy_block is not None:
+                return policy_block
+            revision = int(ledger["scoped_revisions"].get(inbound_id, 0))
+        return Resolution(
+            resolution.state,
+            "no_admission_finalization_pending",
+            scoped_revision=revision,
+            ledger_revision=revision,
+            activation_generation=current_policy.generation,
+            readiness_generation=current_policy.generation,
+        )
+
+    def finalize(
+        self,
+        record: dict,
+        resolution: Resolution,
+        *,
+        expected_revision: int | None = None,
+    ) -> Resolution:
+        if not (resolution.terminal or resolution.allows_legacy_commit):
+            raise GateError("nonterminal resolution cannot finalize")
+        projection_block: str | None = None
+        projection_reserved_at: object = None
+        durable_zero_work_terminal = False
+        key = resolution.key
+        no_admission_policy: PolicySnapshot | None = None
+        no_admission_messages: list[Message] | None = None
+        if key is not None and any((
+            key.responder != self.agent,
+            record.get("id") != key.inbound_id,
+            record.get("to") != key.responder,
+            record.get("from") != key.requester,
+            record.get("correlation_id") != key.correlation_id,
+        )):
+            raise GateError("finalizer record does not match the exact inbound key")
+        inbound_id = str(key.inbound_id if key is not None else record.get("id"))
+        key_digest = key.digest if key is not None else None
+        if key is None:
+            try:
+                no_admission_messages, _ = self._validated_messages()
+            except LedgerUnreadable as exc:
+                return Resolution(ResolverState.BLOCKED, str(exc))
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            write_required = True
+            if key is not None:
+                admission = ledger["obligations"].get(key.digest)
+                if not isinstance(admission, dict):
+                    return Resolution(ResolverState.INDETERMINATE, "finalizer admission missing")
+                disposition_state = (
+                    "delivery_failed"
+                    if resolution.state == ResolverState.DELIVERY_EXHAUSTED
+                    else resolution.state.value
+                )
+                persisted_admission_state = (
+                    "delivery_failed"
+                    if resolution.state == ResolverState.DELIVERY_EXHAUSTED
+                    else "operator_resolved"
+                    if resolution.state == ResolverState.OPERATOR_RESOLVED
+                    else "transferred"
+                    if resolution.state == ResolverState.TRANSFERRED
+                    else "broadcast_policy_satisfied"
+                    if resolution.state == ResolverState.BROADCAST_POLICY_SATISFIED
+                    else "finalized"
+                )
+                disposition = ledger["cursor_dispositions"].get(self.agent)
+                already_disposed = (
+                    admission.get("state") == persisted_admission_state
+                    and admission.get("terminal_state") == resolution.state.value
+                    and isinstance(disposition, dict)
+                    and disposition.get("inbound_id") == record.get("id")
+                    and disposition.get("mode") == record.get("mode", "global")
+                    and disposition.get("state") == disposition_state
+                )
+                if already_disposed:
+                    if (
+                        resolution.state == ResolverState.DELIVERY_EXHAUSTED
+                        and not self._delivery_transaction_intact(
+                            ledger,
+                            admission,
+                            key,
+                            record,
+                        )
+                    ):
+                        reason = "failed-delivery transaction is structurally torn"
+                        admission["state"] = "blocked"
+                        admission["blocked_reason"] = reason
+                        self._append(
+                            ledger,
+                            "OBLIGATION_BLOCKED",
+                            scope=key.inbound_id,
+                            key_digest=key.digest,
+                            data={"reason": reason},
+                        )
+                        self._write(ledger)
+                        return Resolution(ResolverState.BLOCKED, reason, key)
+                    write_required = False
+                else:
+                    policy_or_transfer_preclosed = bool(
+                        resolution.state in {
+                            ResolverState.TRANSFERRED,
+                            ResolverState.BROADCAST_POLICY_SATISFIED,
+                        }
+                        and admission.get("state") == persisted_admission_state
+                        and admission.get("terminal_state") == resolution.state.value
+                    )
+                    if admission.get("state") != "open" and not policy_or_transfer_preclosed:
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "finalized cursor disposition is torn",
+                            key,
+                        )
+                    if not policy_or_transfer_preclosed and int(
+                        ledger["scoped_revisions"].get(key.inbound_id, 0)
+                    ) != (
+                        resolution.scoped_revision
+                    ):
+                        exhausted = self._record_finalization_miss_locked(
+                            ledger,
+                            admission,
+                            inbound_id=key.inbound_id,
+                            key_digest=key.digest,
+                        )
+                        self._write(ledger)
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            (
+                                "finalization CAS contention exhausted"
+                                if exhausted
+                                else "finalizer scoped CAS miss"
+                            ),
+                            key,
+                        )
+                    admission["state"] = persisted_admission_state
+                    admission["finalization_retry_inflight"] = False
+                    admission["terminal_state"] = resolution.state.value
+                    if not policy_or_transfer_preclosed:
+                        admission["terminal_evidence_id"] = resolution.evidence_id
+                    admission["finalized_at"] = self.now()
+                    self._append(
+                        ledger,
+                        "CURSOR_FINALIZED",
+                        scope=key.inbound_id,
+                        key_digest=key.digest,
+                        data={"state": resolution.state.value},
+                    )
+                    if resolution.compliance_success:
+                        self._reset_compliance_streak_locked(ledger, key)
+                    if resolution.state == ResolverState.SATISFIED:
+                        self._apply_broadcast_policy_locked(
+                            ledger,
+                            broadcast_id=admission.get("broadcast_id"),
+                            broadcast_generation=admission.get("broadcast_generation"),
+                        )
+                owner = admission
+            else:
+                claim = ledger["no_admission_claims"].get(record.get("id"))
+                if not isinstance(claim, dict):
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "no-admission finalizer claim missing",
+                    )
+                current_policy = self._current_policy()
+                no_admission_policy = current_policy
+                if self._policy_blocks_durable_terminal_projection(current_policy):
+                    return Resolution(current_policy.status, current_policy.reason)
+                terminal_authority = self._recognized_zero_work_terminal_authority(
+                    record,
+                    no_admission_messages or [],
+                    ledger,
+                    claim,
+                )
+                if (
+                    terminal_authority is not None
+                    and terminal_authority.state == ResolverState.INDETERMINATE
+                ):
+                    return terminal_authority
+                terminal_immune = bool(
+                    terminal_authority is not None
+                    and terminal_authority.state == resolution.state
+                    and terminal_authority.evidence_id == resolution.evidence_id
+                )
+                if terminal_authority is not None and not terminal_immune:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "no-admission finalizer terminal authority changed",
+                    )
+                if claim.get("resolution") != resolution.state.value:
+                    return Resolution(
+                        ResolverState.INDETERMINATE,
+                        "no-admission finalizer replay mismatch",
+                    )
+                if claim.get("state") == "blocked":
+                    return Resolution(
+                        ResolverState.BLOCKED,
+                        str(claim.get("blocked_reason") or "finalization blocked"),
+                    )
+                if claim.get("state") == "finalized":
+                    disposition = ledger["cursor_dispositions"].get(self.agent)
+                    disposition_state = (
+                        "delivery_failed"
+                        if resolution.state == ResolverState.DELIVERY_EXHAUSTED
+                        else resolution.state.value
+                    )
+                    if not isinstance(disposition, dict) or any((
+                        disposition.get("inbound_id") != record.get("id"),
+                        disposition.get("mode") != record.get("mode", "global"),
+                        disposition.get("state") != disposition_state,
+                        claim.get("terminal_evidence_id") != resolution.evidence_id,
+                    )):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission finalized disposition is torn",
+                        )
+                    if not terminal_immune and not self._claim_has_no_legacy_work(
+                        claim
+                    ) and (
+                        not self._claim_matches_policy(claim, current_policy)
+                        or resolution.activation_generation
+                        not in {None, current_policy.generation}
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason="no-admission policy changed before finalization",
+                        )
+                    write_required = (
+                        self._rebind_zero_work_terminal_authority_locked(
+                            ledger,
+                            claim,
+                            record,
+                            terminal_authority,
+                            current_policy,
+                        )
+                        if terminal_immune and terminal_authority is not None
+                        else False
+                    )
+                else:
+                    if not terminal_immune and (
+                        not self._claim_matches_policy(claim, current_policy)
+                        or resolution.activation_generation
+                        not in {None, current_policy.generation}
+                    ):
+                        return self._policy_authority_failure(
+                            current_policy,
+                            reason="no-admission policy changed before finalization",
+                        )
+                    if claim.get("state") not in {
+                        "open",
+                        "finalization_pending",
+                    } or (
+                        claim.get("fence") != self.fence
+                        and (
+                            not terminal_immune
+                            or not self._can_reassign_no_admission_claim(claim)
+                        )
+                    ):
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission finalizer fence mismatch",
+                        )
+                    if expected_revision is None:
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission finalizer requires a scoped revision",
+                        )
+                    if int(ledger["scoped_revisions"].get(record.get("id"), 0)) != (
+                        expected_revision
+                    ):
+                        exhausted = self._record_finalization_miss_locked(
+                            ledger,
+                            claim,
+                            inbound_id=str(record.get("id")),
+                            key_digest=None,
+                        )
+                        if exhausted:
+                            reason = "no-admission finalization CAS contention exhausted"
+                            claim["state"] = "blocked"
+                            claim["blocked_reason"] = reason
+                            self._append(
+                                ledger,
+                                "NO_ADMISSION_FINALIZATION_BLOCKED",
+                                scope=str(record.get("id")),
+                                data={"reason": reason},
+                            )
+                            self._write(ledger)
+                            return Resolution(ResolverState.BLOCKED, reason)
+                        self._write(ledger)
+                        return Resolution(
+                            ResolverState.INDETERMINATE,
+                            "no-admission finalizer CAS miss",
+                        )
+                    if terminal_immune and terminal_authority is not None:
+                        self._rebind_zero_work_terminal_authority_locked(
+                            ledger,
+                            claim,
+                            record,
+                            terminal_authority,
+                            current_policy,
+                        )
+                    self._append(
+                        ledger,
+                        "PRE_ADMISSION_FINALIZED",
+                        scope=record.get("id"),
+                        source_id=resolution.evidence_id,
+                        data={"state": resolution.state.value},
+                    )
+                    claim["state"] = "finalized"
+                    claim["finalized_at"] = self.now()
+                    claim["terminal_evidence_id"] = resolution.evidence_id
+                    if resolution.state == ResolverState.SATISFIED:
+                        indexed = ledger["messages"].get(record.get("id"), {})
+                        self._apply_broadcast_policy_locked(
+                            ledger,
+                            broadcast_id=indexed.get("broadcast_id"),
+                            broadcast_generation=indexed.get("broadcast_generation"),
+                        )
+                owner = claim
+            if write_required:
+                disposition_state = (
+                    "delivery_failed"
+                    if resolution.state == ResolverState.DELIVERY_EXHAUSTED
+                    else resolution.state.value
+                )
+                ledger["cursor_dispositions"][self.agent] = {
+                    "inbound_id": record.get("id"),
+                    "mode": record.get("mode", "global"),
+                    "state": disposition_state,
+                    "at": self.now(),
+                }
+            durable_zero_work_terminal = (
+                no_admission_policy is not None
+                and owner.get("state") == "finalized"
+                and self._claim_has_no_legacy_work(owner)
+            )
+            if durable_zero_work_terminal and write_required:
+                # The terminal and its exact disposition become authoritative before
+                # policy is checked for the pending physical projection.  A crash or
+                # unreadable policy here therefore leaves no false cursor attempt.
+                self._write(ledger)
+                write_required = False
+                policy_block = self._revalidate_no_admission_projection_policy(
+                    no_admission_policy,
+                    owner,
+                )
+                if policy_block is not None:
+                    return policy_block
+                rebound_policy = self._current_policy()
+                if self._policy_blocks_durable_terminal_projection(rebound_policy):
+                    return Resolution(rebound_policy.status, rebound_policy.reason)
+                recognized = self._recognized_zero_work_terminal_authority(
+                    record,
+                    no_admission_messages or [],
+                    ledger,
+                    owner,
+                )
+                if (
+                    recognized is not None
+                    and recognized.state == ResolverState.INDETERMINATE
+                ):
+                    return recognized
+                if recognized is not None:
+                    no_admission_policy = rebound_policy
+                    if self._rebind_zero_work_terminal_authority_locked(
+                        ledger,
+                        owner,
+                        record,
+                        recognized,
+                        rebound_policy,
+                    ):
+                        self._write(ledger)
+            if self._cursor_projection_is_complete(record):
+                projection_was_inflight = owner.get("cursor_projection_inflight") is True
+                self._clear_cursor_projection_reservation_locked(owner)
+                if write_required or projection_was_inflight:
+                    self._write(ledger)
+                return resolution
+            projection_block = self._reserve_cursor_projection_locked(
+                ledger,
+                owner,
+                inbound_id=inbound_id,
+                key_digest=key_digest,
+            )
+            projection_reserved_at = owner.get("cursor_projection_reserved_at")
+            self._write(ledger)
+            if (
+                no_admission_policy is not None
+                and projection_block is None
+            ):
+                policy_block = self._revalidate_no_admission_projection_policy(
+                    no_admission_policy,
+                    owner,
+                )
+                if policy_block is not None:
+                    self._clear_cursor_projection_reservation_locked(owner)
+                    self._write(ledger)
+                    return policy_block
+        if projection_block is not None:
+            self._record_disposition_block(reason=projection_block)
+            return Resolution(ResolverState.INDETERMINATE, projection_block, key)
+        # The physical cursor is a projection of the authoritative disposition.
+        # Its write-ahead reservation makes a crash an accounted miss before any
+        # subsequent retry, while the exact disposition makes the side effect
+        # idempotent and prevents duplicate terminal transitions.
+        if no_admission_policy is not None:
+            policy_block = self._revalidate_no_admission_projection_policy(
+                no_admission_policy,
+                owner,
+            )
+            if policy_block is not None:
+                self._defer_cursor_projection_for_policy(
+                    record,
+                    key_digest=key_digest,
+                    reserved_at=projection_reserved_at,
+                )
+                return policy_block
+        try:
+            self._advance_record_cursor(record)
+        except (OSError, TimeoutError, ValueError, RuntimeError) as exc:
+            reason = f"cursor projection failed: {type(exc).__name__}"
+            exhausted = False
+            try:
+                with self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"), timeout=10.0,
+                ):
+                    ledger = self._load()
+                    owner = (
+                        ledger["obligations"].get(key_digest)
+                        if key_digest is not None
+                        else ledger["no_admission_claims"].get(record.get("id"))
+                    )
+                    if not isinstance(owner, dict):
+                        raise LedgerUnreadable("cursor projection owner is missing")
+                    if owner.get("cursor_projection_inflight") is True:
+                        exhausted = self._record_cursor_projection_miss_locked(
+                            ledger,
+                            owner,
+                            inbound_id=inbound_id,
+                            key_digest=key_digest,
+                            reason=reason,
+                        )
+                    if exhausted:
+                        reason = self._block_cursor_projection_locked(
+                            ledger,
+                            owner,
+                            inbound_id=inbound_id,
+                            key_digest=key_digest,
+                        )
+                    self._write(ledger)
+            except (OSError, TimeoutError, ValueError, RuntimeError, LedgerUnreadable):
+                reason = "cursor projection failure accounting is unavailable"
+                exhausted = True
+            if exhausted:
+                self._record_disposition_block(reason=reason)
+            return Resolution(ResolverState.INDETERMINATE, reason, key)
+        try:
+            with self.store._exclusive_lock(
+                self.path.with_suffix(".lock"), timeout=10.0,
+            ):
+                ledger = self._load()
+                owner = (
+                    ledger["obligations"].get(key_digest)
+                    if key_digest is not None
+                    else ledger["no_admission_claims"].get(record.get("id"))
+                )
+                if isinstance(owner, dict) and owner.get("cursor_projection_inflight"):
+                    owner["cursor_projection_inflight"] = False
+                    owner["cursor_projection_reserved_at"] = None
+                    owner["cursor_projection_completed_at"] = self.now()
+                    self._append(
+                        ledger,
+                        "CURSOR_PROJECTION_COMPLETED",
+                        scope=inbound_id,
+                        key_digest=key_digest,
+                    )
+                    self._write(ledger)
+        except (OSError, TimeoutError, ValueError, RuntimeError, LedgerUnreadable):
+            # The authoritative disposition and its physical projection are both
+            # already durable; completion telemetry is best-effort after success.
+            pass
+        return resolution
+
+    def _broadcast_qualifying_answers_locked(
+        self,
+        ledger: dict,
+        aggregate: dict,
+    ) -> list[tuple[int, str, str, str]]:
+        """Return canonical answer evidence for the current aggregate generation."""
+        descriptor = aggregate.get("descriptor")
+        if not isinstance(descriptor, dict):
+            return []
+        bid = descriptor.get("broadcast_id")
+        requester = descriptor.get("requester")
+        members = descriptor.get("membership_snapshot")
+        if (
+            not isinstance(bid, str)
+            or not isinstance(requester, str)
+            or not isinstance(members, list)
+        ):
+            return []
+        generation = int(aggregate.get("generation", 1))
+        qualifying: list[tuple[int, str, str, str]] = []
+        for member, inbound_ids in aggregate.get("member_inbounds", {}).items():
+            if member not in members or not isinstance(inbound_ids, list):
+                continue
+            for inbound_id in inbound_ids:
+                inbound_row = ledger["messages"].get(inbound_id)
+                if not isinstance(inbound_id, str) or not isinstance(inbound_row, dict):
+                    continue
+                if any((
+                    int(inbound_row.get("broadcast_generation", 1)) != generation,
+                    inbound_row.get("kind") != "question",
+                    inbound_row.get("sender") != requester,
+                    inbound_row.get("recipient") != member,
+                    inbound_row.get("correlation_id") != bid,
+                    inbound_row.get("request_id") != bid,
+                    inbound_row.get("broadcast_id") != bid,
+                )):
+                    continue
+                key_id = ledger["inbound_index"].get(inbound_id)
+                admission = ledger["obligations"].get(key_id) if key_id else None
+                reservations: dict = {}
+                if isinstance(admission, dict):
+                    try:
+                        key = self._key_from(admission.get("key"))
+                    except (TypeError, ValueError):
+                        continue
+                    if any((
+                        key.inbound_id != inbound_id,
+                        key.correlation_id != bid,
+                        key.requester != requester,
+                        key.responder != member,
+                        admission.get("obligation_class") != "answer",
+                        int(admission.get("broadcast_generation") or 1) != generation,
+                    )):
+                        continue
+                    reservations = admission.get("reservations", {})
+                    if not isinstance(reservations, dict):
+                        continue
+                else:
+                    claim = ledger["no_admission_claims"].get(inbound_id)
+                    evidence_id = (
+                        claim.get("terminal_evidence_id")
+                        if isinstance(claim, dict)
+                        and claim.get("resolution") == ResolverState.SATISFIED.value
+                        and claim.get("state") in {"finalization_pending", "finalized"}
+                        else None
+                    )
+                    evidence = ledger["messages"].get(evidence_id)
+                    if not isinstance(evidence, dict) or any((
+                        int(evidence.get("sequence", 0))
+                        <= int(inbound_row.get("sequence", 0)),
+                        evidence.get("in_reply_to") != inbound_id,
+                        evidence.get("correlation_id") != bid,
+                        evidence.get("sender") != member,
+                        evidence.get("recipient") != requester,
+                        evidence.get("kind") in CONTROL_KINDS,
+                    )):
+                        continue
+                    qualifying.append((
+                        int(evidence["sequence"]),
+                        str(evidence_id),
+                        str(member),
+                        inbound_id,
+                    ))
+                    continue
+
+                for message_id, message_row in ledger["messages"].items():
+                    if not isinstance(message_row, dict):
+                        continue
+                    nonce = message_row.get("operation_nonce")
+                    if not (
+                        int(message_row.get("sequence", 0))
+                        > int(inbound_row.get("sequence", 0))
+                        and message_row.get("in_reply_to") == inbound_id
+                        and message_row.get("correlation_id") == bid
+                        and message_row.get("sender") == member
+                        and message_row.get("recipient") == requester
+                        and message_row.get("kind") not in CONTROL_KINDS
+                        and message_row.get("operation_payload_valid") is True
+                        and isinstance(nonce, str)
+                        and isinstance(reservations.get(nonce), dict)
+                    ):
+                        continue
+                    qualifying.append((
+                        int(message_row["sequence"]),
+                        message_id,
+                        str(member),
+                        inbound_id,
+                    ))
+                    break
+        return sorted(qualifying, key=lambda item: (item[0], item[1]))
+
+    def _apply_broadcast_policy_locked(
+        self,
+        ledger: dict,
+        *,
+        broadcast_id: object,
+        broadcast_generation: object,
+    ) -> None:
+        bid = broadcast_id
+        if not isinstance(bid, str):
+            return
+        aggregate = ledger["broadcasts"].get(bid)
+        if not isinstance(aggregate, dict) or aggregate.get("state") != "open":
+            return
+        if int(broadcast_generation or 1) != int(aggregate.get("generation", 1)):
+            return
+        descriptor = aggregate.get("descriptor")
+        if not isinstance(descriptor, dict):
+            return
+        policy = descriptor.get("response_policy")
+        members = descriptor.get("membership_snapshot")
+        requester = descriptor.get("requester")
+        if (
+            policy not in {"each", "any", "quorum"}
+            or not isinstance(members, list)
+            or not isinstance(requester, str)
+        ):
+            return
+        qualifying = self._broadcast_qualifying_answers_locked(ledger, aggregate)
+        threshold = (
+            len(members)
+            if policy == "each"
+            else 1
+            if policy == "any"
+            else descriptor.get("response_quorum")
+        )
+        if not isinstance(threshold, int) or threshold < 1:
+            return
+        earliest_by_member: dict[str, tuple[int, str, str, str]] = {}
+        for candidate in qualifying:
+            earliest_by_member.setdefault(candidate[2], candidate)
+        ordered = sorted(earliest_by_member.values(), key=lambda item: item[0])
+        if policy == "each":
+            if set(earliest_by_member) != set(members):
+                return
+            winners = ordered
+        else:
+            if len(ordered) < threshold:
+                return
+            winners = ordered[:threshold]
+        winning_ids = [candidate[1] for candidate in winners]
+        winning_inbounds = {candidate[3] for candidate in winners}
+        transaction_id = hashlib.sha256(_canonical({
+            "broadcast_descriptor_digest": aggregate.get("descriptor_digest"),
+            "winning_ids": winning_ids,
+        }).encode("utf-8")).hexdigest()
+
+        affected: list[dict] = []
+        close_candidates: list[tuple[str, str | None, dict | None, str]] = []
+        pending_candidates: list[tuple[dict, dict]] = []
+        conflict: tuple[str, str | None, str] | None = None
+        current_generation = int(aggregate.get("generation", 1))
+        for member, inbound_ids in sorted(aggregate.get("member_inbounds", {}).items()):
+            if member not in members or not isinstance(inbound_ids, list):
+                continue
+            for inbound_id in inbound_ids:
+                inbound_row = ledger["messages"].get(inbound_id)
+                if (
+                    not isinstance(inbound_id, str)
+                    or not isinstance(inbound_row, dict)
+                    or int(inbound_row.get("broadcast_generation", 1))
+                    != current_generation
+                ):
+                    continue
+                if inbound_id in winning_inbounds:
+                    continue
+                key_id = ledger["inbound_index"].get(inbound_id)
+                admission = ledger["obligations"].get(key_id) if key_id else None
+                outcome = "prospective_policy_close"
+                if isinstance(admission, dict):
+                    if admission.get("state") != "open":
+                        continue
+                    try:
+                        affected_key = self._key_from(admission.get("key"))
+                    except (TypeError, ValueError):
+                        conflict = conflict or (
+                            inbound_id,
+                            key_id,
+                            "broadcast admission key is invalid",
+                        )
+                        continue
+                    if any((
+                        affected_key.inbound_id != inbound_id,
+                        affected_key.correlation_id != bid,
+                        affected_key.requester != requester,
+                        affected_key.responder != member,
+                        int(admission.get("broadcast_generation") or 1)
+                        != current_generation,
+                    )):
+                        conflict = conflict or (
+                            inbound_id,
+                            key_id,
+                            "broadcast admission identity conflicts with frozen policy",
+                        )
+                        continue
+                    reservations = admission.get("reservations", {})
+                    if not isinstance(reservations, dict):
+                        conflict = conflict or (
+                            inbound_id,
+                            key_id,
+                            "broadcast admission reservations are invalid",
+                        )
+                        continue
+                    armed = any(
+                        isinstance(row, dict)
+                        and row.get("state") in {"reserved", "dispatching", "action_infra"}
+                        for row in reservations.values()
+                    )
+                    if armed:
+                        outcome = "reservation_won"
+                    else:
+                        outcome = "policy_close"
+                affected.append({
+                    "member": member,
+                    "inbound_id": inbound_id,
+                    "key_digest": key_id,
+                    "scoped_revision": int(
+                        ledger["scoped_revisions"].get(inbound_id, 0)
+                    ),
+                    "outcome": outcome,
+                })
+                if outcome == "reservation_won" and isinstance(admission, dict):
+                    pending_candidates.append((admission, {
+                        "transaction_id": transaction_id,
+                        "winning_ids": list(winning_ids),
+                        "winning_classes": ["answer"] * len(winning_ids),
+                        "broadcast_id": bid,
+                        "broadcast_generation": current_generation,
+                        "policy": policy,
+                    }))
+                else:
+                    close_candidates.append((inbound_id, key_id, admission, member))
+
+        if conflict is not None:
+            conflict_inbound, conflict_key, conflict_reason = conflict
+            aggregate["state"] = "blocked"
+            aggregate["blocked_reason"] = conflict_reason
+            self._append(
+                ledger,
+                "BROADCAST_POLICY_CONFLICT",
+                scope=conflict_inbound,
+                key_digest=conflict_key,
+                data={"broadcast_id": bid, "reason": conflict_reason},
+            )
+            return
+
+        aggregate_event = self._append(
+            ledger,
+            "BROADCAST_POLICY_SATISFIED",
+            source_id=winning_ids[-1],
+            data={
+                "aggregate": True,
+                "broadcast_id": bid,
+                "broadcast_policy_version": descriptor["broadcast_policy_version"],
+                "broadcast_generation": aggregate.get("generation", 1),
+                "policy": policy,
+                "response_quorum": descriptor.get("response_quorum"),
+                "winning_ids": winning_ids,
+                "winning_classes": ["answer"] * len(winning_ids),
+                "affected_member_keys": affected,
+                "transaction_id": transaction_id,
+                "descriptor_digest": aggregate.get("descriptor_digest"),
+            },
+        )
+        aggregate.update({
+            "state": "policy_satisfied",
+            "winning_ids": winning_ids,
+            "winning_classes": ["answer"] * len(winning_ids),
+            "affected_member_keys": affected,
+            "transaction_id": transaction_id,
+            "aggregate_sequence": aggregate_event["sequence"],
+        })
+        ledger["delivery_index"].setdefault(bid, []).append({
+            "kind": "BROADCAST_POLICY_SATISFIED",
+            "sequence": aggregate_event["sequence"],
+            "key_digest": (
+                ledger["inbound_index"].get(winners[-1][3])
+                if winners
+                else None
+            ),
+            "inbound_id": winners[-1][3],
+            "question_generation": None,
+            "delivery_generation": None,
+            "requester": requester,
+            "responder": "*",
+            "state": ResolverState.BROADCAST_POLICY_SATISFIED.value,
+            "aggregate": True,
+            "broadcast_id": bid,
+            "response_policy": policy,
+            "response_quorum": descriptor.get("response_quorum"),
+            "broadcast_policy_version": descriptor["broadcast_policy_version"],
+            "broadcast_generation": aggregate.get("generation", 1),
+            "winning_ids": winning_ids,
+            "transaction_id": transaction_id,
+        })
+        for admission, pending in pending_candidates:
+            admission["broadcast_policy_close_pending"] = pending
+        for inbound_id, key_id, admission, _member in close_candidates:
+            member_event = self._append(
+                ledger,
+                "BROADCAST_POLICY_SATISFIED",
+                scope=inbound_id,
+                source_id=winning_ids[-1],
+                key_digest=key_id,
+                data={
+                    "aggregate": False,
+                    "broadcast_id": bid,
+                    "inbound_id": inbound_id,
+                    "winning_ids": winning_ids,
+                    "winning_classes": ["answer"] * len(winning_ids),
+                    "policy": policy,
+                    "broadcast_policy_version": descriptor["broadcast_policy_version"],
+                    "broadcast_generation": aggregate.get("generation", 1),
+                    "transaction_id": transaction_id,
+                },
+            )
+            if isinstance(admission, dict):
+                admission["state"] = "broadcast_policy_satisfied"
+                admission["terminal_state"] = (
+                    ResolverState.BROADCAST_POLICY_SATISFIED.value
+                )
+                admission["terminal_evidence_id"] = str(member_event["sequence"])
+
+    def _complete_pending_broadcast_close_locked(
+        self,
+        ledger: dict,
+        admission: dict,
+        key: ObligationKey,
+    ) -> None:
+        """Close a nonwinning member after its already-reserved call is classified."""
+        pending = admission.get("broadcast_policy_close_pending")
+        if not isinstance(pending, dict) or admission.get("state") != "open":
+            return
+        bid = pending.get("broadcast_id")
+        winning_ids = pending.get("winning_ids")
+        aggregate = ledger["broadcasts"].get(bid) if isinstance(bid, str) else None
+        descriptor = aggregate.get("descriptor") if isinstance(aggregate, dict) else None
+        pending_generation = pending.get("broadcast_generation")
+        transaction_id = pending.get("transaction_id")
+        descriptor_digest = (
+            aggregate.get("descriptor_digest")
+            if isinstance(aggregate, dict)
+            else None
+        )
+        expected_transaction_id = (
+            hashlib.sha256(_canonical({
+                "broadcast_descriptor_digest": descriptor_digest,
+                "winning_ids": winning_ids,
+            }).encode("utf-8")).hexdigest()
+            if isinstance(winning_ids, list)
+            else None
+        )
+        affected = (
+            aggregate.get("affected_member_keys")
+            if isinstance(aggregate, dict)
+            else None
+        )
+        inbound_row = ledger["messages"].get(key.inbound_id)
+        exact_affected = [
+            row for row in affected
+            if isinstance(row, dict)
+            and row.get("member") == key.responder
+            and row.get("inbound_id") == key.inbound_id
+            and row.get("key_digest") == key.digest
+            and row.get("outcome") == "reservation_won"
+        ] if isinstance(affected, list) else []
+        proof_valid = bool(
+            isinstance(bid, str)
+            and isinstance(winning_ids, list)
+            and winning_ids
+            and all(isinstance(message_id, str) for message_id in winning_ids)
+            and isinstance(pending_generation, int)
+            and isinstance(transaction_id, str)
+            and transaction_id
+            and isinstance(aggregate, dict)
+            and aggregate.get("state") == "policy_satisfied"
+            and aggregate.get("generation") == pending_generation
+            and aggregate.get("transaction_id") == transaction_id
+            and transaction_id == expected_transaction_id
+            and aggregate.get("winning_ids") == winning_ids
+            and aggregate.get("winning_classes") == pending.get("winning_classes")
+            and isinstance(descriptor, dict)
+            and descriptor_digest == _broadcast_descriptor_digest(descriptor)
+            and descriptor.get("broadcast_id") == bid
+            and descriptor.get("requester") == key.requester
+            and isinstance(descriptor.get("membership_snapshot"), list)
+            and key.responder in descriptor["membership_snapshot"]
+            and descriptor.get("response_policy") == pending.get("policy")
+            and key.correlation_id == bid
+            and admission.get("broadcast_id") == bid
+            and admission.get("broadcast_generation") == pending_generation
+            and ledger["inbound_index"].get(key.inbound_id) == key.digest
+            and ledger["obligations"].get(key.digest) is admission
+            and isinstance(inbound_row, dict)
+            and inbound_row.get("sender") == key.requester
+            and inbound_row.get("recipient") == key.responder
+            and inbound_row.get("correlation_id") == bid
+            and inbound_row.get("request_id") == bid
+            and inbound_row.get("broadcast_id") == bid
+            and inbound_row.get("broadcast_generation") == pending_generation
+            and len(exact_affected) == 1
+        )
+        if not proof_valid:
+            admission["state"] = "blocked"
+            admission["blocked_reason"] = (
+                "pending broadcast close does not match the policy-satisfied aggregate"
+            )
+            self._append(
+                ledger,
+                "OBLIGATION_BLOCKED",
+                scope=key.inbound_id,
+                key_digest=key.digest,
+                data={"reason": admission["blocked_reason"]},
+            )
+            admission.pop("broadcast_policy_close_pending", None)
+            return
+        member_event = self._append(
+            ledger,
+            "BROADCAST_POLICY_SATISFIED",
+            scope=key.inbound_id,
+            source_id=winning_ids[-1],
+            key_digest=key.digest,
+            data={
+                "aggregate": False,
+                "broadcast_id": bid,
+                "inbound_id": key.inbound_id,
+                "winning_ids": list(winning_ids),
+                "winning_classes": list(pending.get("winning_classes") or []),
+                "policy": pending.get("policy"),
+                "broadcast_policy_version": 1,
+                "broadcast_generation": pending.get("broadcast_generation"),
+                "transaction_id": transaction_id,
+                "reservation_won": True,
+            },
+        )
+        admission["state"] = "broadcast_policy_satisfied"
+        admission["terminal_state"] = ResolverState.BROADCAST_POLICY_SATISFIED.value
+        admission["terminal_evidence_id"] = str(member_event["sequence"])
+        admission.pop("broadcast_policy_close_pending", None)
+
+        aggregate_sequence = int(aggregate.get("aggregate_sequence", 0))
+        already_late = {
+            event.get("source_id")
+            for event in ledger["transitions"]
+            if event.get("transition") == "LATE_RESPONSE"
+            and event.get("key_digest") == key.digest
+        }
+        for message_id, row in ledger["messages"].items():
+            if not isinstance(row, dict) or any((
+                int(row.get("sequence", 0)) <= aggregate_sequence,
+                row.get("in_reply_to") != key.inbound_id,
+                row.get("correlation_id") != bid,
+                row.get("sender") != key.responder,
+                row.get("recipient") != key.requester,
+                row.get("kind") in CONTROL_KINDS,
+                message_id in winning_ids,
+                message_id in already_late,
+            )):
+                continue
+            self._append(
+                ledger,
+                "LATE_RESPONSE",
+                scope=key.inbound_id,
+                source_id=message_id,
+                key_digest=key.digest,
+                data={
+                    "broadcast_id": bid,
+                    "closed_state": "broadcast_policy_satisfied",
+                    "transaction_id": transaction_id,
+                },
+            )
+
+    def _reconcile_landed_pending_broadcast_close(
+        self,
+        key: ObligationKey,
+    ) -> bool:
+        """Make a landed reserved response informational before replay can classify it."""
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if (
+                not isinstance(admission, dict)
+                or not isinstance(admission.get("broadcast_policy_close_pending"), dict)
+            ):
+                return False
+            aggregate = ledger["broadcasts"].get(admission.get("broadcast_id"))
+            if not isinstance(aggregate, dict):
+                return False
+            landed = any(
+                candidate[3] == key.inbound_id
+                for candidate in self._broadcast_qualifying_answers_locked(
+                    ledger,
+                    aggregate,
+                )
+            )
+            if not landed:
+                return False
+            self._complete_pending_broadcast_close_locked(ledger, admission, key)
+            self._write(ledger)
+            return True
+
+    @staticmethod
+    def _delivery_transaction_intact(
+        ledger: dict,
+        admission: dict,
+        key: ObligationKey,
+        record: dict,
+    ) -> bool:
+        failure_sequence = admission.get("delivery_failure_sequence")
+        incident_sequence = admission.get("delivery_failure_incident_sequence")
+        reference = admission.get("dead_letter_reference")
+        if (
+            not isinstance(failure_sequence, int)
+            or not isinstance(incident_sequence, int)
+            or not isinstance(reference, dict)
+            or set(reference) != {
+                "kind",
+                "immutable_inbound_id",
+                "admission_key_digest",
+                "operation_nonces",
+                "incident_sequence",
+                "delivery_failure_sequence",
+            }
+            or reference.get("kind") != "dead_letter_reference"
+            or reference.get("immutable_inbound_id") != key.inbound_id
+            or reference.get("admission_key_digest") != key.digest
+            or reference.get("operation_nonces")
+            != sorted(admission.get("reservations", {}))
+            or reference.get("incident_sequence") != incident_sequence
+            or reference.get("delivery_failure_sequence") != failure_sequence
+        ):
+            return False
+        failure_events = [
+            event
+            for event in ledger.get("transitions", [])
+            if isinstance(event, dict)
+            and event.get("sequence") == failure_sequence
+            and event.get("transition") == "DELIVERY_FAILED"
+            and event.get("key_digest") == key.digest
+        ]
+        incident_events = [
+            event
+            for event in ledger.get("transitions", [])
+            if isinstance(event, dict)
+            and event.get("sequence") == incident_sequence
+            and event.get("transition") in {
+                "COMPLIANCE_INCIDENT",
+                "INFRASTRUCTURE_INCIDENT",
+            }
+            and event.get("key_digest") == key.digest
+        ]
+        indexed = [
+            row
+            for row in ledger.get("delivery_index", {}).get(key.correlation_id, [])
+            if isinstance(row, dict)
+            and row.get("sequence") == failure_sequence
+            and row.get("key_digest") == key.digest
+            and row.get("inbound_id") == key.inbound_id
+            and row.get("requester") == key.requester
+            and row.get("responder") == key.responder
+            and row.get("state") == "delivery_failed"
+            and row.get("incident_sequence") == incident_sequence
+            and row.get("dead_letter_reference_key_digest") == key.digest
+        ]
+        disposition = ledger.get("cursor_dispositions", {}).get(key.responder)
+        return (
+            len(failure_events) == 1
+            and len(incident_events) == 1
+            and len(indexed) == 1
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == record.get("id")
+            and disposition.get("mode") == record.get("mode", "global")
+            and disposition.get("state") == "delivery_failed"
+        )
+
+    def delivery_failed(
+        self,
+        record: dict,
+        key: ObligationKey,
+        *,
+        reason: str,
+        expected_revision: int,
+    ) -> Resolution:
+        """Atomically index requester release and dispose the responder assignment."""
+        if record.get("id") != key.inbound_id:
+            raise GateError("delivery failure does not match the exact inbound")
+        liaison = self.store.load_config().get("operator_facing")
+        terminal: Resolution | None = None
+        blocked: Resolution | None = None
+        breaker_tripped = False
+        scoped_revision = expected_revision
+        canonical_reason = reason
+        failure_sequence: int | None = None
+        with ExitStack() as locks:
+            locks.enter_context(self.store._message_publication_lock())
+            messages, _ = self._validated_messages()
+            locks.enter_context(
+                self.store._exclusive_lock(
+                    self.path.with_suffix(".lock"), timeout=10.0,
+                )
+            )
+            ledger = self._load()
+            if ledger["inbound_index"].get(key.inbound_id) != key.digest:
+                raise GateError("delivery failure admission index is stale")
+            admission = ledger["obligations"].get(key.digest)
+            if not isinstance(admission, dict):
+                raise GateError("delivery admission missing")
+            if self._key_from(admission.get("key")) != key:
+                raise GateError("delivery failure key does not match persisted admission")
+            replayed = self._resolve_replay(
+                record,
+                messages,
+                ledger,
+                admission=admission,
+            )
+            if replayed.terminal and replayed.state != ResolverState.DELIVERY_EXHAUSTED:
+                terminal = replayed
+            elif replayed.state in {
+                ResolverState.BLOCKED,
+                ResolverState.BLOCKED_POLICY,
+                ResolverState.BLOCKED_COMPLIANCE,
+            }:
+                blocked = replayed
+            elif admission.get("state") == "delivery_failed":
+                canonical_reason = str(admission.get("delivery_failure_reason") or reason)
+                if not self._delivery_transaction_intact(
+                    ledger,
+                    admission,
+                    key,
+                    record,
+                ):
+                    torn_reason = "failed-delivery transaction is structurally torn"
+                    admission["state"] = "blocked"
+                    admission["blocked_reason"] = torn_reason
+                    self._append(
+                        ledger,
+                        "OBLIGATION_BLOCKED",
+                        scope=key.inbound_id,
+                        key_digest=key.digest,
+                        data={"reason": torn_reason},
+                    )
+                    self._write(ledger)
+                    blocked = Resolution(ResolverState.BLOCKED, torn_reason, key)
+            else:
+                if admission.get("state") != "open":
+                    raise GateError("delivery admission is no longer open")
+                if admission.get("fence") != self.fence or not self._live_dispatch_fence_owned():
+                    raise GateError("delivery failure wrapper fence changed")
+                if int(ledger["scoped_revisions"].get(key.inbound_id, 0)) != (
+                    expected_revision
+                ):
+                    raise StaleRevision("delivery failure scoped revision changed")
+                if not self._dispatch_head_is_current(admission, key):
+                    raise StaleRevision("delivery failure no longer owns the exact cursor head")
+                admission["state"] = "delivery_failed"
+                admission["delivery_failure_reason"] = canonical_reason
+                failure_class = (
+                    "compliance"
+                    if admission.get("last_exhaustion_class") == "compliance"
+                    else "infrastructure"
+                )
+                incident = self._append(
+                    ledger,
+                    (
+                        "COMPLIANCE_INCIDENT"
+                        if failure_class == "compliance"
+                        else "INFRASTRUCTURE_INCIDENT"
+                    ),
+                    scope=key.inbound_id,
+                    key_digest=key.digest,
+                    data={
+                        "reason": canonical_reason,
+                        "failure_class": failure_class,
+                        "requester": key.requester,
+                        "responder": key.responder,
+                        "liaison": liaison,
+                    },
+                )
+                event = self._append(
+                    ledger,
+                    "DELIVERY_FAILED",
+                    scope=key.inbound_id,
+                    key_digest=key.digest,
+                    data={
+                        "reason": canonical_reason,
+                        "requester": key.requester,
+                        "responder": key.responder,
+                        "correlation_id": key.correlation_id,
+                        "incident_sequence": incident["sequence"],
+                    },
+                )
+                dead_letter_reference = {
+                    "kind": "dead_letter_reference",
+                    "immutable_inbound_id": key.inbound_id,
+                    "admission_key_digest": key.digest,
+                    "operation_nonces": sorted(admission.get("reservations", {})),
+                    "incident_sequence": incident["sequence"],
+                    "delivery_failure_sequence": event["sequence"],
+                }
+                admission["delivery_failure_sequence"] = event["sequence"]
+                admission["delivery_failure_incident_sequence"] = incident["sequence"]
+                admission["dead_letter_reference"] = dead_letter_reference
+                admission["terminal_state"] = ResolverState.DELIVERY_EXHAUSTED.value
+                admission["terminal_evidence_id"] = str(event["sequence"])
+                admission["exhausted"] = True
+                admission["exhausted_at"] = self.now()
+                ledger["delivery_index"].setdefault(key.correlation_id, []).append({
+                    "kind": "DELIVERY_FAILED",
+                    "sequence": event["sequence"],
+                    "key_digest": key.digest,
+                    "inbound_id": key.inbound_id,
+                    "question_generation": key.question_generation,
+                    "delivery_generation": key.delivery_generation,
+                    "requester": key.requester,
+                    "responder": key.responder,
+                    "state": "delivery_failed",
+                    "reason": canonical_reason,
+                    "incident_sequence": incident["sequence"],
+                    "dead_letter_reference_key_digest": key.digest,
+                    "broadcast_id": admission.get("broadcast_id"),
+                    "membership_snapshot": admission.get("membership_snapshot"),
+                    "response_policy": admission.get("response_policy"),
+                    "response_quorum": admission.get("response_quorum"),
+                    "broadcast_policy_version": admission.get(
+                        "broadcast_policy_version"
+                    ),
+                })
+                ledger["cursor_dispositions"][self.agent] = {
+                    "inbound_id": record.get("id"),
+                    "mode": record.get("mode", "global"),
+                    "state": "delivery_failed",
+                    "at": self.now(),
+                }
+                self._apply_delivery_exhaustion(ledger, key, admission, event)
+                self._write(ledger)
+            breaker = ledger["breakers"].get(self.agent, {})
+            breaker_tripped = isinstance(breaker, dict) and breaker.get("tripped") is True
+            scoped_revision = int(ledger["scoped_revisions"].get(key.inbound_id, 0))
+            raw_failure_sequence = admission.get("delivery_failure_sequence")
+            failure_sequence = (
+                raw_failure_sequence if isinstance(raw_failure_sequence, int) else None
+            )
+        if terminal is not None:
+            return self.finalize(
+                record,
+                terminal,
+                expected_revision=terminal.scoped_revision,
+            )
+        if blocked is not None:
+            return blocked
+        if breaker_tripped:
+            self._project_compliance_breaker_hold()
+            self._reconcile_compliance_breaker_alert()
+        return self.finalize(
+            record,
+            Resolution(
+                ResolverState.DELIVERY_EXHAUSTED,
+                canonical_reason,
+                key,
+                evidence_id=(
+                    str(failure_sequence) if failure_sequence is not None else None
+                ),
+                scoped_revision=scoped_revision,
+            ),
+            expected_revision=scoped_revision,
+        )
+
+    def _apply_delivery_exhaustion(
+        self,
+        ledger: dict,
+        key: ObligationKey,
+        admission: dict,
+        event: dict,
+    ) -> bool:
+        breaker = self._breaker_state(ledger)
+        if admission.get("last_exhaustion_class") != "compliance":
+            breaker["proof_infra_exhaustions_consecutive"] = int(
+                breaker.get("proof_infra_exhaustions_consecutive", 0),
+            ) + 1
+            self._append(
+                ledger,
+                "PROOF_INFRA_EXHAUSTION_RECORDED",
+                key_digest=key.digest,
+                data={
+                    "count": breaker["proof_infra_exhaustions_consecutive"],
+                    "delivery_sequence": event.get("sequence"),
+                },
+            )
+            return False
+        breaker["owed_action_cap_exhaustions_consecutive"] = int(
+            breaker.get("owed_action_cap_exhaustions_consecutive", 0)) + 1
+        references = breaker.setdefault("compliance_exhaustion_references", [])
+        if not isinstance(references, list):
+            raise LedgerUnreadable("compliance exhaustion references are invalid")
+        references.append({
+            "key_digest": key.digest,
+            "delivery_sequence": event.get("sequence"),
+        })
+        if breaker["owed_action_cap_exhaustions_consecutive"] < COMPLIANCE_BREAKER_TRIP:
+            return False
+        newly_tripped = False
+        if breaker.get("tripped") is not True:
+            breaker["generation"] = int(breaker.get("generation", 0)) + 1
+            breaker["tripped"] = True
+            breaker["config_blocked"] = True
+            breaker["config_blocked_reason"] = "owed_action_compliance_breaker"
+            newly_tripped = True
+            breaker["tripped_at"] = self.now()
+            generation = int(breaker["generation"])
+            alert_nonce = uuid.uuid4().hex
+            alert_request_id = f"esc-owed-breaker-{self.agent}-{generation}"
+            alert_body = (
+                f"Owed-action compliance breaker tripped for {self.agent} "
+                f"at generation {generation}. Paid dispatch is halted. "
+                f"Exhaustion references: {_canonical(references[-COMPLIANCE_BREAKER_TRIP:])}"
+            )
+            breaker.setdefault("alerts", {})[str(generation)] = {
+                "state": "pending",
+                "nonce": alert_nonce,
+                "request_id": alert_request_id,
+                "body": alert_body,
+                "exhaustion_references": list(references[-COMPLIANCE_BREAKER_TRIP:]),
+                "queued_at": self.now(),
+            }
+            self._append(
+                ledger,
+                "COMPLIANCE_BREAKER_TRIPPED",
+                key_digest=key.digest,
+                data={
+                    "agent": self.agent,
+                    "generation": breaker["generation"],
+                    "exhaustion_references": list(references[-COMPLIANCE_BREAKER_TRIP:]),
+                },
+            )
+            self._append(
+                ledger,
+                "COMPLIANCE_BREAKER_ALERT_QUEUED",
+                key_digest=key.digest,
+                data={
+                    "agent": self.agent,
+                    "generation": generation,
+                    "nonce": alert_nonce,
+                },
+            )
+        return newly_tripped
+
+    @staticmethod
+    def _supported_requester_reask(
+        message: Message,
+        *,
+        request_id: str,
+        requester: str,
+    ) -> bool:
+        if message.kind != "question" or message.sender != requester:
+            return False
+        meta = message.meta if isinstance(message.meta, dict) else {}
+        if _true(meta, "consult") is not False:
+            return False
+        broadcast_id = meta.get("broadcast_id")
+        if broadcast_id is None:
+            return meta.get("request_id") == request_id
+        members = meta.get("membership_snapshot")
+        policy = meta.get("response_policy")
+        quorum = meta.get("response_quorum")
+        return bool(
+            broadcast_id == request_id
+            and isinstance(members, list)
+            and message.recipient in members
+            and policy in {"each", "any", "quorum"}
+            and meta.get("broadcast_policy_version") == 1
+            and (
+                policy != "quorum"
+                or isinstance(quorum, int)
+                and not isinstance(quorum, bool)
+                and 1 <= quorum <= len(members)
+            )
+        )
+
+    def delivery_status(self, request_id: str, requester: str) -> dict | None:
+        try:
+            ledger = self._load(create=False)
+        except (LedgerUnreadable, OSError, ValueError, TimeoutError, RuntimeError):
+            return None
+        rows = ledger["delivery_index"].get(request_id, [])
+        failures = [
+            row for row in (rows if isinstance(rows, list) else [])
+            if isinstance(row, dict) and row.get("requester") == requester
+        ]
+        if not failures:
+            return None
+        aggregate_state = ledger["broadcasts"].get(request_id)
+        current_broadcast_generation = (
+            int(aggregate_state.get("generation", 1))
+            if isinstance(aggregate_state, dict)
+            else None
+        )
+        policy_terminals = [
+            row for row in failures
+            if row.get("state") == ResolverState.BROADCAST_POLICY_SATISFIED.value
+            and row.get("aggregate") is True
+            and (
+                current_broadcast_generation is None
+                or int(row.get("broadcast_generation", 1))
+                == current_broadcast_generation
+            )
+        ]
+        if policy_terminals:
+            return dict(policy_terminals[-1])
+        try:
+            messages = self.store.publication_ordered_messages()
+        except (OSError, ValueError, TimeoutError, RuntimeError):
+            return None
+        canonical_order = {
+            message.id: index for index, message in enumerate(messages)
+        }
+        current_failures: list[dict] = []
+        for row in failures:
+            failed_order = canonical_order.get(row.get("inbound_id"), -1)
+            superseded = any(
+                self._supported_requester_reask(
+                    message,
+                    request_id=request_id,
+                    requester=requester,
+                )
+                and message.recipient == row.get("responder")
+                and canonical_order[message.id] > failed_order
+                for message in messages
+            )
+            if not superseded:
+                current_failures.append(row)
+        failures = current_failures
+        if not failures:
+            return None
+        admissions: list[tuple[ObligationKey, dict]] = []
+        for admission in ledger["obligations"].values():
+            if not isinstance(admission, dict):
+                continue
+            try:
+                key = self._key_from(admission.get("key"))
+            except (TypeError, ValueError):
+                continue
+            if key.correlation_id == request_id and key.requester == requester:
+                admissions.append((key, admission))
+        broadcast = [
+            (key, admission) for key, admission in admissions
+            if admission.get("broadcast_id") == request_id
+            and (
+                current_broadcast_generation is None
+                or int(admission.get("broadcast_generation") or 1)
+                == current_broadcast_generation
+            )
+        ]
+        if broadcast and isinstance(aggregate_state, dict):
+            descriptor = aggregate_state.get("descriptor")
+            if not isinstance(descriptor, dict) or descriptor.get("requester") != requester:
+                return None
+            policy = descriptor.get("response_policy")
+            members = descriptor.get("membership_snapshot")
+            threshold = (
+                1
+                if policy == "any"
+                else descriptor.get("response_quorum")
+                if policy == "quorum"
+                else len(members)
+                if policy == "each" and isinstance(members, list)
+                else None
+            )
+            if isinstance(threshold, int) and threshold > 0:
+                qualifying = self._broadcast_qualifying_answers_locked(
+                    ledger,
+                    aggregate_state,
+                )
+                satisfied_members = {candidate[2] for candidate in qualifying}
+                possible_members: set[str] = set()
+                if isinstance(members, list):
+                    by_responder: dict[str, list[dict]] = {}
+                    for key, admission in broadcast:
+                        by_responder.setdefault(key.responder, []).append(admission)
+                    for member in members:
+                        if member in satisfied_members:
+                            continue
+                        member_rows = by_responder.get(member, [])
+                        if not member_rows or any(
+                            row.get("state") == "open" for row in member_rows
+                        ):
+                            possible_members.add(member)
+                # DELIVERY_FAILED is not a qualifying default answer.  The aggregate
+                # waiter stays live while the immutable policy can still be met.
+                if (
+                    len(satisfied_members) >= threshold
+                    or len(satisfied_members | possible_members) >= threshold
+                ):
+                    return None
+                result = dict(failures[-1])
+                result.update({
+                    "aggregate": True,
+                    "response_policy": policy,
+                    "response_quorum": descriptor.get("response_quorum"),
+                })
+                return result
+        if admissions:
+            latest_key, latest = max(
+                admissions,
+                key=lambda item: (
+                    item[0].question_generation,
+                    item[0].delivery_generation,
+                ),
+            )
+            terminal_state = latest.get("state")
+            if terminal_state not in {"delivery_failed", "operator_resolved"}:
+                return None
+            for row in reversed(failures):
+                if (
+                    row.get("key_digest") == latest_key.digest
+                    and row.get("state") == terminal_state
+                ):
+                    return dict(row)
+            return None
+        return dict(failures[-1])
+
+    def broadcast_status(self, request_id: str, requester: str) -> str | None:
+        """Return the normative v1 aggregate state for requester wait projection."""
+        try:
+            ledger = self._load(create=False)
+        except (LedgerUnreadable, OSError, ValueError, TimeoutError, RuntimeError):
+            return None
+        aggregate = ledger["broadcasts"].get(request_id)
+        if not isinstance(aggregate, dict):
+            return None
+        descriptor = aggregate.get("descriptor")
+        if not isinstance(descriptor, dict):
+            return None
+        return (
+            str(aggregate.get("state"))
+            if descriptor.get("requester") == requester
+            else None
+        )
+
+    def schedule_continuation(self, key: ObligationKey, *, producer_token: str) -> str:
+        with self.store._exclusive_lock(self.path.with_suffix(".lock"), timeout=10.0):
+            ledger = self._load()
+            admission = ledger["obligations"].get(key.digest)
+            if not isinstance(admission, dict) or admission.get("state") != "open":
+                raise GateError("continuation admission missing")
+            if int(admission.get("paid_dispatches_total", 0)) != 1:
+                raise DispatchRefused("continuation requires exactly one paid dispatch")
+            if admission.get("recovery_used") or admission.get("continuation_used"):
+                raise DispatchRefused("extra dispatch budget already assigned")
+            existing = admission.get("durable_continuation")
+            if isinstance(existing, dict) and existing.get("state") == "scheduled":
+                if admission.get("producer_token") != producer_token:
+                    raise DispatchRefused("continuation is already owned by another producer")
+                return str(existing["operation_nonce"])
+            operation_nonce = uuid.uuid4().hex
+            admission["producer_token"] = producer_token
+            admission["first_deferred_at"] = admission.get("first_deferred_at") or self.now()
+            admission["durable_continuation"] = {
+                "operation_nonce": operation_nonce,
+                "state": "scheduled",
+            }
+            self._append(
+                ledger,
+                "CONTINUATION_SCHEDULED",
+                scope=key.inbound_id,
+                key_digest=key.digest,
+                data={"operation_nonce": operation_nonce},
+            )
+            self._write(ledger)
+        return operation_nonce
+
+    def roster_snapshot(self) -> dict:
+        return _roster_snapshot(self.store.load_config())
+
+    def operator_resolve(
+        self,
+        record: dict,
+        key: ObligationKey,
+        *,
+        actor: str,
+        expected_roster_revision: str,
+        reason: str,
+    ) -> Resolution:
+        if not reason.strip():
+            raise ValueError("operator resolution requires an audit reason")
+        if any((
+            key.responder != self.agent,
+            record.get("id") != key.inbound_id,
+            record.get("from") != key.requester,
+            record.get("to") != key.responder,
+            record.get("correlation_id") != key.correlation_id,
+        )):
+            raise GateError(
+                "operator resolution record does not match the exact inbound key"
+            )
+        resolution: Resolution
+        with self.store._config_lock(timeout=10.0):
+            roster = _roster_snapshot(self.store.load_config())
+            if roster["revision"] != expected_roster_revision:
+                raise StaleRevision("roster changed before operator resolution")
+            if actor not in roster["authorized_liaisons"]:
+                raise PermissionError("actor is not an event-time authorized liaison or lead")
+            with ExitStack() as locks:
+                locks.enter_context(self.store._message_publication_lock())
+                messages, _ = self._validated_messages()
+                canonical = self._record_message(record, messages)
+                if canonical is None or any((
+                    canonical.sender != key.requester,
+                    canonical.recipient != key.responder,
+                    _correlation(canonical.meta) != key.correlation_id,
+                )):
+                    raise GateError("operator resolution canonical inbound mismatch")
+                locks.enter_context(
+                    self.store._exclusive_lock(
+                        self.path.with_suffix(".lock"), timeout=10.0
+                    )
+                )
+                ledger = self._load()
+                admission = ledger["obligations"].get(key.digest)
+                if not isinstance(admission, dict) or admission.get("state") not in {
+                    "open",
+                    "delivery_failed",
+                }:
+                    raise GateError("operator resolution target is not recoverable")
+                replayed = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=admission,
+                )
+                if replayed.terminal and replayed.state != ResolverState.DELIVERY_EXHAUSTED:
+                    resolution = replayed
+                elif replayed.state in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    ResolverState.INDETERMINATE,
+                }:
+                    return replayed
+                else:
+                    admission["state"] = "operator_resolved"
+                    admission["terminal_state"] = ResolverState.OPERATOR_RESOLVED.value
+                    event = self._append(
+                        ledger,
+                        "OPERATOR_RESOLUTION",
+                        scope=key.inbound_id,
+                        source_id=actor,
+                        key_digest=key.digest,
+                        data={
+                            "actor": actor,
+                            "reason": reason.strip(),
+                            "roster_revision": expected_roster_revision,
+                        },
+                    )
+                    ledger["delivery_index"].setdefault(key.correlation_id, []).append({
+                        "kind": "OPERATOR_RESOLUTION",
+                        "sequence": event["sequence"],
+                        "key_digest": key.digest,
+                        "inbound_id": key.inbound_id,
+                        "question_generation": key.question_generation,
+                        "delivery_generation": key.delivery_generation,
+                        "requester": key.requester,
+                        "responder": key.responder,
+                        "state": "operator_resolved",
+                        "reason": reason.strip(),
+                        "actor": actor,
+                        "roster_revision": expected_roster_revision,
+                        "broadcast_id": admission.get("broadcast_id"),
+                    })
+                    ledger["cursor_dispositions"][self.agent] = {
+                        "inbound_id": record.get("id"),
+                        "mode": record.get("mode", "global"),
+                        "state": ResolverState.OPERATOR_RESOLVED.value,
+                        "at": self.now(),
+                    }
+                    self._write(ledger)
+                    scoped_revision = int(
+                        ledger["scoped_revisions"].get(key.inbound_id, 0)
+                    )
+                    resolution = Resolution(
+                        ResolverState.OPERATOR_RESOLVED,
+                        reason.strip(),
+                        key,
+                        evidence_id=str(event["sequence"]),
+                        scoped_revision=scoped_revision,
+                        ledger_revision=scoped_revision,
+                    )
+        return self.finalize(
+            record,
+            resolution,
+            expected_revision=resolution.scoped_revision,
+        )
+
+    def transfer(
+        self,
+        record: dict,
+        key: ObligationKey,
+        *,
+        destination: str,
+        new_inbound_id: str,
+        destination_policy: PolicySnapshot,
+        actor: str,
+        expected_roster_revision: str,
+        expected_revision: int,
+    ) -> Resolution:
+        """Close the source and create one fenced destination generation atomically."""
+        if any((
+            key.responder != self.agent,
+            record.get("id") != key.inbound_id,
+            record.get("from") != key.requester,
+            record.get("to") != key.responder,
+            record.get("correlation_id") != key.correlation_id,
+        )):
+            raise GateError("transfer record does not match the exact inbound key")
+        resolution: Resolution
+        with self.store._config_lock(timeout=10.0):
+            cfg = self.store.load_config()
+            roster = _roster_snapshot(cfg)
+            if roster["revision"] != expected_roster_revision:
+                raise StaleRevision("roster changed before transfer")
+            if actor not in roster["authorized_liaisons"]:
+                raise PermissionError("transfer actor is not an authorized liaison or lead")
+            if destination not in (cfg.get("agents") or []):
+                raise ValueError("transfer destination is not active")
+            current_policy = self._current_policy()
+            destination_policy_block_state = (
+                destination_policy.status
+                if destination_policy.status in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                }
+                else None
+            )
+            destination_policy_block_reason = (
+                destination_policy.reason
+                or "transfer destination policy is unreadable"
+            )
+            if destination_policy_block_state is None and (
+                current_policy.status != ResolverState.ACTIVE
+                or current_policy.generation != destination_policy.generation
+                or destination_policy.status != ResolverState.ACTIVE
+                or destination_policy.agent != destination
+                or destination_policy.grade != DETECTION_GRADE
+                or not _valid_hex_digest(destination_policy.generation)
+            ):
+                raise GateError(
+                    "transfer destination policy is not detection-grade active"
+                )
+            if (
+                destination_policy_block_state is not None
+                and destination_policy.agent not in {None, destination}
+            ):
+                raise GateError("transfer destination policy is bound to another agent")
+            with ExitStack() as locks:
+                locks.enter_context(self.store._message_publication_lock())
+                messages, projected = self._validated_messages()
+                canonical_source = self._record_message(record, messages)
+                source_meta = (
+                    canonical_source.meta
+                    if canonical_source is not None
+                    and isinstance(canonical_source.meta, dict)
+                    else {}
+                )
+                if canonical_source is None or any((
+                    canonical_source.id != record.get("id"),
+                    canonical_source.ts != record.get("ts"),
+                    canonical_source.sender != record.get("from"),
+                    canonical_source.recipient != record.get("to"),
+                    canonical_source.kind != record.get("kind"),
+                    canonical_source.subject != record.get("subject"),
+                    canonical_source.body != record.get("body"),
+                    source_meta != record.get("meta"),
+                    _correlation(source_meta) != key.correlation_id,
+                )):
+                    raise GateError("transfer canonical source record mismatch")
+                projected_source = projected["obligations"].get(key.digest)
+                if (
+                    isinstance(projected_source, dict)
+                    and self._key_from(projected_source.get("key")) == key
+                ):
+                    published_source = self._resolve_replay(
+                        record,
+                        messages,
+                        projected,
+                        admission=projected_source,
+                    )
+                    if (
+                        published_source.terminal
+                        and published_source.state
+                        != ResolverState.DELIVERY_EXHAUSTED
+                    ):
+                        return self.finalize(
+                            record,
+                            published_source,
+                            expected_revision=published_source.scoped_revision,
+                        )
+                next_inbound = next(
+                    (message for message in messages if message.id == new_inbound_id),
+                    None,
+                )
+                meta = (
+                    next_inbound.meta
+                    if next_inbound is not None and isinstance(next_inbound.meta, dict)
+                    else {}
+                )
+                if (
+                    next_inbound is None
+                    or next_inbound.kind != "question"
+                    or next_inbound.sender != key.requester
+                    or next_inbound.recipient != destination
+                    or _correlation(meta) != key.correlation_id
+                    or _true(meta, "consult") is not False
+                    or meta.get("transfer_from_key_digest") != key.digest
+                    or meta.get("transfer_policy_generation")
+                    != destination_policy.generation
+                    or (
+                        _true(meta, "escalation_required") is True
+                        if key.obligation_class == "answer"
+                        else _true(meta, "escalation_required") is not True
+                    )
+                ):
+                    raise ValueError(
+                        "transfer destination inbound is missing or semantically unadmittable"
+                    )
+                source_descriptor = _broadcast_descriptor(
+                    source_meta,
+                    requester=canonical_source.sender,
+                )
+                target_descriptor = _broadcast_descriptor(
+                    meta,
+                    requester=next_inbound.sender,
+                )
+                if (
+                    (source_descriptor is None) != (target_descriptor is None)
+                    or source_descriptor is not None
+                    and source_descriptor != target_descriptor
+                    or target_descriptor is not None
+                    and destination not in target_descriptor["membership_snapshot"]
+                ):
+                    raise ValueError("transfer destination changed frozen broadcast policy")
+                locks.enter_context(
+                    self.store._exclusive_lock(
+                        self.path.with_suffix(".lock"), timeout=10.0
+                    )
+                )
+                ledger = self._load()
+                old = ledger["obligations"].get(key.digest)
+                if not isinstance(old, dict) or self._key_from(old.get("key")) != key:
+                    raise GateError("transfer source admission is missing or mismatched")
+                if old.get("state") not in {"open", "delivery_failed"}:
+                    raise GateError("transfer source is not recoverable")
+                if int(ledger["scoped_revisions"].get(key.inbound_id, 0)) != (
+                    expected_revision
+                ):
+                    raise StaleRevision("transfer source scoped revision changed")
+                if old.get("state") == "open" and (
+                    old.get("fence") != self.fence
+                    or not self._live_dispatch_fence_owned()
+                    or not self._dispatch_head_is_current(old, key)
+                ):
+                    raise GateError("transfer source wrapper no longer owns the exact head")
+                old.pop("transfer_blocked_state", None)
+                old.pop("transfer_blocked_reason", None)
+                source_replay = self._resolve_replay(
+                    record,
+                    messages,
+                    ledger,
+                    admission=old,
+                )
+                if (
+                    source_replay.terminal
+                    and source_replay.state != ResolverState.DELIVERY_EXHAUSTED
+                ):
+                    return source_replay
+                if destination_policy_block_state is not None:
+                    old["transfer_blocked_state"] = destination_policy_block_state.value
+                    old["transfer_blocked_reason"] = destination_policy_block_reason
+                    self._append(
+                        ledger,
+                        "TRANSFER_DESTINATION_BLOCKED",
+                        scope=key.inbound_id,
+                        key_digest=key.digest,
+                        data={
+                            "state": destination_policy_block_state.value,
+                            "reason": destination_policy_block_reason,
+                        },
+                    )
+                    self._write(ledger)
+                    return Resolution(
+                        destination_policy_block_state,
+                        destination_policy_block_reason,
+                        key,
+                        scoped_revision=int(
+                            ledger["scoped_revisions"].get(key.inbound_id, 0)
+                        ),
+                    )
+                if target_descriptor is not None:
+                    aggregate = ledger["broadcasts"].get(
+                        target_descriptor["broadcast_id"]
+                    )
+                    if (
+                        isinstance(aggregate, dict)
+                        and aggregate.get("state") == "blocked"
+                    ):
+                        reason = "transfer destination broadcast aggregate is blocked"
+                        old["transfer_blocked_state"] = ResolverState.BLOCKED.value
+                        old["transfer_blocked_reason"] = reason
+                        self._append(
+                            ledger,
+                            "TRANSFER_DESTINATION_BLOCKED",
+                            scope=key.inbound_id,
+                            key_digest=key.digest,
+                            data={"state": ResolverState.BLOCKED.value, "reason": reason},
+                        )
+                        self._write(ledger)
+                        scoped_revision = int(
+                            ledger["scoped_revisions"].get(key.inbound_id, 0)
+                        )
+                        return Resolution(
+                            ResolverState.BLOCKED,
+                            reason,
+                            key,
+                            scoped_revision=scoped_revision,
+                            ledger_revision=scoped_revision,
+                        )
+                destination_breaker = ledger["breakers"].get(destination, {})
+                if isinstance(destination_breaker, dict) and (
+                    destination_breaker.get("tripped") is True
+                    or destination_breaker.get("config_blocked") is True
+                ):
+                    reason = "transfer destination compliance breaker is tripped"
+                    old["transfer_blocked_state"] = (
+                        ResolverState.BLOCKED_COMPLIANCE.value
+                    )
+                    old["transfer_blocked_reason"] = reason
+                    self._append(
+                        ledger,
+                        "TRANSFER_DESTINATION_BLOCKED",
+                        scope=key.inbound_id,
+                        key_digest=key.digest,
+                        data={
+                            "state": ResolverState.BLOCKED_COMPLIANCE.value,
+                            "reason": reason,
+                        },
+                    )
+                    self._write(ledger)
+                    scoped_revision = int(
+                        ledger["scoped_revisions"].get(key.inbound_id, 0)
+                    )
+                    return Resolution(
+                        ResolverState.BLOCKED_COMPLIANCE,
+                        reason,
+                        key,
+                        scoped_revision=scoped_revision,
+                        ledger_revision=scoped_revision,
+                    )
+                if source_replay.state in {
+                    ResolverState.BLOCKED,
+                    ResolverState.BLOCKED_POLICY,
+                    ResolverState.BLOCKED_COMPLIANCE,
+                    ResolverState.INDETERMINATE,
+                }:
+                    raise GateError(
+                        f"transfer source replay is {source_replay.state.value}"
+                    )
+                if (
+                    new_inbound_id in ledger["inbound_index"]
+                    or new_inbound_id in ledger["no_admission_claims"]
+                ):
+                    raise StaleRevision("transfer destination was already claimed")
+                indexed = ledger["messages"].get(new_inbound_id)
+                if not isinstance(indexed, dict):
+                    raise GateError("transfer destination is absent from canonical replay")
+                target_record = {
+                    "id": next_inbound.id,
+                    "ts": next_inbound.ts,
+                    "from": next_inbound.sender,
+                    "to": next_inbound.recipient,
+                    "kind": next_inbound.kind,
+                    "subject": next_inbound.subject,
+                    "body": next_inbound.body,
+                    "meta": dict(meta),
+                    "request_id": meta.get("request_id"),
+                    "broadcast_id": meta.get("broadcast_id"),
+                    "correlation_id": _correlation(meta),
+                    "mode": "global",
+                }
+                destination_gate = DetectionCommitGate(
+                    self.store,
+                    destination,
+                    destination_policy,
+                    fence="transfer-pre-admission-validation",
+                    now=self.now,
+                )
+                prospective = destination_gate._resolve_replay(
+                    target_record,
+                    messages,
+                    ledger,
+                    admission=None,
+                )
+                if prospective.state in TERMINAL_STATES:
+                    raise GateError(
+                        "transfer destination already terminal before admission"
+                    )
+                if prospective.state != ResolverState.OWED_UNSATISFIED:
+                    raise GateError(
+                        "transfer destination replay is not safely admissible"
+                    )
+
+                next_key = ObligationKey(
+                    store_epoch=key.store_epoch,
+                    inbound_id=new_inbound_id,
+                    correlation_id=key.correlation_id,
+                    requester=key.requester,
+                    responder=destination,
+                    question_generation=key.question_generation,
+                    delivery_generation=key.delivery_generation + 1,
+                    obligation_class=key.obligation_class,
+                    reducer_version=key.reducer_version,
+                    participant_capabilities_digest=key.participant_capabilities_digest,
+                )
+                next_admission = {
+                    "key": next_key.to_dict(),
+                    "correlation_id": key.correlation_id,
+                    "obligation_class": key.obligation_class,
+                    "state": "open",
+                    "watermark_sequence": ledger["append_sequence"],
+                    "scoped_revision": int(
+                        ledger["scoped_revisions"].get(new_inbound_id, 0)
+                    ),
+                    "activation_generation": destination_policy.generation,
+                    "readiness_generation": destination_policy.generation,
+                    "fence": "unclaimed",
+                    "owner_pid": None,
+                    "delivery_mode": old.get("delivery_mode", "global"),
+                    "scoped_request_id": old.get("scoped_request_id"),
+                    "paid_dispatches_total": 0,
+                    "paid_initial_dispatches_total": 0,
+                    "paid_recoveries_total": 0,
+                    "paid_continuations_total": 0,
+                    "continuation_used": False,
+                    "recovery_used": False,
+                    "first_dispatch_classified": False,
+                    "last_exhaustion_class": None,
+                    "reservations": {},
+                    "operation_infra_attempts": 0,
+                    "operation_infra_first_at": None,
+                    "operation_infra_retry_inflight": False,
+                    "finalization_misses": 0,
+                    "finalization_first_at": None,
+                    "finalization_retry_inflight": False,
+                    "cursor_projection_misses": 0,
+                    "cursor_projection_first_at": None,
+                    "cursor_projection_inflight": False,
+                    "cursor_projection_reserved_at": None,
+                    "owed_action_missing_seen": False,
+                    "created_at": self.now(),
+                    "broadcast_id": meta.get("broadcast_id"),
+                    "membership_snapshot": meta.get("membership_snapshot"),
+                    "response_policy": meta.get("response_policy"),
+                    "response_quorum": meta.get("response_quorum"),
+                    "broadcast_policy_version": meta.get("broadcast_policy_version"),
+                    "broadcast_generation": indexed.get("broadcast_generation"),
+                    "exhausted": False,
+                    "exhausted_at": None,
+                    "delivery_failure_reason": None,
+                    "delivery_failure_sequence": None,
+                    "delivery_failure_incident_sequence": None,
+                    "dead_letter_reference": None,
+                }
+                transaction_id = uuid.uuid4().hex
+                ledger["obligations"][next_key.digest] = next_admission
+                ledger["inbound_index"][new_inbound_id] = next_key.digest
+                self._append(
+                    ledger,
+                    "OBLIGATION_ADMITTED",
+                    scope=new_inbound_id,
+                    source_id=new_inbound_id,
+                    key_digest=next_key.digest,
+                    data={
+                        "key": next_key.to_dict(),
+                        "transfer_from": key.digest,
+                        "transaction_id": transaction_id,
+                        "destination_policy_generation": destination_policy.generation,
+                    },
+                )
+                transfer_event = self._append(
+                    ledger,
+                    "TRANSFERRED",
+                    scope=key.inbound_id,
+                    source_id=actor,
+                    key_digest=key.digest,
+                    data={
+                        "destination": destination,
+                        "new_key": next_key.to_dict(),
+                        "transaction_id": transaction_id,
+                        "roster_revision": expected_roster_revision,
+                    },
+                )
+                old["state"] = "transferred"
+                old["terminal_state"] = ResolverState.TRANSFERRED.value
+                old["terminal_evidence_id"] = str(transfer_event["sequence"])
+                old["transferred_at"] = self.now()
+                ledger["cursor_dispositions"][self.agent] = {
+                    "inbound_id": record.get("id"),
+                    "mode": record.get("mode", "global"),
+                    "state": ResolverState.TRANSFERRED.value,
+                    "at": self.now(),
+                }
+                self._write(ledger)
+                scoped_revision = int(
+                    ledger["scoped_revisions"].get(key.inbound_id, 0)
+                )
+                resolution = Resolution(
+                    ResolverState.TRANSFERRED,
+                    "transferred",
+                    key,
+                    str(transfer_event["sequence"]),
+                    scoped_revision,
+                )
+        return self.finalize(record, resolution, expected_revision=scoped_revision)
+
+    def close_broadcast_members(self, winning_key: ObligationKey,
+                                remaining: list[ObligationKey], *, winning_ids: list[str]) -> None:
+        del winning_key, remaining, winning_ids
+        raise GateError("direct broadcast closure is forbidden; use canonical replay")
+
+    def status(self) -> dict:
+        policy = self._current_policy()
+        result = {
+            "agent": self.agent,
+            "grade": policy.grade,
+            "policy_generation": policy.generation,
+            "status": (
+                "ACTIVE (detection-grade)"
+                if policy.status == ResolverState.ACTIVE
+                else policy.status.value.upper()
+            ),
+            "reason": policy.reason,
+            "security_grade": False,
+        }
+        if self.proof_health_path.exists():
+            try:
+                proof_health = json.loads(
+                    self.proof_health_path.read_text(encoding="utf-8")
+                )
+                if not isinstance(proof_health, dict):
+                    raise ValueError("proof health is not an object")
+            except (OSError, ValueError, json.JSONDecodeError):
+                proof_health = {"state": "blocked", "unreadable": True}
+            result["proof_health"] = proof_health
+            if (
+                policy.status == ResolverState.ACTIVE
+                and proof_health.get("state") == "blocked"
+            ):
+                result["status"] = ResolverState.BLOCKED.value.upper()
+                result["reason"] = (
+                    "canonical replay proof health is unreadable"
+                    if proof_health.get("unreadable") is True
+                    else "canonical replay proof is blocked pending a successful replay"
+                )
+        if not self.path.exists() and not self.epoch_anchor_path.exists():
+            result["store_epoch"] = None
+            result["append_sequence"] = 0
+            result["breaker"] = {}
+            result["open_obligations"] = 0
+            result["legacy_broadcast"] = {
+                "enforcement": "none",
+                "unenforced_total": 0,
+            }
+            return result
+        try:
+            ledger = self._load(create=False)
+        except LedgerUnreadable as exc:
+            if policy.status == ResolverState.ACTIVE:
+                result["status"] = ResolverState.BLOCKED.value.upper()
+                result["reason"] = str(exc)
+            result["ledger_error"] = str(exc)
+            return result
+        result["store_epoch"] = ledger["store_epoch"]
+        result["append_sequence"] = ledger["append_sequence"]
+        result["legacy_broadcast"] = {
+            "enforcement": "none",
+            "unenforced_total": int(
+                ledger["telemetry"].get("legacy_broadcast_unenforced_total", 0)
+            ),
+        }
+        breaker = ledger["breakers"].get(self.agent, {})
+        result["breaker"] = breaker
+        if (
+            policy.status == ResolverState.ACTIVE
+            and isinstance(breaker, dict)
+            and breaker.get("tripped") is True
+        ):
+            result["status"] = ResolverState.BLOCKED_COMPLIANCE.value.upper()
+            result["reason"] = "owed_action_compliance_breaker"
+            self._project_compliance_breaker_hold()
+            self._reconcile_compliance_breaker_alert()
+        elif isinstance(breaker, dict) and breaker.get("config_blocked") is False:
+            self._clear_compliance_breaker_hold()
+        result["open_obligations"] = sum(
+            1 for row in ledger["obligations"].values()
+            if isinstance(row, dict) and row.get("state") == "open"
+        )
+        return result
+
+
+def note_bus_message(store, message: Message) -> None:
+    """Best-effort eager indexing; authoritative replay repairs missed hooks."""
+    gate = DetectionCommitGate(
+        store,
+        message.recipient,
+        PolicySnapshot.inactive("append service"),
+        fence="append-service",
+    )
+    if not gate.path.exists():
+        return
+    # Re-read the immutable publication stream so a prior failed eager hook is
+    # repaired before the newest message.  Indexing only ``message`` could invert
+    # canonical winner order when the earlier projection was delayed or missed.
+    gate._index_messages(
+        store.publication_ordered_messages(),
+        invalid_records=store.list_invalid_messages(),
+    )
+
+
+def note_manual_close(store, agent: str, request_id: str) -> None:
+    """Canonicalize a no-message ACK/manual close for admitted generations."""
+    gate = DetectionCommitGate(
+        store, agent, PolicySnapshot.inactive("append service"), fence="append-service",
+    )
+    messages = store.publication_ordered_messages()
+    inbounds = [
+        message for message in messages
+        if message.kind == "question"
+        and message.recipient == agent
+        and _correlation(message.meta) == request_id
+    ]
+    if not inbounds:
+        return
+    gate._index_messages(messages, invalid_records=store.list_invalid_messages())
+    with store._exclusive_lock(gate.path.with_suffix(".lock"), timeout=10.0):
+        ledger = gate._load()
+        changed = False
+        for inbound in inbounds:
+            key_id = ledger["inbound_index"].get(inbound.id)
+            admission = ledger["obligations"].get(key_id) if key_id else None
+            if isinstance(admission, dict) and admission.get("state") != "open":
+                continue
+            duplicate = any(
+                event.get("transition") == "MANUAL_CLOSE"
+                and (
+                    event.get("key_digest") == key_id
+                    if key_id
+                    else isinstance(event.get("data"), dict)
+                    and event["data"].get("inbound_id") == inbound.id
+                )
+                for event in ledger["transitions"]
+            )
+            if duplicate:
+                continue
+            gate._append(
+                ledger,
+                "MANUAL_CLOSE",
+                scope=inbound.id,
+                source_id=inbound.id,
+                key_digest=key_id,
+                data={
+                    "agent": agent,
+                    "request_id": request_id,
+                    "inbound_id": inbound.id,
+                },
+            )
+            changed = True
+        if changed:
+            gate._write(ledger)
+
+
+def requester_terminal_for(store, request_id: str, requester: str) -> dict | None:
+    gate = DetectionCommitGate(
+        store,
+        requester,
+        PolicySnapshot.inactive("delivery index read"),
+        fence="read-only",
+    )
+    return gate.delivery_status(request_id, requester)
+
+
+def requester_broadcast_policy_state(
+    store,
+    request_id: str,
+    requester: str,
+) -> str | None:
+    gate = DetectionCommitGate(
+        store,
+        requester,
+        PolicySnapshot.inactive("broadcast state read"),
+        fence="read-only",
+    )
+    return gate.broadcast_status(request_id, requester)
+
+
+def delivery_failed_for(store, request_id: str, requester: str) -> dict | None:
+    terminal = requester_terminal_for(store, request_id, requester)
+    if terminal is None or terminal.get("state") != "delivery_failed":
+        return None
+    return terminal

--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -64,7 +64,8 @@ _DEFAULT_RULES = (
     "- question with meta.consult=true: ATTACK the draft, do not endorse; reply "
     "kind=message echoing request_id + consult=true + round, ending with agree / "
     "disagree / qualified-agree; do not start your own consult.\n"
-    "- question (plain): answer on the thread. A broadcast question that does not "
+    "- ordinary tracked question owing a plain answer: answer on the thread. A "
+    "broadcast question that does not "
     "concern your role: reply --na (never placeholder-ack, never go silent).\n"
     "- review-result / proposal-response: a verdict on something YOU sent - act on "
     "it (proceed / revise), do not reply only to ack.\n"
@@ -75,8 +76,8 @@ _DEFAULT_RULES = (
     "`& \"$env:AGENTTALK_PY\" -m agenttalk send`, "
     "`& \"$env:AGENTTALK_PY\" -m agenttalk escalate`, proposal-response / review-result via "
     "`& \"$env:AGENTTALK_PY\" -m agenttalk reply --kind ...`, and "
-    "`& \"$env:AGENTTALK_PY\" -m agenttalk composing --to-request <id>` to mark a long draft "
-    "in flight (repeat ~every 2 min).\n"
+    "`& \"$env:AGENTTALK_PY\" -m agenttalk composing --to-request <id>` only when "
+    "the wrapper supplied a durable continuation. A composing marker is not an answer.\n"
     "\n"
     "You are HEADLESS: there is no human at your console. If you need a human "
     "decision, DO NOT ask your own window - run "
@@ -121,6 +122,18 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
     out.append("```")
     if lessons:
         out += ["== LESSONS TO CHECK ==", lessons]
+    owed = record.get("owed_action")
+    if isinstance(owed, dict):
+        out += [
+            "== OWED ACTION TRANSPORT ==",
+            "This ordinary tracked question is commit-gated. Write the answer as UTF-8 "
+            "bytes to the exact draft_path with your structured Write/Edit tool. Then run "
+            "the fixed argv operation shown below. Do not put answer text in a shell "
+            "command, do not use -m, and do not substitute another inbound anchor.",
+            "```json",
+            json.dumps(owed, ensure_ascii=False, indent=2, sort_keys=True),
+            "```",
+        ]
     out += ["== HOW TO HANDLE ==", rules]
     return "\n".join(out)
 

--- a/src/agenttalk/wrapper/recv_api.py
+++ b/src/agenttalk/wrapper/recv_api.py
@@ -75,6 +75,24 @@ def _terminal_state(store, agent: str, rid: str) -> tuple[bool, bool]:
     return (False, False)
 
 
+def _requester_terminal(store, agent: str, rid: str) -> dict | None:
+    from .obligations import requester_terminal_for
+
+    return requester_terminal_for(store, rid, agent)
+
+
+def _requester_broadcast_state(store, agent: str, rid: str) -> str | None:
+    from .obligations import requester_broadcast_policy_state
+
+    return requester_broadcast_policy_state(store, rid, agent)
+
+
+def _delivery_failed(terminal: dict | None) -> dict | None:
+    if terminal is None or terminal.get("state") != "delivery_failed":
+        return None
+    return terminal
+
+
 def records(store, agent: str, *, scoped_request_id: str | None = None,
             since: str | None = None, include_control: bool = False) -> list[dict]:
     """All currently-unread messages for ``agent`` as structured records (oldest
@@ -97,10 +115,18 @@ def records(store, agent: str, *, scoped_request_id: str | None = None,
         msgs = [m for m in msgs if m.kind not in CONTROL_KINDS]
     msgs = [m for m in msgs if m.meta.get("request_id") == rid]
     closed, superseded = _terminal_state(store, agent, rid)
+    terminal = _requester_terminal(store, agent, rid)
+    broadcast_state = _requester_broadcast_state(store, agent, rid)
+    if broadcast_state in {"open", "blocked"} and terminal is None:
+        closed = superseded
+    failed = _delivery_failed(terminal)
+    closed = closed or terminal is not None
     out = []
     for m in msgs:
         scoped = {"request_id": rid, "seen_before": seen, "seen_after": m.id,
-                  "closed": closed, "superseded": superseded}
+                  "closed": closed, "superseded": superseded,
+                  "delivery_terminal": terminal,
+                  "delivery_failed": failed}
         # cursor before==after: scoped recv NEVER moves the global cursor.
         out.append(to_record(m, mode=SCOPED, cursor_before=gcur, cursor_after=gcur,
                              scoped=scoped))
@@ -125,11 +151,23 @@ def poll(store, agent: str, *, scoped_request_id: str | None = None,
     }
     if scoped_request_id is not None:
         closed, superseded = _terminal_state(store, agent, scoped_request_id)
+        terminal = _requester_terminal(store, agent, scoped_request_id)
+        broadcast_state = _requester_broadcast_state(
+            store,
+            agent,
+            scoped_request_id,
+        )
+        if broadcast_state in {"open", "blocked"} and terminal is None:
+            closed = superseded
+        failed = _delivery_failed(terminal)
+        closed = closed or terminal is not None
         env["scoped"] = {
             "request_id": scoped_request_id,
             "seen": store.thread_seen(agent, scoped_request_id),
             "closed": closed,
             "superseded": superseded,
+            "delivery_terminal": terminal,
+            "delivery_failed": failed,
         }
     return env
 

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1690,6 +1690,8 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                "retryable": False, "rc": None, "error": None, "terminal_text": "",
                "config_blocked": False, "config_blocked_text": "", "bus_failure": None,
                "setup_failure": None,
+               "bus_action_attempted": False, "bus_action_infra": False,
+               "bus_action_rejected": False,
                "structured_errors": [], "child_output_tail": None,
                "lesson_exposure_error": None}
         child_output_lines: list[dict[str, str]] = []
@@ -1759,6 +1761,9 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             # be classed poison (lead verify P1).
                             sig["terminal_text"] = ev.text or sig["terminal_text"]
                     elif ev.type == EventType.TOOL_FINISHED:
+                        verb = _bus_command_verb(ev.tool)
+                        if verb in _REQUIRED_BUS_WRITE_VERBS:
+                            sig["bus_action_attempted"] = True
                         bus = classify_bus_execution(ev.tool, ev.text, ev.exit_code, ev.raw)
                         if bus["kind"] == BUS_KIND_CONFIG_BLOCKED:
                             sig["config_blocked"] = True
@@ -1768,6 +1773,10 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             BUS_KIND_UNKNOWN_FAILURE,
                         ):
                             sig["bus_failure"] = bus
+                            if bus["kind"] == BUS_KIND_SEMANTIC_FAILURE:
+                                sig["bus_action_rejected"] = True
+                            else:
+                                sig["bus_action_infra"] = True
                         setup_failure = classify_setup_execution(
                             ev.tool, ev.text, ev.exit_code, ev.raw)
                         if setup_failure is not None:
@@ -1935,7 +1944,12 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 persist(session_state)
             if health_writer.state != health_model.STATE_DEGRADED_OUTPUT:
                 health_writer.idle(reason_code="turn_completed")
-            return DriveOutcome(ok=True)
+            return DriveOutcome(
+                ok=True,
+                bus_action_attempted=bool(sig.get("bus_action_attempted")),
+                bus_action_infra=bool(sig.get("bus_action_infra")),
+                bus_action_rejected=bool(sig.get("bus_action_rejected")),
+            )
         # the turn FAILED (no completed boundary / nonzero exit / spawn error, after
         # any resume->fresh retry): undo any heartbeat its streaming progress stamped,
         # so a failed attempt leaves NO fresh heartbeat - AND reset the engine throttle
@@ -1962,7 +1976,10 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             else:
                 store.write_heartbeat(agent)
         return DriveOutcome(ok=False, failure_class=failure_class, summary=summary,
-                            child_output_tail=sig.get("child_output_tail"))
+                            child_output_tail=sig.get("child_output_tail"),
+                            bus_action_attempted=bool(sig.get("bus_action_attempted")),
+                            bus_action_infra=bool(sig.get("bus_action_infra")),
+                            bus_action_rejected=bool(sig.get("bus_action_rejected")))
 
     return drive
 

--- a/tests/test_owed_action_detection.py
+++ b/tests/test_owed_action_detection.py
@@ -89,6 +89,24 @@ def _ledger(gate: DetectionCommitGate) -> dict:
     return json.loads(gate.path.read_text(encoding="utf-8"))
 
 
+def _symlink_or_skip_windows(
+    link: Path,
+    target: Path,
+    *,
+    target_is_directory: bool = False,
+) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except NotImplementedError as exc:
+        if os.name != "nt":
+            raise
+        pytest.skip(f"Windows file symlinks are unavailable: {exc}")
+    except OSError as exc:
+        if os.name != "nt" or getattr(exc, "winerror", None) != 1314:
+            raise
+        pytest.skip(f"Windows file symlink privilege is unavailable: {exc}")
+
+
 def _record_captured_intent(
     store: Store,
     gate: DetectionCommitGate,
@@ -1108,6 +1126,56 @@ def test_dispatch_record_rejects_a_tampered_permit_draft_path(tmp_path: Path) ->
     admission = _ledger(gate)["obligations"][permit.key_digest]
     assert admission["reservations"][permit.nonce]["state"] == "reserved"
     assert not tampered.draft_path.exists()
+
+
+def test_dispatch_record_pins_regular_python_symlink_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = Path(os.sys.executable).resolve(strict=True)
+    launcher = tmp_path / f"python-link{target.suffix}"
+    _symlink_or_skip_windows(launcher, target)
+    monkeypatch.setenv("AGENTTALK_PY", str(launcher))
+    store = _store(tmp_path / "store")
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+
+    dispatched = gate.dispatch_record(record, permit)
+
+    assert dispatched["owed_action"]["argv"][0] == str(target)
+    assert dispatched["owed_action"]["composing_argv"][0] == str(target)
+
+
+@pytest.mark.parametrize(
+    ("target_kind", "error"),
+    [
+        ("dangling", "unavailable"),
+        ("directory", "regular file"),
+        ("loop", "unavailable"),
+    ],
+)
+def test_pinned_executable_rejects_symlink_without_regular_file_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target_kind: str,
+    error: str,
+) -> None:
+    launcher = tmp_path / "python-link"
+    target = launcher if target_kind == "loop" else tmp_path / "target"
+    if target_kind == "directory":
+        target.mkdir()
+    _symlink_or_skip_windows(
+        launcher,
+        target,
+        target_is_directory=target_kind == "directory",
+    )
+    monkeypatch.setenv("AGENTTALK_PY", str(launcher))
+
+    with pytest.raises(DispatchRefused, match=error):
+        DetectionCommitGate._pinned_executable()  # noqa: SLF001 - path policy boundary
 
 
 def test_scheduled_continuation_excludes_recovery_before_second_launch(

--- a/tests/test_owed_action_detection.py
+++ b/tests/test_owed_action_detection.py
@@ -1,0 +1,9947 @@
+"""Detection-grade owed-action protocol acceptance tests (design v3.1.1 §14)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agenttalk import cli, doctor, signing, threads
+from agenttalk.store import Store
+from agenttalk.wrapper import loop, obligations, recv_api
+from agenttalk.wrapper.obligations import (
+    COMPLIANCE_BREAKER_TRIP,
+    DETECTION_GRADE,
+    DispatchRefused,
+    DetectionCommitGate,
+    GateError,
+    LedgerUnreadable,
+    PolicySnapshot,
+    ResolverState,
+    SECURITY_GRADE,
+    StaleRevision,
+    note_manual_close,
+    operation_payload_digest,
+)
+
+
+def _store(tmp_path: Path, agents: list[str] | None = None) -> Store:
+    store = Store(tmp_path)
+    store.init(agents or ["alpha", "beta", "lead", "gamma"])
+    store.set_operator_facing("lead")
+    return store
+
+
+def _policy(*agents: str) -> PolicySnapshot:
+    return PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {agent: {"grade": DETECTION_GRADE} for agent in agents},
+    }, agents[0] if agents else "beta")
+
+
+def _gate(
+    store: Store,
+    *,
+    fence: str = "wrapper-1",
+    now=None,
+    agent: str = "beta",
+    policy_agents: tuple[str, ...] | None = None,
+    producer_alive=None,
+) -> DetectionCommitGate:
+    store.write_waiting(agent, {
+        "mode": "wrapper-loop",
+        "wrapper_generation": fence,
+        "wait_token": fence,
+        "pid": os.getpid(),
+    })
+    kwargs = {"fence": fence}
+    if now is not None:
+        kwargs["now"] = now
+    if producer_alive is not None:
+        kwargs["producer_alive"] = producer_alive
+    peers = tuple(name for name in (policy_agents or (agent,)) if name != agent)
+    return DetectionCommitGate(store, agent, _policy(agent, *peers), **kwargs)
+
+
+def _question(store: Store, rid: str = "q-1", **meta):
+    return store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="question",
+        body="What is 19 * 21?",
+        meta={"request_id": rid, **meta},
+    )
+
+
+def _record(store: Store, rid: str | None = None, *, agent: str = "beta") -> dict:
+    record = recv_api.next_record(store, agent, scoped_request_id=rid)
+    assert record is not None
+    return record
+
+
+def _ledger(gate: DetectionCommitGate) -> dict:
+    return json.loads(gate.path.read_text(encoding="utf-8"))
+
+
+def _record_captured_intent(
+    store: Store,
+    gate: DetectionCommitGate,
+    permit,
+) -> str:
+    row = _ledger(gate)["obligations"][permit.key_digest]["reservations"][permit.nonce]
+    intent = row["operation_intent"]
+    body = permit.draft_path.read_text(encoding="utf-8")
+    digest = operation_payload_digest(
+        operation=intent["operation"],
+        body=body,
+        kind=intent["kind"],
+        recipient=intent["recipient"],
+        in_reply_to=intent.get("in_reply_to"),
+        request_id=intent.get("request_id"),
+        broadcast_id=intent.get("broadcast_id"),
+        origin_request_id=intent.get("origin_request_id"),
+        origin_inbound_id=intent.get("origin_inbound_id"),
+        origin_obligation_key_digest=intent.get("origin_obligation_key_digest"),
+        expected_roster_revision=intent.get("expected_roster_revision"),
+    )
+    store.record_operation_intent(
+        sender="beta",
+        operation_nonce=permit.nonce,
+        operation_digest=digest,
+        body=body,
+        operation_intent=intent,
+    )
+    return digest
+
+
+def _answer_reserved(
+    root: Path,
+    gate: DetectionCommitGate,
+    record: dict,
+    *,
+    body: str = "399",
+) -> tuple[object, object]:
+    resolution = gate.admit_or_finalize(record)
+    assert resolution.key is not None
+    permit = gate.reserve_dispatch(resolution, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    Path(dispatched["owed_action"]["draft_path"]).write_text(body, encoding="utf-8")
+    assert cli.main([
+        "--root", str(root), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+    return resolution, permit
+
+
+def _record_delivery_exhaustion(
+    store: Store,
+    gate: DetectionCommitGate,
+    *,
+    request_id: str,
+    compliance_dominant: bool,
+) -> None:
+    _question(store, request_id)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(
+        permit,
+        action_attempted=not compliance_dominant,
+        action_infra=not compliance_dominant,
+    )
+    current = gate.resolve(record)
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="test exhaustion",
+        expected_revision=current.scoped_revision,
+    )
+
+
+def _broadcast_question(
+    store: Store,
+    recipient: str,
+    *,
+    broadcast_id: str,
+    members: list[str],
+    policy: str,
+    quorum: int | None = None,
+):
+    meta = {
+        "request_id": broadcast_id,
+        "broadcast_id": broadcast_id,
+        "membership_snapshot": members,
+        "response_policy": policy,
+        "broadcast_policy_version": 1,
+    }
+    if quorum is not None:
+        meta["response_quorum"] = quorum
+    return store.send(
+        sender="alpha",
+        recipient=recipient,
+        kind="question",
+        body="broadcast question",
+        meta=meta,
+    )
+
+
+def _transfer_question(
+    store: Store,
+    source_key,
+    destination: str,
+    destination_policy: PolicySnapshot,
+    *,
+    consult: object = False,
+):
+    return store.send(
+        sender=source_key.requester,
+        recipient=destination,
+        kind="question",
+        body="transferred question",
+        meta={
+            "request_id": source_key.correlation_id,
+            "consult": consult,
+            "transfer_from_key_digest": source_key.digest,
+            "transfer_policy_generation": destination_policy.generation,
+        },
+    )
+
+
+def test_policy_snapshot_distinguishes_absent_agent_from_corrupt_policy(tmp_path: Path) -> None:
+    absent = PolicySnapshot.from_mapping({"schema_version": 1, "agents": {}}, "beta")
+    corrupt = PolicySnapshot.from_mapping({"schema_version": 1, "agents": []}, "beta")
+
+    assert absent.status == ResolverState.NOT_OWED
+    assert corrupt.status == ResolverState.BLOCKED_POLICY
+
+    path = tmp_path / "policy.json"
+    path.write_text("{", encoding="utf-8")
+    assert PolicySnapshot.from_path(path, "beta").status == ResolverState.BLOCKED_POLICY
+
+
+def test_readable_policy_reports_detection_grade() -> None:
+    snapshot = _policy("beta")
+
+    assert snapshot.status == ResolverState.ACTIVE
+    assert snapshot.grade == "detection"
+    assert len(snapshot.generation) == 64
+
+
+def test_operator_disabled_policy_is_inactive_and_audited(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    policy = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+    }, "beta")
+    gate = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    record = _record(store)
+
+    resolution = gate.admit_or_finalize(record)
+
+    assert policy.status == ResolverState.INACTIVE
+    assert resolution.state == ResolverState.INACTIVE
+    assert resolution.allows_legacy_commit is True
+    assert any(
+        row["transition"] == "POLICY_INACTIVE"
+        for row in _ledger(gate)["transitions"]
+    )
+    assert gate.finalize(
+        record,
+        resolution,
+        expected_revision=resolution.ledger_revision,
+    ).state == ResolverState.INACTIVE
+    assert store.cursor("beta") == inbound.id
+    assert gate.status()["status"] == "INACTIVE"
+    assert PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": "security", "enabled": False}},
+    }, "beta").status == ResolverState.INACTIVE
+
+
+@pytest.mark.parametrize("enabled", [None, 0, "false"])
+def test_malformed_enabled_policy_fails_closed(enabled: object) -> None:
+    snapshot = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": enabled}},
+    }, "beta")
+
+    assert snapshot.status == ResolverState.BLOCKED_POLICY
+
+
+def test_admission_allocates_epoch_monotonic_sequence_and_replay_visible_key(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+
+    resolution = gate.admit_or_finalize(_record(store))
+    ledger = _ledger(gate)
+    admitted = [
+        event for event in ledger["transitions"]
+        if event["transition"] == "OBLIGATION_ADMITTED"
+    ]
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None
+    assert resolution.key.inbound_id == inbound.id
+    assert resolution.key.store_epoch == ledger["store_epoch"]
+    assert admitted[0]["data"]["key"] == resolution.key.to_dict()
+    assert [row["sequence"] for row in ledger["transitions"]] == list(
+        range(1, ledger["append_sequence"] + 1)
+    )
+
+
+def test_pre_admission_answer_normalizes_without_obligation_key(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    gate = _gate(store)
+    record = _record(store)
+
+    resolution = gate.admit_or_finalize(record)
+    assert resolution.state == ResolverState.SATISFIED
+    assert resolution.key is None
+    assert resolution.evidence_id == answer.id
+
+    gate.finalize(record, resolution, expected_revision=resolution.ledger_revision)
+    assert store.cursor("beta") == inbound.id
+    assert not _ledger(gate)["obligations"]
+
+
+def test_pre_admission_manual_close_and_legacy_rescind_are_terminal(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.close_thread("beta", "q-1", seen_msg_id=inbound.id)
+    closed = _gate(store).admit_or_finalize(_record(store))
+    assert closed.state == ResolverState.SATISFIED
+    assert closed.key is None
+
+    other = _question(store, "q-2")
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn",
+        meta={"request_id": "q-2", "target_msg_id": other.id},
+    )
+    rescinded = _gate(store).admit_or_finalize(
+        recv_api.records(store, "beta")[-2]
+    )
+    assert rescinded.state == ResolverState.SUPERSEDED
+
+
+def test_pre_admission_answer_cannot_satisfy_required_escalation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, escalation_required=True)
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="answered instead of escalating",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+
+    resolution = _gate(store).admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None
+    assert resolution.key.obligation_class == "human_escalation"
+
+
+def test_pre_admission_human_escalation_normalizes_without_key(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, escalation_required=True)
+    gate = _gate(store)
+    roster = gate.roster_snapshot()
+    escalation = store.send(
+        sender="beta",
+        recipient="lead",
+        kind="question",
+        body="operator decision needed",
+        meta={
+            "request_id": "esc-1",
+            "origin_request_id": "q-1",
+            "origin_inbound_id": inbound.id,
+            "in_reply_to": inbound.id,
+            "expected_roster_revision": roster["revision"],
+        },
+    )
+    record = _record(store)
+
+    resolution = gate.admit_or_finalize(record)
+
+    assert resolution.state == ResolverState.SATISFIED
+    assert resolution.key is None
+    assert resolution.evidence_id == escalation.id
+    gate.finalize(record, resolution, expected_revision=resolution.ledger_revision)
+    assert store.cursor("beta") == inbound.id
+
+
+def test_pre_admission_delivery_failed_cannot_terminalize(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    gate._validated_messages()  # noqa: SLF001 - inject a forbidden canonical transition
+    with store._exclusive_lock(gate.path.with_suffix(".lock"), timeout=10.0):
+        ledger = gate._load()  # noqa: SLF001 - crash-boundary fixture
+        gate._append(  # noqa: SLF001 - crash-boundary fixture
+            ledger,
+            "DELIVERY_FAILED",
+            scope=inbound.id,
+            data={"inbound_id": inbound.id},
+        )
+        gate._write(ledger)  # noqa: SLF001 - crash-boundary fixture
+
+    resolution = gate.admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None
+
+
+def test_dispatch_reservation_is_scoped_revision_cas_linearization(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        kind="composing",
+        body="drafting",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+
+    with pytest.raises(StaleRevision):
+        gate.reserve_dispatch(resolution, purpose="initial")
+
+
+@pytest.mark.parametrize("stale_boundary", ["lease", "cursor"])
+def test_reserve_dispatch_revalidates_live_fence_and_cursor_head(
+    tmp_path: Path,
+    stale_boundary: str,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+    assert resolution.key is not None
+    if stale_boundary == "lease":
+        store.write_waiting("beta", {
+            "mode": "wrapper-loop",
+            "wrapper_generation": "wrapper-2",
+        })
+    else:
+        store.advance_cursor("beta", inbound.id)
+
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(resolution, purpose="initial")
+
+    admission = _ledger(gate)["obligations"][resolution.key.digest]
+    assert admission["paid_dispatches_total"] == 0
+
+
+def test_reserve_dispatch_revalidates_readiness_generation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+    assert resolution.key is not None
+    with store._exclusive_lock(gate.path.with_suffix(".lock"), timeout=10.0):
+        ledger = gate._load()  # noqa: SLF001 - generation-race fixture
+        ledger["obligations"][resolution.key.digest]["readiness_generation"] = "stale"
+        gate._write(ledger)  # noqa: SLF001 - generation-race fixture
+
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(resolution, purpose="initial")
+
+    admission = _ledger(gate)["obligations"][resolution.key.digest]
+    assert admission["paid_dispatches_total"] == 0
+
+
+def test_reservation_nonce_is_idempotent_and_purpose_bound(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+    assert resolution.key is not None
+    nonce = "1" * 32
+    budgets = {
+        "token_ceiling": 4096,
+        "wall_time_seconds": 60.0,
+        "reserved_cost": 1.0,
+        "concurrency": 1,
+    }
+
+    first = gate.reserve_dispatch(
+        resolution,
+        purpose="initial",
+        nonce=nonce,
+        budgets=budgets,
+    )
+    repeated = gate.reserve_dispatch(
+        resolution,
+        purpose="initial",
+        nonce=nonce,
+        budgets=budgets,
+    )
+
+    assert repeated == first
+    assert _ledger(gate)["obligations"][resolution.key.digest][
+        "paid_dispatches_total"
+    ] == 1
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(
+            resolution,
+            purpose="recovery",
+            nonce=nonce,
+            budgets=budgets,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    [
+        ("token_ceiling", 0),
+        ("wall_time_seconds", float("inf")),
+        ("reserved_cost", 101.0),
+        ("concurrency", 2),
+    ],
+)
+def test_reservation_rejects_unbounded_or_exhausted_per_call_budget(
+    tmp_path: Path,
+    field: str,
+    invalid: object,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+    assert resolution.key is not None
+    budgets = {
+        "token_ceiling": 4096,
+        "wall_time_seconds": 60.0,
+        "reserved_cost": 1.0,
+        "concurrency": 1,
+    }
+    budgets[field] = invalid
+
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(resolution, purpose="initial", budgets=budgets)
+
+    assert _ledger(gate)["obligations"][resolution.key.digest][
+        "paid_dispatches_total"
+    ] == 0
+
+
+def test_competing_reservations_have_one_cas_winner(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    owner = _gate(store)
+    resolution = owner.admit_or_finalize(_record(store))
+    assert resolution.key is not None
+    barrier = threading.Barrier(3)
+    permits: list[object] = []
+    refusals: list[Exception] = []
+
+    def reserve(nonce: str) -> None:
+        contender = _gate(store)
+        barrier.wait()
+        try:
+            permits.append(contender.reserve_dispatch(
+                resolution,
+                purpose="initial",
+                nonce=nonce,
+            ))
+        except (DispatchRefused, StaleRevision) as exc:
+            refusals.append(exc)
+
+    workers = [
+        threading.Thread(target=reserve, args=(character * 32,))
+        for character in ("a", "b")
+    ]
+    for worker in workers:
+        worker.start()
+    barrier.wait()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(permits) == 1
+    assert len(refusals) == 1
+    ledger = _ledger(owner)
+    admission = ledger["obligations"][resolution.key.digest]
+    assert admission["paid_dispatches_total"] == 1
+    assert sum(
+        row["transition"] == "DISPATCH_RESERVED"
+        for row in ledger["transitions"]
+    ) == 1
+
+
+def test_concurrency_budget_is_agent_wide_across_scoped_admissions(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    gate = _gate(store)
+    first = gate.admit_or_finalize(_record(store, "q-1"))
+    second = gate.admit_or_finalize(_record(store, "q-2"))
+    assert first.key is not None and second.key is not None
+
+    gate.reserve_dispatch(first, purpose="initial")
+    with pytest.raises(DispatchRefused, match="concurrency"):
+        gate.reserve_dispatch(second, purpose="initial")
+
+    ledger = _ledger(gate)
+    assert sum(
+        row.get("state") in {"reserved", "dispatching"}
+        for admission in ledger["obligations"].values()
+        if isinstance(admission, dict)
+        for row in admission.get("reservations", {}).values()
+        if isinstance(row, dict)
+    ) == 1
+
+
+def test_terminal_admission_keeps_its_inflight_concurrency_slot(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    gate = _gate(store)
+    first_record = _record(store, "q-1")
+    first = gate.admit_or_finalize(first_record)
+    assert first.key is not None
+    permit = gate.reserve_dispatch(first, purpose="initial")
+    gate.dispatch_record(first_record, permit)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn while dispatch is live",
+        meta={"request_id": "q-1"},
+    )
+    terminal = gate.resolve(first_record)
+    gate.finalize(first_record, terminal)
+    second = gate.admit_or_finalize(_record(store, "q-2"))
+
+    assert terminal.state == ResolverState.SUPERSEDED
+    with pytest.raises(DispatchRefused, match="concurrency"):
+        gate.reserve_dispatch(second, purpose="initial")
+
+    admission = _ledger(gate)["obligations"][first.key.digest]
+    assert admission["state"] == "finalized"
+    assert admission["reservations"][permit.nonce]["state"] == "dispatching"
+
+
+def test_dead_owner_terminal_admission_releases_slot_for_next_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    owner = _gate(store, fence="wrapper-1")
+    first_record = _record(store, "q-1")
+    first = owner.admit_or_finalize(first_record)
+    assert first.key is not None
+    old_permit = owner.reserve_dispatch(first, purpose="initial")
+    owner.dispatch_record(first_record, old_permit)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn while dispatch is live",
+        meta={"request_id": "q-1"},
+    )
+    terminal = owner.resolve(first_record)
+    owner.finalize(first_record, terminal)
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    second = restarted.admit_or_finalize(_record(store, "q-2"))
+    new_permit = restarted.reserve_dispatch(second, purpose="initial")
+
+    ledger = _ledger(restarted)
+    old_row = ledger["obligations"][first.key.digest]["reservations"][
+        old_permit.nonce
+    ]
+    assert new_permit.paid_dispatches_total == 1
+    assert old_row["state"] == "cancelled_terminal"
+    assert any(
+        row["transition"] == "TERMINAL_DISPATCH_RECONCILED"
+        and row.get("key_digest") == first.key.digest
+        for row in ledger["transitions"]
+    )
+
+
+def test_unknown_admission_state_never_releases_a_dispatch_slot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    owner = _gate(store, fence="wrapper-1")
+    first_record = _record(store, "q-1")
+    first = owner.admit_or_finalize(first_record)
+    assert first.key is not None
+    old_permit = owner.reserve_dispatch(first, purpose="initial")
+    owner.dispatch_record(first_record, old_permit)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn while dispatch is live",
+        meta={"request_id": "q-1"},
+    )
+    owner.finalize(first_record, owner.resolve(first_record))
+    ledger = _ledger(owner)
+    ledger["obligations"][first.key.digest]["state"] = "unknown-corrupt-state"
+    owner.path.write_text(json.dumps(ledger), encoding="utf-8")
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    second = restarted.admit_or_finalize(_record(store, "q-2"))
+    with pytest.raises(DispatchRefused, match="concurrency"):
+        restarted.reserve_dispatch(second, purpose="initial")
+
+    old_row = _ledger(restarted)["obligations"][first.key.digest]["reservations"][
+        old_permit.nonce
+    ]
+    assert old_row["state"] == "dispatching"
+
+
+def test_managed_mode_transition_cannot_cancel_a_live_ordinary_dispatch(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    ordinary = _gate(store, fence="wrapper-1")
+    first_record = _record(store, "q-1")
+    first = ordinary.admit_or_finalize(first_record)
+    assert first.key is not None
+    old_permit = ordinary.reserve_dispatch(first, purpose="initial")
+    ordinary.dispatch_record(first_record, old_permit)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn while dispatch is live",
+        meta={"request_id": "q-1"},
+    )
+    ordinary.finalize(first_record, ordinary.resolve(first_record))
+    store.set_managed_lead_loop("beta")
+    lease = store.acquire_lead_loop_lease(
+        "beta",
+        owner_pid=os.getpid(),
+        wrapper_generation="wrapper-2",
+    )
+    assert lease is not None
+
+    managed = _gate(store, fence="wrapper-2")
+    second = managed.admit_or_finalize(_record(store, "q-2"))
+    with pytest.raises(DispatchRefused, match="concurrency"):
+        managed.reserve_dispatch(second, purpose="initial")
+
+    old_row = _ledger(managed)["obligations"][first.key.digest]["reservations"][
+        old_permit.nonce
+    ]
+    assert old_row["state"] == "dispatching"
+
+
+def test_missing_waiting_marker_refuses_paid_reservation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+    store.clear_waiting("beta")
+
+    with pytest.raises(DispatchRefused, match="fence"):
+        gate.reserve_dispatch(admitted, purpose="initial")
+
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "paid_dispatches_total"
+    ] == 0
+
+
+def test_reservation_precedes_drive_and_second_dispatch_is_xor(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+
+    first = gate.reserve_dispatch(resolution, purpose="initial")
+    assert first.paid_dispatches_total == 1
+    gate.dispatch_record(_record(store), first)
+    gate.mark_dispatch_result(first, action_attempted=False)
+    refreshed = gate.resolve(_record(store))
+    second = gate.reserve_dispatch(refreshed, purpose="recovery")
+    assert second.paid_dispatches_total == 2
+
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(gate.resolve(_record(store)), purpose="continuation")
+
+
+@pytest.mark.parametrize("scoped", [False, True])
+def test_action_rejected_gets_one_corrected_retry_within_paid_cap(
+    tmp_path: Path,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    purposes: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        purposes.append(record["owed_action"]["purpose"])
+        if len(purposes) == 1:
+            return loop.DriveOutcome(
+                ok=False,
+                failure_class=loop.CLASS_AMBIGUOUS,
+                summary="deterministic schema rejection",
+                bus_action_attempted=True,
+                bus_action_rejected=True,
+            )
+        Path(record["owed_action"]["draft_path"]).write_text(
+            "399",
+            encoding="utf-8",
+        )
+        assert cli.main([
+            "--root",
+            str(tmp_path),
+            *record["owed_action"]["argv"][3:],
+            "--quiet",
+        ]) == 0
+        return loop.DriveOutcome(ok=True, bus_action_attempted=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        only_request_id="q-1" if scoped else None,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_turns=1,
+        max_polls=4,
+    )
+
+    admission = next(iter(_ledger(gate)["obligations"].values()))
+    transitions = _ledger(gate)["transitions"]
+    rejected = [
+        index
+        for index, row in enumerate(transitions)
+        if row["transition"] == "ACTION_REJECTED"
+    ]
+    recovery = next(
+        index
+        for index, row in enumerate(transitions)
+        if row["transition"] == "DISPATCH_RESERVED"
+        and row["data"].get("purpose") == "recovery"
+    )
+    first_nonce = next(iter(admission["reservations"]))
+
+    assert turns == 1
+    assert purposes == ["initial", "recovery"]
+    assert admission["paid_dispatches_total"] == 2
+    assert admission["paid_recoveries_total"] == 1
+    assert admission["reservations"][first_nonce]["state"] == "action_rejected"
+    assert len(rejected) == 1
+    assert rejected[0] < recovery
+
+
+def test_wrong_class_retry_waits_for_durable_rejection_after_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, escalation_required=True)
+    owner = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    admitted = owner.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = owner.reserve_dispatch(admitted, purpose="initial")
+    owner.dispatch_record(record, first)
+    first.draft_path.write_text("I answered instead", encoding="utf-8")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        "reply",
+        "--from",
+        "beta",
+        "--to-id",
+        inbound.id,
+        "--operation-nonce",
+        first.nonce,
+        "--file",
+        str(first.draft_path),
+        "--quiet",
+    ]) == 0
+    # Model the old split-write crash point: the side effect/result is durable,
+    # but its replay-proven wrong class has not yet been classified.
+    owner.mark_dispatch_result(first, action_attempted=True)
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    purposes: list[str] = []
+
+    def corrected_drive(recovery_record: dict) -> loop.DriveOutcome:
+        owed = recovery_record["owed_action"]
+        purposes.append(owed["purpose"])
+        Path(owed["draft_path"]).write_text(
+            "Operator decision needed",
+            encoding="utf-8",
+        )
+        assert cli.main([
+            "--root",
+            str(tmp_path),
+            *owed["argv"][3:],
+            "--quiet",
+        ]) == 0
+        return loop.DriveOutcome(ok=True, bus_action_attempted=True)
+
+    assert loop.run_loop(
+        store,
+        "beta",
+        corrected_drive,
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_turns=1,
+        max_polls=2,
+    ) == 1
+
+    ledger = _ledger(restarted)
+    admission = ledger["obligations"][admitted.key.digest]
+    rejection = next(
+        index
+        for index, row in enumerate(ledger["transitions"])
+        if row["transition"] == "ACTION_REJECTED"
+    )
+    recovery = next(
+        index
+        for index, row in enumerate(ledger["transitions"])
+        if row["transition"] == "DISPATCH_RESERVED"
+        and row["data"].get("purpose") == "recovery"
+    )
+    assert purposes == ["recovery"]
+    assert admission["paid_dispatches_total"] == 2
+    assert admission["reservations"][first.nonce]["state"] == "action_rejected"
+    assert rejection < recovery
+
+
+def test_unsatisfied_attempt_revalidation_failure_returns_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, first)
+    gate.mark_dispatch_result(first, action_attempted=True)
+    original = gate._validated_messages
+    reads = 0
+
+    def fail_second_read():
+        nonlocal reads
+        reads += 1
+        if reads == 2:
+            raise LedgerUnreadable("injected second replay failure")
+        return original()
+
+    monkeypatch.setattr(gate, "_validated_messages", fail_second_read)
+
+    blocked = gate.resolve(record)
+
+    assert blocked.state == ResolverState.BLOCKED
+    assert "injected second replay failure" in blocked.reason
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "paid_dispatches_total"
+    ] == 1
+
+
+@pytest.mark.parametrize(
+    ("first_class", "second_class", "second_purpose", "expected_states"),
+    [
+        ("missing", "infrastructure", "recovery", ("completed", "uncaptured_infra")),
+        ("infrastructure", "rejected", "continuation", ("uncaptured_infra", "action_rejected")),
+        ("rejected", "ambiguous", "recovery", ("action_rejected", "completed")),
+        ("ambiguous", "missing", "continuation", ("completed", "completed")),
+        ("wrong_class", "wrong_class", "recovery", ("action_rejected", "action_rejected")),
+    ],
+)
+def test_all_class_mixes_never_reserve_a_third_paid_dispatch(
+    tmp_path: Path,
+    first_class: str,
+    second_class: str,
+    second_purpose: str,
+    expected_states: tuple[str, str],
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(
+        store,
+        escalation_required="wrong_class" in {first_class, second_class},
+    )
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+
+    def classify(permit, classification: str) -> None:
+        if classification == "infrastructure":
+            gate.mark_dispatch_result(
+                permit,
+                action_attempted=True,
+                action_infra=True,
+            )
+        elif classification == "rejected":
+            gate.mark_dispatch_result(
+                permit,
+                action_attempted=True,
+                action_rejected=True,
+            )
+        elif classification == "wrong_class":
+            permit.draft_path.write_text("I answered instead", encoding="utf-8")
+            assert cli.main([
+                "--root",
+                str(tmp_path),
+                "reply",
+                "--from",
+                "beta",
+                "--to-id",
+                inbound.id,
+                "--operation-nonce",
+                permit.nonce,
+                "--file",
+                str(permit.draft_path),
+                "--quiet",
+            ]) == 0
+            gate.mark_dispatch_result(permit, action_attempted=True)
+            assert gate.resolve(record).state == ResolverState.OWED_UNSATISFIED
+            gate.mark_unsatisfied_attempt(
+                permit,
+                reason="answered instead of escalating",
+            )
+        elif classification == "ambiguous":
+            # Ambiguous/no-authoritative-evidence and explicit missing both
+            # reach the gate as non-proof; the wrapper's failure class only
+            # affects diagnostics outside the paid reservation ledger.
+            gate.mark_dispatch_result(permit, action_attempted=False)
+        else:
+            gate.mark_dispatch_result(permit, action_attempted=False)
+
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, first)
+    classify(first, first_class)
+    if second_purpose == "continuation":
+        gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    second = gate.reserve_dispatch(gate.resolve(record), purpose=second_purpose)
+    gate.dispatch_record(record, second)
+    classify(second, second_class)
+
+    with pytest.raises(DispatchRefused, match="paid dispatch budget exhausted"):
+        gate.reserve_dispatch(
+            gate.resolve(record),
+            purpose="continuation" if second_purpose == "recovery" else "recovery",
+            nonce="f" * 32,
+        )
+
+    ledger = _ledger(gate)
+    admission = ledger["obligations"][admitted.key.digest]
+    assert admission["paid_dispatches_total"] == 2
+    assert admission["paid_initial_dispatches_total"] == 1
+    assert admission["paid_recoveries_total"] == (second_purpose == "recovery")
+    assert admission["paid_continuations_total"] == (second_purpose == "continuation")
+    assert admission["reservations"][first.nonce]["state"] == expected_states[0]
+    assert admission["reservations"][second.nonce]["state"] == expected_states[1]
+    assert sum(
+        row["transition"] == "ACTION_REJECTED"
+        for row in ledger["transitions"]
+    ) == sum(
+        classification in {"rejected", "wrong_class"}
+        for classification in (first_class, second_class)
+    )
+
+
+def test_dispatch_record_rejects_a_tampered_permit_draft_path(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    tampered = replace(permit, draft_path=tmp_path / "outside-owned.txt")
+
+    with pytest.raises(DispatchRefused, match="draft path"):
+        gate.dispatch_record(record, tampered)
+
+    admission = _ledger(gate)["obligations"][permit.key_digest]
+    assert admission["reservations"][permit.nonce]["state"] == "reserved"
+    assert not tampered.draft_path.exists()
+
+
+def test_scheduled_continuation_excludes_recovery_before_second_launch(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    assert resolution.key is not None
+    first = gate.reserve_dispatch(resolution, purpose="initial")
+    gate.dispatch_record(record, first)
+    gate.mark_dispatch_result(first, action_attempted=False)
+    gate.schedule_continuation(resolution.key, producer_token="producer-1")
+
+    assert gate.next_dispatch_purpose(resolution.key) == "continuation"
+    refreshed = gate.resolve(record)
+    with pytest.raises(DispatchRefused):
+        gate.reserve_dispatch(refreshed, purpose="recovery")
+    continuation = gate.reserve_dispatch(refreshed, purpose="continuation")
+    admission = _ledger(gate)["obligations"][resolution.key.digest]
+    assert continuation.paid_dispatches_total == 2
+    assert admission["paid_continuations_total"] == 1
+    assert admission["recovery_used"] is False
+
+
+def test_missing_dispatch_result_is_durable_before_recovery_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    assert resolution.key is not None
+    first = gate.reserve_dispatch(resolution, purpose="initial")
+    gate.dispatch_record(record, first)
+
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = _gate(store, fence="wrapper-2")
+    refreshed = restarted.resolve(record)
+    assert refreshed.state == ResolverState.OWED_UNSATISFIED
+    assert restarted.next_dispatch_purpose(resolution.key) == "recovery"
+    ledger = _ledger(restarted)
+    missing = [
+        row for row in ledger["transitions"]
+        if row["transition"] == "DISPATCH_RESULT_MISSING"
+    ]
+    assert len(missing) == 1
+    second = restarted.reserve_dispatch(refreshed, purpose="recovery")
+    assert second.paid_dispatches_total == 2
+    transitions = _ledger(restarted)["transitions"]
+    assert next(
+        index for index, row in enumerate(transitions)
+        if row["transition"] == "DISPATCH_RESULT_MISSING"
+    ) < next(
+        index for index, row in enumerate(transitions)
+        if row["transition"] == "DISPATCH_RESERVED" and row["data"]["total"] == 2
+    )
+
+
+def test_live_same_fence_owner_cannot_be_declared_missing(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+
+    contender = _gate(store, fence="wrapper-1")
+
+    assert contender.next_dispatch_purpose(admitted.key) is None
+    admission = _ledger(contender)["obligations"][admitted.key.digest]
+    assert admission["paid_dispatches_total"] == 1
+    assert [row["state"] for row in admission["reservations"].values()] == [
+        "dispatching"
+    ]
+
+
+def test_loop_never_calls_drive_without_durable_reservation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    observed: list[dict] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        ledger = _ledger(gate)
+        admission_id = ledger["inbound_index"][inbound.id]
+        admission = ledger["obligations"][admission_id]
+        assert admission["paid_dispatches_total"] == 1
+        assert any(
+            row["state"] == "dispatching"
+            for row in admission["reservations"].values()
+        )
+        observed.append(record["owed_action"])
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert len(observed) == 1
+    assert observed[0]["exact_inbound_id"] == inbound.id
+    assert observed[0]["body_transport"] == "structured-write-then-file"
+
+
+@pytest.mark.parametrize("scoped", [False, True])
+def test_loop_never_dispatches_when_reservation_cas_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    request_id = "q-scoped" if scoped else "q-global"
+    _question(store, request_id)
+    gate = _gate(store)
+    calls = 0
+
+    def refuse(*_args, **_kwargs):
+        raise DispatchRefused("injected reservation CAS loss")
+
+    def drive(_record: dict) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    monkeypatch.setattr(gate, "reserve_dispatch", refuse)
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        only_request_id=request_id if scoped else None,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert calls == 0
+    assert store.cursor("beta") == ""
+
+
+def test_loop_routes_scheduled_second_call_through_continuation_reservation(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    purposes: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        purpose = record["owed_action"]["purpose"]
+        purposes.append(purpose)
+        if purpose == "initial":
+            admission = _ledger(gate)["obligations"][
+                record["owed_action"]["obligation_key_digest"]
+            ]
+            gate.schedule_continuation(
+                gate._key_from(admission["key"]),  # noqa: SLF001 - loop contract fixture
+                producer_token="producer-1",
+            )
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    assert purposes == ["initial", "continuation"]
+    admission = next(iter(_ledger(gate)["obligations"].values()))
+    assert admission["paid_dispatches_total"] == 2
+    assert admission["paid_continuations_total"] == 1
+    assert admission["paid_recoveries_total"] == 0
+
+
+def test_print_not_run_is_never_committed_and_caps_at_two_paid_dispatches(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=4,
+    )
+
+    assert calls == 2
+    assert store.cursor("beta") == inbound.id
+    status = gate.delivery_status("q-1", "alpha")
+    assert status is not None and status["state"] == "delivery_failed"
+    assert any(message.id == inbound.id for message in store.valid_messages())
+
+
+def test_reply_lands_then_nonzero_child_commits_without_duplicate(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    calls = 0
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        owed = record["owed_action"]
+        Path(owed["draft_path"]).write_text("399", encoding="utf-8")
+        assert cli.main([
+            "--root", str(tmp_path), *owed["argv"][3:], "--quiet",
+        ]) == 0
+        return loop.DriveOutcome(
+            ok=False,
+            failure_class=loop.CLASS_AMBIGUOUS,
+            summary="child crashed after send",
+            bus_action_attempted=True,
+        )
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_turns=1,
+        max_polls=3,
+    )
+
+    assert turns == 1
+    assert calls == 1
+    assert store.cursor("beta") == inbound.id
+
+
+def test_note_is_not_enforced_and_creates_no_spurious_reply(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    note = store.send(sender="alpha", recipient="beta", kind="note", body="FYI")
+    gate = _gate(store)
+    calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_turns=1,
+    )
+
+    assert calls == 1
+    assert store.cursor("beta") == note.id
+    assert not [message for message in store.valid_messages() if message.sender == "beta"]
+
+
+def test_composing_is_nonterminal_and_requires_live_producer_or_continuation(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(_record(store), permit)
+    gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    composing_argv = dispatched["owed_action"]["composing_argv"]
+    assert cli.main([
+        "--root", str(tmp_path), *composing_argv[3:], "--quiet",
+    ]) == 0
+
+    deferred = gate.resolve(_record(store))
+    assert deferred.state == ResolverState.IN_PROGRESS
+    assert deferred.terminal is False
+    assert store.cursor("beta") == ""
+
+
+def test_durable_retry_barrier_records_missing_outcome_before_restart_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("captured answer", encoding="utf-8")
+    _record_captured_intent(store, gate, permit)
+    gate.mark_dispatch_result(
+        permit,
+        action_attempted=True,
+        action_infra=True,
+    )
+    current = gate.resolve(record)
+
+    def crash_after_barrier(*_args, **_kwargs):
+        admission = _ledger(gate)["obligations"][admitted.key.digest]
+        assert admission["operation_infra_attempts"] == 2
+        assert admission["operation_infra_retry_inflight"] is True
+        raise RuntimeError("captured retry crash")
+
+    assert gate.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is True
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.subprocess.run",
+        crash_after_barrier,
+    )
+    with pytest.raises(RuntimeError, match="captured retry crash"):
+        gate.retry_captured_operation(permit, record)
+    restarted = _gate(store, fence="wrapper-1")
+    assert restarted.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is True
+    admission = _ledger(restarted)["obligations"][admitted.key.digest]
+
+    assert admission["operation_infra_attempts"] == 3
+    assert admission["operation_infra_first_at"]
+    transitions = _ledger(restarted)["transitions"]
+    missing_index = next(
+        index for index, row in enumerate(transitions)
+        if row["transition"] == "OPERATION_RETRY_OUTCOME_MISSING"
+    )
+    retry_indexes = [
+        index for index, row in enumerate(transitions)
+        if row["transition"] == "OPERATION_RETRY_RECORDED"
+    ]
+    assert missing_index < retry_indexes[-1]
+    restarted.complete_retry_barrier(admitted.key, category="operation_infra")
+    assert restarted.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is True
+    assert (
+        _ledger(restarted)["obligations"][admitted.key.digest][
+            "operation_infra_attempts"
+        ]
+        == 4
+    )
+
+
+def test_captured_retry_rejects_draft_reparse_before_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-reparse-draft")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("captured answer", encoding="utf-8")
+    _record_captured_intent(store, gate, permit)
+    gate.mark_dispatch_result(permit, action_attempted=True, action_infra=True)
+    current = gate.resolve(record)
+    assert gate.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is True
+    original_is_symlink = Path.is_symlink
+    monkeypatch.setattr(
+        Path,
+        "is_symlink",
+        lambda candidate: (
+            candidate == permit.draft_path or original_is_symlink(candidate)
+        ),
+    )
+    invoked = False
+
+    def unexpected_subprocess(*_args, **_kwargs):
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("unsafe reparse draft reached subprocess")
+
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.subprocess.run",
+        unexpected_subprocess,
+    )
+
+    assert gate.retry_captured_operation(permit, record) is False
+    assert invoked is False
+
+
+def test_captured_escalation_retry_reuses_persisted_target_and_request_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, escalation_required=True)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("captured operator request", encoding="utf-8")
+    _record_captured_intent(store, gate, permit)
+    gate.mark_dispatch_result(permit, action_attempted=True, action_infra=True)
+    current = gate.resolve(record)
+    assert gate.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is True
+    store.set_operator_facing("gamma")
+    observed: list[str] = []
+
+    def capture(argv, **_kwargs):
+        observed.extend(argv)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("agenttalk.wrapper.obligations.subprocess.run", capture)
+
+    assert gate.retry_captured_operation(permit, record) is True
+    initial = dispatched["owed_action"]["argv"]
+    assert observed[observed.index("--to") + 1] == initial[initial.index("--to") + 1]
+    assert observed[observed.index("--meta") + 1] == initial[initial.index("--meta") + 1]
+
+
+def test_unmarked_torn_draft_is_never_retried_as_a_captured_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    owner = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    admitted = owner.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = owner.reserve_dispatch(admitted, purpose="initial")
+    owner.dispatch_record(record, permit)
+    permit.draft_path.write_text("TRUNCATED MID-WRITE: ", encoding="utf-8")
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    restarted.resolve(record)
+
+    assert restarted.captured_operation(admitted.key) is None
+    assert restarted.next_dispatch_purpose(admitted.key) == "recovery"
+    row = _ledger(restarted)["obligations"][admitted.key.digest]["reservations"][
+        permit.nonce
+    ]
+    assert row["state"] == "dispatch_result_missing"
+
+
+def test_draft_capture_survives_new_generation_without_second_model_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    owner = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    admitted = owner.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = owner.reserve_dispatch(admitted, purpose="initial")
+    owner.dispatch_record(record, permit)
+    permit.draft_path.write_text("captured before append", encoding="utf-8")
+    _record_captured_intent(store, owner, permit)
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    recovered = restarted.resolve(record)
+    captured = restarted.captured_operation(admitted.key)
+
+    assert recovered.state == ResolverState.OWED_UNSATISFIED
+    assert captured is not None
+    assert captured.nonce == permit.nonce
+    assert restarted.next_dispatch_purpose(admitted.key) is None
+    admission = _ledger(restarted)["obligations"][admitted.key.digest]
+    assert admission["paid_dispatches_total"] == 1
+    assert admission["operation_infra_attempts"] == 1
+    assert admission["operation_infra_first_at"]
+    assert admission["reservations"][permit.nonce]["operation_payload_digest"]
+    assert any(
+        row["transition"] == "OPERATION_INTENT_RECOVERED"
+        for row in _ledger(restarted)["transitions"]
+    )
+
+
+def test_delivery_failed_indexes_requester_and_disposition_before_cursor_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+
+    def crash_projection(_record: dict) -> None:
+        raise OSError("crash barrier")
+
+    monkeypatch.setattr(gate, "_advance_record_cursor", crash_projection)
+    failed = gate.delivery_failed(
+        _record(store),
+        admitted.key,
+        reason="test failure",
+        expected_revision=admitted.scoped_revision,
+    )
+    assert failed.state == ResolverState.INDETERMINATE
+    assert failed.reason == "cursor projection failed: OSError"
+
+    ledger = _ledger(gate)
+    assert ledger["delivery_index"]["q-1"][0]["state"] == "delivery_failed"
+    assert ledger["cursor_dispositions"]["beta"]["inbound_id"] == inbound.id
+    assert store.cursor("beta") == ""
+
+    restarted = _gate(store)
+    terminal = restarted.resolve(_record(store))
+    assert terminal.state == ResolverState.DELIVERY_EXHAUSTED
+    restarted.finalize(_record(store), terminal)
+    assert store.cursor("beta") == inbound.id
+    assert restarted.delivery_status("q-1", "alpha")["state"] == "delivery_failed"
+    assert _ledger(restarted)["obligations"][admitted.key.digest]["state"] == (
+        "delivery_failed"
+    )
+
+
+def test_delivery_failed_is_idempotent_for_one_exact_key(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+
+    first = gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="canonical reason",
+        expected_revision=current.scoped_revision,
+    )
+    second = gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="must be ignored",
+        expected_revision=current.scoped_revision,
+    )
+
+    assert first.state == second.state == ResolverState.DELIVERY_EXHAUSTED
+    ledger = _ledger(gate)
+    assert sum(
+        row["transition"] == "DELIVERY_FAILED" for row in ledger["transitions"]
+    ) == 1
+    assert len(ledger["delivery_index"]["q-1"]) == 1
+    assert ledger["breakers"]["beta"][
+        "owed_action_cap_exhaustions_consecutive"
+    ] == 1
+    assert second.reason == "canonical reason"
+
+
+def test_delivery_failed_rejects_a_mismatched_exact_record(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-1")
+    _question(store, "q-2")
+    gate = _gate(store)
+    first_record = _record(store, "q-1")
+    admitted = gate.admit_or_finalize(first_record)
+    assert admitted.key is not None
+
+    with pytest.raises(GateError, match="exact inbound"):
+        gate.delivery_failed(
+            _record(store, "q-2"),
+            admitted.key,
+            reason="wrong record",
+            expected_revision=admitted.scoped_revision,
+        )
+
+    ledger = _ledger(gate)
+    assert not [
+        row for row in ledger["transitions"] if row["transition"] == "DELIVERY_FAILED"
+    ]
+
+
+def test_delivery_failed_loses_when_scoped_revision_changes(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        kind="composing",
+        body="new scoped evidence",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    gate.resolve(record)
+
+    with pytest.raises(StaleRevision, match="scoped revision"):
+        gate.delivery_failed(
+            record,
+            admitted.key,
+            reason="stale failure disposition",
+            expected_revision=admitted.scoped_revision,
+        )
+
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["state"] == "open"
+
+
+def test_compliance_breaker_trips_after_three_dominant_exhaustions(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    messages = [_question(store, f"q-{index}") for index in range(1, 5)]
+    gate = _gate(store)
+    calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=14,
+    )
+
+    breaker = gate.status()["breaker"]
+    assert COMPLIANCE_BREAKER_TRIP == 3
+    assert breaker["tripped"] is True
+    assert breaker["config_blocked"] is True
+    assert breaker["config_blocked_reason"] == "owed_action_compliance_breaker"
+    assert breaker["owed_action_cap_exhaustions_consecutive"] == 3
+    assert len(breaker["compliance_exhaustion_references"]) == 3
+    assert calls == 6
+    assert store.cursor("beta") == messages[2].id
+    alerts = [
+        event for event in _ledger(gate)["transitions"]
+        if event["transition"] == "COMPLIANCE_BREAKER_ALERT"
+    ]
+    assert len(alerts) == 1
+    delivered_alerts = [
+        message
+        for message in store.valid_messages()
+        if message.sender == "beta"
+        and message.recipient == "lead"
+        and (message.meta or {}).get("compliance_breaker_alert_generation")
+        == breaker["generation"]
+    ]
+    assert len(delivered_alerts) == 1
+
+
+def test_breaker_trip_persists_config_block_before_cursor_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-crash-1",
+        compliance_dominant=True,
+    )
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-crash-2",
+        compliance_dominant=True,
+    )
+    inbound = _question(store, "q-crash-3")
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+    monkeypatch.setattr(
+        gate,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("cursor crash")),
+    )
+
+    failed = gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="third compliance exhaustion",
+        expected_revision=current.scoped_revision,
+    )
+    assert failed.state == ResolverState.INDETERMINATE
+
+    assert store.cursor("beta") != inbound.id
+    assert _ledger(gate)["breakers"]["beta"]["tripped"] is True
+    hold = store.read_config_blocked_hold("beta")
+    assert hold is not None
+    assert hold["summary"] == "owed_action_compliance_breaker"
+    restarted = _gate(store, fence="wrapper-1")
+    terminal = restarted.resolve(record)
+    assert terminal.state == ResolverState.DELIVERY_EXHAUSTED
+    restarted.finalize(record, terminal)
+    assert store.cursor("beta") == inbound.id
+    blocked_inbound = _question(store, "q-crash-4")
+    blocked = restarted.resolve(_record(store))
+    assert blocked.state == ResolverState.BLOCKED_COMPLIANCE
+    assert blocked_inbound.id not in _ledger(restarted)["inbound_index"]
+
+
+def test_breaker_alert_outbox_reconciles_crash_after_bus_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    for index in range(2):
+        _record_delivery_exhaustion(
+            store,
+            gate,
+            request_id=f"q-alert-crash-{index}",
+            compliance_dominant=True,
+        )
+    _question(store, "q-alert-crash-3")
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+    publish = store.send_operation
+
+    def publish_then_crash(*args, **kwargs):
+        publish(*args, **kwargs)
+        raise RuntimeError("crash after alert publication")
+
+    monkeypatch.setattr(store, "send_operation", publish_then_crash)
+    with pytest.raises(RuntimeError, match="after alert publication"):
+        gate.delivery_failed(
+            record,
+            admitted.key,
+            reason="third compliance exhaustion",
+            expected_revision=current.scoped_revision,
+        )
+    monkeypatch.setattr(store, "send_operation", publish)
+
+    before = _ledger(gate)
+    generation = before["breakers"]["beta"]["generation"]
+    assert before["breakers"]["beta"]["alerts"][str(generation)]["state"] == "pending"
+    assert not [
+        row for row in before["transitions"]
+        if row["transition"] == "COMPLIANCE_BREAKER_ALERT"
+    ]
+    store.set_operator_facing("gamma")
+    restarted = _gate(store, fence="wrapper-1")
+    assert restarted.resolve(record).state == ResolverState.DELIVERY_EXHAUSTED
+
+    delivered = [
+        message for message in store.valid_messages()
+        if (message.meta or {}).get("compliance_breaker_alert_generation") == generation
+    ]
+    after = _ledger(restarted)
+    assert len(delivered) == 1
+    assert delivered[0].recipient == "lead"
+    assert after["breakers"]["beta"]["alerts"][str(generation)]["state"] == "delivered"
+    assert sum(
+        row["transition"] == "COMPLIANCE_BREAKER_ALERT"
+        for row in after["transitions"]
+    ) == 1
+
+
+def test_breaker_hold_projection_failure_heals_on_terminal_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    for index in range(2):
+        _record_delivery_exhaustion(
+            store,
+            gate,
+            request_id=f"q-hold-crash-{index}",
+            compliance_dominant=True,
+        )
+    _question(store, "q-hold-crash-3")
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+    project = store.write_config_blocked_hold
+    monkeypatch.setattr(
+        store,
+        "write_config_blocked_hold",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("hold projection crash")),
+    )
+
+    with pytest.raises(OSError, match="hold projection crash"):
+        gate.delivery_failed(
+            record,
+            admitted.key,
+            reason="third compliance exhaustion",
+            expected_revision=current.scoped_revision,
+        )
+    assert _ledger(gate)["breakers"]["beta"]["tripped"] is True
+    assert store.read_config_blocked_hold("beta") is None
+    monkeypatch.setattr(store, "write_config_blocked_hold", project)
+
+    restarted = _gate(store, fence="wrapper-1")
+    assert restarted.resolve(record).state == ResolverState.DELIVERY_EXHAUSTED
+    hold = store.read_config_blocked_hold("beta")
+    assert hold is not None
+    assert hold["summary"] == "owed_action_compliance_breaker"
+
+
+def test_transfer_validates_destination_before_closing_source(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    destination_policy = _policy("gamma", "beta")
+    gate = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    roster = gate.roster_snapshot()
+
+    with pytest.raises(ValueError):
+        gate.transfer(
+            record,
+            admitted.key,
+            destination="missing",
+            new_inbound_id="next-1",
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=admitted.scoped_revision,
+        )
+    assert _ledger(gate)["obligations"][admitted.key.digest]["state"] == "open"
+
+    transferred = _transfer_question(
+        store, admitted.key, "gamma", destination_policy,
+    )
+    current = gate.resolve(record)
+    gate.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=transferred.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+    ledger = _ledger(gate)
+    assert ledger["obligations"][admitted.key.digest]["state"] == "transferred"
+    assert transferred.id in ledger["inbound_index"]
+
+
+def test_invalid_metadata_is_classification_unknown_and_commits_with_telemetry_scope(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, consult={"unsupported": True})
+    resolution = _gate(store).admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.CLASSIFICATION_UNKNOWN
+    assert resolution.allows_legacy_commit is True
+
+
+def test_one_shot_question_uses_same_gate_and_does_not_commit_print_only(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-scoped")
+    gate = _gate(store)
+    calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        only_request_id="q-scoped",
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    assert turns == 0
+    assert calls == 2
+    assert store.thread_seen("beta", "q-scoped")
+    assert gate.delivery_status("q-scoped", "alpha")["state"] == "delivery_failed"
+
+
+def test_cli_reply_exact_anchor_and_literal_file_transport_round_trip(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    body = "-$ $env:HOME $() `tick` \"quotes\"\nUnicode: \u2603\n'@\n"
+    draft = tmp_path / "answer.txt"
+    draft.write_text(body, encoding="utf-8", newline="")
+
+    rc = cli.main([
+        "--root", str(tmp_path), "reply", "--from", "beta",
+        "--to-id", inbound.id, "--file", str(draft), "--quiet",
+    ])
+    answer = [message for message in store.valid_messages() if message.sender == "beta"][-1]
+
+    assert rc == 0
+    assert answer.body == body
+    assert answer.meta["request_id"] == "q-1"
+    assert answer.meta["in_reply_to"] == inbound.id
+
+
+def test_wrong_sender_request_anchor_and_control_record_are_nonproof(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+
+    store.send(
+        sender="gamma", recipient="alpha", body="forged actor",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    store.send(
+        sender="beta", recipient="alpha", body="wrong thread",
+        meta={"request_id": "q-other", "in_reply_to": inbound.id},
+    )
+    store.send(
+        sender="beta", recipient="alpha", kind="composing", body="not terminal",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+
+    assert gate.resolve(_record(store)).state == ResolverState.OWED_UNSATISFIED
+
+
+def test_prior_generation_answer_does_not_satisfy_same_rid_reask(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "reused")
+    store.send(
+        sender="beta", recipient="alpha", body="old answer",
+        meta={"request_id": "reused", "in_reply_to": first.id},
+    )
+    store.advance_cursor("beta", first.id)
+    second = _question(store, "reused")
+    gate = _gate(store)
+    resolution = gate.admit_or_finalize(_record(store))
+
+    assert second.id != first.id
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None and resolution.key.inbound_id == second.id
+
+
+def test_delayed_prior_generation_answer_does_not_satisfy_same_rid_reask(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "reused")
+    store.advance_cursor("beta", first.id)
+    second = _question(store, "reused")
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="delayed old answer",
+        meta={"request_id": "reused", "in_reply_to": first.id},
+    )
+
+    resolution = _gate(store).admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None and resolution.key.inbound_id == second.id
+
+
+def test_pre_admission_answer_requires_exact_correlation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="wrong correlation",
+        meta={
+            "request_id": "q-other",
+            "origin_request_id": "q-1",
+            "in_reply_to": inbound.id,
+        },
+    )
+
+    resolution = _gate(store).admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None
+
+
+def test_pre_admission_finalize_ignores_unrelated_revision(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta", recipient="alpha", body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    gate = _gate(store)
+    record = _record(store)
+    terminal = gate.admit_or_finalize(record)
+    store.send(sender="gamma", recipient="alpha", body="concurrent unrelated")
+
+    result = gate.finalize(
+        record,
+        terminal,
+        expected_revision=terminal.ledger_revision,
+    )
+
+    assert result.state == ResolverState.SATISFIED
+
+
+def test_pre_admission_finalize_rejects_correlated_revision_race(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta", recipient="alpha", body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    gate = _gate(store)
+    record = _record(store)
+    terminal = gate.admit_or_finalize(record)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn",
+        meta={"request_id": "q-1"},
+    )
+    gate.resolve(record)
+
+    result = gate.finalize(
+        record,
+        terminal,
+        expected_revision=terminal.ledger_revision,
+    )
+
+    assert result.state == ResolverState.INDETERMINATE
+    assert store.cursor("beta") == ""
+
+
+def test_semantic_no_admission_claim_rejects_correlated_revision_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, consult=True)
+    gate = _gate(store)
+    original = gate._validated_messages  # noqa: SLF001 - deterministic CAS race
+
+    def replay_then_race():
+        messages, ledger = original()
+        store.send(
+            sender="gamma",
+            recipient="beta",
+            body="correlated concurrent append",
+            meta={"request_id": "q-1"},
+        )
+        return messages, ledger
+
+    monkeypatch.setattr(gate, "_validated_messages", replay_then_race)
+
+    resolution = gate.admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.INDETERMINATE
+    assert not _ledger(gate)["no_admission_claims"]
+
+
+def test_alternating_global_projection_errors_exhaust_by_elapsed_time_only(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    first_gate = _gate(store)
+    first_gate.admit_or_finalize(_record(store))
+    first_gate.path.write_text("{", encoding="utf-8")
+    times = iter(["2026-01-01T00:00:00Z", "2026-01-01T00:15:01Z"])
+    gate = _gate(store, now=lambda: next(times))
+
+    assert gate.resolve(_record(store)).state == ResolverState.BLOCKED
+    first_health = json.loads(gate.proof_health_path.read_text(encoding="utf-8"))
+    assert first_health["first_failure_at"] == "2026-01-01T00:00:00Z"
+    assert first_health["last_failure_at"] == "2026-01-01T00:00:00Z"
+    assert first_health["last_rebuild_at"] == "2026-01-01T00:00:00Z"
+    assert first_health["elapsed_seconds"] == 0
+    assert first_health.get("exhausted") is not True
+    health = gate.record_proof_failure(error_class="DifferentError", path="other-path")
+
+    assert health["exhausted"] is True
+    assert health["first_failure_at"] == first_health["first_failure_at"]
+    assert health["last_failure_at"] == "2026-01-01T00:15:01Z"
+    assert health["failures"] == 2
+    assert health["elapsed_seconds"] >= 900
+    assert health["fingerprint"] == {
+        "error_class": "DifferentError", "path": "other-path",
+    }
+    assert health["incident"]["kind"] == "PROOF_REPLAY_INCIDENT"
+    assert health["incident"]["authority"] == "elapsed_time"
+    assert health["incident_id"] == health["incident"]["incident_id"]
+    assert store.cursor("beta") == ""
+
+
+def test_requester_wait_is_released_by_structured_delivery_failed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+    gate.delivery_failed(
+        _record(store),
+        admitted.key,
+        reason="delivery exhausted",
+        expected_revision=admitted.scoped_revision,
+    )
+
+    rc = cli.main([
+        "--root", str(tmp_path), "wait", "--for", "alpha",
+        "--to-request", "q-1", "--timeout", "1", "--interval", "0.1",
+    ])
+    output = capsys.readouterr().out
+
+    assert rc == 4
+    assert "DELIVERY FAILED" in output
+    assert '"state": "delivery_failed"' in output
+    assert recv_api.poll(store, "alpha", scoped_request_id="q-1")["scoped"][
+        "delivery_failed"
+    ]["reason"] == "delivery exhausted"
+
+
+def test_doctor_reports_active_detection_grade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store(tmp_path)
+    policy = tmp_path.parent / f"{tmp_path.name}-operator-policy.json"
+    policy.write_text(json.dumps({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": "detection"}},
+    }), encoding="utf-8")
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy))
+
+    report = doctor.run(tmp_path)
+    check = next(row for row in report.checks if row.name == "wrapped_commit_gate")
+
+    assert check.status == "ok"
+    beta = next(row for row in check.data["agents"] if row["agent"] == "beta")
+    assert beta["status"] == "ACTIVE (detection-grade)"
+    assert beta["security_grade"] is False
+
+
+def test_invalid_hmac_reply_is_nonproof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTALK_HMAC_KEY_FILE", str(tmp_path.parent / "owed-hmac.key"))
+    store = _store(tmp_path)
+    signing.init_key(store.project_id(), force=True)
+    inbound = _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+    forged = store.send(
+        sender="beta", recipient="alpha", body="forged",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    path = store.messages_dir / f"{forged.id}.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["body"] = "tampered after signing"
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert gate.resolve(_record(store)).state == ResolverState.OWED_UNSATISFIED
+
+
+def test_infrastructure_exhaustion_uses_separate_counter_without_resetting_compliance(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-compliance-1",
+        compliance_dominant=True,
+    )
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-infra",
+        compliance_dominant=False,
+    )
+    between = gate.status()["breaker"]
+    assert between["owed_action_cap_exhaustions_consecutive"] == 1
+    assert between["proof_infra_exhaustions_consecutive"] == 1
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-compliance-2",
+        compliance_dominant=True,
+    )
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-compliance-3",
+        compliance_dominant=True,
+    )
+
+    breaker = gate.status()["breaker"]
+    assert breaker["tripped"] is True
+    assert breaker["owed_action_cap_exhaustions_consecutive"] == 3
+    assert breaker["proof_infra_exhaustions_consecutive"] == 1
+
+
+def test_final_infrastructure_failure_does_not_blame_an_earlier_missing_action(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, first)
+    gate.mark_dispatch_result(first, action_attempted=False)
+    recovery = gate.reserve_dispatch(gate.resolve(record), purpose="recovery")
+    gate.dispatch_record(record, recovery)
+    gate.mark_dispatch_result(
+        recovery,
+        action_attempted=True,
+        action_infra=True,
+    )
+    current = gate.resolve(record)
+
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="captured operation exhausted",
+        expected_revision=current.scoped_revision,
+    )
+
+    breaker = gate.status()["breaker"]
+    assert breaker["owed_action_cap_exhaustions_consecutive"] == 0
+    assert breaker["proof_infra_exhaustions_consecutive"] == 1
+
+
+def test_missing_recovery_result_overrides_prior_compliance_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, first)
+    gate.mark_dispatch_result(first, action_attempted=False)
+    recovery = gate.reserve_dispatch(gate.resolve(record), purpose="recovery")
+    gate.dispatch_record(record, recovery)
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    refreshed = restarted.resolve(record)
+    assert restarted.next_dispatch_purpose(admitted.key) is None
+    restarted.delivery_failed(
+        record,
+        admitted.key,
+        reason="recovery result was lost",
+        expected_revision=refreshed.scoped_revision,
+    )
+
+    assert refreshed.state == ResolverState.OWED_UNSATISFIED
+    breaker = restarted.status()["breaker"]
+    assert breaker["owed_action_cap_exhaustions_consecutive"] == 0
+    assert breaker["proof_infra_exhaustions_consecutive"] == 1
+
+
+def test_successful_finalization_resets_compliance_streak_before_cursor_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-reset-streak-1",
+        compliance_dominant=True,
+    )
+    _question(store, "q-reset-streak-2")
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    terminal = gate.resolve(record)
+    monkeypatch.setattr(
+        gate,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("cursor crash")),
+    )
+
+    finalized = gate.finalize(record, terminal)
+    assert finalized.state == ResolverState.INDETERMINATE
+
+    breaker = _ledger(gate)["breakers"]["beta"]
+    assert breaker["owed_action_cap_exhaustions_consecutive"] == 0
+    assert breaker["compliance_exhaustion_references"] == []
+
+
+def test_breaker_reset_requires_authorized_actor_and_audit_reason(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    for index in range(COMPLIANCE_BREAKER_TRIP):
+        _question(store, f"q-reset-{index}")
+    gate = _gate(store)
+    loop.run_loop(
+        store,
+        "beta",
+        lambda _record: loop.DriveOutcome(ok=True),
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=12,
+    )
+    assert gate.status()["breaker"]["tripped"] is True
+    trip_generation = gate.status()["breaker"]["generation"]
+
+    with pytest.raises(PermissionError):
+        gate.reset_compliance_breaker(actor="gamma", reason="not authorized")
+    gate.reset_compliance_breaker(actor="lead", reason="operator approved prompt repair")
+
+    breaker = gate.status()["breaker"]
+    assert breaker["tripped"] is False
+    assert breaker["generation"] == trip_generation + 1
+    assert store.read_config_blocked_hold("beta") is None
+    reset = next(
+        row for row in reversed(_ledger(gate)["transitions"])
+        if row["transition"] == "COMPLIANCE_BREAKER_RESET"
+    )
+    assert reset["data"] == {
+        "agent": "beta",
+        "actor": "lead",
+        "reason": "operator approved prompt repair",
+        "generation": breaker["generation"],
+    }
+
+
+def test_breaker_status_and_reset_never_clear_an_unrelated_config_hold(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    _record_delivery_exhaustion(
+        store,
+        gate,
+        request_id="q-infra",
+        compliance_dominant=False,
+    )
+    store.write_config_blocked_hold("beta", summary="unrelated_launch_config_error")
+
+    gate.status()
+    gate.reset_compliance_breaker(actor="lead", reason="reset owed-action state")
+
+    hold = store.read_config_blocked_hold("beta")
+    assert hold is not None
+    assert hold["summary"] == "unrelated_launch_config_error"
+
+
+def test_security_grade_never_downgrades_to_detection(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    policy = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": "security"}},
+    }, "beta")
+    gate = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert policy.status == ResolverState.BLOCKED
+    assert policy.grade == "security"
+    assert calls == 0
+    assert store.cursor("beta") != inbound.id
+
+
+def test_no_admission_finalizer_is_revision_and_fence_guarded(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    policy = PolicySnapshot.from_mapping({"schema_version": 1, "agents": {}}, "beta")
+    owner = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    record = _record(store)
+    resolution = owner.admit_or_finalize(record)
+    contender = DetectionCommitGate(store, "beta", policy, fence="wrapper-2")
+
+    unfenced = owner.finalize(record, resolution)
+    rejected = contender.finalize(
+        record,
+        resolution,
+        expected_revision=resolution.ledger_revision,
+    )
+    finalized = owner.finalize(
+        record,
+        resolution,
+        expected_revision=resolution.ledger_revision,
+    )
+
+    assert unfenced.state == ResolverState.INDETERMINATE
+    assert rejected.state == ResolverState.INDETERMINATE
+    assert finalized.state == ResolverState.NOT_OWED
+
+
+def test_open_no_admission_claim_is_recoverable_by_new_wrapper_fence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    record = _record(store)
+    first = _gate(store, fence="wrapper-1").admit_or_finalize(record)
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+
+    restarted = _gate(store, fence="wrapper-2")
+    recovered = restarted.admit_or_finalize(record)
+
+    assert first.state == ResolverState.SATISFIED
+    assert recovered.state == ResolverState.SATISFIED
+    assert _ledger(restarted)["no_admission_claims"][inbound.id]["fence"] == "wrapper-2"
+    restarted.finalize(
+        record,
+        recovered,
+        expected_revision=recovered.ledger_revision,
+    )
+    assert store.cursor("beta") == inbound.id
+
+
+def test_live_no_admission_claim_owner_cannot_be_displaced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    record = _record(store)
+    _gate(store, fence="wrapper-1").admit_or_finalize(record)
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "alive",
+    )
+
+    resolution = _gate(store, fence="wrapper-2").admit_or_finalize(record)
+
+    assert resolution.state == ResolverState.INDETERMINATE
+    assert _ledger(_gate(store))["no_admission_claims"][inbound.id]["fence"] == (
+        "wrapper-1"
+    )
+
+
+def test_finalized_no_admission_disposition_replays_cursor_after_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": "q-1", "in_reply_to": inbound.id},
+    )
+    record = _record(store)
+    owner = _gate(store, fence="wrapper-1")
+    terminal = owner.admit_or_finalize(record)
+    monkeypatch.setattr(
+        owner,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("crash barrier")),
+    )
+    finalized = owner.finalize(
+        record,
+        terminal,
+        expected_revision=terminal.ledger_revision,
+    )
+    assert finalized.state == ResolverState.INDETERMINATE
+    assert store.cursor("beta") == ""
+
+    restarted = _gate(store, fence="wrapper-2")
+    recovered = restarted.admit_or_finalize(record)
+    restarted.finalize(
+        record,
+        recovered,
+        expected_revision=recovered.ledger_revision,
+    )
+
+    assert store.cursor("beta") == inbound.id
+
+
+def test_sidecar_only_close_is_not_replay_proof(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    store._write_threadstate(  # noqa: SLF001 - simulate a torn legacy sidecar
+        "beta",
+        {"q-1": {"closed": True, "closed_reason": "sidecar-only"}},
+    )
+
+    resolution = _gate(store).admit_or_finalize(_record(store))
+
+    assert resolution.state == ResolverState.OWED_UNSATISFIED
+    assert resolution.key is not None
+
+
+def test_epoch_anchor_detects_append_counter_rollback(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    gate.admit_or_finalize(_record(store))
+    ledger = _ledger(gate)
+    ledger["append_sequence"] -= 1
+    gate.path.write_text(json.dumps(ledger), encoding="utf-8")
+
+    resolution = gate.resolve(_record(store))
+
+    assert resolution.state == ResolverState.BLOCKED
+    blocked = gate.status()
+    assert blocked["status"] == "BLOCKED"
+    assert blocked["proof_health"]["state"] == "blocked"
+    assert store.cursor("beta") == ""
+
+    assert gate.resolve(_record(store)).state == ResolverState.OWED_UNSATISFIED
+    assert gate.status()["status"] == "ACTIVE (detection-grade)"
+
+
+def test_unreadable_proof_health_is_visible_as_blocked(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    gate.admit_or_finalize(_record(store))
+    gate.proof_health_path.write_text("{", encoding="utf-8")
+
+    status = gate.status()
+
+    assert status["status"] == "BLOCKED"
+    assert status["proof_health"] == {"state": "blocked", "unreadable": True}
+
+
+def test_operation_nonce_is_idempotent_and_payload_bound(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    draft = Path(dispatched["owed_action"]["draft_path"])
+    command = [
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]
+    draft.write_text("399", encoding="utf-8")
+
+    assert cli.main(command) == 0
+    assert cli.main(command) == 0
+    draft.write_text("400", encoding="utf-8")
+    assert cli.main(command) == 2
+
+    matching = [
+        message for message in store.valid_messages()
+        if (message.meta or {}).get("operation_nonce") == permit.nonce
+    ]
+    assert len(matching) == 1
+    assert matching[0].body == "399"
+
+
+def test_operation_nonce_publication_is_atomic_under_concurrency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    original = cli._operation_idempotency  # noqa: SLF001 - crash-race fixture
+
+    def run_pair(nonce: str, bodies: tuple[str, str]) -> list[int]:
+        barrier = threading.Barrier(2)
+
+        def synchronized(*args, **kwargs):
+            result = original(*args, **kwargs)
+            barrier.wait(timeout=10)
+            return result
+
+        monkeypatch.setattr(cli, "_operation_idempotency", synchronized)
+        results: list[int] = []
+
+        def invoke(body: str) -> None:
+            results.append(cli.main([
+                "--root",
+                str(tmp_path),
+                "reply",
+                "--from",
+                "beta",
+                "--to-id",
+                inbound.id,
+                "--operation-nonce",
+                nonce,
+                "-m",
+                body,
+                "--quiet",
+            ]))
+
+        workers = [threading.Thread(target=invoke, args=(body,)) for body in bodies]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=15)
+        assert all(not worker.is_alive() for worker in workers)
+        monkeypatch.setattr(cli, "_operation_idempotency", original)
+        return results
+
+    same_nonce = "a" * 32
+    assert sorted(run_pair(same_nonce, ("399", "399"))) == [0, 0]
+    same = [
+        message for message in store.valid_messages()
+        if (message.meta or {}).get("operation_nonce") == same_nonce
+    ]
+    assert len(same) == 1
+
+    conflicting_nonce = "b" * 32
+    assert sorted(run_pair(conflicting_nonce, ("400", "401"))) == [0, 2]
+    conflicting = [
+        message for message in store.valid_messages()
+        if (message.meta or {}).get("operation_nonce") == conflicting_nonce
+    ]
+    assert len(conflicting) == 1
+
+
+def test_composing_and_terminal_use_separate_tokens_and_terminal_wins(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["composing_argv"][3:],
+        "--quiet",
+    ]) == 0
+    Path(dispatched["owed_action"]["draft_path"]).write_text("399", encoding="utf-8")
+    assert cli.main([
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+
+    terminal = gate.resolve(record)
+
+    assert permit.nonce != permit.composing_nonce
+    assert terminal.state == ResolverState.SATISFIED
+
+
+def test_composing_without_live_producer_or_continuation_does_not_park(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store, producer_alive=lambda _token: False)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["composing_argv"][3:],
+        "--quiet",
+    ]) == 0
+
+    assert gate.resolve(record).state == ResolverState.OWED_UNSATISFIED
+
+
+def test_post_budget_composing_is_durably_missing_and_cannot_escape_paid_cap(
+    tmp_path: Path,
+) -> None:
+    current = {"value": "2026-01-01T00:00:00Z"}
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(
+        store,
+        now=lambda: current["value"],
+        producer_alive=lambda _token: True,
+    )
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, first)
+    gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["composing_argv"][3:],
+        "--quiet",
+    ]) == 0
+    current["value"] = "2026-01-01T01:00:00Z"
+    assert gate.resolve(record).state == ResolverState.IN_PROGRESS
+    current["value"] = "2026-01-01T01:00:00.001Z"
+
+    expired = gate.resolve(record)
+    replayed = gate.resolve(record)
+
+    ledger = _ledger(gate)
+    admission = ledger["obligations"][admitted.key.digest]
+    evidence_id = admission.get("post_budget_composing_evidence_id")
+    assert expired.state == ResolverState.OWED_UNSATISFIED
+    assert expired.reason == "post_budget_composing"
+    assert expired.evidence_id == evidence_id
+    assert replayed.evidence_id == evidence_id
+    assert admission["owed_action_missing_seen"] is True
+    assert admission["first_dispatch_classified"] is True
+    assert admission["last_exhaustion_class"] == "compliance"
+    assert sum(
+        row["transition"] == "OWED_ACTION_MISSING"
+        and row.get("source_id") == evidence_id
+        and row["data"].get("evidence") == "post_budget_composing"
+        for row in ledger["transitions"]
+    ) == 1
+
+    gate.mark_dispatch_result(
+        first,
+        action_attempted=True,
+        action_infra=True,
+    )
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "last_exhaustion_class"
+    ] == "infrastructure"
+    reasserted = gate.resolve(record)
+    assert reasserted.reason == "post_budget_composing"
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "last_exhaustion_class"
+    ] == "compliance"
+    second = gate.reserve_dispatch(expired, purpose="continuation")
+    gate.dispatch_record(record, second)
+    gate.mark_dispatch_result(second, action_attempted=False)
+    with pytest.raises(DispatchRefused, match="paid dispatch budget exhausted"):
+        gate.reserve_dispatch(
+            gate.resolve(record),
+            purpose="recovery",
+            nonce="e" * 32,
+        )
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "paid_dispatches_total"
+    ] == 2
+
+
+def test_post_budget_composing_outranks_child_infra_in_loop(tmp_path: Path) -> None:
+    current = {"value": "2026-01-01T00:00:00Z"}
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(
+        store,
+        now=lambda: current["value"],
+        producer_alive=lambda _token: True,
+    )
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        gate.schedule_continuation(admitted.key, producer_token="producer-1")
+        assert cli.main([
+            "--root",
+            str(tmp_path),
+            *record["owed_action"]["composing_argv"][3:],
+            "--quiet",
+        ]) == 0
+        current["value"] = "2026-01-01T01:00:00.001Z"
+        return loop.DriveOutcome(
+            ok=False,
+            failure_class=loop.CLASS_INFRA,
+            bus_action_infra=True,
+        )
+
+    assert loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    ) == 0
+
+    ledger = _ledger(gate)
+    admission = ledger["obligations"][admitted.key.digest]
+    first = next(iter(admission["reservations"].values()))
+    assert first["state"] == "uncaptured_infra"
+    assert admission["last_exhaustion_class"] == "compliance"
+    assert not any(
+        row["transition"] == "OPERATION_RETRY_RECORDED"
+        for row in ledger["transitions"]
+    )
+
+
+def test_post_budget_composing_preserves_captured_operation_infra(
+    tmp_path: Path,
+) -> None:
+    current = {"value": "2026-01-01T00:00:00Z"}
+    store = _store(tmp_path)
+    _question(store, escalation_required=True)
+    gate = _gate(
+        store,
+        now=lambda: current["value"],
+        producer_alive=lambda _token: True,
+    )
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, first)
+    gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["composing_argv"][3:],
+        "--quiet",
+    ]) == 0
+    current["value"] = "2026-01-01T01:00:00.001Z"
+    assert gate.resolve(record).reason == "post_budget_composing"
+    first.draft_path.write_text("399", encoding="utf-8")
+    captured_digest = _record_captured_intent(store, gate, first)
+    gate.mark_dispatch_result(
+        first,
+        action_attempted=True,
+        action_infra=True,
+    )
+
+    replayed = gate.resolve(record)
+    ledger = _ledger(gate)
+    admission = ledger["obligations"][admitted.key.digest]
+    row = admission["reservations"][first.nonce]
+    captured = gate.captured_operation(admitted.key)
+
+    assert replayed.reason == "post_budget_composing"
+    assert admission["last_exhaustion_class"] == "infrastructure"
+    assert row["state"] == "action_infra"
+    assert row["operation_payload_digest"] == captured_digest
+    assert captured is not None
+    assert captured.nonce == first.nonce
+
+    first.draft_path.unlink()
+    after_loss = gate.resolve(record)
+    admission_after_loss = _ledger(gate)["obligations"][admitted.key.digest]
+    assert after_loss.reason == "post_budget_composing"
+    assert admission_after_loss["last_exhaustion_class"] == "infrastructure"
+
+    corrupt = _ledger(gate)
+    corrupt_row = corrupt["obligations"][admitted.key.digest]["reservations"][
+        first.nonce
+    ]
+    corrupt_row["operation_intent"]["recipient"] = "gamma"
+    gate.path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    invalid = gate.resolve(record)
+    assert invalid.state == ResolverState.INDETERMINATE
+    assert "captured infrastructure evidence" in invalid.reason
+
+
+@pytest.mark.parametrize("escalation_required", [False, True])
+def test_canonical_terminal_blocks_stale_post_budget_reservation_when_hook_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    escalation_required: bool,
+) -> None:
+    current = {"value": "2026-01-01T00:00:00Z"}
+    store = _store(tmp_path)
+    _question(store, escalation_required=escalation_required)
+    gate = _gate(
+        store,
+        now=lambda: current["value"],
+        producer_alive=lambda _token: True,
+    )
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    first = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, first)
+    gate.schedule_continuation(admitted.key, producer_token="producer-1")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["composing_argv"][3:],
+        "--quiet",
+    ]) == 0
+    current["value"] = "2026-01-01T01:00:00.001Z"
+    stale = gate.resolve(record)
+    gate.mark_dispatch_result(first, action_attempted=False)
+
+    def fail_eager_index(_store, _message) -> None:
+        raise OSError("injected projection hook failure")
+
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.note_bus_message",
+        fail_eager_index,
+    )
+    first.draft_path.write_text("399", encoding="utf-8")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["argv"][3:],
+        "--quiet",
+    ]) == 0
+
+    with pytest.raises((DispatchRefused, StaleRevision)):
+        gate.reserve_dispatch(stale, purpose="continuation")
+
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["paid_dispatches_total"] == 1
+    assert gate.resolve(record).state == ResolverState.SATISFIED
+
+
+def test_wrong_class_answer_does_not_satisfy_required_escalation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, escalation_required=True)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    with pytest.raises(GateError, match="durably classified"):
+        gate.mark_unsatisfied_attempt(permit, reason="answered instead of escalating")
+    gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("I answered instead", encoding="utf-8")
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        "reply",
+        "--from",
+        "beta",
+        "--to-id",
+        inbound.id,
+        "--operation-nonce",
+        permit.nonce,
+        "--file",
+        str(permit.draft_path),
+        "--quiet",
+    ]) == 0
+    unresolved = gate.resolve(record)
+    gate.mark_dispatch_result(
+        permit,
+        action_attempted=True,
+        action_rejected=unresolved.state == ResolverState.OWED_UNSATISFIED,
+    )
+    gate.mark_unsatisfied_attempt(permit, reason="answered instead of escalating")
+
+    assert unresolved.state == ResolverState.OWED_UNSATISFIED
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["owed_action_missing_seen"] is True
+
+
+def test_event_time_liaison_escalation_survives_later_repoint(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store, escalation_required=True)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("Operator decision needed", encoding="utf-8")
+    assert cli.main([
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+    store.set_operator_facing("gamma")
+
+    resolution = gate.resolve(record)
+
+    assert resolution.state == ResolverState.SATISFIED
+    assert resolution.compliance_success is True
+
+
+def test_roster_revision_cas_rejects_stale_escalation_append(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, escalation_required=True)
+    gate = _gate(store)
+    old = gate.roster_snapshot()
+    store.set_operator_facing("gamma")
+
+    with pytest.raises(ValueError, match="roster revision changed"):
+        store.send(
+            sender="beta",
+            recipient="lead",
+            kind="question",
+            body="stale escalation",
+            meta={
+                "request_id": "esc-stale",
+                "origin_request_id": "q-1",
+                "origin_inbound_id": inbound.id,
+                "expected_roster_revision": old["revision"],
+            },
+        )
+
+
+def test_operator_resolution_cas_rejects_revoke_then_accepts_current_authority(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    old = gate.roster_snapshot()
+    store.set_operator_facing("gamma")
+
+    with pytest.raises(StaleRevision):
+        gate.operator_resolve(
+            record,
+            admitted.key,
+            actor="lead",
+            expected_roster_revision=old["revision"],
+            reason="stale authority",
+        )
+    current = gate.roster_snapshot()
+    resolved = gate.operator_resolve(
+        record,
+        admitted.key,
+        actor="gamma",
+        expected_roster_revision=current["revision"],
+        reason="operator disposition",
+    )
+
+    assert resolved.state == ResolverState.OPERATOR_RESOLVED
+    assert store.cursor("beta") == record["id"]
+
+
+def test_transferred_admission_is_claimed_by_destination_wrapper(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    inbound = _transfer_question(
+        store, admitted.key, "gamma", destination_policy,
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+    source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=inbound.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+    destination = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    claimed = destination.admit_or_finalize(_record(store, agent="gamma"))
+
+    assert claimed.state == ResolverState.OWED_UNSATISFIED
+    assert claimed.key is not None and claimed.key.responder == "gamma"
+    assert destination.reserve_dispatch(claimed, purpose="initial").paid_dispatches_total == 1
+
+
+def test_each_broadcast_does_not_policy_close_other_member(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-each",
+        members=members,
+        policy="each",
+    )
+    _broadcast_question(
+        store,
+        "gamma",
+        broadcast_id="b-each",
+        members=members,
+        policy="each",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    beta_record = _record(store)
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+
+    assert gamma.resolve(gamma_record).state == ResolverState.OWED_UNSATISFIED
+    assert gamma_open.key is not None
+
+
+def test_any_broadcast_policy_closes_member_and_records_late_reply(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-any",
+        members=members,
+        policy="any",
+    )
+    gamma_inbound = _broadcast_question(
+        store,
+        "gamma",
+        broadcast_id="b-any",
+        members=members,
+        policy="any",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    beta_record = _record(store)
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta_terminal = beta.resolve(beta_record)
+    beta.finalize(beta_record, beta_terminal)
+    store.send(
+        sender="gamma",
+        recipient="alpha",
+        body="late informational answer",
+        meta={"broadcast_id": "b-any", "in_reply_to": gamma_inbound.id},
+    )
+    policy_closed = gamma.resolve(gamma_record)
+    gamma.finalize(gamma_record, policy_closed)
+    ledger = _ledger(gamma)
+
+    assert gamma_open.key is not None
+    assert policy_closed.state == ResolverState.BROADCAST_POLICY_SATISFIED
+    assert ledger["obligations"][gamma_open.key.digest]["paid_dispatches_total"] == 0
+    assert any(
+        row["transition"] == "LATE_RESPONSE"
+        and row["source_id"] is not None
+        for row in ledger["transitions"]
+    )
+
+
+def test_quorum_closes_all_nonresponders_and_excludes_delivery_failed(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, ["alpha", "beta", "gamma", "lead", "delta"])
+    members = ["beta", "gamma", "lead", "delta"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-quorum",
+            members=members,
+            policy="quorum",
+            quorum=2,
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma", "lead", "delta"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta", "lead", "delta"),
+    )
+    lead = _gate(
+        store,
+        agent="lead",
+        fence="wrapper-lead",
+        policy_agents=("lead", "beta", "gamma", "delta"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    lead_record = _record(store, agent="lead")
+    beta_open = beta.admit_or_finalize(beta_record)
+    gamma.admit_or_finalize(gamma_record)
+    lead_open = lead.admit_or_finalize(lead_record)
+    assert beta_open.key is not None and lead_open.key is not None
+    beta.delivery_failed(
+        beta_record,
+        beta_open.key,
+        reason="head-local exhaustion",
+        expected_revision=beta_open.scoped_revision,
+    )
+    _answer_reserved(tmp_path, gamma, gamma_record)
+    gamma.finalize(gamma_record, gamma.resolve(gamma_record))
+
+    assert lead.resolve(lead_record).state == ResolverState.OWED_UNSATISFIED
+
+    # A failed delivery did not count. A second qualifying answer is required.
+    lead_resolution = lead.resolve(lead_record)
+    lead_permit = lead.reserve_dispatch(lead_resolution, purpose="initial")
+    lead_dispatch = lead.dispatch_record(lead_record, lead_permit)
+    lead_permit.draft_path.write_text("lead answer", encoding="utf-8")
+    assert cli.main([
+        "--root", str(tmp_path), *lead_dispatch["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+    lead.finalize(lead_record, lead.resolve(lead_record))
+    ledger = _ledger(lead)
+    winner_sets = [
+        row["data"]["winning_ids"]
+        for row in ledger["transitions"]
+        if row["transition"] == "BROADCAST_POLICY_SATISFIED"
+    ]
+
+    assert all(len(winners) == 2 for winners in winner_sets)
+
+
+def test_transfer_and_policy_close_win_against_stale_dispatch_reservations(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    stale = source.admit_or_finalize(record)
+    assert stale.key is not None
+    transferred = _transfer_question(
+        store, stale.key, "gamma", destination_policy,
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+    source.transfer(
+        record,
+        stale.key,
+        destination="gamma",
+        new_inbound_id=transferred.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+    with pytest.raises(DispatchRefused):
+        source.reserve_dispatch(stale, purpose="initial")
+
+    second = _store(tmp_path.parent / "broadcast-race")
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        second,
+        "beta",
+        broadcast_id="b-race",
+        members=members,
+        policy="any",
+    )
+    _broadcast_question(
+        second,
+        "gamma",
+        broadcast_id="b-race",
+        members=members,
+        policy="any",
+    )
+    beta = _gate(second, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        second,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    beta_record = _record(second)
+    gamma_record = _record(second, agent="gamma")
+    stale_member = gamma.admit_or_finalize(gamma_record)
+    _answer_reserved(second.root, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+    with pytest.raises(DispatchRefused):
+        gamma.reserve_dispatch(stale_member, purpose="initial")
+
+
+def test_transfer_is_pre_admission_fenced_and_commits_one_complete_transaction(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-atomic")
+    source_policy = _policy("beta", "gamma")
+    destination_policy = _policy("gamma", "beta")
+    source = DetectionCommitGate(store, "beta", source_policy, fence="wrapper-1")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop", "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1", "pid": os.getpid(),
+    })
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(
+        store, admitted.key, "gamma", destination_policy,
+    )
+    destination = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    assert target.id not in _ledger(source)["inbound_index"]
+
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+    transferred = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+    ledger = _ledger(source)
+    next_digest = ledger["inbound_index"][target.id]
+    next_admission = ledger["obligations"][next_digest]
+    transaction = [
+        row for row in ledger["transitions"]
+        if row["transition"] in {"OBLIGATION_ADMITTED", "TRANSFERRED"}
+        and (
+            row.get("key_digest") in {admitted.key.digest, next_digest}
+            or row.get("source_id") == target.id
+        )
+    ]
+
+    assert transferred.state == ResolverState.TRANSFERRED
+    assert ledger["obligations"][admitted.key.digest]["state"] == "transferred"
+    assert next_admission["state"] == "open"
+    assert next_admission["fence"] == "unclaimed"
+    assert next_admission["activation_generation"] == destination_policy.generation
+    assert next_admission["readiness_generation"] == destination_policy.generation
+    assert next_admission["paid_dispatches_total"] == 0
+    assert next_admission.get("terminal_state") is None
+    assert [row["transition"] for row in transaction[-2:]] == [
+        "OBLIGATION_ADMITTED", "TRANSFERRED",
+    ]
+    assert ledger["cursor_dispositions"]["beta"]["inbound_id"] == record["id"]
+    assert store.cursor("beta") == record["id"]
+    claimed = destination.admit_or_finalize(_record(store, agent="gamma"))
+    assert claimed.state == ResolverState.OWED_UNSATISFIED
+    assert sum(
+        row.get("key", {}).get("inbound_id") == target.id
+        for row in ledger["obligations"].values()
+        if isinstance(row, dict)
+    ) == 1
+
+
+def test_transfer_crash_or_stale_roster_leaves_source_open_and_target_unadmitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-crash")
+    source_policy = _policy("beta", "gamma")
+    destination_policy = _policy("gamma", "beta")
+    source = DetectionCommitGate(store, "beta", source_policy, fence="wrapper-1")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop", "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1", "pid": os.getpid(),
+    })
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(
+        store, admitted.key, "gamma", destination_policy,
+    )
+    current = source.resolve(record)
+    stale_roster = source.roster_snapshot()
+    store.set_operator_facing("gamma")
+
+    with pytest.raises(StaleRevision):
+        source.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=stale_roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+    assert _ledger(source)["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in _ledger(source)["inbound_index"]
+
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+    real_write = source._write
+    monkeypatch.setattr(
+        source,
+        "_write",
+        lambda _ledger_value: (_ for _ in ()).throw(OSError("transfer crash")),
+    )
+    with pytest.raises(OSError, match="transfer crash"):
+        source.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="gamma",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+    monkeypatch.setattr(source, "_write", real_write)
+    after = _ledger(source)
+    assert after["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in after["inbound_index"]
+
+
+def test_transfer_rejects_destination_outside_frozen_broadcast_membership(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, ["alpha", "beta", "gamma", "delta", "lead"])
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-transfer-membership",
+        members=members,
+        policy="each",
+    )
+    destination_policy = _policy("delta", "beta", "gamma")
+    source = _gate(store, policy_agents=("beta", "gamma", "delta"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = store.send(
+        sender="alpha",
+        recipient="delta",
+        kind="question",
+        body="invalid transferred broadcast slot",
+        meta={
+            "broadcast_id": "b-transfer-membership",
+            "membership_snapshot": members,
+            "response_policy": "each",
+            "broadcast_policy_version": 1,
+            "consult": False,
+            "transfer_from_key_digest": admitted.key.digest,
+            "transfer_policy_generation": destination_policy.generation,
+        },
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    with pytest.raises(ValueError, match="frozen broadcast policy"):
+        source.transfer(
+            record,
+            admitted.key,
+            destination="delta",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+    assert _ledger(source)["obligations"][admitted.key.digest]["state"] == "open"
+
+
+@pytest.mark.parametrize(
+    "destination_policy,consult",
+    [
+        (PolicySnapshot(ResolverState.BLOCKED_POLICY, "unreadable"), False),
+        (PolicySnapshot(ResolverState.INACTIVE, "disabled", DETECTION_GRADE), False),
+        (_policy("gamma", "beta"), {"unsupported": True}),
+    ],
+)
+def test_transfer_rejects_unadmittable_destination_before_source_close(
+    tmp_path: Path,
+    destination_policy: PolicySnapshot,
+    consult: object,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-invalid")
+    source_policy = _policy("beta", "gamma")
+    source = DetectionCommitGate(store, "beta", source_policy, fence="wrapper-1")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop", "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1", "pid": os.getpid(),
+    })
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(
+        store,
+        admitted.key,
+        "gamma",
+        destination_policy,
+        consult=consult,
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    if destination_policy.status == ResolverState.BLOCKED_POLICY:
+        result = source.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+        assert result.state == ResolverState.BLOCKED_POLICY
+    else:
+        with pytest.raises((GateError, ValueError)):
+            source.transfer(
+                record,
+                admitted.key,
+                destination="gamma",
+                new_inbound_id=target.id,
+                destination_policy=destination_policy,
+                actor="lead",
+                expected_roster_revision=roster["revision"],
+                expected_revision=current.scoped_revision,
+            )
+    ledger = _ledger(source)
+    assert ledger["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in ledger["inbound_index"]
+
+
+def test_transfer_rejects_forged_source_record_before_mutating_either_assignment(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-source-forgery")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    forged = {**record, "meta": {**record["meta"], "forged": True}}
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    with pytest.raises(GateError, match="canonical source"):
+        source.transfer(
+            forged,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+
+    ledger = _ledger(source)
+    assert ledger["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in ledger["inbound_index"]
+
+
+def test_transfer_rejects_active_policy_snapshot_bound_to_another_agent(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-policy-binding")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    wrong_agent_policy = _policy("beta", "gamma")
+    target = _transfer_question(store, admitted.key, "gamma", wrong_agent_policy)
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    with pytest.raises(GateError, match="destination policy"):
+        source.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=wrong_agent_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+
+    ledger = _ledger(source)
+    assert ledger["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in ledger["inbound_index"]
+
+
+def test_unreadable_transfer_destination_policy_holds_source_visibly_blocked(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-policy-block")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    blocked_policy = PolicySnapshot(
+        ResolverState.BLOCKED_POLICY,
+        "unreadable",
+        reason="destination policy unreadable",
+        agent="gamma",
+    )
+    target = _transfer_question(store, admitted.key, "gamma", blocked_policy)
+    roster = source.roster_snapshot()
+    result = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=blocked_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=source.resolve(record).scoped_revision,
+    )
+
+    row = _ledger(source)["obligations"][admitted.key.digest]
+    assert result.state == ResolverState.BLOCKED_POLICY
+    assert source.resolve(record).state == ResolverState.BLOCKED_POLICY
+    assert row["state"] == "open"
+    assert row["transfer_blocked_state"] == ResolverState.BLOCKED_POLICY.value
+    assert store.cursor("beta") == ""
+    with pytest.raises(DispatchRefused):
+        source.reserve_dispatch(admitted, purpose="initial")
+
+
+def test_retired_source_wrapper_cannot_persist_transfer_destination_block(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-policy-block-owner")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    blocked_policy = PolicySnapshot(
+        ResolverState.BLOCKED_POLICY,
+        "unreadable",
+        reason="destination policy unreadable",
+        agent="gamma",
+    )
+    target = _transfer_question(store, admitted.key, "gamma", blocked_policy)
+    current = source.resolve(record)
+    retired = DetectionCommitGate(
+        store,
+        "beta",
+        source.policy,
+        fence="retired-wrapper",
+    )
+
+    with pytest.raises(GateError, match="no longer owns"):
+        retired.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=blocked_policy,
+            actor="lead",
+            expected_roster_revision=source.roster_snapshot()["revision"],
+            expected_revision=current.scoped_revision,
+        )
+
+    row = _ledger(source)["obligations"][admitted.key.digest]
+    assert row["state"] == "open"
+    assert row.get("transfer_blocked_state") is None
+    assert source.resolve(record).state == ResolverState.OWED_UNSATISFIED
+
+
+def test_transfer_replays_source_and_preserves_answer_that_won_publication_race(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-source-answer-race")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    _answer_reserved(tmp_path, source, record, body="answer won before transfer")
+    current = source.resolve(record)
+    assert current.state == ResolverState.SATISFIED
+    roster = source.roster_snapshot()
+
+    result = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+
+    ledger = _ledger(source)
+    assert result.state == ResolverState.SATISFIED
+    assert ledger["obligations"][admitted.key.digest]["state"] == "finalized"
+    assert target.id not in ledger["inbound_index"]
+    assert not any(
+        row["transition"] == "TRANSFERRED"
+        and row.get("key_digest") == admitted.key.digest
+        for row in ledger["transitions"]
+    )
+
+
+def test_landed_source_terminal_precedes_blocked_broadcast_aggregate(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-transfer-terminal-precedence",
+        members=members,
+        policy="each",
+    )
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = store.send(
+        sender="alpha",
+        recipient="gamma",
+        kind="question",
+        body="transferred broadcast target",
+        meta={
+            "request_id": "b-transfer-terminal-precedence",
+            "broadcast_id": "b-transfer-terminal-precedence",
+            "membership_snapshot": members,
+            "response_policy": "each",
+            "broadcast_policy_version": 1,
+            "consult": False,
+            "transfer_from_key_digest": admitted.key.digest,
+            "transfer_policy_generation": destination_policy.generation,
+        },
+    )
+    _answer_reserved(tmp_path, source, record, body="canonical terminal wins")
+    ledger = _ledger(source)
+    aggregate = ledger["broadcasts"]["b-transfer-terminal-precedence"]
+    aggregate["state"] = "blocked"
+    aggregate["blocked_reason"] = "conflict observed after terminal"
+    source._write(ledger)
+
+    replayed = source.resolve(record)
+    assert replayed.state == ResolverState.SATISFIED
+    result = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=source.roster_snapshot()["revision"],
+        expected_revision=replayed.scoped_revision,
+    )
+
+    after = _ledger(source)
+    source_row = after["obligations"][admitted.key.digest]
+    assert result.state == ResolverState.SATISFIED
+    assert source_row["state"] == "finalized"
+    assert source_row.get("transfer_blocked_state") is None
+    assert target.id not in after["inbound_index"]
+
+
+def test_transfer_rejects_destination_with_tripped_compliance_breaker(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-destination-breaker")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    ledger = _ledger(source)
+    ledger["breakers"]["gamma"] = {"tripped": True, "config_blocked": True}
+    source._write(ledger)
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    blocked = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+
+    after = _ledger(source)
+    assert blocked.state == ResolverState.BLOCKED_COMPLIANCE
+    assert source.resolve(record).state == ResolverState.BLOCKED_COMPLIANCE
+    assert after["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in after["inbound_index"]
+
+
+def test_transfer_rejects_destination_in_blocked_broadcast_aggregate(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-transfer-blocked",
+        members=members,
+        policy="each",
+    )
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = store.send(
+        sender="alpha",
+        recipient="gamma",
+        kind="question",
+        body="transferred broadcast target",
+        meta={
+            "request_id": "b-transfer-blocked",
+            "broadcast_id": "b-transfer-blocked",
+            "membership_snapshot": members,
+            "response_policy": "each",
+            "broadcast_policy_version": 1,
+            "consult": False,
+            "transfer_from_key_digest": admitted.key.digest,
+            "transfer_policy_generation": destination_policy.generation,
+        },
+    )
+    source.resolve(record)
+    ledger = _ledger(source)
+    ledger["broadcasts"]["b-transfer-blocked"]["state"] = "blocked"
+    ledger["broadcasts"]["b-transfer-blocked"]["blocked_reason"] = "test conflict"
+    source._write(ledger)
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    blocked = source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=target.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+
+    after = _ledger(source)
+    assert blocked.state == ResolverState.BLOCKED
+    assert source.resolve(record).state == ResolverState.BLOCKED
+    assert after["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in after["inbound_index"]
+
+
+def test_transfer_rejects_target_with_prospective_terminal_answer(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-target-preanswered")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    store.send(
+        sender="gamma",
+        recipient="alpha",
+        body="already answered before assignment",
+        meta={
+            "request_id": admitted.key.correlation_id,
+            "in_reply_to": target.id,
+        },
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    with pytest.raises(GateError, match="already terminal"):
+        source.transfer(
+            record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+
+    ledger = _ledger(source)
+    assert ledger["obligations"][admitted.key.digest]["state"] == "open"
+    assert target.id not in ledger["inbound_index"]
+
+
+def test_uncommitted_transfer_target_abort_wins_cas_and_unblocks_destination_queue(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-transfer-abort")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    source_record = _record(store)
+    admitted = source.admit_or_finalize(source_record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    next_message = store.send(
+        sender="alpha",
+        recipient="gamma",
+        kind="question",
+        body="next live destination work",
+        meta={"request_id": "q-after-aborted-transfer"},
+    )
+    destination = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    target_record = _record(store, agent="gamma")
+
+    aborted = destination.admit_or_finalize(target_record)
+    assert aborted.state == ResolverState.NOT_OWED
+    assert aborted.reason == "no_admission_finalization_pending"
+    finalized = destination.finalize(
+        target_record,
+        aborted,
+        expected_revision=aborted.ledger_revision,
+    )
+    assert finalized.state == ResolverState.NOT_OWED
+    assert store.cursor("gamma") == target.id
+    assert _record(store, agent="gamma")["id"] == next_message.id
+
+    current = source.resolve(source_record)
+    roster = source.roster_snapshot()
+    with pytest.raises(StaleRevision, match="already claimed"):
+        source.transfer(
+            source_record,
+            admitted.key,
+            destination="gamma",
+            new_inbound_id=target.id,
+            destination_policy=destination_policy,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            expected_revision=current.scoped_revision,
+        )
+
+    claim = _ledger(destination)["no_admission_claims"][target.id]
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.NOT_OWED.value
+
+
+def test_finalized_transfer_target_abort_projects_across_policy_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    initial_agents = {
+        "beta": {"grade": DETECTION_GRADE},
+        "gamma": {"grade": DETECTION_GRADE},
+    }
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": initial_agents}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    _question(store, "q-transfer-abort-policy-drift")
+    destination_policy = PolicySnapshot.from_path(policy_path, "gamma")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    source_record = _record(store)
+    admitted = source.admit_or_finalize(source_record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    destination = DetectionCommitGate.from_environment(
+        store,
+        "gamma",
+        fence="wrapper-gamma-1",
+    )
+    target_record = _record(store, agent="gamma")
+    aborted = destination.admit_or_finalize(target_record)
+    original_write = destination._write
+    drifted = False
+
+    def drift_after_terminal_ledger_write(ledger: dict) -> None:
+        nonlocal drifted
+        original_write(ledger)
+        claim = ledger["no_admission_claims"].get(target.id)
+        disposition = ledger["cursor_dispositions"].get("gamma")
+        if (
+            not drifted
+            and isinstance(claim, dict)
+            and claim.get("state") == "finalized"
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == target.id
+        ):
+            drifted = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        **initial_agents,
+                        "lead": {"grade": DETECTION_GRADE},
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(destination, "_write", drift_after_terminal_ledger_write)
+    monkeypatch.setattr(
+        destination,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("crash barrier")),
+    )
+
+    destination.finalize(
+        target_record,
+        aborted,
+        expected_revision=aborted.ledger_revision,
+    )
+
+    assert drifted is True
+    assert store.cursor("gamma") == ""
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "gamma",
+        fence="wrapper-gamma-2",
+    )
+    recovered = restarted.admit_or_finalize(target_record)
+    assert recovered.state == ResolverState.NOT_OWED
+    assert recovered.reason == "no_admission_disposition_pending"
+    projected = restarted.finalize(
+        target_record,
+        recovered,
+        expected_revision=recovered.ledger_revision,
+    )
+    assert projected.state == ResolverState.NOT_OWED
+    assert store.cursor("gamma") == target.id
+
+
+@pytest.mark.parametrize(
+    "updated_agents",
+    [
+        {
+            "beta": {"grade": DETECTION_GRADE},
+            "gamma": {"grade": DETECTION_GRADE},
+            "lead": {"grade": DETECTION_GRADE},
+        },
+        {"beta": {"grade": DETECTION_GRADE}},
+        {
+            "beta": {"grade": DETECTION_GRADE},
+            "gamma": {"grade": SECURITY_GRADE},
+        },
+    ],
+    ids=["unrelated-agent-edit", "active-to-no-grade", "active-to-security"],
+)
+def test_open_transfer_target_abort_is_zero_work_terminal_across_policy_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updated_agents: dict[str, dict[str, str]],
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    initial_agents = {
+        "beta": {"grade": DETECTION_GRADE},
+        "gamma": {"grade": DETECTION_GRADE},
+    }
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": initial_agents}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    _question(store, "q-open-transfer-abort-policy-drift")
+    destination_policy = PolicySnapshot.from_path(policy_path, "gamma")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    source_record = _record(store)
+    admitted = source.admit_or_finalize(source_record)
+    assert admitted.key is not None
+    target = _transfer_question(store, admitted.key, "gamma", destination_policy)
+    destination = DetectionCommitGate.from_environment(
+        store,
+        "gamma",
+        fence="wrapper-gamma-1",
+    )
+    original_admit = destination.admit_or_finalize
+    drifted = False
+
+    def drift_after_transfer_abort_normalization(
+        record: dict,
+    ) -> obligations.Resolution:
+        nonlocal drifted
+        resolution = original_admit(record)
+        claim = _ledger(destination)["no_admission_claims"].get(target.id)
+        if (
+            not drifted
+            and resolution.state == ResolverState.NOT_OWED
+            and isinstance(claim, dict)
+            and claim.get("state") == "open"
+            and claim.get("claim_kind") == "transfer_target_abort"
+        ):
+            drifted = True
+            policy_path.write_text(
+                json.dumps({"schema_version": 1, "agents": updated_agents}),
+                encoding="utf-8",
+            )
+        return resolution
+
+    monkeypatch.setattr(
+        destination,
+        "admit_or_finalize",
+        drift_after_transfer_abort_normalization,
+    )
+    drive_paths: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        drive_paths.append("enforced" if "owed_action" in record else "legacy")
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "gamma",
+        drive,
+        commit_gate=destination,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    current_policy = PolicySnapshot.from_path(policy_path, "gamma")
+    claim = _ledger(destination)["no_admission_claims"][target.id]
+    assert drifted is True
+    assert turns == 1
+    assert drive_paths == []
+    assert store.cursor("gamma") == target.id
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.NOT_OWED.value
+    assert claim["claim_kind"] == "transfer_target_abort"
+    assert claim["policy_status"] == current_policy.status.value
+    assert claim["policy_generation"] == current_policy.generation
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+
+
+def test_human_escalation_pins_roster_revision_and_repoint_rejects_append(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-escalation-roster", escalation_required=True)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    row = _ledger(gate)["obligations"][permit.key_digest]["reservations"][permit.nonce]
+    pinned = row["operation_intent"]["expected_roster_revision"]
+    assert row["operation_intent"]["origin_obligation_key_digest"] == permit.key_digest
+    assert f"expected_roster_revision={pinned}" in dispatched["owed_action"]["argv"]
+
+    permit.draft_path.write_text("operator input required", encoding="utf-8")
+    store.set_operator_facing("gamma")
+    assert cli.main([
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 2
+    assert not any(
+        (message.meta or {}).get("origin_inbound_id") == record["id"]
+        for message in store.valid_messages()
+    )
+
+
+def test_legacy_operation_digest_and_intent_replay_remain_compatible(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    body = "399"
+    nonce = "a" * 32
+    legacy_intent = {
+        "operation": "terminal",
+        "kind": "message",
+        "recipient": "alpha",
+        "in_reply_to": "legacy-inbound",
+        "request_id": "q-legacy-operation",
+        "broadcast_id": None,
+        "origin_request_id": None,
+        "origin_inbound_id": None,
+    }
+    legacy_payload = {**legacy_intent, "body": body}
+    expected = hashlib.sha256(
+        json.dumps(
+            legacy_payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    digest = operation_payload_digest(body=body, **legacy_intent)
+    store.record_operation_intent(
+        sender="beta",
+        operation_nonce=nonce,
+        operation_digest=expected,
+        body=body,
+        operation_intent=legacy_intent,
+    )
+    message, created = store.send_operation(
+        sender="beta",
+        recipient="alpha",
+        body=body,
+        kind="message",
+        meta={
+            "in_reply_to": "legacy-inbound",
+            "request_id": "q-legacy-operation",
+        },
+        operation_nonce=nonce,
+        operation_digest=expected,
+    )
+
+    assert digest == expected
+    assert created is True
+    assert (message.meta or {})["operation_digest"] == expected
+
+
+def test_operator_resolution_rejects_record_key_mismatch_without_cursor_move(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "q-operator-a")
+    gate = _gate(store)
+    first_record = _record(store)
+    admitted = gate.admit_or_finalize(first_record)
+    assert admitted.key is not None
+    second = _question(store, "q-operator-b")
+    second_record = recv_api.to_record(
+        second,
+        mode="global",
+        cursor_before="",
+        cursor_after=second.id,
+    )
+    roster = gate.roster_snapshot()
+
+    with pytest.raises(GateError, match="exact inbound"):
+        gate.operator_resolve(
+            second_record,
+            admitted.key,
+            actor="lead",
+            expected_roster_revision=roster["revision"],
+            reason="wrong record",
+        )
+    assert _ledger(gate)["obligations"][admitted.key.digest]["state"] == "open"
+    assert store.cursor("beta") != second.id
+    assert first.id == first_record["id"]
+
+
+def test_quorum_pins_earliest_canonical_qualifying_events_and_exact_transaction(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, ["alpha", "beta", "gamma", "lead"])
+    members = ["beta", "gamma", "lead"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-canonical-quorum",
+            members=members,
+            policy="quorum",
+            quorum=2,
+        )
+    beta = _gate(store, policy_agents=tuple(members))
+    gamma = _gate(
+        store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta", "lead"),
+    )
+    lead = _gate(
+        store, agent="lead", fence="wrapper-lead",
+        policy_agents=("lead", "beta", "gamma"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    lead_record = _record(store, agent="lead")
+    beta_resolution, beta_permit = _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    gamma_permit = gamma.reserve_dispatch(gamma_open, purpose="initial")
+    gamma_dispatch = gamma.dispatch_record(gamma_record, gamma_permit)
+    gamma_permit.draft_path.write_text("gamma answer", encoding="utf-8")
+    assert cli.main([
+        "--root", str(tmp_path), *gamma_dispatch["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+    lead_resolution, lead_permit = _answer_reserved(tmp_path, lead, lead_record)
+    lead.finalize(lead_record, lead.resolve(lead_record))
+    messages = store.valid_messages()
+    beta_id = next(
+        message.id for message in messages
+        if (message.meta or {}).get("operation_nonce") == beta_permit.nonce
+    )
+    gamma_id = next(
+        message.id for message in messages
+        if (message.meta or {}).get("operation_nonce") == gamma_permit.nonce
+    )
+    lead_id = next(
+        message.id for message in messages
+        if (message.meta or {}).get("operation_nonce") == lead_permit.nonce
+    )
+    ledger = _ledger(lead)
+    aggregates = [
+        row for row in ledger["transitions"]
+        if row["transition"] == "BROADCAST_POLICY_SATISFIED"
+        and row["data"].get("aggregate") is True
+        and row["data"].get("broadcast_id") == "b-canonical-quorum"
+    ]
+
+    assert beta_resolution.key is not None and lead_resolution.key is not None
+    assert len(aggregates) == 1
+    assert aggregates[0]["data"]["winning_ids"] == [beta_id, gamma_id]
+    assert lead_id not in aggregates[0]["data"]["winning_ids"]
+    assert aggregates[0]["data"]["broadcast_policy_version"] == 1
+    assert aggregates[0]["data"]["winning_classes"] == ["answer", "answer"]
+    assert isinstance(aggregates[0]["data"]["transaction_id"], str)
+    assert gamma.resolve(gamma_record).state == ResolverState.SATISFIED
+
+
+def test_missed_eager_projection_repairs_in_publication_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-projection-order")
+    gate = _gate(store)
+    record = _record(store)
+    gate.admit_or_finalize(record)
+    original = obligations.note_bus_message
+    missed = False
+
+    def miss_first_projection(current_store, message):
+        nonlocal missed
+        if message.body == "first canonical response" and not missed:
+            missed = True
+            raise OSError("injected eager projection miss")
+        return original(current_store, message)
+
+    monkeypatch.setattr(obligations, "note_bus_message", miss_first_projection)
+    message_ids = iter([
+        "20990101-000000-000002-AAAA",
+        "20990101-000000-000001-BBBB",
+    ])
+    monkeypatch.setattr("agenttalk.store._new_id", lambda: next(message_ids))
+    first = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="first canonical response",
+        meta={"request_id": "q-projection-order", "in_reply_to": record["id"]},
+    )
+    second = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="second canonical response",
+        meta={"request_id": "q-projection-order", "in_reply_to": record["id"]},
+    )
+    ledger = _ledger(gate)
+
+    assert missed is True
+    assert first.id > second.id  # Cross-process IDs need not follow commit order.
+    assert ledger["messages"][first.id]["sequence"] < (
+        ledger["messages"][second.id]["sequence"]
+    )
+
+
+@pytest.mark.parametrize("damage", ["rollback", "reorder", "duplicate"])
+def test_publication_order_sidecar_damage_fails_closed(
+    tmp_path: Path,
+    damage: str,
+) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "q-publication-anchor-a")
+    order_path = store.state_dir / "message-publication-order.json"
+    first_order = order_path.read_text(encoding="utf-8")
+    second = _question(store, "q-publication-anchor-b")
+    if damage == "rollback":
+        order_path.write_text(first_order, encoding="utf-8")
+        error = "rolled back"
+    elif damage == "reorder":
+        order = json.loads(order_path.read_text(encoding="utf-8"))
+        order["messages"][first.id], order["messages"][second.id] = (
+            order["messages"][second.id],
+            order["messages"][first.id],
+        )
+        order_path.write_text(json.dumps(order), encoding="utf-8")
+        error = "changed below its anchor"
+    else:
+        order = json.loads(order_path.read_text(encoding="utf-8"))
+        order["messages"]["20990101-000000-000003-CCCC"] = 1
+        order_path.write_text(json.dumps(order), encoding="utf-8")
+        error = "sequence is non-contiguous"
+    published_before = len(store.valid_messages())
+
+    with pytest.raises(ValueError, match=error):
+        store.publication_ordered_messages()
+    with pytest.raises(ValueError, match=error):
+        _question(store, "q-publication-anchor-c")
+
+    assert len(store.valid_messages()) == published_before
+
+
+def test_prepublish_order_reservation_gap_does_not_block_later_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    real_replace = os.replace
+    failed = False
+
+    def fail_first_message_publish(source, destination) -> None:
+        nonlocal failed
+        if (
+            not failed
+            and Path(source).name.endswith(".pending")
+            and Path(destination).parent == store.messages_dir
+        ):
+            failed = True
+            raise OSError("injected failure after order reservation")
+        real_replace(source, destination)
+
+    monkeypatch.setattr("agenttalk.store.os.replace", fail_first_message_publish)
+    with pytest.raises(OSError, match="after order reservation"):
+        _question(store, "q-publication-gap-lost")
+    landed = _question(store, "q-publication-gap-landed")
+    order = json.loads(
+        (store.state_dir / "message-publication-order.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert failed is True
+    assert order["append_sequence"] == 2
+    assert sorted(order["messages"].values()) == [1, 2]
+    assert order["messages"][landed.id] == 2
+    assert [message.id for message in store.publication_ordered_messages()] == [
+        landed.id
+    ]
+
+
+def test_broadcast_policy_conflict_and_manual_close_do_not_qualify(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store, "beta", broadcast_id="b-conflict", members=members, policy="any",
+    )
+    _broadcast_question(
+        store, "gamma", broadcast_id="b-conflict", members=members, policy="each",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    assert beta.admit_or_finalize(beta_record).state == ResolverState.BLOCKED
+    assert gamma.admit_or_finalize(gamma_record).state == ResolverState.BLOCKED
+
+    manual_store = _store(tmp_path.parent / "manual-close")
+    for member in members:
+        _broadcast_question(
+            manual_store,
+            member,
+            broadcast_id="b-manual",
+            members=members,
+            policy="any",
+        )
+    manual_beta = _gate(manual_store, policy_agents=("beta", "gamma"))
+    manual_gamma = _gate(
+        manual_store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    br = _record(manual_store)
+    gr = _record(manual_store, agent="gamma")
+    manual_beta.admit_or_finalize(br)
+    gamma_open = manual_gamma.admit_or_finalize(gr)
+    note_manual_close(manual_store, "beta", "b-manual")
+    manual_beta.finalize(br, manual_beta.resolve(br))
+    assert manual_gamma.resolve(gr).state == ResolverState.OWED_UNSATISFIED
+    assert gamma_open.key is not None
+
+
+def test_manual_close_never_suppresses_impossible_broadcast_delivery_failure(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-manual-failure",
+            members=members,
+            policy="any",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    beta.admit_or_finalize(beta_record)
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    assert gamma_open.key is not None
+    note_manual_close(store, "beta", "b-manual-failure")
+    beta.finalize(beta_record, beta.resolve(beta_record))
+    gamma.delivery_failed(
+        gamma_record,
+        gamma_open.key,
+        reason="remaining answer slot failed",
+        expected_revision=gamma.resolve(gamma_record).scoped_revision,
+    )
+
+    scoped = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-manual-failure",
+    )["scoped"]
+    assert scoped["closed"] is True
+    assert scoped["delivery_terminal"]["state"] == "delivery_failed"
+    assert scoped["delivery_terminal"]["aggregate"] is True
+
+
+def test_any_threshold_closes_requester_and_late_member_without_model_call(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store, "beta", broadcast_id="b-late-copy", members=members, policy="any",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    beta_record = _record(store)
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+
+    requester = recv_api.poll(store, "alpha", scoped_request_id="b-late-copy")
+    assert requester["scoped"]["closed"] is True
+    assert requester["scoped"]["delivery_terminal"]["state"] == (
+        ResolverState.BROADCAST_POLICY_SATISFIED.value
+    )
+
+    gamma_inbound = _broadcast_question(
+        store, "gamma", broadcast_id="b-late-copy", members=members, policy="any",
+    )
+    gamma = _gate(
+        store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    policy_closed = gamma.admit_or_finalize(gamma_record)
+    assert policy_closed.state == ResolverState.BROADCAST_POLICY_SATISFIED
+    gamma.finalize(
+        gamma_record,
+        policy_closed,
+        expected_revision=policy_closed.ledger_revision,
+    )
+    assert store.cursor("gamma") == gamma_inbound.id
+    assert gamma.next_dispatch_purpose(policy_closed.key) is None if policy_closed.key else True
+
+
+def test_broadcast_policy_close_and_dispatch_reservation_have_one_cas_winner(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    for member in members:
+        _broadcast_question(
+            store, member, broadcast_id="b-reserve-first", members=members, policy="any",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    gamma_permit = gamma.reserve_dispatch(gamma_open, purpose="initial")
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+
+    ledger = _ledger(gamma)
+    gamma_row = ledger["obligations"][gamma_permit.key_digest]
+    assert gamma_row["state"] == "open"
+    assert gamma_row["reservations"][gamma_permit.nonce]["state"] == "reserved"
+    dispatched = gamma.dispatch_record(gamma_record, gamma_permit)
+    gamma_permit.draft_path.write_text("late reserved answer", encoding="utf-8")
+    assert cli.main([
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+    assert gamma.resolve(gamma_record).state == (
+        ResolverState.BROADCAST_POLICY_SATISFIED
+    )
+    assert gamma_open.key is not None
+    assert gamma.next_dispatch_purpose(gamma_open.key) is None
+    aggregates = [
+        row for row in _ledger(gamma)["transitions"]
+        if row["transition"] == "BROADCAST_POLICY_SATISFIED"
+        and row["data"].get("aggregate") is True
+    ]
+    assert len(aggregates) == 1
+    assert len(aggregates[0]["data"]["winning_ids"]) == 1
+
+
+def test_reserved_nonwinner_closes_after_first_result_without_recovery(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-reserved-result",
+            members=members,
+            policy="any",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    assert gamma_open.key is not None
+    permit = gamma.reserve_dispatch(gamma_open, purpose="initial")
+    gamma.dispatch_record(gamma_record, permit)
+
+    beta_record = _record(store)
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+    gamma.mark_dispatch_result(permit, action_attempted=False)
+
+    assert gamma.resolve(gamma_record).state == (
+        ResolverState.BROADCAST_POLICY_SATISFIED
+    )
+    assert gamma.next_dispatch_purpose(gamma_open.key) is None
+    with pytest.raises(DispatchRefused):
+        gamma.reserve_dispatch(gamma_open, purpose="recovery")
+
+
+def test_pre_admission_broadcast_answer_atomically_closes_aggregate(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    beta_inbound = _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-pre-admission-answer",
+        members=members,
+        policy="any",
+    )
+    _broadcast_question(
+        store,
+        "gamma",
+        broadcast_id="b-pre-admission-answer",
+        members=members,
+        policy="any",
+    )
+    response = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="answer before wrapper admission",
+        meta={
+            "request_id": "b-pre-admission-answer",
+            "in_reply_to": beta_inbound.id,
+        },
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    terminal = beta.admit_or_finalize(record)
+
+    assert terminal.state == ResolverState.SATISFIED
+    assert terminal.key is None
+    beta.finalize(record, terminal, expected_revision=terminal.scoped_revision)
+    ledger = _ledger(beta)
+    aggregate = ledger["broadcasts"]["b-pre-admission-answer"]
+    assert aggregate["state"] == "policy_satisfied"
+    assert aggregate["winning_ids"] == [response.id]
+    assert recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-pre-admission-answer",
+    )["scoped"]["closed"] is True
+
+
+def test_policy_close_covers_every_open_member_inbound_generation(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    first = _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-all-open-generations",
+        members=members,
+        policy="any",
+    )
+    second = _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-all-open-generations",
+        members=members,
+        policy="any",
+    )
+    _broadcast_question(
+        store,
+        "gamma",
+        broadcast_id="b-all-open-generations",
+        members=members,
+        policy="any",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    first_record = _record(store)
+    first_open = beta.admit_or_finalize(first_record)
+    assert first_open.key is not None
+    store.advance_cursor("beta", first.id)
+    second_record = _record(store)
+    second_open = beta.admit_or_finalize(second_record)
+    assert second_open.key is not None and second_record["id"] == second.id
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    _answer_reserved(tmp_path, gamma, gamma_record)
+    gamma.finalize(gamma_record, gamma.resolve(gamma_record))
+    obligations = _ledger(beta)["obligations"]
+
+    assert obligations[first_open.key.digest]["state"] == (
+        "broadcast_policy_satisfied"
+    )
+    assert obligations[second_open.key.digest]["state"] == (
+        "broadcast_policy_satisfied"
+    )
+
+
+def test_broadcast_policy_validation_failure_never_leaks_pending_close(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma", "lead"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-invalid-later-member",
+            members=members,
+            policy="any",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma", "lead"))
+    beta_record = _record(store)
+    beta_open = beta.admit_or_finalize(beta_record)
+    assert beta_open.key is not None
+    beta.reserve_dispatch(beta_open, purpose="initial")
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta", "lead"),
+    )
+    gamma_open = gamma.admit_or_finalize(_record(store, agent="gamma"))
+    assert gamma_open.key is not None
+    ledger = _ledger(gamma)
+    ledger["obligations"][gamma_open.key.digest]["key"]["requester"] = "delta"
+    gamma._write(ledger)  # noqa: SLF001 - later-member validation failure injection
+
+    lead = _gate(
+        store,
+        agent="lead",
+        fence="wrapper-lead",
+        policy_agents=("lead", "beta", "gamma"),
+    )
+    lead_record = _record(store, agent="lead")
+    _answer_reserved(tmp_path, lead, lead_record)
+    lead.finalize(lead_record, lead.resolve(lead_record))
+
+    persisted = _ledger(beta)
+    beta_admission = persisted["obligations"][beta_open.key.digest]
+    assert persisted["broadcasts"]["b-invalid-later-member"]["state"] == "blocked"
+    assert beta_admission["state"] == "open"
+    assert "broadcast_policy_close_pending" not in beta_admission
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["aggregate_state", "generation", "transaction", "identity"],
+)
+def test_pending_broadcast_close_requires_exact_aggregate_proof(
+    tmp_path: Path,
+    corruption: str,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    beta_inbound = _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-pending-proof",
+        members=members,
+        policy="any",
+    )
+    gamma_inbound = _broadcast_question(
+        store,
+        "gamma",
+        broadcast_id="b-pending-proof",
+        members=members,
+        policy="any",
+    )
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    gamma_record = _record(store, agent="gamma")
+    gamma_open = gamma.admit_or_finalize(gamma_record)
+    assert gamma_open.key is not None
+    permit = gamma.reserve_dispatch(gamma_open, purpose="initial")
+    gamma.dispatch_record(gamma_record, permit)
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    beta_record = _record(store)
+    assert beta_record["id"] == beta_inbound.id
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+
+    ledger = _ledger(gamma)
+    aggregate = ledger["broadcasts"]["b-pending-proof"]
+    admission = ledger["obligations"][gamma_open.key.digest]
+    assert aggregate["state"] == "policy_satisfied"
+    assert isinstance(admission.get("broadcast_policy_close_pending"), dict)
+    if corruption == "aggregate_state":
+        aggregate["state"] = "blocked"
+    elif corruption == "generation":
+        admission["broadcast_policy_close_pending"]["broadcast_generation"] += 1
+    elif corruption == "transaction":
+        admission["broadcast_policy_close_pending"]["transaction_id"] = "stale"
+    else:
+        affected = next(
+            row for row in aggregate["affected_member_keys"]
+            if row["inbound_id"] == gamma_inbound.id
+        )
+        affected["member"] = "delta"
+    gamma._write(ledger)  # noqa: SLF001 - corrupt/stale pending-proof injection
+
+    gamma.mark_dispatch_result(permit, action_attempted=False)
+
+    persisted = _ledger(gamma)
+    admission = persisted["obligations"][gamma_open.key.digest]
+    assert admission["state"] == "blocked"
+    assert admission.get("terminal_state") != (
+        ResolverState.BROADCAST_POLICY_SATISFIED.value
+    )
+    assert "broadcast_policy_close_pending" not in admission
+    assert not any(
+        row["transition"] == "BROADCAST_POLICY_SATISFIED"
+        and row.get("scope") == gamma_inbound.id
+        for row in persisted["transitions"]
+    )
+
+
+def test_broadcast_identity_collision_between_requesters_fails_closed(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, ["alpha", "beta", "gamma", "delta", "lead"])
+    members = ["beta", "gamma"]
+    _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-requester-collision",
+        members=members,
+        policy="any",
+    )
+    store.send(
+        sender="delta",
+        recipient="gamma",
+        kind="question",
+        body="different requester reuses broadcast id",
+        meta={
+            "request_id": "b-requester-collision",
+            "broadcast_id": "b-requester-collision",
+            "membership_snapshot": members,
+            "response_policy": "any",
+            "broadcast_policy_version": 1,
+        },
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+
+    assert beta.admit_or_finalize(_record(store)).state == ResolverState.BLOCKED
+    assert gamma.admit_or_finalize(
+        _record(store, agent="gamma")
+    ).state == ResolverState.BLOCKED
+    aggregate = _ledger(beta)["broadcasts"]["b-requester-collision"]
+    assert aggregate["state"] == "blocked"
+    assert aggregate["descriptor"]["requester"] == "alpha"
+
+
+def test_late_response_requires_exact_closed_member_actor_and_anchor(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    beta_inbound = _broadcast_question(
+        store, "beta", broadcast_id="b-late", members=members, policy="any",
+    )
+    gamma_inbound = _broadcast_question(
+        store, "gamma", broadcast_id="b-late", members=members, policy="any",
+    )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    _answer_reserved(tmp_path, beta, _record(store))
+    beta.finalize(_record(store), beta.resolve(_record(store)))
+    store.send(
+        sender="lead", recipient="alpha", body="wrong actor",
+        meta={"broadcast_id": "b-late", "in_reply_to": gamma_inbound.id},
+    )
+    store.send(
+        sender="gamma", recipient="beta", body="wrong recipient",
+        meta={"broadcast_id": "b-late", "in_reply_to": gamma_inbound.id},
+    )
+    store.send(
+        sender="gamma", recipient="alpha", kind="composing", body="control",
+        meta={"broadcast_id": "b-late", "in_reply_to": gamma_inbound.id},
+    )
+    valid = store.send(
+        sender="gamma", recipient="alpha", body="late answer",
+        meta={"broadcast_id": "b-late", "in_reply_to": gamma_inbound.id},
+    )
+    beta.resolve(_record(store))
+    late = [
+        row for row in _ledger(beta)["transitions"]
+        if row["transition"] == "LATE_RESPONSE"
+        and row["data"].get("broadcast_id") == "b-late"
+    ]
+    assert beta_inbound.id != gamma_inbound.id
+    assert [row["source_id"] for row in late] == [valid.id]
+
+
+def test_each_requester_wait_uses_pinned_exact_qualifying_events(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    for member in members:
+        _broadcast_question(
+            store, member, broadcast_id="b-each-pinned", members=members, policy="each",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    gamma = _gate(
+        store, agent="gamma", fence="wrapper-gamma",
+        policy_agents=("gamma", "beta"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    beta.admit_or_finalize(beta_record)
+    gamma.admit_or_finalize(gamma_record)
+    store.send(
+        sender="beta", recipient="alpha", body="unreserved chatter",
+        meta={"broadcast_id": "b-each-pinned"},
+    )
+    store.send(
+        sender="gamma", recipient="alpha", body="unreserved chatter",
+        meta={"broadcast_id": "b-each-pinned"},
+    )
+    assert recv_api.poll(
+        store, "alpha", scoped_request_id="b-each-pinned",
+    )["scoped"]["closed"] is False
+
+    _answer_reserved(tmp_path, beta, beta_record)
+    beta.finalize(beta_record, beta.resolve(beta_record))
+    assert recv_api.poll(
+        store, "alpha", scoped_request_id="b-each-pinned",
+    )["scoped"]["closed"] is False
+    _answer_reserved(tmp_path, gamma, gamma_record)
+    gamma.finalize(gamma_record, gamma.resolve(gamma_record))
+    terminal = recv_api.poll(
+        store, "alpha", scoped_request_id="b-each-pinned",
+    )["scoped"]
+    assert terminal["closed"] is True
+    assert terminal["delivery_terminal"]["state"] == (
+        ResolverState.BROADCAST_POLICY_SATISFIED.value
+    )
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"broadcast_id": "legacy-b"},
+        {
+            "broadcast_id": "legacy-b",
+            "membership_snapshot": ["beta"],
+            "response_policy": "any",
+        },
+        {
+            "broadcast_id": "legacy-b",
+            "membership_snapshot": ["beta"],
+            "response_policy": "any",
+            "broadcast_policy_version": 99,
+        },
+    ],
+)
+def test_legacy_broadcast_is_classification_unknown_with_public_telemetry(
+    tmp_path: Path,
+    meta: dict,
+) -> None:
+    store = _store(tmp_path)
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="question",
+        body="legacy broadcast",
+        meta=meta,
+    )
+    gate = _gate(store)
+    record = _record(store)
+
+    resolution = gate.admit_or_finalize(record)
+    replayed = gate.admit_or_finalize(record)
+    finalized = gate.finalize(
+        record,
+        replayed,
+        expected_revision=replayed.scoped_revision,
+    )
+    status = gate.status()
+    doctor_check = doctor._check_detection_commit_gate(store)  # noqa: SLF001
+
+    assert resolution.state == ResolverState.CLASSIFICATION_UNKNOWN
+    assert replayed.state == ResolverState.CLASSIFICATION_UNKNOWN
+    assert finalized.state == ResolverState.CLASSIFICATION_UNKNOWN
+    assert store.cursor("beta") == record["id"]
+    assert _ledger(gate)["telemetry"]["legacy_broadcast_unenforced_total"] == 1
+    assert status["legacy_broadcast"] == {
+        "enforcement": "none",
+        "unenforced_total": 1,
+    }
+    assert doctor_check.status == "warn"
+    assert "legacy_unenforced=1" in doctor_check.details
+
+
+def test_conflicting_request_and_broadcast_identity_is_not_enforcement_eligible(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="question",
+        body="split identity",
+        meta={
+            "request_id": "q-split",
+            "broadcast_id": "b-split",
+            "membership_snapshot": ["beta"],
+            "response_policy": "any",
+            "broadcast_policy_version": 1,
+        },
+    )
+    gate = _gate(store)
+    record = _record(store)
+    result = gate.admit_or_finalize(record)
+
+    assert record["id"] == inbound.id
+    assert result.state == ResolverState.CLASSIFICATION_UNKNOWN
+    assert result.key is None
+    assert "legacy broadcast" in result.reason
+    assert "b-split" not in _ledger(gate)["broadcasts"]
+
+
+def test_blocked_policy_never_dispatches_or_advances_cursor(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-blocked-policy-runtime")
+    gate = DetectionCommitGate(
+        store,
+        "beta",
+        PolicySnapshot(ResolverState.BLOCKED_POLICY, "unreadable", reason="corrupt"),
+        fence="wrapper-1",
+    )
+    before = store.cursor("beta")
+
+    blocked = gate.admit_or_finalize(_record(store))
+
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert blocked.key is None
+    assert store.cursor("beta") == before
+    assert inbound.id not in _ledger(gate).get("inbound_index", {}) if gate.path.exists() else True
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_live_policy_no_grade_to_active_admits_before_legacy_drive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    assert gate.policy.status == ResolverState.NOT_OWED
+    inbound = _question(store, "q-policy-no-grade-to-active")
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+        }),
+        encoding="utf-8",
+    )
+    observed = PolicySnapshot.from_path(policy_path, "beta")
+    drive_paths: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        drive_paths.append("enforced" if "owed_action" in record else "legacy")
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id="q-policy-no-grade-to-active" if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    ledger = _ledger(gate)
+    key_digest = ledger["inbound_index"][inbound.id]
+    admission = ledger["obligations"][key_digest]
+    assert turns == 0
+    assert drive_paths == ["enforced"]
+    assert store.cursor("beta") != inbound.id
+    if scoped:
+        assert store.thread_seen("beta", "q-policy-no-grade-to-active") != inbound.id
+    assert inbound.id not in ledger["no_admission_claims"]
+    assert admission["activation_generation"] == observed.generation
+    assert admission["readiness_generation"] == observed.generation
+    assert admission["activation_generation"] != gate.policy.generation
+    assert gate.status()["status"] == "ACTIVE (detection-grade)"
+    assert gate.status()["policy_generation"] == observed.generation
+    assert gate.status()["grade"] == DETECTION_GRADE
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_live_policy_inactive_to_active_admits_before_legacy_drive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    assert gate.policy.status == ResolverState.INACTIVE
+    inbound = _question(store, "q-policy-inactive-to-active")
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+        }),
+        encoding="utf-8",
+    )
+    observed = PolicySnapshot.from_path(policy_path, "beta")
+    drive_paths: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        drive_paths.append("enforced" if "owed_action" in record else "legacy")
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id="q-policy-inactive-to-active" if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    ledger = _ledger(gate)
+    key_digest = ledger["inbound_index"][inbound.id]
+    admission = ledger["obligations"][key_digest]
+    assert turns == 0
+    assert drive_paths == ["enforced"]
+    assert store.cursor("beta") != inbound.id
+    if scoped:
+        assert store.thread_seen("beta", "q-policy-inactive-to-active") != inbound.id
+    assert inbound.id not in ledger["no_admission_claims"]
+    assert admission["activation_generation"] == observed.generation
+    assert admission["readiness_generation"] == observed.generation
+    assert admission["activation_generation"] != gate.policy.generation
+
+
+def test_live_policy_generation_cas_blocks_mid_admission_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    first_policy = {
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+    }
+    policy_path.write_text(json.dumps(first_policy), encoding="utf-8")
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-mid-admission-drift")
+    record = _record(store)
+    original_validated_messages = gate._validated_messages
+    drifted = False
+
+    def drift_after_replay():
+        nonlocal drifted
+        result = original_validated_messages()
+        if not drifted:
+            drifted = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                        "gamma": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+        return result
+
+    monkeypatch.setattr(gate, "_validated_messages", drift_after_replay)
+
+    blocked = gate.admit_or_finalize(record)
+
+    assert drifted is True
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") != inbound.id
+    if gate.path.exists():
+        ledger = _ledger(gate)
+        assert inbound.id not in ledger["inbound_index"]
+        assert inbound.id not in ledger["no_admission_claims"]
+
+
+def test_no_admission_policy_cas_recovers_activation_after_persist_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-persist-race")
+    record = _record(store)
+    original_write = gate._write
+    activated = False
+
+    def activate_after_claim_persist(ledger: dict) -> None:
+        nonlocal activated
+        original_write(ledger)
+        if not activated and inbound.id in ledger["no_admission_claims"]:
+            activated = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(gate, "_write", activate_after_claim_persist)
+
+    blocked = gate.admit_or_finalize(record)
+
+    assert activated is True
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert inbound.id not in _ledger(gate)["no_admission_claims"]
+    monkeypatch.setattr(gate, "_write", original_write)
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+
+    admitted = restarted.admit_or_finalize(record)
+
+    assert admitted.state == ResolverState.OWED_UNSATISFIED
+    assert admitted.activation_generation == PolicySnapshot.from_path(
+        policy_path,
+        "beta",
+    ).generation
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_loop_rechecks_policy_after_no_admission_before_legacy_drive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-pre-drive-race")
+    original_admit = gate.admit_or_finalize
+    activated = False
+
+    def activate_after_no_admission(record: dict) -> obligations.Resolution:
+        nonlocal activated
+        resolution = original_admit(record)
+        if not activated and resolution.allows_legacy_commit:
+            activated = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+        return resolution
+
+    monkeypatch.setattr(gate, "admit_or_finalize", activate_after_no_admission)
+    drive_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        return True
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id="q-policy-pre-drive-race" if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert activated is True
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.cursor("beta") != inbound.id
+    if scoped:
+        assert store.thread_seen("beta", "q-policy-pre-drive-race") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    admitted = restarted.admit_or_finalize(_record(store))
+    assert admitted.state == ResolverState.OWED_UNSATISFIED
+
+
+def test_no_admission_drive_reservation_blocks_policy_change_during_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-drive-reservation-race")
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    original_write = gate._write
+    activated = False
+
+    def activate_after_drive_reservation(ledger: dict) -> None:
+        nonlocal activated
+        original_write(ledger)
+        if (
+            not activated
+            and ledger["transitions"]
+            and ledger["transitions"][-1]["transition"]
+            == "PRE_ADMISSION_DRIVE_AUTHORIZED"
+        ):
+            activated = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(gate, "_write", activate_after_drive_reservation)
+
+    blocked = gate.authorize_no_admission_drive(record, resolution)
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert activated is True
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert claim["drive_started_at"]
+    assert not claim.get("drive_succeeded_at")
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    assert restarted.admit_or_finalize(record).state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") != inbound.id
+
+
+def test_no_admission_drive_reservation_is_inside_publication_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-atomic-no-admission-drive-reservation")
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    original_write = gate._write
+    barrier_observed = False
+
+    def write_under_barrier(ledger: dict) -> None:
+        nonlocal barrier_observed
+        if (
+            ledger["transitions"]
+            and ledger["transitions"][-1]["transition"]
+            == "PRE_ADMISSION_DRIVE_AUTHORIZED"
+        ):
+            with pytest.raises(TimeoutError, match="message publication"):
+                with store._message_publication_lock(timeout=0.02, poll=0.005):
+                    pass
+            with pytest.raises(TimeoutError, match="lock"):
+                with store._exclusive_lock(
+                    gate.path.with_suffix(".lock"),
+                    timeout=0.02,
+                    poll=0.005,
+                ):
+                    pass
+            barrier_observed = True
+        original_write(ledger)
+
+    monkeypatch.setattr(gate, "_write", write_under_barrier)
+
+    authorized = gate.authorize_no_admission_drive(record, resolution)
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert authorized.state == ResolverState.NOT_OWED
+    assert barrier_observed is True
+    assert claim["drive_started_at"]
+    assert not claim.get("drive_succeeded_at")
+    assert store.cursor("beta") != inbound.id
+
+
+def test_no_ledger_drive_reservation_rechecks_policy_after_ledger_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-no-ledger-drive-load-race")
+    original_authorize = gate.authorize_no_admission_drive
+    original_load = gate._load
+    inside_authorize = False
+    authorize_loads = 0
+    activated = False
+
+    def authorizing(
+        record: dict,
+        resolution: obligations.Resolution,
+    ) -> obligations.Resolution:
+        nonlocal inside_authorize
+        inside_authorize = True
+        try:
+            return original_authorize(record, resolution)
+        finally:
+            inside_authorize = False
+
+    def activate_after_authority_ledger_load(*args, **kwargs):
+        nonlocal activated, authorize_loads
+        ledger = original_load(*args, **kwargs)
+        if inside_authorize:
+            authorize_loads += 1
+            if authorize_loads == 2:
+                activated = True
+                monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+        return ledger
+
+    monkeypatch.setattr(gate, "authorize_no_admission_drive", authorizing)
+    monkeypatch.setattr(gate, "_load", activate_after_authority_ledger_load)
+    drive_paths: list[str] = []
+
+    def drive(current_record: dict) -> loop.DriveOutcome:
+        drive_paths.append(
+            "enforced" if "owed_action" in current_record else "legacy"
+        )
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert activated is True
+    assert authorize_loads == 2
+    assert turns == 0
+    assert drive_paths == []
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    assert restarted.admit_or_finalize(_record(store)).state == (
+        ResolverState.OWED_UNSATISFIED
+    )
+
+
+def test_unconfigured_gate_continuous_success_commits_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-unconfigured-continuous-success")
+    drive_calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    assert turns == 1
+    assert drive_calls == 1
+    assert store.cursor("beta") == inbound.id
+    assert store.attempt_record("beta", inbound.id) is None
+    assert inbound.id not in _ledger(gate)["no_admission_claims"]
+
+
+def test_legacy_cap_disposal_rechecks_policy_after_attempt_reconciliation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-cap-dispose-race")
+    record = _record(store)
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_reconcile = store.reconcile_crash_in_progress
+    activated = False
+
+    def activate_after_reconcile(*args, **kwargs):
+        nonlocal activated
+        result = original_reconcile(*args, **kwargs)
+        if not activated:
+            activated = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+        return result
+
+    monkeypatch.setattr(store, "reconcile_crash_in_progress", activate_after_reconcile)
+    drive_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        return False
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        k_poison=1,
+    )
+
+    assert activated is True
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    admitted = restarted.admit_or_finalize(_record(store))
+    assert admitted.state == ResolverState.OWED_UNSATISFIED
+
+
+def test_exact_terminal_at_disposal_boundary_prevents_dead_letter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-terminal-at-disposal-boundary"
+    inbound = _question(store, request_id)
+    record = _record(store)
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_validate = gate.validate_no_admission_authority
+    answer_id: str | None = None
+
+    def publish_before_atomic_disposal(
+        current_record: dict,
+        resolution: obligations.Resolution,
+        **kwargs,
+    ) -> obligations.Resolution:
+        nonlocal answer_id
+        if answer_id is None:
+            answer = store.send(
+                sender="beta",
+                recipient="alpha",
+                body="399",
+                meta={"request_id": request_id, "in_reply_to": inbound.id},
+            )
+            answer_id = answer.id
+        return original_validate(current_record, resolution, **kwargs)
+
+    monkeypatch.setattr(
+        gate,
+        "validate_no_admission_authority",
+        publish_before_atomic_disposal,
+    )
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+        k_poison=1,
+    )
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer_id
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+
+
+def test_unconfigured_gate_terminal_at_disposal_boundary_prevents_dead_letter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-unconfigured-terminal-at-disposal"
+    inbound = _question(store, request_id)
+    record = _record(store)
+    initial = gate.admit_or_finalize(record)
+    assert initial.state == ResolverState.NOT_OWED
+    assert initial.ledger_revision is None
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_validate = gate.validate_no_admission_authority
+    answer_id: str | None = None
+
+    def publish_before_atomic_disposal(
+        current_record: dict,
+        resolution: obligations.Resolution,
+        **kwargs,
+    ) -> obligations.Resolution:
+        nonlocal answer_id
+        if answer_id is None:
+            answer = store.send(
+                sender="beta",
+                recipient="alpha",
+                body="399",
+                meta={"request_id": request_id, "in_reply_to": inbound.id},
+            )
+            answer_id = answer.id
+        return original_validate(current_record, resolution, **kwargs)
+
+    monkeypatch.setattr(
+        gate,
+        "validate_no_admission_authority",
+        publish_before_atomic_disposal,
+    )
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+        k_poison=1,
+    )
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer_id
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+
+
+@pytest.mark.parametrize(
+    "configured_policy",
+    [True, False],
+    ids=["ledger-claim", "no-ledger-claim"],
+)
+def test_no_admission_dead_letter_is_inside_publication_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_policy: bool,
+) -> None:
+    store = _store(tmp_path)
+    if configured_policy:
+        policy_path = tmp_path / "operator-policy.json"
+        policy_path.write_text(
+            json.dumps({"schema_version": 1, "agents": {}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    else:
+        monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-atomic-no-admission-dead-letter")
+    record = _record(store)
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_dead_letter = store.dead_letter
+    barrier_observed = False
+
+    def dead_letter_under_barrier(*args, **kwargs) -> None:
+        nonlocal barrier_observed
+        with pytest.raises(TimeoutError, match="message publication"):
+            with store._message_publication_lock(timeout=0.02, poll=0.005):
+                pass
+        with pytest.raises(TimeoutError, match="lock"):
+            with store._exclusive_lock(
+                gate.path.with_suffix(".lock"),
+                timeout=0.02,
+                poll=0.005,
+            ):
+                pass
+        barrier_observed = True
+        original_dead_letter(*args, **kwargs)
+
+    monkeypatch.setattr(store, "dead_letter", dead_letter_under_barrier)
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        k_poison=1,
+    )
+
+    assert turns == 0
+    assert drive_calls == 0
+    assert barrier_observed is True
+    assert store.dead_lettered_count("beta") == 1
+    assert store.cursor("beta") == inbound.id
+
+
+def test_legacy_disposal_policy_cas_rechecks_after_claim_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-dispose-load-race")
+    record = _record(store)
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_validate = gate.validate_no_admission_authority
+    original_load = gate._load
+    inside_validation = False
+    activated = False
+
+    def validating(
+        record: dict,
+        resolution: obligations.Resolution,
+        **kwargs,
+    ) -> obligations.Resolution:
+        nonlocal inside_validation
+        inside_validation = True
+        try:
+            return original_validate(record, resolution, **kwargs)
+        finally:
+            inside_validation = False
+
+    def activate_after_claim_load(*args, **kwargs):
+        nonlocal activated
+        ledger = original_load(*args, **kwargs)
+        if inside_validation and not activated:
+            activated = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {
+                        "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                    },
+                }),
+                encoding="utf-8",
+            )
+        return ledger
+
+    monkeypatch.setattr(gate, "validate_no_admission_authority", validating)
+    monkeypatch.setattr(gate, "_load", activate_after_claim_load)
+    drive_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        return False
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        k_poison=1,
+    )
+
+    assert activated is True
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") != inbound.id
+
+
+def test_no_ledger_disposal_policy_cas_rechecks_after_ledger_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-no-ledger-dispose-load-race")
+    record = _record(store)
+    initial = gate.admit_or_finalize(record)
+    assert initial.state == ResolverState.NOT_OWED
+    assert initial.ledger_revision is None
+    store.record_attempt_start("beta", record, attempt_id="seed", at="t")
+    store.record_attempt_result(
+        "beta",
+        inbound.id,
+        failure_class=loop.CLASS_POISON,
+        summary="seed poison",
+        at="t",
+    )
+    original_validate = gate.validate_no_admission_authority
+    original_load = gate._load
+    inside_validation = False
+    validation_loads = 0
+    activated = False
+
+    def validating(
+        current_record: dict,
+        resolution: obligations.Resolution,
+        **kwargs,
+    ) -> obligations.Resolution:
+        nonlocal inside_validation
+        inside_validation = True
+        try:
+            return original_validate(current_record, resolution, **kwargs)
+        finally:
+            inside_validation = False
+
+    def activate_after_authority_ledger_load(*args, **kwargs):
+        nonlocal activated, validation_loads
+        ledger = original_load(*args, **kwargs)
+        if inside_validation:
+            validation_loads += 1
+            if validation_loads == 2:
+                activated = True
+                monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+        return ledger
+
+    monkeypatch.setattr(gate, "validate_no_admission_authority", validating)
+    monkeypatch.setattr(gate, "_load", activate_after_authority_ledger_load)
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        k_poison=1,
+    )
+
+    assert activated is True
+    assert validation_loads == 2
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    assert restarted.admit_or_finalize(_record(store)).state == (
+        ResolverState.OWED_UNSATISFIED
+    )
+
+
+def test_legacy_failed_drive_disposal_rechecks_current_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-drive-dispose-race")
+    drive_calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        policy_path.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "agents": {
+                    "beta": {"grade": DETECTION_GRADE, "enabled": True},
+                },
+            }),
+            encoding="utf-8",
+        )
+        return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_POISON)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        k_poison=1,
+    )
+
+    assert turns == 0
+    assert drive_calls == 1
+    assert store.dead_lettered_count("beta") == 0
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    blocked = restarted.admit_or_finalize(_record(store))
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+
+
+def test_no_admission_finalizer_blocks_activation_after_legacy_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-policy-finalizer-race")
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, resolution)
+    retained = gate.record_no_admission_success(record, authorized)
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": True}},
+        }),
+        encoding="utf-8",
+    )
+
+    blocked = gate.finalize(
+        record,
+        retained,
+        expected_revision=retained.ledger_revision,
+    )
+
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") != inbound.id
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    replayed = restarted.admit_or_finalize(record)
+    assert replayed.state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") != inbound.id
+
+
+@pytest.mark.parametrize(
+    "updated_agents",
+    [
+        {"gamma": {"grade": DETECTION_GRADE}},
+        {
+            "beta": {"grade": DETECTION_GRADE},
+            "gamma": {"grade": DETECTION_GRADE},
+        },
+        {"beta": {"grade": SECURITY_GRADE}},
+    ],
+    ids=["active-to-no-grade", "unrelated-agent-edit", "active-to-security"],
+)
+def test_finalized_pre_admission_terminal_projects_across_readable_policy_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updated_agents: dict[str, dict[str, str]],
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-terminal-policy-drift")
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-terminal-policy-drift",
+            "in_reply_to": inbound.id,
+        },
+    )
+    record = _record(store)
+    terminal = gate.admit_or_finalize(record)
+    original_write = gate._write
+    drifted = False
+
+    def drift_after_terminal_ledger_write(ledger: dict) -> None:
+        nonlocal drifted
+        original_write(ledger)
+        claim = ledger["no_admission_claims"].get(inbound.id)
+        disposition = ledger["cursor_dispositions"].get("beta")
+        if (
+            not drifted
+            and isinstance(claim, dict)
+            and claim.get("state") == "finalized"
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == inbound.id
+        ):
+            drifted = True
+            policy_path.write_text(
+                json.dumps({"schema_version": 1, "agents": updated_agents}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(gate, "_write", drift_after_terminal_ledger_write)
+    monkeypatch.setattr(
+        gate,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("crash barrier")),
+    )
+
+    gate.finalize(
+        record,
+        terminal,
+        expected_revision=terminal.ledger_revision,
+    )
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert drifted is True
+    assert claim["state"] == "finalized"
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+    assert store.cursor("beta") == ""
+
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    replayed = restarted.admit_or_finalize(record)
+
+    assert replayed.state == ResolverState.SATISFIED
+    assert replayed.evidence_id == answer.id
+    projected = restarted.finalize(
+        record,
+        replayed,
+        expected_revision=replayed.ledger_revision,
+    )
+    assert projected.state == ResolverState.SATISFIED
+    assert store.cursor("beta") == inbound.id
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["post_replay", "post_normalization", "post_finalization"],
+    ids=[
+        "replayed-before-normalization",
+        "normalized-open",
+        "finalized-before-projection",
+    ],
+)
+@pytest.mark.parametrize(
+    "updated_agents",
+    [
+        {
+            "beta": {"grade": DETECTION_GRADE},
+            "gamma": {"grade": DETECTION_GRADE},
+        },
+        {"gamma": {"grade": DETECTION_GRADE}},
+        {"beta": {"grade": SECURITY_GRADE}},
+    ],
+    ids=["unrelated-agent-edit", "active-to-no-grade", "active-to-security"],
+)
+def test_pre_admission_terminal_immunity_boundary_matrix_uses_zero_drive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    updated_agents: dict[str, dict[str, str]],
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-terminal-immunity-matrix")
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-terminal-immunity-matrix",
+            "in_reply_to": inbound.id,
+        },
+    )
+    drifted = False
+
+    def drift_policy() -> None:
+        nonlocal drifted
+        drifted = True
+        policy_path.write_text(
+            json.dumps({"schema_version": 1, "agents": updated_agents}),
+            encoding="utf-8",
+        )
+
+    if boundary == "post_replay":
+        original_resolve_replay = gate._resolve_replay
+
+        def drift_after_terminal_replay(
+            record: dict,
+            messages: list,
+            ledger: dict,
+            *,
+            admission: dict | None,
+        ) -> obligations.Resolution:
+            resolution = original_resolve_replay(
+                record,
+                messages,
+                ledger,
+                admission=admission,
+            )
+            if (
+                not drifted
+                and admission is None
+                and resolution.state == ResolverState.SATISFIED
+                and inbound.id not in ledger["no_admission_claims"]
+            ):
+                drift_policy()
+            return resolution
+
+        monkeypatch.setattr(gate, "_resolve_replay", drift_after_terminal_replay)
+    elif boundary == "post_normalization":
+        original_admit = gate.admit_or_finalize
+
+        def drift_after_terminal_normalization(record: dict) -> obligations.Resolution:
+            resolution = original_admit(record)
+            claim = _ledger(gate)["no_admission_claims"].get(inbound.id)
+            if (
+                not drifted
+                and resolution.state == ResolverState.SATISFIED
+                and isinstance(claim, dict)
+                and claim.get("state") == "open"
+            ):
+                drift_policy()
+            return resolution
+
+        monkeypatch.setattr(
+            gate,
+            "admit_or_finalize",
+            drift_after_terminal_normalization,
+        )
+    else:
+        original_write = gate._write
+
+        def drift_after_terminal_finalization(ledger: dict) -> None:
+            original_write(ledger)
+            claim = ledger["no_admission_claims"].get(inbound.id)
+            disposition = ledger["cursor_dispositions"].get("beta")
+            if (
+                not drifted
+                and isinstance(claim, dict)
+                and claim.get("state") == "finalized"
+                and isinstance(disposition, dict)
+                and disposition.get("inbound_id") == inbound.id
+            ):
+                drift_policy()
+
+        monkeypatch.setattr(gate, "_write", drift_after_terminal_finalization)
+
+    drive_paths: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        drive_paths.append("enforced" if "owed_action" in record else "legacy")
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    ledger = _ledger(gate)
+    claim = ledger["no_admission_claims"][inbound.id]
+    current_policy = PolicySnapshot.from_path(policy_path, "beta")
+    assert drifted is True
+    assert drive_paths == []
+    assert store.cursor("beta") == inbound.id
+    assert inbound.id not in ledger["inbound_index"]
+    assert not ledger["obligations"]
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.SATISFIED.value
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["policy_status"] == current_policy.status.value
+    assert claim["policy_generation"] == current_policy.generation
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+    assert ledger["cursor_dispositions"]["beta"] == {
+        "inbound_id": inbound.id,
+        "mode": "global",
+        "state": ResolverState.SATISFIED.value,
+        "at": ledger["cursor_dispositions"]["beta"]["at"],
+    }
+    assert not any(
+        event["transition"] == "NO_ADMISSION_CLAIM_POLICY_SUPERSEDED"
+        for event in ledger["transitions"]
+    )
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["normalized-open", "finalized-unprojected"],
+)
+def test_durable_terminal_projects_after_policy_path_is_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-terminal-policy-path-removed"
+    inbound = _question(store, request_id)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": request_id, "in_reply_to": inbound.id},
+    )
+    record = _record(store)
+    terminal = gate.admit_or_finalize(record)
+    assert terminal.state == ResolverState.SATISFIED
+    assert terminal.evidence_id == answer.id
+
+    if boundary == "finalized-unprojected":
+        monkeypatch.setattr(
+            gate,
+            "_advance_record_cursor",
+            lambda _record: (_ for _ in ()).throw(RuntimeError("crash barrier")),
+        )
+        gate.finalize(
+            record,
+            terminal,
+            expected_revision=terminal.ledger_revision,
+        )
+
+    before_restart = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert before_restart["state"] == (
+        "finalized" if boundary == "finalized-unprojected" else "open"
+    )
+    assert not before_restart.get("drive_started_at")
+    assert not before_restart.get("drive_succeeded_at")
+    assert store.cursor("beta") == ""
+
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    drive_paths: list[str] = []
+
+    def drive(current_record: dict) -> loop.DriveOutcome:
+        drive_paths.append(
+            "enforced" if "owed_action" in current_record else "legacy"
+        )
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    claim = _ledger(restarted)["no_admission_claims"][inbound.id]
+    assert drive_paths == []
+    assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.SATISFIED.value
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["policy_generation"] == "inactive"
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+
+
+def test_normalized_terminal_keeps_exact_winner_after_concurrent_terminal(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    inbound = _question(store, "q-concurrent-terminal-winner")
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-concurrent-terminal-winner",
+            "in_reply_to": inbound.id,
+        },
+    )
+    record = _record(store)
+    normalized = gate.admit_or_finalize(record)
+    assert normalized.state == ResolverState.SATISFIED
+    assert normalized.evidence_id == answer.id
+
+    note_manual_close(store, "beta", "q-concurrent-terminal-winner")
+    drive_paths: list[str] = []
+
+    def drive(next_record: dict) -> loop.DriveOutcome:
+        drive_paths.append(
+            "enforced" if "owed_action" in next_record else "legacy"
+        )
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    ledger = _ledger(gate)
+    claim = ledger["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_paths == []
+    assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.SATISFIED.value
+    assert claim["terminal_evidence_id"] == answer.id
+    assert any(
+        event["transition"] == "MANUAL_CLOSE"
+        and event["data"].get("inbound_id") == inbound.id
+        for event in ledger["transitions"]
+    )
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["post_replay", "post_normalization", "post_finalization"],
+    ids=[
+        "replayed-before-normalization",
+        "normalized-open",
+        "finalized-before-projection",
+    ],
+)
+def test_pre_admission_terminal_immunity_waits_for_policy_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-terminal-immunity-corrupt")
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-terminal-immunity-corrupt",
+            "in_reply_to": inbound.id,
+        },
+    )
+    corrupted = False
+
+    def corrupt_policy() -> None:
+        nonlocal corrupted
+        corrupted = True
+        policy_path.write_text("{", encoding="utf-8")
+
+    if boundary == "post_replay":
+        original_resolve_replay = gate._resolve_replay
+
+        def corrupt_after_terminal_replay(
+            record: dict,
+            messages: list,
+            ledger: dict,
+            *,
+            admission: dict | None,
+        ) -> obligations.Resolution:
+            resolution = original_resolve_replay(
+                record,
+                messages,
+                ledger,
+                admission=admission,
+            )
+            if (
+                not corrupted
+                and admission is None
+                and resolution.state == ResolverState.SATISFIED
+                and inbound.id not in ledger["no_admission_claims"]
+            ):
+                corrupt_policy()
+            return resolution
+
+        monkeypatch.setattr(gate, "_resolve_replay", corrupt_after_terminal_replay)
+    elif boundary == "post_normalization":
+        original_admit = gate.admit_or_finalize
+
+        def corrupt_after_terminal_normalization(
+            record: dict,
+        ) -> obligations.Resolution:
+            resolution = original_admit(record)
+            claim = _ledger(gate)["no_admission_claims"].get(inbound.id)
+            if (
+                not corrupted
+                and resolution.state == ResolverState.SATISFIED
+                and isinstance(claim, dict)
+                and claim.get("state") == "open"
+            ):
+                corrupt_policy()
+            return resolution
+
+        monkeypatch.setattr(
+            gate,
+            "admit_or_finalize",
+            corrupt_after_terminal_normalization,
+        )
+    else:
+        original_write = gate._write
+
+        def corrupt_after_terminal_finalization(ledger: dict) -> None:
+            original_write(ledger)
+            claim = ledger["no_admission_claims"].get(inbound.id)
+            disposition = ledger["cursor_dispositions"].get("beta")
+            if (
+                not corrupted
+                and isinstance(claim, dict)
+                and claim.get("state") == "finalized"
+                and isinstance(disposition, dict)
+                and disposition.get("inbound_id") == inbound.id
+            ):
+                corrupt_policy()
+
+        monkeypatch.setattr(gate, "_write", corrupt_after_terminal_finalization)
+
+    drive_paths: list[str] = []
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        drive_paths.append("enforced" if "owed_action" in record else "legacy")
+        return loop.DriveOutcome(ok=True)
+
+    first_turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    assert corrupted is True
+    assert first_turns == 0
+    assert drive_paths == []
+    assert store.cursor("beta") == ""
+    if gate.path.exists():
+        blocked_claim = _ledger(gate)["no_admission_claims"].get(inbound.id)
+        if isinstance(blocked_claim, dict):
+            assert not blocked_claim.get("drive_started_at")
+            assert not blocked_claim.get("drive_succeeded_at")
+
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {
+                "beta": {"grade": DETECTION_GRADE},
+                "gamma": {"grade": DETECTION_GRADE},
+            },
+        }),
+        encoding="utf-8",
+    )
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    recovered_turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    claim = _ledger(restarted)["no_admission_claims"][inbound.id]
+    assert recovered_turns == 0
+    assert drive_paths == []
+    assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+
+
+def test_finalized_pre_admission_terminal_waits_for_readable_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-terminal-corrupt-policy")
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-terminal-corrupt-policy",
+            "in_reply_to": inbound.id,
+        },
+    )
+    record = _record(store)
+    terminal = gate.admit_or_finalize(record)
+    original_write = gate._write
+    corrupted = False
+
+    def corrupt_after_terminal_ledger_write(ledger: dict) -> None:
+        nonlocal corrupted
+        original_write(ledger)
+        claim = ledger["no_admission_claims"].get(inbound.id)
+        disposition = ledger["cursor_dispositions"].get("beta")
+        if (
+            not corrupted
+            and isinstance(claim, dict)
+            and claim.get("state") == "finalized"
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == inbound.id
+        ):
+            corrupted = True
+            policy_path.write_text("{", encoding="utf-8")
+
+    monkeypatch.setattr(gate, "_write", corrupt_after_terminal_ledger_write)
+    blocked = gate.finalize(
+        record,
+        terminal,
+        expected_revision=terminal.ledger_revision,
+    )
+
+    assert corrupted is True
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") == ""
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert claim["cursor_projection_misses"] == 0
+
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    assert restarted.admit_or_finalize(record).state == ResolverState.BLOCKED_POLICY
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {
+                "beta": {"grade": DETECTION_GRADE},
+                "gamma": {"grade": DETECTION_GRADE},
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    recovered = restarted.admit_or_finalize(record)
+    assert recovered.state == ResolverState.SATISFIED
+    projected = restarted.finalize(
+        record,
+        recovered,
+        expected_revision=recovered.ledger_revision,
+    )
+    assert projected.state == ResolverState.SATISFIED
+    assert store.cursor("beta") == inbound.id
+    assert _ledger(restarted)["no_admission_claims"][inbound.id][
+        "cursor_projection_misses"
+    ] == 0
+
+
+def test_finalized_legacy_drive_remains_blocked_across_policy_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    inbound = _question(store, "q-finalized-legacy-policy-drift")
+    record = _record(store)
+    resolution = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, resolution)
+    retained = gate.record_no_admission_success(record, authorized)
+    original_write = gate._write
+    drifted = False
+
+    def drift_after_terminal_ledger_write(ledger: dict) -> None:
+        nonlocal drifted
+        original_write(ledger)
+        claim = ledger["no_admission_claims"].get(inbound.id)
+        disposition = ledger["cursor_dispositions"].get("beta")
+        if (
+            not drifted
+            and isinstance(claim, dict)
+            and claim.get("state") == "finalized"
+            and isinstance(disposition, dict)
+            and disposition.get("inbound_id") == inbound.id
+        ):
+            drifted = True
+            policy_path.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "agents": {"beta": {"grade": DETECTION_GRADE}},
+                }),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(gate, "_write", drift_after_terminal_ledger_write)
+    blocked = gate.finalize(
+        record,
+        retained,
+        expected_revision=retained.ledger_revision,
+    )
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert drifted is True
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert claim["state"] == "finalized"
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+    assert store.cursor("beta") == ""
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    assert restarted.admit_or_finalize(record).state == ResolverState.BLOCKED_POLICY
+    assert store.cursor("beta") == ""
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_retained_legacy_terminal_stays_fenced_across_policy_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-retained-legacy-policy-drift"
+    inbound = _question(store, request_id)
+    record = _record(store, request_id if scoped else None)
+    semantic = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, semantic)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": request_id, "in_reply_to": inbound.id},
+    )
+    retained = gate.record_no_admission_success(record, authorized)
+    retained_claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert retained.state == ResolverState.SATISFIED
+    assert retained_claim["state"] == "finalization_pending"
+    assert retained_claim["claim_kind"] == "same_generation_legacy_terminal"
+    assert retained_claim["terminal_evidence_id"] == answer.id
+
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    blocked = restarted.admit_or_finalize(record)
+    drive_calls = 0
+
+    def must_not_redrive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_redrive,
+        commit_gate=restarted,
+        only_request_id=request_id if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    claim = _ledger(restarted)["no_admission_claims"][inbound.id]
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.cursor("beta") == ""
+    if scoped:
+        assert store.thread_seen("beta", request_id) == ""
+    assert claim["state"] == "finalization_pending"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+
+
+@pytest.mark.parametrize(
+    "retained_success",
+    [False, True],
+    ids=["drive-started", "drive-started-and-succeeded"],
+)
+def test_started_legacy_claim_cannot_gain_terminal_immunity_after_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    retained_success: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, f"q-started-terminal-{retained_success}")
+    record = _record(store)
+    semantic = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, semantic)
+    if retained_success:
+        gate.record_no_admission_success(record, authorized)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": f"q-started-terminal-{retained_success}",
+            "in_reply_to": inbound.id,
+        },
+    )
+    policy_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": DETECTION_GRADE}},
+        }),
+        encoding="utf-8",
+    )
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    drive_paths: list[str] = []
+
+    def drive(next_record: dict) -> loop.DriveOutcome:
+        drive_paths.append(
+            "enforced" if "owed_action" in next_record else "legacy"
+        )
+        return loop.DriveOutcome(ok=True)
+
+    blocked = restarted.admit_or_finalize(record)
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    ledger = _ledger(restarted)
+    claim = ledger["no_admission_claims"][inbound.id]
+    assert blocked.state == ResolverState.BLOCKED_POLICY
+    assert turns == 0
+    assert drive_paths == []
+    assert store.cursor("beta") == ""
+    assert claim["resolution"] == ResolverState.NOT_OWED.value
+    assert claim["state"] == (
+        "finalization_pending" if retained_success else "open"
+    )
+    assert claim["drive_started_at"]
+    assert bool(claim.get("drive_succeeded_at")) is retained_success
+    assert not any(
+        event["transition"] == "ZERO_WORK_TERMINAL_AUTHORITY_REBOUND"
+        and event.get("source_id") == answer.id
+        for event in ledger["transitions"]
+    )
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+@pytest.mark.parametrize(
+    "agents",
+    [
+        {},
+        {"gamma": {"grade": DETECTION_GRADE}},
+        {"beta": {"grade": DETECTION_GRADE}},
+        {"beta": {"grade": SECURITY_GRADE}},
+    ],
+    ids=["same-generation", "unrelated-edit", "activate", "security"],
+)
+def test_untouched_semantic_claim_converts_to_exact_terminal_without_drive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+    agents: dict,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-semantic-claim-terminal"
+    inbound = _question(store, request_id)
+    record = _record(store, request_id if scoped else None)
+    semantic = gate.admit_or_finalize(record)
+    assert semantic.state == ResolverState.NOT_OWED
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": request_id, "in_reply_to": inbound.id},
+    )
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": agents}),
+        encoding="utf-8",
+    )
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        only_request_id=request_id if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    ledger = _ledger(gate)
+    claim = ledger["no_admission_claims"][inbound.id]
+    normalized = [
+        event
+        for event in ledger["transitions"]
+        if event["transition"] == "PRE_ADMISSION_TERMINAL_NORMALIZED"
+        and event.get("source_id") == answer.id
+    ]
+    assert turns == 0
+    assert drive_calls == 0
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen("beta", request_id) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+    assert len(normalized) == 1
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+@pytest.mark.parametrize(
+    "agents",
+    [
+        {},
+        {"gamma": {"grade": DETECTION_GRADE}},
+        {"beta": {"grade": DETECTION_GRADE}},
+        {"beta": {"grade": SECURITY_GRADE}},
+    ],
+    ids=["same-generation", "unrelated-edit", "activate", "security"],
+)
+def test_terminal_between_admission_and_drive_authorization_never_drives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+    agents: dict,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-terminal-before-drive-authorization"
+    inbound = _question(store, request_id)
+    original_admit = gate.admit_or_finalize
+    answer_id: str | None = None
+
+    def publish_after_admission(record: dict) -> obligations.Resolution:
+        nonlocal answer_id
+        resolution = original_admit(record)
+        if answer_id is None and resolution.allows_legacy_commit:
+            answer = store.send(
+                sender="beta",
+                recipient="alpha",
+                body="399",
+                meta={"request_id": request_id, "in_reply_to": inbound.id},
+            )
+            answer_id = answer.id
+            policy_path.write_text(
+                json.dumps({"schema_version": 1, "agents": agents}),
+                encoding="utf-8",
+            )
+        return resolution
+
+    monkeypatch.setattr(gate, "admit_or_finalize", publish_after_admission)
+    drive_calls = 0
+
+    def must_not_drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_drive,
+        commit_gate=gate,
+        only_request_id=request_id if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    ledger = _ledger(gate)
+    claim = ledger["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 0
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen("beta", request_id) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["claim_kind"] == "pre_admission_terminal"
+    assert claim["terminal_evidence_id"] == answer_id
+    assert not claim.get("drive_started_at")
+    assert not claim.get("drive_succeeded_at")
+    assert not any(
+        event["transition"] == "PRE_ADMISSION_DRIVE_AUTHORIZED"
+        and event.get("source_id") == inbound.id
+        for event in ledger["transitions"]
+    )
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_same_policy_legacy_drive_can_publish_and_finalize_exact_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-same-policy-legacy-terminal")
+    drive_calls = 0
+    answer_id: str | None = None
+
+    def drive(record: dict) -> loop.DriveOutcome:
+        nonlocal answer_id, drive_calls
+        drive_calls += 1
+        answer = store.send(
+            sender="beta",
+            recipient="alpha",
+            body="399",
+            meta={
+                "request_id": "q-same-policy-legacy-terminal",
+                "in_reply_to": record["id"],
+            },
+        )
+        answer_id = answer.id
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id="q-same-policy-legacy-terminal" if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    ledger = _ledger(gate)
+    claim = ledger["no_admission_claims"][inbound.id]
+    assert turns == 1
+    assert drive_calls == 1
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen(
+            "beta",
+            "q-same-policy-legacy-terminal",
+        ) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["resolution"] == ResolverState.SATISFIED.value
+    assert claim["claim_kind"] == "same_generation_legacy_terminal"
+    assert claim["terminal_evidence_id"] == answer_id
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_same_policy_legacy_terminal_recovers_after_retention_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    inbound = _question(store, "q-legacy-terminal-retention-crash")
+    record = _record(
+        store,
+        "q-legacy-terminal-retention-crash" if scoped else None,
+    )
+    semantic = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, semantic)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={
+            "request_id": "q-legacy-terminal-retention-crash",
+            "in_reply_to": inbound.id,
+        },
+    )
+    retained = gate.record_no_admission_success(record, authorized)
+    assert retained.state == ResolverState.SATISFIED
+    assert retained.reason == "no_admission_finalization_pending"
+    assert store.cursor("beta") == ""
+
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    drive_calls = 0
+
+    def must_not_redrive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_redrive,
+        commit_gate=restarted,
+        only_request_id=(
+            "q-legacy-terminal-retention-crash" if scoped else None
+        ),
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    claim = _ledger(restarted)["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 0
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen(
+            "beta",
+            "q-legacy-terminal-retention-crash",
+        ) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_same_policy_legacy_terminal_recovers_before_retention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-legacy-terminal-before-retention"
+    inbound = _question(store, request_id)
+    record = _record(store, request_id if scoped else None)
+    semantic = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, semantic)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": request_id, "in_reply_to": inbound.id},
+    )
+    assert authorized.allows_legacy_commit
+    assert store.cursor("beta") == ""
+
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations._process_liveness",
+        lambda _pid: "dead",
+    )
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    drive_calls = 0
+
+    def must_not_redrive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_redrive,
+        commit_gate=restarted,
+        only_request_id=request_id if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    ledger = _ledger(restarted)
+    claim = ledger["no_admission_claims"][inbound.id]
+    retained = [
+        event
+        for event in ledger["transitions"]
+        if event["transition"] == "LEGACY_DRIVE_TERMINAL_RETAINED"
+        and event.get("source_id") == answer.id
+    ]
+    assert turns == 0
+    assert drive_calls == 0
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen("beta", request_id) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["claim_kind"] == "same_generation_legacy_terminal"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+    assert len(retained) == 1
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_same_policy_legacy_terminal_recovers_after_projection_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "q-legacy-terminal-projection-crash"
+    inbound = _question(store, request_id)
+    record = _record(store, request_id if scoped else None)
+    semantic = gate.admit_or_finalize(record)
+    authorized = gate.authorize_no_admission_drive(record, semantic)
+    answer = store.send(
+        sender="beta",
+        recipient="alpha",
+        body="399",
+        meta={"request_id": request_id, "in_reply_to": inbound.id},
+    )
+    retained = gate.record_no_admission_success(record, authorized)
+
+    def fail_projection(_record: dict) -> None:
+        raise RuntimeError("injected cursor projection crash")
+
+    monkeypatch.setattr(gate, "_advance_record_cursor", fail_projection)
+    failed = gate.finalize(
+        record,
+        retained,
+        expected_revision=retained.ledger_revision,
+    )
+    failed_claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert failed.state == ResolverState.INDETERMINATE
+    assert failed_claim["state"] == "finalized"
+    assert failed_claim["cursor_projection_misses"] == 1
+    assert store.cursor("beta") == ""
+
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-2",
+    })
+    restarted = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-2",
+    )
+    drive_calls = 0
+
+    def must_not_redrive(_record: dict) -> loop.DriveOutcome:
+        nonlocal drive_calls
+        drive_calls += 1
+        return loop.DriveOutcome(ok=False)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        must_not_redrive,
+        commit_gate=restarted,
+        only_request_id=request_id if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    claim = _ledger(restarted)["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 0
+    if scoped:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen("beta", request_id) == inbound.id
+    else:
+        assert store.cursor("beta") == inbound.id
+    assert claim["state"] == "finalized"
+    assert claim["terminal_evidence_id"] == answer.id
+    assert claim["drive_started_at"]
+    assert claim["drive_succeeded_at"]
+
+
+@pytest.mark.parametrize("scoped", [False, True], ids=["continuous", "scoped"])
+def test_live_policy_corruption_after_noneligible_startup_blocks_legacy_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scoped: bool,
+) -> None:
+    store = _store(tmp_path)
+    policy_path = tmp_path / "operator-policy.json"
+    policy_path.write_text(
+        json.dumps({"schema_version": 1, "agents": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTTALK_COMMIT_GATE_POLICY", str(policy_path))
+    gate = DetectionCommitGate.from_environment(
+        store,
+        "beta",
+        fence="wrapper-1",
+    )
+    assert gate.policy.status == ResolverState.NOT_OWED
+    inbound = _question(store, "q-policy-corrupt-after-startup")
+    policy_path.write_text("{", encoding="utf-8")
+    drive_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        return True
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id="q-policy-corrupt-after-startup" if scoped else None,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    status = gate.status()
+    assert turns == 0
+    assert drive_calls == 0
+    assert store.cursor("beta") != inbound.id
+    if scoped:
+        assert store.thread_seen("beta", "q-policy-corrupt-after-startup") != inbound.id
+    assert status["status"] == "BLOCKED_POLICY"
+    assert status["policy_generation"] == "unreadable"
+    assert status["reason"].startswith("operator policy unreadable:")
+    if gate.path.exists():
+        ledger = _ledger(gate)
+        assert inbound.id not in ledger["inbound_index"]
+        assert inbound.id not in ledger["no_admission_claims"]
+        assert ledger["obligations"] == {}
+
+
+def test_status_keeps_current_inactive_policy_ahead_of_prior_breaker(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store)
+    with store._exclusive_lock(gate.path.with_suffix(".lock"), timeout=10.0):
+        ledger = gate._load()
+        ledger["breakers"]["beta"] = {
+            "tripped": True,
+            "config_blocked": True,
+            "trip_generation": 1,
+        }
+        gate._write(ledger)
+    inactive = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+    }, "beta")
+    gate.policy_loader = lambda: inactive
+
+    status = gate.status()
+
+    assert status["status"] == "INACTIVE"
+    assert status["policy_generation"] == inactive.generation
+    assert status["breaker"]["tripped"] is True
+
+
+def test_exact_key_supersession_closes_only_named_generation_and_malformed_blocks(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "q-exact-supersede")
+    gate = _gate(store)
+    first_record = _record(store)
+    first_open = gate.admit_or_finalize(first_record)
+    assert first_open.key is not None
+    store.advance_cursor("beta", first.id)
+    second = _question(store, "q-exact-supersede")
+    second_record = _record(store)
+    second_open = gate.admit_or_finalize(second_record)
+    assert second_open.key is not None
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="supersede first generation only",
+        meta={
+            "request_id": "q-exact-supersede",
+            "target_msg_id": first.id,
+            "supersedes": first_open.key.to_dict(),
+        },
+    )
+
+    assert gate.resolve(first_record).state == ResolverState.SUPERSEDED
+    assert gate.resolve(second_record).state == ResolverState.OWED_UNSATISFIED
+
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="malformed exact transition",
+        meta={
+            "request_id": "q-exact-supersede",
+            "target_msg_id": second.id,
+            "supersedes": {"inbound_id": second.id},
+        },
+    )
+    malformed = gate.resolve(second_record)
+    assert malformed.state == ResolverState.INDETERMINATE
+    assert "uninterpretable" in malformed.reason
+
+
+def test_reused_broadcast_id_starts_fresh_generation_without_old_winner_leak(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    members = ["beta", "gamma"]
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-reused-generation",
+            members=members,
+            policy="any",
+        )
+    beta = _gate(store, policy_agents=("beta", "gamma"))
+    first_record = _record(store)
+    _answer_reserved(tmp_path, beta, first_record)
+    beta.finalize(first_record, beta.resolve(first_record))
+    assert recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-reused-generation",
+    )["scoped"]["closed"] is True
+
+    second = _broadcast_question(
+        store,
+        "beta",
+        broadcast_id="b-reused-generation",
+        members=members,
+        policy="any",
+    )
+    second_record = _record(store)
+    second_open = beta.admit_or_finalize(second_record)
+    aggregate = _ledger(beta)["broadcasts"]["b-reused-generation"]
+
+    assert second_open.state == ResolverState.OWED_UNSATISFIED
+    assert second_open.key is not None and second_open.key.inbound_id == second.id
+    assert aggregate["state"] == "open"
+    assert aggregate["generation"] == 2
+    assert recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-reused-generation",
+    )["scoped"]["closed"] is False
+
+
+@pytest.mark.parametrize(
+    ("category", "limit", "counter"),
+    [
+        ("operation_infra", 16, "operation_infra_attempts"),
+        ("finalization", 12, "finalization_misses"),
+    ],
+)
+def test_nonpaid_retry_bounds_persist_across_cycles(
+    tmp_path: Path,
+    category: str,
+    limit: int,
+    counter: str,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    admitted = gate.admit_or_finalize(_record(store))
+    assert admitted.key is not None
+    for _index in range(limit):
+        assert gate.record_retry_barrier(
+            admitted.key,
+            category=category,
+            expected_revision=admitted.scoped_revision,
+        ) is True
+        gate.complete_retry_barrier(admitted.key, category=category)
+    assert gate.record_retry_barrier(
+        admitted.key,
+        category=category,
+        expected_revision=admitted.scoped_revision,
+    ) is False
+    restarted = _gate(store, fence="wrapper-1")
+
+    assert restarted.record_retry_barrier(
+        admitted.key,
+        category=category,
+        expected_revision=admitted.scoped_revision,
+    ) is False
+    assert _ledger(restarted)["obligations"][admitted.key.digest][counter] == limit
+
+
+def test_terminal_append_before_cursor_crash_replays_without_model_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    terminal = gate.resolve(record)
+    monkeypatch.setattr(
+        gate,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("crash barrier")),
+    )
+    finalized = gate.finalize(record, terminal)
+    assert finalized.state == ResolverState.INDETERMINATE
+    assert store.cursor("beta") == ""
+    calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    restarted = _gate(store, fence="wrapper-1")
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    assert calls == 0
+    assert store.cursor("beta") == inbound.id
+
+
+def test_cursor_projection_reservation_reconciles_crash_before_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-projection-crash-barrier")
+    owner = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    _answer_reserved(tmp_path, owner, record)
+    terminal = owner.resolve(record)
+    monkeypatch.setattr(
+        owner,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(SystemExit("hard crash")),
+    )
+
+    with pytest.raises(SystemExit, match="hard crash"):
+        owner.finalize(record, terminal)
+
+    admission = _ledger(owner)["obligations"][terminal.key.digest]
+    assert admission["cursor_projection_inflight"] is True
+    assert admission["cursor_projection_misses"] == 0
+
+    restarted = _gate(store, fence="wrapper-1")
+    monkeypatch.setattr(
+        restarted,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(OSError("retry failed")),
+    )
+    retried = restarted.finalize(record, restarted.resolve(record))
+
+    assert retried.state == ResolverState.INDETERMINATE
+    admission = _ledger(restarted)["obligations"][terminal.key.digest]
+    assert admission["cursor_projection_inflight"] is False
+    assert admission["cursor_projection_misses"] == 2
+    assert sum(
+        row["transition"] == "CURSOR_FINALIZED"
+        for row in _ledger(restarted)["transitions"]
+    ) == 1
+
+
+def test_cursor_projection_elapsed_bound_starts_at_crashed_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-projection-elapsed-crash")
+    owner = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:00:00Z",
+    )
+    record = _record(store)
+    _answer_reserved(tmp_path, owner, record)
+    terminal = owner.resolve(record)
+    monkeypatch.setattr(
+        owner,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(SystemExit("hard crash")),
+    )
+    with pytest.raises(SystemExit, match="hard crash"):
+        owner.finalize(record, terminal)
+    admission = _ledger(owner)["obligations"][terminal.key.digest]
+    assert admission["cursor_projection_reserved_at"] == "2026-01-01T00:00:00Z"
+
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:15:01Z",
+    )
+    attempted = False
+
+    def project(_record: dict) -> None:
+        nonlocal attempted
+        attempted = True
+
+    monkeypatch.setattr(restarted, "_advance_record_cursor", project)
+    result = restarted.finalize(record, restarted.resolve(record))
+
+    assert result.state == ResolverState.INDETERMINATE
+    assert result.reason == "cursor projection retry bound exhausted"
+    assert attempted is False
+    admission = _ledger(restarted)["obligations"][terminal.key.digest]
+    assert admission["cursor_projection_misses"] == 1
+    assert admission["cursor_projection_first_at"] == "2026-01-01T00:00:00Z"
+    assert admission["cursor_projection_blocked"] is True
+    assert restarted.resolve(record).state == ResolverState.BLOCKED
+
+
+def test_persistent_cursor_projection_failure_blocks_after_durable_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-projection-bound")
+    owner = _gate(store, fence="wrapper-1")
+    record = _record(store)
+    _answer_reserved(tmp_path, owner, record)
+    key = owner.resolve(record).key
+    assert key is not None
+
+    for _attempt in range(12):
+        restarted = _gate(store, fence="wrapper-1")
+        monkeypatch.setattr(
+            restarted,
+            "_advance_record_cursor",
+            lambda _record: (_ for _ in ()).throw(OSError("persistent failure")),
+        )
+        result = restarted.finalize(record, restarted.resolve(record))
+        assert result.state == ResolverState.INDETERMINATE
+
+    ledger = _ledger(restarted)
+    admission = ledger["obligations"][key.digest]
+    assert admission["cursor_projection_misses"] == 12
+    assert admission["cursor_projection_blocked"] is True
+    assert admission["cursor_projection_inflight"] is False
+    assert store.cursor("beta") == ""
+    assert restarted.resolve(record).state == ResolverState.BLOCKED
+    assert restarted.status()["status"] == "BLOCKED"
+    assert sum(
+        row["transition"] == "CURSOR_FINALIZED"
+        for row in ledger["transitions"]
+    ) == 1
+    assert sum(
+        row["transition"] == "CURSOR_PROJECTION_BLOCKED"
+        for row in ledger["transitions"]
+    ) == 1
+
+
+def test_unwritable_disposition_never_advances_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    monkeypatch.setattr(
+        gate,
+        "_write",
+        lambda _ledger: (_ for _ in ()).throw(OSError("store unavailable")),
+    )
+
+    with pytest.raises(OSError, match="store unavailable"):
+        gate.delivery_failed(
+            record,
+            admitted.key,
+            reason="cannot persist",
+            expected_revision=admitted.scoped_revision,
+        )
+    assert store.cursor("beta") == ""
+
+
+def test_global_ledger_corruption_blocks_without_dispatch_or_queue_drain(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    gate.admit_or_finalize(_record(store))
+    gate.path.write_text("{", encoding="utf-8")
+    calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert calls == 0
+    assert store.cursor("beta") == ""
+    assert gate.proof_health_path.exists()
+    assert json.loads(gate.path.read_text(encoding="utf-8"))["store_epoch"]
+    health = json.loads(gate.proof_health_path.read_text(encoding="utf-8"))
+    assert health["last_rebuild_succeeded"] is True
+
+
+def test_at_cap_failed_delivery_transaction_is_complete_before_cursor_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-atomic-failure")
+    gate = _gate(store)
+    calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    monkeypatch.setattr(
+        gate,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(OSError("cursor projection crash")),
+    )
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=4,
+    )
+
+    ledger = _ledger(gate)
+    key_digest = ledger["inbound_index"][inbound.id]
+    admission = ledger["obligations"][key_digest]
+    incident = [
+        row for row in ledger["transitions"]
+        if row["transition"] == "COMPLIANCE_INCIDENT"
+        and row.get("key_digest") == key_digest
+    ]
+    failed = [
+        row for row in ledger["transitions"]
+        if row["transition"] == "DELIVERY_FAILED"
+        and row.get("key_digest") == key_digest
+    ]
+
+    assert calls == 2
+    assert len(incident) == len(failed) == 1
+    assert admission["state"] == "delivery_failed"
+    assert admission["paid_dispatches_total"] == 2
+    assert admission["delivery_failure_sequence"] == failed[0]["sequence"]
+    assert ledger["breakers"]["beta"][
+        "owed_action_cap_exhaustions_consecutive"
+    ] == 1
+    indexed = ledger["delivery_index"]["q-atomic-failure"]
+    assert len(indexed) == 1
+    assert indexed[0]["key_digest"] == key_digest
+    assert indexed[0]["incident_sequence"] == incident[0]["sequence"]
+    assert ledger["cursor_dispositions"]["beta"] == {
+        "inbound_id": inbound.id,
+        "mode": "global",
+        "state": "delivery_failed",
+        "at": ledger["cursor_dispositions"]["beta"]["at"],
+    }
+
+    stack: list[object] = [ledger]
+    dead_letter_references: list[dict] = []
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            if value.get("kind") == "dead_letter_reference":
+                dead_letter_references.append(value)
+            stack.extend(value.values())
+        elif isinstance(value, list):
+            stack.extend(value)
+    assert len(dead_letter_references) == 1
+    reference = json.dumps(dead_letter_references[0], sort_keys=True)
+    assert inbound.id in reference
+    assert key_digest in reference
+    assert str(incident[0]["sequence"]) in reference
+    assert str(failed[0]["sequence"]) in reference
+    for nonce in admission["reservations"]:
+        assert nonce in reference
+
+    assert store.cursor("beta") == ""
+    assert any(message.id == inbound.id for message in store.valid_messages())
+
+
+def test_blocked_pairwise_waiter_wakes_from_transactional_delivery_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-blocked-waiter")
+    gate = _gate(store)
+    marker_written = threading.Event()
+    original_write_marker = cli._write_waiting_marker  # noqa: SLF001
+
+    def write_marker_then_signal(*args, **kwargs):
+        result = original_write_marker(*args, **kwargs)
+        marker_written.set()
+        return result
+
+    monkeypatch.setattr(cli, "_write_waiting_marker", write_marker_then_signal)
+    wait_results: list[int] = []
+
+    def wait_for_failure() -> None:
+        wait_results.append(cli.main([
+            "--root",
+            str(tmp_path),
+            "wait",
+            "--for",
+            "alpha",
+            "--to-request",
+            "q-blocked-waiter",
+            "--timeout",
+            "2",
+            "--interval",
+            "0.1",
+        ]))
+
+    waiter = threading.Thread(target=wait_for_failure)
+    waiter.start()
+    assert marker_written.wait(timeout=5)
+    assert wait_results == []
+
+    calls = 0
+
+    def drive(_record: dict) -> loop.DriveOutcome:
+        nonlocal calls
+        calls += 1
+        return loop.DriveOutcome(ok=True)
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=4,
+    )
+    waiter.join(timeout=5)
+
+    assert not waiter.is_alive()
+    assert calls == 2
+    assert wait_results == [4]
+    output = capsys.readouterr().out
+    assert "AGENTTALK :: DELIVERY FAILED" in output
+    payload = json.loads(next(
+        line for line in reversed(output.splitlines()) if line.startswith("{")
+    ))
+    assert payload["state"] == "delivery_failed"
+    assert payload["delivery_generation"] == 1
+    assert isinstance(payload["incident_sequence"], int)
+
+
+def test_failed_broadcast_member_does_not_terminalize_pinned_quorum_recv(
+    tmp_path: Path,
+) -> None:
+    members = ["beta", "gamma", "lead"]
+    store = _store(tmp_path, ["alpha", *members])
+    for member in members:
+        _broadcast_question(
+            store,
+            member,
+            broadcast_id="b-pinned-quorum",
+            members=members,
+            policy="quorum",
+            quorum=2,
+        )
+    beta = _gate(store, policy_agents=tuple(members))
+    gamma = _gate(
+        store,
+        agent="gamma",
+        fence="wrapper-gamma",
+        policy_agents=("gamma", "beta", "lead"),
+    )
+    beta_record = _record(store)
+    gamma_record = _record(store, agent="gamma")
+    beta_open = beta.admit_or_finalize(beta_record)
+    assert beta_open.key is not None
+    beta.delivery_failed(
+        beta_record,
+        beta_open.key,
+        reason="one member exhausted",
+        expected_revision=beta_open.scoped_revision,
+    )
+
+    before_answer = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-pinned-quorum",
+    )
+    assert before_answer["scoped"]["closed"] is False
+    assert before_answer["scoped"]["delivery_failed"] is None
+
+    _answer_reserved(tmp_path, gamma, gamma_record, body="one qualifying answer")
+    gamma.finalize(gamma_record, gamma.resolve(gamma_record))
+    after_one_answer = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="b-pinned-quorum",
+    )
+
+    assert after_one_answer["scoped"]["closed"] is False
+    assert after_one_answer["scoped"]["delivery_failed"] is None
+
+
+def test_failed_delivery_replay_exhausts_assignment_but_leaves_conversation_unanswered(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-unanswered")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="delivery exhausted",
+        expected_revision=admitted.scoped_revision,
+    )
+
+    replayed = gate.resolve(record)
+    requester_threads = threads.derive_threads(
+        store.valid_messages(),
+        agent="alpha",
+        cursor="",
+    )
+    requester_thread = next(
+        row for row in requester_threads if row.request_id == "q-unanswered"
+    )
+
+    assert replayed.state == ResolverState.DELIVERY_EXHAUSTED
+    assert replayed.key == admitted.key
+    assert gate.delivery_status("q-unanswered", "alpha")["state"] == "delivery_failed"
+    assert requester_thread.state == "open-outbound"
+    assert any(message.id == inbound.id for message in store.valid_messages())
+
+
+def test_explicit_reask_after_failed_delivery_gets_fresh_budget_without_reopening_old(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    old_inbound = _question(store, "q-new-delivery")
+    gate = _gate(store)
+    old_record = _record(store)
+    old = gate.admit_or_finalize(old_record)
+    assert old.key is not None
+    old_permit = gate.reserve_dispatch(old, purpose="initial")
+    gate.dispatch_record(old_record, old_permit)
+    gate.mark_dispatch_result(old_permit, action_attempted=False)
+    old_current = gate.resolve(old_record)
+    gate.delivery_failed(
+        old_record,
+        old.key,
+        reason="old delivery exhausted",
+        expected_revision=old_current.scoped_revision,
+    )
+    old_before_reask = dict(_ledger(gate)["obligations"][old.key.digest])
+
+    new_inbound = _question(store, "q-new-delivery")
+    restarted = _gate(store, fence="wrapper-2")
+    new_record = _record(store)
+    assert new_record["id"] == new_inbound.id
+    new = restarted.admit_or_finalize(new_record)
+    assert new.key is not None
+
+    assert new.key.digest != old.key.digest
+    assert (
+        new.key.question_generation,
+        new.key.delivery_generation,
+    ) != (
+        old.key.question_generation,
+        old.key.delivery_generation,
+    )
+    ledger = _ledger(restarted)
+    assert ledger["obligations"][old.key.digest] == old_before_reask
+    assert ledger["obligations"][old.key.digest]["state"] == "delivery_failed"
+    assert ledger["obligations"][new.key.digest]["state"] == "open"
+    assert ledger["obligations"][new.key.digest]["paid_dispatches_total"] == 0
+
+    new_permit = restarted.reserve_dispatch(new, purpose="initial")
+    after_reservation = _ledger(restarted)["obligations"]
+    assert new_permit.paid_dispatches_total == 1
+    assert after_reservation[new.key.digest]["paid_dispatches_total"] == 1
+    assert after_reservation[old.key.digest]["paid_dispatches_total"] == (
+        old_before_reask["paid_dispatches_total"]
+    )
+    assert after_reservation[old.key.digest]["state"] == "delivery_failed"
+    assert any(message.id == old_inbound.id for message in store.valid_messages())
+    assert restarted.delivery_status("q-new-delivery", "alpha") is None
+
+
+def _captured_infra_attempt(
+    store: Store,
+    gate: DetectionCommitGate,
+    *,
+    rid: str | None = None,
+):
+    record = _record(store, rid)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("captured answer", encoding="utf-8")
+    _record_captured_intent(store, gate, permit)
+    gate.mark_dispatch_result(
+        permit,
+        action_attempted=True,
+        action_infra=True,
+    )
+    return record, admitted, permit, dispatched
+
+
+def _race_scoped_revision(store: Store, sequence: int, *, rid: str = "q-1") -> None:
+    store.send(
+        sender="gamma",
+        recipient="alpha",
+        kind="note",
+        body=f"correlated revision race {sequence}",
+        meta={"request_id": rid},
+    )
+
+
+def _consume_operation_retry_budget(
+    gate: DetectionCommitGate,
+    admitted,
+    *,
+    already_executed: int = 1,
+) -> int:
+    executions = already_executed
+    current = gate.resolve(_record(gate.store))
+    while executions < 16:
+        assert gate.record_retry_barrier(
+            admitted.key,
+            category="operation_infra",
+            expected_revision=current.scoped_revision,
+        ) is True
+        executions += 1
+        gate.complete_retry_barrier(admitted.key, category="operation_infra")
+    return executions
+
+
+def test_finalization_cas_miss_is_durable_when_finalize_returns_and_after_restart(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store, now=lambda: "2026-01-01T00:00:00Z")
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    terminal = gate.resolve(record)
+    _race_scoped_revision(store, 1)
+
+    missed = gate.finalize(record, terminal)
+    admission = _ledger(gate)["obligations"][terminal.key.digest]
+
+    assert missed.state == ResolverState.INDETERMINATE
+    assert admission["finalization_misses"] == 1
+    assert admission["finalization_first_at"] == "2026-01-01T00:00:00Z"
+    assert store.cursor("beta") != inbound.id
+
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:00:01Z",
+    )
+    persisted = _ledger(restarted)["obligations"][terminal.key.digest]
+    assert persisted["finalization_misses"] == 1
+    assert persisted["finalization_first_at"] == "2026-01-01T00:00:00Z"
+
+
+def test_three_finalization_misses_back_off_indeterminate_without_model_spend(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    results = []
+
+    for sequence in range(1, 4):
+        terminal = gate.resolve(record)
+        _race_scoped_revision(store, sequence)
+        results.append(gate.finalize(record, terminal).state)
+        gate = _gate(store, fence="wrapper-1")
+
+    admission = _ledger(gate)["obligations"][terminal.key.digest]
+    assert results == [ResolverState.INDETERMINATE] * 3
+    assert admission["finalization_misses"] == 3
+    assert admission["paid_dispatches_total"] == 1
+    assert admission["state"] == "open"
+    assert store.cursor("beta") == ""
+
+
+def test_twelfth_finalization_miss_replays_latest_terminal_and_finalizes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+
+    for sequence in range(1, 12):
+        terminal = gate.resolve(record)
+        _race_scoped_revision(store, sequence)
+        assert gate.finalize(record, terminal).state == ResolverState.INDETERMINATE
+
+    original_finalize = gate.finalize
+    raced = False
+
+    def race_twelfth_finalize(current_record, resolution, **kwargs):
+        nonlocal raced
+        if not raced:
+            raced = True
+            _race_scoped_revision(store, 12)
+        return original_finalize(current_record, resolution, **kwargs)
+
+    monkeypatch.setattr(gate, "finalize", race_twelfth_finalize)
+    model_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal model_calls
+        model_calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    admission = _ledger(gate)["obligations"][terminal.key.digest]
+    assert raced is True
+    assert admission["finalization_misses"] == 12
+    assert admission["state"] == "finalized"
+    assert admission["terminal_state"] == ResolverState.SATISFIED.value
+    assert store.cursor("beta") == inbound.id
+    assert model_calls == 0
+
+
+def test_no_admission_finalization_bound_is_visible_across_restart(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    record = _record(store)
+    policy = PolicySnapshot.from_mapping({"schema_version": 1, "agents": {}}, "beta")
+    outcomes = []
+
+    for sequence in range(1, 13):
+        gate = DetectionCommitGate(
+            store,
+            "beta",
+            policy,
+            fence="wrapper-1",
+            now=lambda: "2026-01-01T00:00:00Z",
+        )
+        resolution = gate.admit_or_finalize(record)
+        _race_scoped_revision(store, sequence)
+        outcomes.append(gate.finalize(
+            record,
+            resolution,
+            expected_revision=resolution.ledger_revision,
+        ).state)
+
+    assert outcomes[:11] == [ResolverState.INDETERMINATE] * 11
+    assert outcomes[11] == ResolverState.BLOCKED
+    claim = _ledger(gate)["no_admission_claims"][record["id"]]
+    assert claim["finalization_misses"] == 12
+    assert claim["finalization_first_at"] == "2026-01-01T00:00:00Z"
+
+    restarted = DetectionCommitGate(
+        store,
+        "beta",
+        policy,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:00:01Z",
+    )
+    assert restarted.admit_or_finalize(record).state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+
+
+def test_operation_infra_clock_starts_at_initial_captured_failure_and_survives_restart(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store, now=lambda: "2026-01-01T00:00:00Z")
+    _record_, admitted, _permit, _dispatched = _captured_infra_attempt(store, gate)
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+
+    assert admission["operation_infra_attempts"] == 1
+    assert admission["operation_infra_first_at"] == "2026-01-01T00:00:00Z"
+
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:14:59Z",
+    )
+    persisted = _ledger(restarted)["obligations"][admitted.key.digest]
+    assert persisted["operation_infra_attempts"] == 1
+    assert persisted["operation_infra_first_at"] == "2026-01-01T00:00:00Z"
+
+
+def test_operation_retry_barrier_allows_exactly_sixteen_executions(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    _record_, admitted, _permit, _dispatched = _captured_infra_attempt(store, gate)
+
+    executions = _consume_operation_retry_budget(gate, admitted)
+    current = gate.resolve(_record(store))
+
+    assert executions == 16
+    assert gate.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is False
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["operation_infra_attempts"] == 16
+
+
+def test_stale_terminal_refuses_operation_retry_before_execution(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record, admitted, _permit, dispatched = _captured_infra_attempt(store, gate)
+    stale = gate.resolve(record)
+    before = _ledger(gate)["obligations"][admitted.key.digest][
+        "operation_infra_attempts"
+    ]
+    assert cli.main([
+        "--root", str(tmp_path), *dispatched["owed_action"]["argv"][3:], "--quiet",
+    ]) == 0
+
+    allowed = gate.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=stale.scoped_revision,
+    )
+
+    assert allowed is False
+    assert gate.resolve(record).state == ResolverState.SATISFIED
+    assert _ledger(gate)["obligations"][admitted.key.digest][
+        "operation_infra_attempts"
+    ] == before
+
+
+def test_operation_cap_fresh_replay_lets_concurrent_terminal_win(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record, admitted, _permit, dispatched = _captured_infra_attempt(store, gate)
+    assert _consume_operation_retry_budget(gate, admitted) == 16
+    original_captured = gate.captured_operation
+    published = False
+
+    def publish_before_cap_check(key):
+        nonlocal published
+        captured = original_captured(key)
+        if not published:
+            published = True
+            assert cli.main([
+                "--root",
+                str(tmp_path),
+                *dispatched["owed_action"]["argv"][3:],
+                "--quiet",
+            ]) == 0
+        return captured
+
+    monkeypatch.setattr(gate, "captured_operation", publish_before_cap_check)
+    model_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal model_calls
+        model_calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    assert published is True
+    assert model_calls == 0
+    assert store.cursor("beta") == inbound.id
+    assert gate.resolve(record).state == ResolverState.SATISFIED
+    assert gate.delivery_status("q-1", "alpha") is None
+
+
+def test_unlocalizable_operation_exhaustion_is_durably_blocked_after_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+    assert _consume_operation_retry_budget(gate, admitted) == 16
+    original_captured = gate.captured_operation
+
+    def fail_replay_after_initial_resolution(key):
+        captured = original_captured(key)
+
+        def unreadable_replay():
+            raise LedgerUnreadable("global projection unavailable at exhaustion")
+
+        monkeypatch.setattr(gate, "_validated_messages", unreadable_replay)
+        return captured
+
+    monkeypatch.setattr(gate, "captured_operation", fail_replay_after_initial_resolution)
+    model_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal model_calls
+        model_calls += 1
+        return True
+
+    loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert model_calls == 0
+    assert store.cursor("beta") != inbound.id
+    assert gate.delivery_status("q-1", "alpha") is None
+
+    restarted = _gate(store, fence="wrapper-1")
+    assert restarted.resolve(record).state == ResolverState.BLOCKED
+    admission = _ledger(restarted)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+
+
+def test_operation_infra_elapsed_ceiling_survives_restart_without_another_attempt(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store, now=lambda: "2026-01-01T00:00:00Z")
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:15:01Z",
+    )
+    current = restarted.resolve(record)
+    assert restarted.record_retry_barrier(
+        admitted.key,
+        category="operation_infra",
+        expected_revision=current.scoped_revision,
+    ) is False
+    admission = _ledger(restarted)["obligations"][admitted.key.digest]
+
+    assert admission["operation_infra_attempts"] == 1
+    assert admission["operation_infra_first_at"] == "2026-01-01T00:00:00Z"
+    settled = restarted.settle_retry_exhaustion(
+        record,
+        admitted.key,
+        category="operation_infra",
+        reason="operation elapsed ceiling exhausted",
+        permit=permit,
+    )
+    assert settled.state == ResolverState.BLOCKED
+    assert restarted.delivery_status("q-1", "alpha") is None
+
+
+@pytest.mark.parametrize("only_request_id", [None, "q-loop-infra-bound"])
+def test_loop_operation_infra_bound_requires_proven_head_local_failure(
+    tmp_path: Path,
+    only_request_id: str | None,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-loop-infra-bound")
+    gate = _gate(store)
+    record, admitted, _permit, _dispatched = _captured_infra_attempt(
+        store,
+        gate,
+        rid=only_request_id,
+    )
+    ledger = _ledger(gate)
+    admission = ledger["obligations"][admitted.key.digest]
+    admission["operation_infra_attempts"] = 16
+    gate._write(ledger)  # noqa: SLF001 - inject the durable cross-restart cap
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        lambda _record: pytest.fail("model was called after operation cap"),
+        commit_gate=gate,
+        only_request_id=only_request_id,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert turns == 0
+    assert store.cursor("beta") == ""
+    assert any(message.id == inbound.id for message in store.valid_messages())
+    assert gate.delivery_status("q-loop-infra-bound", "alpha") is None
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+    assert "not proven" in admission["blocked_reason"]
+    assert gate.resolve(record).state == ResolverState.BLOCKED
+
+
+def test_finalization_elapsed_ceiling_survives_restart_and_replays_terminal(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store, now=lambda: "2026-01-01T00:00:00Z")
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    first = gate.resolve(record)
+    _race_scoped_revision(store, 1)
+    assert gate.finalize(record, first).state == ResolverState.INDETERMINATE
+
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:15:01Z",
+    )
+    latest = restarted.resolve(record)
+    _race_scoped_revision(store, 2)
+    exhausted = restarted.finalize(record, latest)
+
+    assert exhausted.state == ResolverState.INDETERMINATE
+    assert exhausted.reason == "finalization CAS contention exhausted"
+    admission = _ledger(restarted)["obligations"][latest.key.digest]
+    assert admission["finalization_misses"] == 2
+    assert admission["finalization_first_at"] == "2026-01-01T00:00:00Z"
+    settled = restarted.settle_retry_exhaustion(
+        record,
+        latest.key,
+        category="finalization",
+        reason="finalization elapsed ceiling exhausted",
+    )
+    assert settled.state == ResolverState.SATISFIED
+    assert store.cursor("beta") == inbound.id
+
+
+def test_unwritable_failed_delivery_becomes_visible_blocked_without_cursor_advance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    monkeypatch.setattr(
+        gate,
+        "_write",
+        lambda _ledger: (_ for _ in ()).throw(OSError("disposition unavailable")),
+    )
+
+    blocked = gate.fail_delivery_or_block(
+        record,
+        admitted.key,
+        reason="cannot persist failed delivery",
+        expected_revision=admitted.scoped_revision,
+    )
+
+    assert blocked.state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+    health = json.loads(gate.proof_health_path.read_text(encoding="utf-8"))
+    assert health["state"] == "blocked"
+    assert health["disposition_block"] is True
+    restarted = _gate(store, fence="wrapper-1")
+    assert restarted.admit_or_finalize(record).state == ResolverState.BLOCKED
+    assert restarted.status()["status"] == "BLOCKED"
+
+
+def test_head_local_failed_delivery_does_not_dispose_an_unrelated_head(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    first = _question(store, "q-local")
+    second = _question(store, "q-unrelated")
+    gate = _gate(store)
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+    permit.draft_path.write_text("tampered after durable capture", encoding="utf-8")
+    current = gate.resolve(record)
+
+    result = gate.fail_head_local_corruption_or_block(
+        record,
+        admitted.key,
+        permit,
+        reason="captured operation proof is corrupt",
+        expected_revision=current.scoped_revision,
+    )
+
+    assert result.state == ResolverState.DELIVERY_EXHAUSTED
+    assert gate.delivery_status("q-local", "alpha") is not None
+    assert gate.delivery_status("q-unrelated", "alpha") is None
+    assert any(message.id == first.id for message in store.valid_messages())
+    assert any(message.id == second.id for message in store.valid_messages())
+    proof = _ledger(gate)["obligations"][admitted.key.digest][
+        "head_local_proof_failure"
+    ]
+    assert proof["kind"] == "HEAD_LOCAL_PROOF_FAILURE"
+    assert proof["inbound_id"] == first.id
+    assert proof["operation_nonce"] == permit.nonce
+    assert proof["expected_payload_sha256"] != proof["observed_payload_sha256"]
+    assert _record(store)["id"] == second.id
+
+
+def test_unreadable_head_local_artifact_blocks_instead_of_failed_delivery(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-unproven-local")
+    gate = _gate(store)
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+    permit.draft_path.unlink()
+    current = gate.resolve(record)
+
+    result = gate.fail_head_local_corruption_or_block(
+        record,
+        admitted.key,
+        permit,
+        reason="unreadable local artifact",
+        expected_revision=current.scoped_revision,
+    )
+
+    assert result.state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+    assert gate.delivery_status("q-unproven-local", "alpha") is None
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+    assert "unreadable" in admission["blocked_reason"]
+
+
+@pytest.mark.parametrize("tamper", ["marker", "reservation"])
+def test_disagreeing_durable_operation_proofs_cannot_authorize_failed_delivery(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-untrusted-local-proof")
+    gate = _gate(store)
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+    if tamper == "marker":
+        marker_path = store._operation_intent_path(  # noqa: SLF001 - corruption injection
+            "beta",
+            permit.nonce,
+        )
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["operation_digest"] = "0" * 64
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+    else:
+        ledger = _ledger(gate)
+        ledger["obligations"][admitted.key.digest]["reservations"][permit.nonce][
+            "operation_payload_digest"
+        ] = "0" * 64
+        gate._write(ledger)  # noqa: SLF001 - corruption injection
+    current = gate.resolve(record)
+
+    result = gate.fail_head_local_corruption_or_block(
+        record,
+        admitted.key,
+        permit,
+        reason="untrusted durable proof",
+        expected_revision=current.scoped_revision,
+    )
+
+    assert result.state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+    assert gate.delivery_status("q-untrusted-local-proof", "alpha") is None
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+    assert "proofs disagree" in admission["blocked_reason"]
+    assert not any(
+        row["transition"] == "DELIVERY_FAILED"
+        for row in _ledger(gate)["transitions"]
+    )
+
+
+def test_terminal_append_and_finalizer_concurrency_has_no_deadlock_or_stale_commit(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+    terminal = gate.resolve(record)
+    start = threading.Barrier(2)
+    results: list[ResolverState] = []
+    failures: list[BaseException] = []
+
+    def append_evidence() -> None:
+        try:
+            start.wait(timeout=5)
+            store.send(
+                sender="gamma",
+                recipient="alpha",
+                kind="note",
+                body="concurrent correlated evidence",
+                meta={"request_id": "q-1"},
+            )
+        except BaseException as exc:  # pragma: no cover - assertion captures thread errors
+            failures.append(exc)
+
+    def finalize_terminal() -> None:
+        try:
+            start.wait(timeout=5)
+            results.append(gate.finalize(record, terminal).state)
+        except BaseException as exc:  # pragma: no cover - assertion captures thread errors
+            failures.append(exc)
+
+    threads_ = [
+        threading.Thread(target=append_evidence),
+        threading.Thread(target=finalize_terminal),
+    ]
+    for worker in threads_:
+        worker.start()
+    for worker in threads_:
+        worker.join(timeout=10)
+
+    assert not failures
+    assert all(not worker.is_alive() for worker in threads_)
+    assert results[0] in {ResolverState.SATISFIED, ResolverState.INDETERMINATE}
+    if results[0] == ResolverState.INDETERMINATE:
+        latest = gate.resolve(record)
+        assert gate.finalize(record, latest).state == ResolverState.SATISFIED
+    assert store.cursor("beta") == inbound.id
+    assert sum(
+        row["transition"] == "CURSOR_FINALIZED"
+        for row in _ledger(gate)["transitions"]
+    ) == 1
+
+
+def test_identical_proof_error_fingerprint_emits_one_elapsed_authority(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    gate = _gate(store, now=lambda: "2026-01-01T00:00:00Z")
+    first = gate.record_proof_failure(error_class="OSError", path="ledger.json")
+    restarted = _gate(
+        store,
+        fence="wrapper-1",
+        now=lambda: "2026-01-01T00:15:01Z",
+    )
+    exhausted = restarted.record_proof_failure(
+        error_class="OSError",
+        path="ledger.json",
+    )
+    again = restarted.record_proof_failure(
+        error_class="OSError",
+        path="ledger.json",
+    )
+
+    assert exhausted["exhausted"] is True
+    assert exhausted["fingerprint"] == first["fingerprint"]
+    assert exhausted["first_failure_at"] == first["first_failure_at"]
+    assert again["alerted_at"] == exhausted["alerted_at"]
+    assert again["incident_id"] == exhausted["incident_id"]
+    assert again["incident"] == exhausted["incident"]
+
+
+def test_stale_nonterminal_retry_revision_does_not_exhaust_operation_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record, admitted, permit, _dispatched = _captured_infra_attempt(store, gate)
+    original_captured = gate.captured_operation
+    raced = False
+
+    def race_before_barrier(key):
+        nonlocal raced
+        captured = original_captured(key)
+        if not raced:
+            raced = True
+            _race_scoped_revision(store, 1)
+        return captured
+
+    monkeypatch.setattr(gate, "captured_operation", race_before_barrier)
+    monkeypatch.setattr(
+        gate,
+        "retry_captured_operation",
+        lambda *_args, **_kwargs: pytest.fail("stale retry executed"),
+    )
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        lambda _record: pytest.fail("model was called"),
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert raced is True
+    assert turns == 0
+    assert admission["operation_infra_attempts"] == 1
+    assert admission["state"] == "open"
+    assert permit.draft_path.exists()
+    assert gate.retry_bound_exhausted(
+        admitted.key,
+        category="operation_infra",
+    ) is False
+    assert gate.delivery_status("q-1", "alpha") is None
+
+
+def test_immediate_operation_retry_does_not_claim_turn_on_finalization_cas_miss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    permits: list[object] = []
+    dispatched_records: list[dict] = []
+    original_reserve = gate.reserve_dispatch
+    original_finalize = gate.finalize
+
+    def reserve(*args, **kwargs):
+        permit = original_reserve(*args, **kwargs)
+        permits.append(permit)
+        return permit
+
+    def drive(dispatch_record: dict) -> loop.DriveOutcome:
+        dispatched_records.append(dispatch_record)
+        permit = permits[-1]
+        permit.draft_path.write_text("captured answer", encoding="utf-8")
+        _record_captured_intent(store, gate, permit)
+        return loop.DriveOutcome(
+            ok=False,
+            failure_class=loop.CLASS_INFRA,
+            bus_action_attempted=True,
+            bus_action_infra=True,
+        )
+
+    def publish_retry(_permit, _record) -> bool:
+        argv = dispatched_records[-1]["owed_action"]["argv"]
+        assert cli.main(["--root", str(tmp_path), *argv[3:], "--quiet"]) == 0
+        return True
+
+    raced = False
+
+    def race_finalize(current_record, resolution, **kwargs):
+        nonlocal raced
+        if not raced:
+            raced = True
+            _race_scoped_revision(store, 1)
+        return original_finalize(current_record, resolution, **kwargs)
+
+    monkeypatch.setattr(gate, "reserve_dispatch", reserve)
+    monkeypatch.setattr(gate, "retry_captured_operation", publish_retry)
+    monkeypatch.setattr(gate, "finalize", race_finalize)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    admission = _ledger(gate)["obligations"][permits[0].key_digest]
+    assert raced is True
+    assert turns == 0
+    assert admission["finalization_misses"] == 1
+    assert admission["state"] == "open"
+    assert permits[0].draft_path.exists()
+
+
+@pytest.mark.parametrize("only_request_id", [None, "q-no-key-retry"])
+def test_no_admission_finalization_contention_never_redrives_successful_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    only_request_id: str | None,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-no-key-retry")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1",
+        "pid": os.getpid(),
+    })
+    policy = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+    }, "beta")
+    gate = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    original_finalize = gate.finalize
+    finalize_calls = 0
+    drive_calls = 0
+
+    def race_each_finalize(current_record, resolution, **kwargs):
+        nonlocal finalize_calls
+        finalize_calls += 1
+        _race_scoped_revision(
+            store,
+            finalize_calls,
+            rid="q-no-key-retry",
+        )
+        return original_finalize(current_record, resolution, **kwargs)
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        return True
+
+    monkeypatch.setattr(gate, "finalize", race_each_finalize)
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id=only_request_id,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=3,
+    )
+
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert turns == 0
+    assert drive_calls == 1
+    assert finalize_calls == 3
+    assert claim["state"] == "finalization_pending"
+    assert claim["finalization_misses"] == 3
+    assert claim["drive_succeeded_at"]
+    assert store.cursor("beta") == ""
+
+
+def test_no_admission_disposition_crash_replays_without_redriving_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-no-key-projection")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1",
+        "pid": os.getpid(),
+    })
+    policy = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+    }, "beta")
+    owner = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    record = _record(store)
+    resolution = owner.admit_or_finalize(record)
+    retained = owner.record_no_admission_success(record, resolution)
+    monkeypatch.setattr(
+        owner,
+        "_advance_record_cursor",
+        lambda _record: (_ for _ in ()).throw(OSError("projection crash")),
+    )
+    finalized = owner.finalize(
+        record,
+        retained,
+        expected_revision=retained.ledger_revision,
+    )
+    assert finalized.state == ResolverState.INDETERMINATE
+    assert store.cursor("beta") == ""
+
+    restarted = DetectionCommitGate(
+        store,
+        "beta",
+        policy,
+        fence="wrapper-1",
+    )
+    turns = loop.run_loop(
+        store,
+        "beta",
+        lambda _record: pytest.fail("model was redriven"),
+        commit_gate=restarted,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+    )
+
+    assert turns == 1
+    assert store.cursor("beta") == inbound.id
+
+
+@pytest.mark.parametrize("only_request_id", [None, "q-no-key-append"])
+def test_no_admission_success_survives_correlated_append_during_drive(
+    tmp_path: Path,
+    only_request_id: str | None,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store, "q-no-key-append")
+    store.write_waiting("beta", {
+        "mode": "wrapper-loop",
+        "wrapper_generation": "wrapper-1",
+        "wait_token": "wrapper-1",
+        "pid": os.getpid(),
+    })
+    policy = PolicySnapshot.from_mapping({
+        "schema_version": 1,
+        "agents": {"beta": {"grade": DETECTION_GRADE, "enabled": False}},
+    }, "beta")
+    gate = DetectionCommitGate(store, "beta", policy, fence="wrapper-1")
+    drive_calls = 0
+
+    def drive(_record: dict) -> bool:
+        nonlocal drive_calls
+        drive_calls += 1
+        store.send(
+            sender="gamma",
+            recipient="alpha",
+            kind="note",
+            body="concurrent correlated append",
+            meta={"request_id": "q-no-key-append"},
+        )
+        return True
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        only_request_id=only_request_id,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=2,
+    )
+
+    assert turns == 1
+    assert drive_calls == 1
+    claim = _ledger(gate)["no_admission_claims"][inbound.id]
+    assert claim["state"] == "finalized"
+    if only_request_id is None:
+        assert store.cursor("beta") == inbound.id
+    else:
+        assert store.cursor("beta") == ""
+        assert store.thread_seen("beta", only_request_id) == inbound.id
+
+
+def test_exhaustion_second_terminal_race_never_synthesizes_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    inbound = _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    _answer_reserved(tmp_path, gate, record)
+
+    for sequence in range(1, 13):
+        terminal = gate.resolve(record)
+        _race_scoped_revision(store, sequence)
+        missed = gate.finalize(record, terminal)
+        assert missed.state == ResolverState.INDETERMINATE
+    assert missed.reason == "finalization CAS contention exhausted"
+
+    original_finalize = gate.finalize
+    raced = False
+
+    def race_settlement_finalize(current_record, resolution, **kwargs):
+        nonlocal raced
+        if not raced:
+            raced = True
+            _race_scoped_revision(store, 13)
+        return original_finalize(current_record, resolution, **kwargs)
+
+    monkeypatch.setattr(gate, "finalize", race_settlement_finalize)
+    settled = gate.settle_retry_exhaustion(
+        record,
+        terminal.key,
+        category="finalization",
+        reason="finalization bound exhausted",
+    )
+
+    assert raced is True
+    assert settled.state == ResolverState.SATISFIED
+    assert not any(
+        row["transition"] == "OBLIGATION_BLOCKED"
+        for row in _ledger(gate)["transitions"]
+    )
+    restarted = _gate(store, fence="wrapper-1")
+    latest = restarted.resolve(record)
+    assert latest.state == ResolverState.SATISFIED
+    assert restarted.finalize(record, latest).state == ResolverState.SATISFIED
+    assert store.cursor("beta") == inbound.id
+
+
+@pytest.mark.parametrize(
+    ("new_responder", "masked"),
+    [("beta", True), ("gamma", False)],
+)
+def test_explicit_reask_masks_failed_delivery_before_new_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    new_responder: str,
+    masked: bool,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-pre-admission-reask")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="old generation exhausted",
+        expected_revision=admitted.scoped_revision,
+    )
+    old = dict(_ledger(gate)["obligations"][admitted.key.digest])
+
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.note_bus_message",
+        lambda _store, _message: None,
+    )
+    new_inbound = store.send(
+        sender="alpha",
+        recipient=new_responder,
+        kind="question",
+        body="retry the unanswered request",
+        meta={"request_id": "q-pre-admission-reask"},
+    )
+
+    assert new_inbound.id not in _ledger(gate)["messages"]
+    status = gate.delivery_status("q-pre-admission-reask", "alpha")
+    assert (status is None) is masked
+    scoped = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="q-pre-admission-reask",
+    )["scoped"]
+    assert scoped["closed"] is (not masked)
+    assert (scoped["delivery_failed"] is None) is masked
+    assert _ledger(gate)["obligations"][admitted.key.digest] == old
+
+
+@pytest.mark.parametrize(
+    "replacement_meta",
+    [
+        {"request_id": "q-invalid-reask", "consult": True},
+        {
+            "broadcast_id": "q-invalid-reask",
+            "broadcast_policy_version": 1,
+        },
+    ],
+)
+def test_non_owed_or_malformed_reask_cannot_mask_failed_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_meta: dict,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-invalid-reask")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="old assignment exhausted",
+        expected_revision=admitted.scoped_revision,
+    )
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.note_bus_message",
+        lambda _store, _message: None,
+    )
+
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="question",
+        body="not an admissible replacement",
+        meta=replacement_meta,
+    )
+
+    status = gate.delivery_status("q-invalid-reask", "alpha")
+    assert status is not None
+    assert status["state"] == "delivery_failed"
+    scoped = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="q-invalid-reask",
+    )["scoped"]
+    assert scoped["closed"] is True
+    assert scoped["delivery_failed"] == status
+
+
+@pytest.mark.parametrize(
+    "tear",
+    ["requester_index", "cursor_disposition", "operation_reference"],
+)
+def test_torn_failed_delivery_transaction_blocks_without_advancing_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tear: str,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-torn-delivery")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+    monkeypatch.setattr(gate, "_advance_record_cursor", lambda _record: None)
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="delivery exhausted",
+        expected_revision=current.scoped_revision,
+    )
+    ledger = _ledger(gate)
+    if tear == "requester_index":
+        del ledger["delivery_index"]["q-torn-delivery"]
+    elif tear == "cursor_disposition":
+        del ledger["cursor_dispositions"]["beta"]
+    else:
+        ledger["obligations"][admitted.key.digest]["dead_letter_reference"][
+            "operation_nonces"
+        ] = []
+    gate._write(ledger)  # noqa: SLF001 - deterministic torn-transaction injection
+
+    restarted = _gate(store, fence="wrapper-1")
+    blocked = restarted.delivery_failed(
+        record,
+        admitted.key,
+        reason="idempotent projection recovery",
+        expected_revision=restarted.resolve(record).scoped_revision,
+    )
+
+    assert blocked.state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+    admission = _ledger(restarted)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+    assert "structurally torn" in admission["blocked_reason"]
+    assert restarted.resolve(record).state == ResolverState.BLOCKED
+
+
+def test_corrupt_config_during_failed_disposition_becomes_visible_blocked(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store)
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    store.config_path.write_text("{", encoding="utf-8")
+
+    blocked = gate.fail_delivery_or_block(
+        record,
+        admitted.key,
+        reason="configuration unreadable during disposition",
+        expected_revision=admitted.scoped_revision,
+    )
+
+    assert blocked.state == ResolverState.BLOCKED
+    assert store.cursor("beta") == ""
+    admission = _ledger(gate)["obligations"][admitted.key.digest]
+    assert admission["state"] == "blocked"
+    assert gate.resolve(record).state == ResolverState.BLOCKED
+
+
+def test_canonical_terminal_with_missed_eager_hook_wins_failed_disposition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-terminal-wins")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    dispatched = gate.dispatch_record(record, permit)
+    permit.draft_path.write_text("canonical answer", encoding="utf-8")
+    monkeypatch.setattr(
+        "agenttalk.wrapper.obligations.note_bus_message",
+        lambda _store, _message: None,
+    )
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        *dispatched["owed_action"]["argv"][3:],
+        "--quiet",
+    ]) == 0
+
+    result = gate.fail_delivery_or_block(
+        record,
+        admitted.key,
+        reason="stale compliance decision",
+        expected_revision=admitted.scoped_revision,
+    )
+
+    assert result.state == ResolverState.SATISFIED
+    assert gate.resolve(record).state == ResolverState.SATISFIED
+    assert gate.delivery_status("q-terminal-wins", "alpha") is None
+    assert store.cursor("beta") == record["id"]
+    assert not any(
+        row["transition"] in {"DELIVERY_FAILED", "OBLIGATION_BLOCKED"}
+        for row in _ledger(gate)["transitions"]
+    )
+
+
+def test_operator_resolution_recovers_failed_delivery_without_resetting_old_budget(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-operator-recovery")
+    gate = _gate(store)
+    record = _record(store)
+    admitted = gate.admit_or_finalize(record)
+    assert admitted.key is not None
+    permit = gate.reserve_dispatch(admitted, purpose="initial")
+    gate.dispatch_record(record, permit)
+    gate.mark_dispatch_result(permit, action_attempted=False)
+    current = gate.resolve(record)
+    gate.delivery_failed(
+        record,
+        admitted.key,
+        reason="assignment exhausted",
+        expected_revision=current.scoped_revision,
+    )
+    spent = dict(_ledger(gate)["obligations"][admitted.key.digest])
+    roster = gate.roster_snapshot()
+
+    resolved = gate.operator_resolve(
+        record,
+        admitted.key,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        reason="operator accepted the unresolved conversation",
+    )
+
+    recovered = _ledger(gate)["obligations"][admitted.key.digest]
+    assert resolved.state == ResolverState.OPERATOR_RESOLVED
+    assert recovered["state"] == "operator_resolved"
+    assert recovered["exhausted"] is True
+    assert recovered["paid_dispatches_total"] == spent["paid_dispatches_total"]
+    terminal = gate.delivery_status("q-operator-recovery", "alpha")
+    assert terminal is not None
+    assert terminal["state"] == "operator_resolved"
+    assert terminal["actor"] == "lead"
+    assert terminal["reason"] == "operator accepted the unresolved conversation"
+    scoped = recv_api.poll(
+        store,
+        "alpha",
+        scoped_request_id="q-operator-recovery",
+    )["scoped"]
+    assert scoped["closed"] is True
+    assert scoped["delivery_failed"] is None
+    assert scoped["delivery_terminal"] == terminal
+
+    rc = cli.main([
+        "--root",
+        str(tmp_path),
+        "wait",
+        "--for",
+        "alpha",
+        "--to-request",
+        "q-operator-recovery",
+        "--timeout",
+        "1",
+        "--interval",
+        "0.1",
+    ])
+    output = capsys.readouterr().out
+    assert rc == 7
+    assert "OPERATOR RESOLVED" in output
+    assert "DELIVERY FAILED" not in output
+    assert '"state": "operator_resolved"' in output
+
+
+def test_reassignment_after_failed_delivery_gets_fresh_generation_and_budget(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _question(store, "q-reassigned-recovery")
+    destination_policy = _policy("gamma", "beta")
+    source = _gate(store, policy_agents=("beta", "gamma"))
+    record = _record(store)
+    admitted = source.admit_or_finalize(record)
+    assert admitted.key is not None
+    source.delivery_failed(
+        record,
+        admitted.key,
+        reason="source assignment exhausted",
+        expected_revision=admitted.scoped_revision,
+    )
+    old_spend = _ledger(source)["obligations"][admitted.key.digest][
+        "paid_dispatches_total"
+    ]
+    next_inbound = _transfer_question(
+        store, admitted.key, "gamma", destination_policy,
+    )
+    current = source.resolve(record)
+    roster = source.roster_snapshot()
+
+    source.transfer(
+        record,
+        admitted.key,
+        destination="gamma",
+        new_inbound_id=next_inbound.id,
+        destination_policy=destination_policy,
+        actor="lead",
+        expected_roster_revision=roster["revision"],
+        expected_revision=current.scoped_revision,
+    )
+
+    ledger = _ledger(source)
+    old = ledger["obligations"][admitted.key.digest]
+    next_digest = ledger["inbound_index"][next_inbound.id]
+    reassigned = ledger["obligations"][next_digest]
+    assert old["state"] == "transferred"
+    assert old["exhausted"] is True
+    assert old["paid_dispatches_total"] == old_spend
+    assert reassigned["state"] == "open"
+    assert reassigned["exhausted"] is False
+    assert reassigned["paid_dispatches_total"] == 0
+    assert reassigned["key"]["delivery_generation"] == (
+        admitted.key.delivery_generation + 1
+    )
+    assert source.delivery_status("q-reassigned-recovery", "alpha") is None


### PR DESCRIPTION
## Re-integrate detection-grade owed-action enforcement + POSIX fix

Re-introduces the detection-grade enforcement engine (previously merged as `594a082`, then **reverted** in `4a805b4` because it failed on POSIX CI) together with the cross-platform fix, so it can land green on all three OSes.

### Why a revert-the-revert (not a plain merge)
master reverted the original merge, so git considers the enforcement commits already-merged ancestors. A naive re-merge of the fix branch would bring only the fix delta and leave the engine absent. This branch instead:
1. `revert 4a805b4` — restores the enforcement engine content (`8e1c44e`).
2. cherry-pick `42d41c9` — the POSIX fix (`7d6fb98`).

The enforcement files (`src/agenttalk/wrapper/obligations.py`, `tests/test_owed_action_detection.py`) are **byte-identical to the validated `42d41c9`**.

### The POSIX fix (root cause)
The original failure was **not** the file-lock primitive. `obligations.py _pinned_executable` refused POSIX `sys.executable` because setup-python exposes it as an **absolute symlink**: strict-resolve succeeded but the old `is_symlink()` check rejected it → 89 refusals → 18 cascades = 107 failures/job on macOS + Ubuntu. Fix: strict-resolve and accept only when the canonical target is a regular file, and emit the canonical target in `reply`/`composing` argv. Dangling/dir/loop/relative targets stay fail-closed.

### Validation already done (by codex-2)
- **Linux** (Docker `python:3.11-slim`): 289/289 passed.
- **Windows** Py3.10 & Py3.14: 285 passed + 4 expected WinError-1314 symlink-privilege skips each.
- Ruff (repo) + Bandit (src) clean on 3.10 and 3.14; 3 independent read-only reviews, no blockers.
- **macOS**: not locally testable — **this PR's CI is the macOS oracle.**

### Merge gate (HOLD)
Do **not** merge until: all-OS CI green here (esp. macOS) **and** operator go. After merge: re-run the deterministic canary (#34) against re-merged master; the paid Qwen OVH run remains a separate operator decision (€25 cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
