### PR TITLE
fix(#43/GH#36): domains.check_path silently accepts a glob descriptor

### DIFF
--- a/src/agenttalk/domains.py
+++ b/src/agenttalk/domains.py
@@ -179,6 +179,11 @@ def check_path(registry: dict[str, Any], path: str, *,
                casefold_paths: bool | None = None) -> dict[str, Any]:
     casefold = default_casefold_paths() if casefold_paths is None else casefold_paths
     display_path = normalize_repo_path(path)
+    if any(metachar in display_path for metachar in "*?["):
+        raise DomainError(
+            f"path {path!r} contains glob metacharacters; check_path needs a concrete "
+            "repo path; use glob_matches() for patterns"
+        )
     domains: list[str] = []
     for domain_id, domain in registry.get("domains", {}).items():
         if any(glob_matches(glob, display_path, casefold=casefold)

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -152,6 +152,27 @@ def test_check_path_can_casefold_globs(tmp_path: Path) -> None:
     assert "docs" in insensitive["domains"]
 
 
+@pytest.mark.parametrize("descriptor", [
+    "src/**/*.py",
+    "src/file?.py",
+    "src/[unterminated.py",
+])
+def test_check_path_rejects_glob_descriptors(
+    tmp_path: Path,
+    descriptor: str,
+) -> None:
+    root = _root(tmp_path)
+    registry = dom.validate_registry(_registry(), Store(root).load_config())
+
+    with pytest.raises(
+        dom.DomainError,
+        match="check_path needs a concrete repo path",
+    ) as exc_info:
+        dom.check_path(registry, descriptor, casefold_paths=False)
+
+    assert descriptor in str(exc_info.value)
+
+
 def test_domain_cli_validate_list_show_and_check_path_json(
     tmp_path: Path, capsys: pytest.CaptureFixture,
 ) -> None:
@@ -181,6 +202,20 @@ def test_domain_cli_validate_list_show_and_check_path_json(
     check_payload = json.loads(capsys.readouterr().out)
     assert check_payload["paths"][0]["overlap"] is True
     assert check_payload["paths"][1]["shared"] is True
+
+
+def test_domain_cli_check_path_rejects_glob_descriptor(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    root = _root(tmp_path)
+    _write_registry(root, _registry())
+
+    assert _run(["domain", "check-path", "src/**/*.py"], root) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "src/**/*.py" in captured.err
+    assert "check_path needs a concrete repo path" in captured.err
 
 
 def test_domain_cli_missing_registry_is_valid_empty(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Bug (GH #36)
`domains.check_path` is a POINT-membership primitive but silently accepts a glob (e.g. `src/agenttalk/**/*.py`), treating the pattern as a literal path and returning a misleading membership answer (reproduced: returns `owned=true`, exit 0).

## Fix
Fail closed at the core `check_path` boundary (after normalization, before point matching): if the path contains fnmatch metacharacters (`*`, `?`, `[`), raise `DomainError` naming the arg and pointing callers to `glob_matches()` for patterns. Single core guard covers every caller incl. the CLI. glob-aware callers unchanged.

## Gate (lead-reviewed + independently gated)
ruff clean; `test_domains.py` 13 pass, incl. new core + CLI glob-rejection regressions. Built by codex-agenttalk-developer-5, plan-first, reproduction served as the producer-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)