### PR TITLE
fix(#41/GH#35): deadman config in supervisor.json is silently inert

### DIFF
--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -148,6 +148,9 @@ def run(project_root: Path | None = None) -> Report:
             report.checks.append(esc_target)
         report.checks.append(_check_identity_registry(store))
         report.checks.append(_check_store_hygiene(store))
+        deadman_config = _check_deadman_config_source(store)
+        if deadman_config is not None:
+            report.checks.append(deadman_config)
         report.checks.extend(_check_skills())
         report.checks.append(_check_devkit())
         report.checks.append(_check_codex_config(root))
@@ -1139,6 +1142,33 @@ def _check_store_hygiene(store: Store) -> Check:
             data=data,
         )
     return Check(name="store_hygiene", status="ok", details="clean", data=data)
+
+
+def _check_deadman_config_source(store: Store) -> Check | None:
+    """Warn when deadman settings are placed in the ignored supervisor config."""
+    supervisor_path = store.dir / "supervisor.json"
+    try:
+        config = sup.load_supervisor_config(supervisor_path)
+    except (OSError, ValueError):
+        return None  # the supervisor config health checks own malformed files
+    if "deadman" not in config:
+        return None
+    return Check(
+        name="deadman_config_source",
+        status="warn",
+        details=(
+            "supervisor.json contains a deadman block that is ignored; "
+            "deadman config is read from config.json"
+        ),
+        fix=(
+            "move the deadman block to .agenttalk/config.json, then remove it "
+            "from .agenttalk/supervisor.json"
+        ),
+        data={
+            "ignored_path": str(supervisor_path),
+            "active_path": str(store.config_path),
+        },
+    )
 
 
 def _check_init(store: Store) -> Check:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -4691,7 +4691,6 @@ CONFIG_TEMPLATE = """\
   "_comment_max_readiness_retries": "After this many relaunches of an agent that NEVER reaches readiness (no first heartbeat - e.g. a manual resume that does not re-enter the listen loop), the supervisor STOPS relaunching and surfaces READINESS_GAVE_UP (warn/notify, no kill) instead of churning forever. Reset by a fresh heartbeat or an operator restart/clear. A WRAPPED agent avoids this class entirely (the wrapper owns the heartbeat regardless of the model prompt) - prefer wrapped for hands-off supervision.",
   "claude_permission_mode": "bypassPermissions",
   "backoff": { "base_seconds": 30, "cap_seconds": 900, "reset_after_seconds": 180 },
-  "deadman": { "mail_age_slo_seconds": 900, "alarm_unread_response": false },
   "notify_sender": null,
   "notify_to": null,
   "ephemeral_reviewers": {

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -40,6 +40,23 @@ def test_doctor_on_initialized_project_includes_all_check_categories(
     assert "heartbeat.beta" in names
 
 
+def test_doctor_warns_when_supervisor_deadman_config_is_ignored(tmp_path: Path) -> None:
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    (store.dir / "supervisor.json").write_text(
+        json.dumps({"deadman": {"mail_age_slo_seconds": 60}}),
+        encoding="utf-8",
+    )
+
+    report = doctor.run(tmp_path)
+
+    check = next(c for c in report.checks if c.name == "deadman_config_source")
+    assert check.status == "warn"
+    assert "supervisor.json contains a deadman block that is ignored" in check.details
+    assert "config.json" in check.details
+    assert ".agenttalk/config.json" in check.fix
+
+
 # ----- hmac check status mapping (review C*: doctor must NOT report a
 # degenerate/garbage key as enabled-OK; closes doctor.py 456-472) ------
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -4514,6 +4514,10 @@ def test_config_template_ships_wrapped_example() -> None:
     assert "RECOMMENDED" in w["_comment_wrapped"] and "LEGACY" in w["_comment_wrapped"]
 
 
+def test_config_template_keeps_deadman_out_of_supervisor_config() -> None:
+    assert "deadman" not in json.loads(sup.CONFIG_TEMPLATE)
+
+
 # ---------- per-CLI wrapped stuck_after defaults + the codex low-threshold guardrail
 
 def test_resolve_stuck_after_per_cli_defaults_and_override() -> None:


### PR DESCRIPTION
## Bug (GH #35)
An operator can put a `deadman` block in `.agenttalk/supervisor.json`, but deadman config is read from `.agenttalk/config.json` (`deadman.py` → `store.load_config()` → `cfg.get("deadman")`). The `supervisor.json` block is silently ignored — the two-sources-of-truth trap.

## Fix
- `config.json` stays the sole deadman owner; **remove** the stray `deadman` block from `supervisor.py` `CONFIG_TEMPLATE` (it was never consumed).
- Add a `doctor` check `deadman_config_source`: **WARN** when `supervisor.json` still contains a `deadman` block, with fix guidance + the ignored/active paths — so a misplaced block is *visible*, never silently dropped (graceful on malformed supervisor.json).
- Tests: `test_doctor_warns_when_supervisor_deadman_config_is_ignored` + `test_config_template_keeps_deadman_out_of_supervisor_config`.

## Gate (lead-reviewed + independently gated, py3.10 PYTHONPATH=src)
ruff clean; test_doctor + test_deadman + template tests = 88 pass. Built by codex-agenttalk-developer-5, plan-first, lead producer-checked the premise at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)