### PR TITLE
feat(store): full-validation snapshot + ordered-but-absent detection (GH #44)

### DIFF
--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -3877,6 +3877,169 @@ class Store:
             sequences = self._extend_order_with_orphans(order, missing)["messages"]
         return sorted(messages, key=lambda message: sequences[message.id])
 
+    @staticmethod
+    def _stable_scan_problem_reason(reason: str) -> str:
+        """Map platform/version-specific scan details to a stable reason code."""
+        if reason.startswith("cannot read file:"):
+            return "message_file_unreadable"
+        if reason.startswith("invalid JSON:"):
+            return "message_json_invalid"
+        if reason.startswith("filename stem "):
+            return "message_filename_mismatch"
+        return "message_schema_invalid"
+
+    def _validated_message_snapshot(
+        self,
+        *,
+        since_id: str | None = None,
+        collect_problems: bool,
+    ) -> tuple[
+        list[Message],
+        list[dict[str, str | None]],
+        set[str],
+    ]:
+        """Run the shared full validation gate over one canonical disk walk.
+
+        The third result is the set of canonical ``.json`` stems observed by
+        that same walk.  The public completeness snapshot uses it to distinguish
+        a present-but-rejected message from a publication-ordered message whose
+        file is absent.
+
+        ``collect_problems=False`` is the delivery hot path.  In particular, it
+        preserves the historical fail-closed early return when no usable roster
+        exists, without touching the message directory.
+        """
+        try:
+            cfg = self.load_config()
+            # D3 (#19): validate history against the KNOWN roster (active ∪
+            # retired) so a retired identity's past messages stay valid.
+            roster = self._known_roster(cfg)
+        except (ValueError, OSError, FileNotFoundError):
+            roster = []
+        if not roster and not collect_problems:
+            # Preserve _validated_messages' existing no-roster fast fail-closed
+            # behavior.  The diagnostic API still scans so it can explain why
+            # every otherwise-parseable file was rejected.
+            return [], [], set()
+
+        require_sig = bool(roster) and self.signing_enforced()
+        project_id = self.project_id() if require_sig else None
+        key: bytes | None = None
+        if require_sig:
+            try:
+                key = _signing.load_key(project_id)
+            except (FileNotFoundError, OSError, ValueError):
+                key = None  # key vanished between check and load — refuse
+
+        scanned, scan_failures = self._scan_messages_with_paths(
+            since_id=since_id,
+        )
+        present_stems = {
+            path.stem for _, path in scanned
+        } | {
+            path.stem for path, _, _ in scan_failures
+        }
+        problems: list[dict[str, str | None]] = []
+
+        def reject(ident: str | None, path: Path, reason: str) -> None:
+            if collect_problems:
+                problems.append(
+                    {"id": ident, "path": str(path), "reason": reason}
+                )
+
+        for path, ident, reason in scan_failures:
+            reject(ident, path, self._stable_scan_problem_reason(reason))
+
+        out: list[Message] = []
+        for message, path in scanned:
+            if not roster:
+                reject(message.id, path, "message_roster_unavailable")
+                continue
+            try:
+                message.validate(roster)
+            except ValueError:
+                reject(message.id, path, "message_roster_invalid")
+                continue
+            if require_sig:
+                if key is None:
+                    reject(message.id, path, "message_signature_key_unavailable")
+                    continue
+                try:
+                    _signing.verify_message(
+                        message.to_dict(), key, expected_key_id=project_id,
+                    )
+                except ValueError:
+                    reject(message.id, path, "message_signature_invalid")
+                    continue
+            out.append(message)
+
+        # Restore the documented "sorted by id (chronological)" contract:
+        # _scan_messages_with_paths yields raw filesystem-iteration (filename)
+        # order, which equals id order ONLY because stem==id is now enforced
+        # above. Sort explicitly so delivery, cursor advance, and thread
+        # replay are correct even if that invariant is ever relaxed (review H1).
+        out.sort(key=lambda message: message.id)
+        # Defensive dedupe by id: stem==id + unique filenames make duplicate
+        # ids structurally impossible today, but double-delivery would be a
+        # silent correctness bug if that ever changed, so guard it cheaply.
+        deduped: list[Message] = []
+        seen_ids: set[str] = set()
+        for message in out:
+            if message.id in seen_ids:
+                continue
+            seen_ids.add(message.id)
+            deduped.append(message)
+        return deduped, problems, present_stems
+
+    def validated_messages_with_problems(
+        self,
+        *,
+        since_id: str | None = None,
+    ) -> tuple[list[Message], list[dict[str, str | None]]]:
+        """Return one full-validation snapshot as ``(valid, problems)``.
+
+        One canonical directory traversal applies schema, known-roster, and
+        (when enforced) signature validation.  ``problems`` also includes a
+        ``publication_ordered_message_absent`` entry for every durable order id
+        whose canonical message file is absent.  That reverse-history gap is
+        reported but never auto-healed.
+
+        Problem dictionaries have exactly ``id``, ``path``, and ``reason``.
+        Reasons are stable machine-readable codes; paths use the host platform's
+        native representation.  ``since_id`` is an exclusive incremental slice,
+        so completeness/integrity consumers should leave it as ``None``.
+        """
+        # send() durably reserves an order entry immediately before publishing
+        # its file under this lock.  Covering BOTH the traversal and order read
+        # prevents that legitimate interval from looking like deleted history.
+        # Retirement uses the same outer lock ordering, so roster removal cannot
+        # race the gate and manufacture a mixed-roster snapshot.
+        with self._retirement_lock(), self._message_publication_lock():
+            valid, problems, present_stems = self._validated_message_snapshot(
+                since_id=since_id,
+                collect_problems=True,
+            )
+            order = self._read_message_publication_order()
+            if order is None:
+                return valid, problems
+            ordered_ids = sorted(
+                order["messages"],
+                key=order["messages"].__getitem__,
+            )
+            for message_id in ordered_ids:
+                if since_id is not None and message_id <= since_id:
+                    continue
+                if message_id in present_stems:
+                    continue
+                problems.append(
+                    {
+                        "id": message_id,
+                        "path": str(self.messages_dir / f"{message_id}.json"),
+                        "reason": "publication_ordered_message_absent",
+                    }
+                )
+            return valid, problems
+
     def _validated_messages(self, *, since_id: str | None = None) -> list[Message]:
         """Shared trust gate behind ``messages_for`` and ``valid_messages``.
 
@@ -3890,63 +4053,11 @@ class Store:
         ``valid_messages`` MUST keep the default ``None`` (full log) —
         epoch / thread / rescind derivation reads the whole history.
         """
-        try:
-            cfg = self.load_config()
-            # D3 (#19): validate history against the KNOWN roster (active ∪
-            # retired) so a retired identity's past messages stay valid.
-            roster = self._known_roster(cfg)
-        except (ValueError, OSError, FileNotFoundError):
-            roster = []
-        if not roster:
-            # Fail CLOSED: a missing/corrupt roster (load_config raised, or an
-            # empty agents list) means there are no valid senders/recipients,
-            # so deliver NOTHING — rather than fall through to Message.validate's
-            # empty-roster fail-open and deliver forged/off-roster messages
-            # (review L). CLI delivery commands already abort earlier on a
-            # corrupt config; this makes the store-level contract explicit.
-            return []
-        require_sig = self.signing_enforced()
-        project_id = self.project_id() if require_sig else None
-        key: bytes | None = None
-        if require_sig:
-            try:
-                key = _signing.load_key(project_id)
-            except (FileNotFoundError, OSError, ValueError):
-                key = None  # key vanished between check and load — refuse
-        valid, _ = self._scan_messages(since_id=since_id)
-        out: list[Message] = []
-        for m in valid:
-            try:
-                m.validate(roster)
-            except ValueError:
-                continue
-            if require_sig:
-                if key is None:
-                    continue  # policy on but no key — refuse everything
-                try:
-                    _signing.verify_message(
-                        m.to_dict(), key, expected_key_id=project_id,
-                    )
-                except ValueError:
-                    continue
-            out.append(m)
-        # Restore the documented "sorted by id (chronological)" contract:
-        # _scan_messages_with_paths yields raw filesystem-iteration (filename)
-        # order, which equals id order ONLY because stem==id is now enforced
-        # above. Sort explicitly so delivery, cursor advance, and thread
-        # replay are correct even if that invariant is ever relaxed (review H1).
-        out.sort(key=lambda m: m.id)
-        # Defensive dedupe by id: stem==id + unique filenames make duplicate
-        # ids structurally impossible today, but double-delivery would be a
-        # silent correctness bug if that ever changed, so guard it cheaply.
-        deduped: list[Message] = []
-        seen_ids: set[str] = set()
-        for m in out:
-            if m.id in seen_ids:
-                continue
-            seen_ids.add(m.id)
-            deduped.append(m)
-        return deduped
+        valid, _, _ = self._validated_message_snapshot(
+            since_id=since_id,
+            collect_problems=False,
+        )
+        return valid
 
     def current_epoch(self) -> str | None:
         """The global epoch id = the message id of the latest validated global

--- a/tests/test_store_validation_snapshot.py
+++ b/tests/test_store_validation_snapshot.py
@@ -1,0 +1,145 @@
+"""Fail-closed validation snapshot coverage (GH #44)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agenttalk import signing
+from agenttalk.store import Store
+
+
+def _message_path(store: Store, message_id: str) -> Path:
+    return store.messages_dir / f"{message_id}.json"
+
+
+def test_snapshot_reports_schema_reject_without_changing_valid_messages(
+    store: Store,
+) -> None:
+    opener = store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="review-request",
+        body="review this",
+        meta={"request_id": "r-schema"},
+    )
+    rejection = store.send(
+        sender="beta",
+        recipient="alpha",
+        kind="review-result",
+        body="blocking finding",
+        meta={"request_id": "r-schema", "status": "rejected"},
+    )
+    rejection_path = _message_path(store, rejection.id)
+    raw = json.loads(rejection_path.read_text(encoding="utf-8"))
+    raw["body"] = 17
+    rejection_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    before = store.valid_messages()
+    valid, problems = store.validated_messages_with_problems()
+    after = store.valid_messages()
+
+    assert [message.id for message in before] == [opener.id]
+    assert valid == before == after
+    assert problems == [
+        {
+            "id": rejection.id,
+            "path": str(rejection_path),
+            "reason": "message_schema_invalid",
+        }
+    ]
+
+
+def test_snapshot_reports_sender_removed_from_roster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTALK_HMAC_KEY_FILE", str(tmp_path / "signing.key"))
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    signing.init_key(store.project_id())
+    message = store.send(sender="alpha", recipient="beta", body="signed history")
+    store.remove_agent("alpha")
+
+    valid, problems = store.validated_messages_with_problems()
+
+    assert valid == []
+    assert problems == [
+        {
+            "id": message.id,
+            "path": str(_message_path(store, message.id)),
+            "reason": "message_roster_invalid",
+        }
+    ]
+    assert store.valid_messages() == []
+
+
+def test_snapshot_reports_unsigned_message_when_signing_becomes_enforced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTALK_HMAC_KEY_FILE", str(tmp_path / "signing.key"))
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    message = store.send(sender="alpha", recipient="beta", body="legacy unsigned")
+    signing.init_key(store.project_id())
+
+    valid, problems = store.validated_messages_with_problems()
+
+    assert valid == []
+    assert problems == [
+        {
+            "id": message.id,
+            "path": str(_message_path(store, message.id)),
+            "reason": "message_signature_invalid",
+        }
+    ]
+    assert store.valid_messages() == []
+
+
+def test_snapshot_surfaces_ordered_but_absent_without_healing(store: Store) -> None:
+    survivor = store.send(sender="alpha", recipient="beta", body="keep")
+    deleted = store.send(sender="beta", recipient="alpha", body="delete")
+    deleted_path = _message_path(store, deleted.id)
+    order_before = store._message_publication_order_path.read_bytes()
+    anchor_before = store._message_publication_order_anchor_path.read_bytes()
+    deleted_path.unlink()
+
+    valid, problems = store.validated_messages_with_problems()
+
+    assert [message.id for message in valid] == [survivor.id]
+    assert problems == [
+        {
+            "id": deleted.id,
+            "path": str(deleted_path),
+            "reason": "publication_ordered_message_absent",
+        }
+    ]
+    assert store._message_publication_order_path.read_bytes() == order_before
+    assert store._message_publication_order_anchor_path.read_bytes() == anchor_before
+
+
+def test_snapshot_uses_one_canonical_message_traversal(
+    store: Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store.send(sender="alpha", recipient="beta", body="one walk")
+    original = store._scan_messages_with_paths
+    call_count = 0
+
+    def counted_scan(
+        *, since_id: str | None = None,
+    ) -> tuple[list[tuple[object, Path]], list[tuple[Path, str, str]]]:
+        nonlocal call_count
+        call_count += 1
+        return original(since_id=since_id)
+
+    monkeypatch.setattr(store, "_scan_messages_with_paths", counted_scan)
+
+    valid, problems = store.validated_messages_with_problems()
+
+    assert len(valid) == 1
+    assert problems == []
+    assert call_count == 1


### PR DESCRIPTION
## GH #44 — Store full-validation snapshot + ordered-but-absent detection

Producer half of the second team's amendment-#15 fail-open fix (they hold review-links non-advancing until this capability lands). Closes the fail-OPEN where `_validated_messages` silently drops a message failing validation, so a consumer cannot tell a clean thread from one where a rejecting review-result was dropped.

**New public API:** `Store.validated_messages_with_problems(*, since_id=None) -> (valid, problems)` — valid + rejected-present + publication-ordered-but-absent from ONE traversal, under the send lock ordering (retirement→publication) so a reserve-before-publish interval can't look like deleted history. 9 stable typed reason codes; deletion is reported, never auto-healed. `valid_messages()`/`messages_for()` behavior unchanged (thin wrapper over the shared snapshot; no-roster fail-closed preserved).

**Reviews:** independent bus review by claude-remediation-reviewer (rq-ce9d384a7ce0) in flight; lead read the diff (LGTM, 2 minor non-blocking notes: startswith reason-mapping is slightly fragile; full scan briefly holds the publication lock).

**Gated (codex-2, both interpreters):** py3.10 + py3.14 each 503 passed / 6 skipped; focused GH#44 5 passed each; ruff + bandit clean; git diff --check clean. Coverage: schema-corrupt rejecting result, roster-removed signer, unsigned-after-enforcement, unchanged valid_messages, one traversal, deleted-ordered-id (sidecar byte-identical, no heal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
