### PR TITLE
merge(#38): fold OVH gateway onto master (ends committed-vs-live divergence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ For operator-facing procedures and examples, use
 - [docs/ASSURANCE.md](docs/ASSURANCE.md) - release attestation and gate
   evidence.
 - [docs/ISSUES.md](docs/ISSUES.md) - living tracker.
+- [docs/QWEN-OVH-TRIAL.md](docs/QWEN-OVH-TRIAL.md) - operator runbook for
+  the watched, cooperative Qwen-on-OVH trial.
 - [CHANGELOG.md](CHANGELOG.md) - release history.
 - [SECURITY.md](SECURITY.md) - security posture and trust model.
 

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -20,6 +20,9 @@ hostile same-user process.
   4.32/M output tokens.
 - Maximum output: 4096 tokens; maximum input context: 262144 tokens.
 - Maximum one-attempt reservation: EUR 0.206439.
+- Maximum one wrapped child turn: 8 provider calls, EUR 0.50 of settled or
+  reserved exposure, and 300 seconds from its first durable opening. The first
+  reached ceiling closes that turn; later calls are refused before transport.
 - Trial cutoff: EUR 25; operator soft stop: EUR 20.
 - External account ceiling: EUR 100. Initialization and readiness require the
   operator-observed opening balance plus the EUR 25 trial cutoff plus one
@@ -34,8 +37,11 @@ or transport.
 
 ## Boundaries
 
-The public front accepts only an authenticated exact `POST /v1/messages` with
-the literal `Host: 127.0.0.1:4000`. It rejects missing or different Host,
+The public front accepts only an exact `POST /v1/messages` carrying a valid
+message-scoped child capability and the literal `Host: 127.0.0.1:4000`. The
+installation's front token authorizes capability issuance by the trusted
+wrapper controller; it does not authorize paid requests. The front rejects a
+static front token, a missing or different Host,
 every Origin header, every other path or method, excess body size, excess token
 limits, and concurrent work. The front never forwards `/health`, models,
 Chat Completions, admin, UI, docs, config, or key routes.
@@ -138,7 +144,11 @@ Claude executable tail:
 
 Do not add an `env` object to this entry. The profile constructs the child
 environment from an empty map, passes only the named safe OS and `AGENTTALK_*`
-variables, and injects the loopback URL and front token. It excludes ambient
+variables, and injects the loopback URL. Immediately before each real model
+spawn, the trusted wrapper binds the immutable inbound message ID to a durable
+turn and replaces the controller-only front token with that turn's opaque
+capability. Executable preflight and the model child never receive the issuer
+token. The profile excludes ambient
 `ANTHROPIC_API_KEY`, `OVH_KEY`, and `ANTHROPIC_AUTH_TOKEN`. Every non-Qwen
 profile retains its prior environment behavior.
 
@@ -156,12 +166,28 @@ supervisor environment. A failed readiness check creates the normal durable
 
 ## Spend and Failure Semantics
 
-Before the single provider transport, SQLite `BEGIN IMMEDIATE` durably records
-a unique attempt reservation. SQLite `synchronous=FULL` commit is the sole
+Before every provider transport, SQLite `BEGIN IMMEDIATE` durably records
+a unique attempt reservation and consumes the next slot in the same child-turn
+transaction. A reservation rejected by the call, cost, or wall-time ceiling
+does not create a provider attempt. Replaying or restarting the same immutable
+message reuses its original durable turn bucket. SQLite `synchronous=FULL`
+commit is the sole
 transaction durability authority; there is no fallible second flush after a
 committed terminal transition. Admission counts committed spend plus every
 unresolved reservation. The concurrency permit remains held through settlement
 or durable hold.
+
+`ovh-qwen` does not support `wrap --lead-loop`. Cadence turns have no immutable
+inbound message scope, so the wrapper and supervisor bootstrap check reject
+that combination instead of launching an uncapped child.
+
+For an existing schema-v1 trial ledger, keep a manual hold in place, reconcile
+every unresolved attempt, and run `agenttalk gateway cap-install` from the
+cap-aware build before enabling worker spend. The migration binds the current
+front token as the issuer, advances both the ledger and install marker to
+schema v2, and is retryable if marker projection fails after the database
+commit. Schema-v1 gateway code rejects the migrated ledger, which prevents a
+rollback to static-token paid admission.
 
 A complete response with exact-model, present, positive integer token usage is
 settled to the original UTC admission period. Missing or invalid usage,

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -48,10 +48,12 @@ Both ports are bound to literal IPv4 `127.0.0.1`; neither uses `localhost`,
 `0.0.0.0`, or `::`.
 
 `store: false` is forced in the generated single-deployment config. Telemetry
-is disabled, there is no spend/success callback, and the managed runner sends
-LiteLLM stdout and stderr to `DEVNULL` rather than retaining its access or error
-output. Stable gateway errors do not include raw upstream bodies,
-Authorization values, the internal URL, or tokens.
+is disabled and there is no spend/success callback. The managed runner combines
+LiteLLM stdout and stderr into a redacted rotating log at
+`%LOCALAPPDATA%\agenttalk-ovh\gateway\litellm.log`. The current log and two
+backups are each capped at 1 MiB. Stable gateway errors and retained diagnostics
+do not include raw upstream bodies, Authorization values, the internal URL, or
+known key/token values.
 
 ## One-Time Morning Setup
 
@@ -88,10 +90,21 @@ or AgentTalk messages.
    ```
 
 The task name is derived from canonical project identity. Installation is
-idempotent for an exact match and refuses a foreign or mismatched task. Startup
-verifies the task, manifest, config hash, ledger, runtime process identity,
-both binds, a no-secret negative-auth public-front probe, and internal
-liveliness before reporting ready.
+idempotent for an exact match and refuses a foreign or mismatched task. The
+executable, arguments, and working directory must round-trip exactly; the
+current-user principal is compared by resolved Windows SID because Task
+Scheduler normalizes account names to SIDs. The Scheduled Task is required for
+operational and worker readiness; direct `gateway run` is not a supported
+worker launch mode. Startup allows LiteLLM up to 120 seconds to become live on
+a cold boot, but fails immediately if the child exits. It then verifies the
+manifest, config hash, ledger, runtime process identity, both binds, a no-secret
+negative-auth public-front probe, and internal liveliness before reporting
+ready.
+
+The non-secret LiteLLM config, task identity, install manifest, and runtime
+marker intentionally live in the project's gitignored `.agenttalk/gateway`
+directory. The provider key, gateway tokens, spend ledger, and bounded child
+log remain under `%LOCALAPPDATA%\agenttalk-ovh`.
 Status and doctor use only the local liveliness route; they do not call OVH or
 spend money.
 

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -133,11 +133,13 @@ The profile also forces `CLAUDE_CONFIG_DIR` to the disposable clone's
 `.agenttalk/gateway/claude-profile` directory. It never inherits the operator's
 `HOME`, `USERPROFILE`, or ambient Claude profile path.
 
-`wrap --loop` refuses to launch this worker unless the gateway is fully ready,
-the roster and supervisor trust classes agree, the model and CLI are pinned,
-and provider keys are absent from the supervisor environment. A failed
-readiness check creates the normal durable `config_blocked` hold before any
-message is consumed.
+Gateway operational readiness remains available before the live canary so the
+operator can run that canary. `wrap --loop` separately requires worker/spend
+readiness: the accounting ledger must be ready and its policy-bound dashboard
+canary must be accepted. The roster and supervisor trust classes must also
+agree, the model and CLI are pinned, and provider keys are absent from the
+supervisor environment. A failed readiness check creates the normal durable
+`config_blocked` hold before any message is consumed.
 
 ## Spend and Failure Semantics
 
@@ -176,7 +178,9 @@ agenttalk gateway hold --reason "dashboard mismatch"
 agenttalk gateway clear-hold --reason "operator reconciled mismatch"
 ```
 
-Clearing a manual hold is refused while any attempt remains unresolved.
+Clearing a manual hold is refused while any attempt remains unresolved. Clearing
+a dashboard mismatch hold does not admit a worker while the persisted canary is
+still absent or mismatched; a fresh accepted canary is required.
 
 ## Stop and Recovery
 

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -1,0 +1,194 @@
+# Watched Qwen-on-OVH Trial
+
+Audience: the operator and non-Qwen lead running the short Qwen build trial on
+Windows.
+
+This is a **same-user cooperative trial**. It is not process isolation or
+secret isolation. A process deliberately acting as the same Windows user can
+read or modify the gateway state, tokens, key, or spend ledger. The controls
+below bound accidental and crash-driven use; they do not defend against a
+hostile same-user process.
+
+## Fixed Trial Policy
+
+- Provider route: Claude Code -> `127.0.0.1:4000` -> LiteLLM on
+  `127.0.0.1:4001` -> OVH OpenAI Chat Completions.
+- Model: `Qwen3.5-397B-A17B` only.
+- Settlement rates: EUR 0.71/M input tokens and EUR 4.25/M output tokens.
+- Reservation rates: EUR 0.852/M input tokens and EUR 5.10/M output tokens.
+- Maximum output: 4096 tokens; maximum input context: 262144 tokens.
+- Maximum one-attempt reservation: EUR 0.244237.
+- Trial cutoff: EUR 25; operator soft stop: EUR 20.
+- Provider attempts: one. LiteLLM, router, and front retries are disabled.
+
+The policy hash is persisted in the install marker, ledger, config manifest,
+runtime marker, readiness result, and status output. A mismatch blocks startup
+or transport.
+
+## Boundaries
+
+The public front accepts only an authenticated exact `POST /v1/messages` with
+the literal `Host: 127.0.0.1:4000`. It rejects missing or different Host,
+every Origin header, every other path or method, excess body size, excess token
+limits, and concurrent work. The front never forwards `/health`, models,
+Chat Completions, admin, UI, docs, config, or key routes.
+
+LiteLLM's wider API remains present on the separate internal loopback port. It
+is not forwarded by the front; model and administration routes require the
+internal LiteLLM master key, while LiteLLM's liveliness route may remain
+unauthenticated. That internal key has full control over this LiteLLM instance.
+Both ports are bound to literal IPv4 `127.0.0.1`; neither uses `localhost`,
+`0.0.0.0`, or `::`.
+
+`store: false` is forced in the generated single-deployment config. Telemetry
+is disabled, there is no spend/success callback, and the managed runner sends
+LiteLLM stdout and stderr to `DEVNULL` rather than retaining its access or error
+output. Stable gateway errors do not include raw upstream bodies,
+Authorization values, the internal URL, or tokens.
+
+## One-Time Morning Setup
+
+Do these steps only with the operator present. Do not put the OVH key in the
+repository, `.agenttalk`, `supervisor.json`, argv, logs, status, doctor output,
+or AgentTalk messages.
+
+1. Verify `OVH_KEY` and `ANTHROPIC_API_KEY` are absent from the shell that will
+   start the supervisor.
+2. Put the OVH key at
+   `%LOCALAPPDATA%\agenttalk-ovh\api_key.txt`. The gateway runner alone reads
+   it and passes it to LiteLLM through the child environment.
+3. Initialize the ledger, config, tokens, and install manifest once:
+
+   ```powershell
+   agenttalk gateway init --litellm-executable C:\path\to\litellm.exe
+   ```
+
+   Initialization is explicit and one-time. Service startup never creates or
+   resets a missing ledger. A partial, corrupt, deleted, rolled-back, or
+   policy-mismatched ledger blocks startup.
+
+4. Install the project-scoped current-user Scheduled Task, then start it:
+
+   ```powershell
+   agenttalk gateway task-install
+   agenttalk gateway start
+   agenttalk gateway status
+   agenttalk doctor
+   ```
+
+The task name is derived from canonical project identity. Installation is
+idempotent for an exact match and refuses a foreign or mismatched task. Startup
+verifies the task, manifest, config hash, ledger, runtime process identity,
+both binds, a no-secret negative-auth public-front probe, and internal
+liveliness before reporting ready.
+Status and doctor use only the local liveliness route; they do not call OVH or
+spend money.
+
+## Wrapped Worker Configuration
+
+Add the worker to the roster with non-authority metadata:
+
+```powershell
+agenttalk roster add qwen-dev-1 --trust-class external-worker
+```
+
+If it already exists:
+
+```powershell
+agenttalk roster set-trust-class qwen-dev-1 external-worker
+```
+
+Merge these fields into the generated wrapped-Claude entry in
+`.agenttalk/supervisor.json`; keep its normal Python wrapper launch and real
+Claude executable tail:
+
+```json
+{
+  "cli": "claude",
+  "wrapped": true,
+  "model": "Qwen3.5-397B-A17B",
+  "backend_profile": "ovh-qwen",
+  "trust_class": "external-worker"
+}
+```
+
+Do not add an `env` object to this entry. The profile constructs the child
+environment from an empty map, passes only the named safe OS and `AGENTTALK_*`
+variables, and injects the loopback URL and front token. It excludes ambient
+`ANTHROPIC_API_KEY`, `OVH_KEY`, and `ANTHROPIC_AUTH_TOKEN`. Every non-Qwen
+profile retains its prior environment behavior.
+
+`wrap --loop` refuses to launch this worker unless the gateway is fully ready,
+the roster and supervisor trust classes agree, the model and CLI are pinned,
+and provider keys are absent from the supervisor environment. A failed
+readiness check creates the normal durable `config_blocked` hold before any
+message is consumed.
+
+## Spend and Failure Semantics
+
+Before the single provider transport, SQLite `BEGIN IMMEDIATE` durably records
+a unique attempt reservation and flushes it. Admission counts committed spend
+plus every unresolved reservation. The concurrency permit remains held through
+settlement or durable hold.
+
+A complete response with exact-model, present, positive integer token usage is
+settled to the original UTC admission period. Missing or invalid usage,
+provider failure after possible send, timeout, stream cancellation, client
+disconnect, callback/settlement error, or process crash retains the full
+reservation and blocks restart and later calls. Reservations never clear at a
+month boundary. Clock rollback and impossible period jumps block the ledger.
+
+Inspect the attempt and reconcile only from provider/dashboard evidence:
+
+```powershell
+agenttalk gateway status
+agenttalk gateway reconcile ATTEMPT_ID --outcome no-send --reason "provider confirms no request"
+agenttalk gateway reconcile ATTEMPT_ID --outcome charge-actual --actual-micro-eur 1234 --reason "OVH dashboard evidence"
+agenttalk gateway reconcile ATTEMPT_ID --outcome charge-reserve --reason "charge remains uncertain"
+```
+
+Use a service hold when the live canary or dashboard does not match the pinned
+price policy:
+
+```powershell
+agenttalk gateway hold --reason "dashboard mismatch"
+agenttalk gateway clear-hold --reason "operator reconciled mismatch"
+```
+
+Clearing a manual hold is refused while any attempt remains unresolved.
+
+## Stop and Recovery
+
+```powershell
+agenttalk gateway stop --timeout 30
+```
+
+Stop uses `.agenttalk/gateway/gateway.kill`, the same actions-disabled
+convention as the supervisor. It rejects new work, drains for a bounded period,
+and lets the runner terminate its verified LiteLLM child. If bounded drain
+expires, Task Scheduler ends the runner; stop then requires the runtime marker
+to be gone and both exact sockets to be bindable, and reports an error instead
+of claiming success if an orphan remains. It never kills a process merely
+because it owns a port. Task restart is bounded to three attempts at one-minute
+intervals; persistent configuration, authentication, policy, and ledger
+failures remain stopped and visible after that ceiling.
+
+## Governance
+
+`external-worker` is worker and breadth-review evidence only. It must never be
+lead, operator-facing, a Tier-3 reviewer, release actor, close/signoff/shared
+path approver, or counted quorum. Roster mutations prevent assigning lead,
+operator-facing, or signoff-candidate eligibility to this trust class.
+
+For this watched trial, the non-Qwen lead additionally controls reviewer
+selection. Every Qwen-built final SHA requires two distinct non-Qwen,
+cross-family reviewers plus the non-Qwen lead. Keep the worker in a disposable
+clone with no push, merge, release, GitHub, or OVH credentials and only
+reversible work.
+
+## Live Acceptance
+
+The live acceptance step is deliberately not part of automated tests. With the
+operator watching the OVH dashboard, run one streamed Claude Code
+Read/Edit/Read turn, verify the exact model and ledger settlement against OVH,
+and place a durable hold on any mismatch before launching the wrapped worker.

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -14,14 +14,18 @@ hostile same-user process.
 - Provider route: Claude Code -> `127.0.0.1:4000` -> LiteLLM on
   `127.0.0.1:4001` -> OVH OpenAI Chat Completions.
 - Model: `Qwen3.5-397B-A17B` only.
-- Settlement rates: EUR 0.71/M input tokens and EUR 4.25/M output tokens.
-- Reservation rates: EUR 0.852/M input tokens and EUR 5.10/M output tokens.
+- Settlement rates: OVH's EUR tariff, EUR 0.60/M input tokens and EUR 3.60/M
+  output tokens.
+- Reservation rates: the tariff plus 20%, EUR 0.72/M input tokens and EUR
+  4.32/M output tokens.
 - Maximum output: 4096 tokens; maximum input context: 262144 tokens.
-- Maximum one-attempt reservation: EUR 0.244237.
+- Maximum one-attempt reservation: EUR 0.206439.
 - Trial cutoff: EUR 25; operator soft stop: EUR 20.
 - External account ceiling: EUR 100. Initialization and readiness require the
   operator-observed opening balance plus the EUR 25 trial cutoff plus one
-  maximum reservation to remain within this ceiling.
+  maximum reservation to remain within this ceiling. Every admission also
+  checks cumulative committed spend across all UTC periods plus unresolved
+  reservations against the same EUR 100 ceiling.
 - Provider attempts: one. LiteLLM, router, and front retries are disabled.
 
 The policy hash is persisted in the install marker, ledger, config manifest,
@@ -125,6 +129,10 @@ variables, and injects the loopback URL and front token. It excludes ambient
 `ANTHROPIC_API_KEY`, `OVH_KEY`, and `ANTHROPIC_AUTH_TOKEN`. Every non-Qwen
 profile retains its prior environment behavior.
 
+The profile also forces `CLAUDE_CONFIG_DIR` to the disposable clone's
+`.agenttalk/gateway/claude-profile` directory. It never inherits the operator's
+`HOME`, `USERPROFILE`, or ambient Claude profile path.
+
 `wrap --loop` refuses to launch this worker unless the gateway is fully ready,
 the roster and supervisor trust classes agree, the model and CLI are pinned,
 and provider keys are absent from the supervisor environment. A failed
@@ -134,9 +142,11 @@ message is consumed.
 ## Spend and Failure Semantics
 
 Before the single provider transport, SQLite `BEGIN IMMEDIATE` durably records
-a unique attempt reservation and flushes it. Admission counts committed spend
-plus every unresolved reservation. The concurrency permit remains held through
-settlement or durable hold.
+a unique attempt reservation. SQLite `synchronous=FULL` commit is the sole
+transaction durability authority; there is no fallible second flush after a
+committed terminal transition. Admission counts committed spend plus every
+unresolved reservation. The concurrency permit remains held through settlement
+or durable hold.
 
 A complete response with exact-model, present, positive integer token usage is
 settled to the original UTC admission period. Missing or invalid usage,
@@ -190,6 +200,9 @@ failures remain stopped and visible after that ceiling.
 lead, operator-facing, a Tier-3 reviewer, release actor, close/signoff/shared
 path approver, or counted quorum. Roster mutations prevent assigning lead,
 operator-facing, or signoff-candidate eligibility to this trust class.
+External-worker trust is sticky: removal creates a permanent non-rebindable
+tombstone, rename carries the trust class, and `init --force` cannot silently
+reclassify or resurrect the identity.
 
 For this watched trial, the non-Qwen lead additionally controls reviewer
 selection. Every Qwen-built final SHA requires two distinct non-Qwen,
@@ -201,5 +214,15 @@ reversible work.
 
 The live acceptance step is deliberately not part of automated tests. With the
 operator watching the OVH dashboard, run one streamed Claude Code
-Read/Edit/Read turn, verify the exact model and ledger settlement against OVH,
-and place a durable hold on any mismatch before launching the wrapped worker.
+Read/Edit/Read turn, then enforce the observed nonzero dashboard delta against
+the settled attempt:
+
+```powershell
+agenttalk gateway canary-verify ATTEMPT_ID --dashboard-delta-eur OBSERVED_DELTA
+```
+
+The delta must be nonzero and within 10% of the ledger's tariff-derived
+settlement. The deterministic 1000-input/100-output fixture settles to 960
+micro-EUR, so its tolerance is 96 micro-EUR. The command persists the numeric
+comparison; zero or out-of-tolerance deltas set a durable
+`dashboard_canary_mismatch` hold and return nonzero before the worker launches.

--- a/docs/QWEN-OVH-TRIAL.md
+++ b/docs/QWEN-OVH-TRIAL.md
@@ -19,6 +19,9 @@ hostile same-user process.
 - Maximum output: 4096 tokens; maximum input context: 262144 tokens.
 - Maximum one-attempt reservation: EUR 0.244237.
 - Trial cutoff: EUR 25; operator soft stop: EUR 20.
+- External account ceiling: EUR 100. Initialization and readiness require the
+  operator-observed opening balance plus the EUR 25 trial cutoff plus one
+  maximum reservation to remain within this ceiling.
 - Provider attempts: one. LiteLLM, router, and front retries are disabled.
 
 The policy hash is persisted in the install marker, ledger, config manifest,
@@ -60,12 +63,16 @@ or AgentTalk messages.
 3. Initialize the ledger, config, tokens, and install manifest once:
 
    ```powershell
-   agenttalk gateway init --litellm-executable C:\path\to\litellm.exe
+   agenttalk gateway init --litellm-executable C:\path\to\litellm.exe `
+     --opening-eur 0.58 `
+     --opening-evidence "OVH AI Endpoints dashboard, observed 2026-07-16 morning"
    ```
 
    Initialization is explicit and one-time. Service startup never creates or
    resets a missing ledger. A partial, corrupt, deleted, rolled-back, or
-   policy-mismatched ledger blocks startup.
+   policy-mismatched ledger blocks startup. The first billing period is seeded
+   with the operator-provided month-to-date opening balance; status and doctor
+   surface its amount, evidence, observation timestamp, and period.
 
 4. Install the project-scoped current-user Scheduled Task, then start it:
 
@@ -143,9 +150,13 @@ Inspect the attempt and reconcile only from provider/dashboard evidence:
 ```powershell
 agenttalk gateway status
 agenttalk gateway reconcile ATTEMPT_ID --outcome no-send --reason "provider confirms no request"
-agenttalk gateway reconcile ATTEMPT_ID --outcome charge-actual --actual-micro-eur 1234 --reason "OVH dashboard evidence"
 agenttalk gateway reconcile ATTEMPT_ID --outcome charge-reserve --reason "charge remains uncertain"
 ```
+
+`no-send` requires recorded provider evidence and cannot erase an already
+recorded charge. `charge-reserve` commits the full conservative reservation.
+The reconciliation surface never accepts a caller-supplied actual cost; valid
+terminal usage settles automatically from the completed provider response.
 
 Use a service hold when the live canary or dashboard does not match the pinned
 price policy:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -17,6 +17,7 @@ import time
 import uuid
 import webbrowser
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, DecimalException
 from pathlib import Path
 
 from agenttalk import __version__
@@ -116,6 +117,21 @@ def _finite_float_arg(value: str) -> float:
     if not math.isfinite(parsed):
         raise argparse.ArgumentTypeError("must be a finite number")
     return parsed
+
+
+def _micro_eur_arg(value: str) -> int:
+    if len(value) > 64:
+        raise argparse.ArgumentTypeError("must be a non-negative EUR amount")
+    try:
+        parsed = Decimal(value)
+        micro_eur = parsed * Decimal(1_000_000)
+    except (DecimalException, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative EUR amount") from exc
+    if not parsed.is_finite() or parsed < 0 or micro_eur != micro_eur.to_integral_value():
+        raise argparse.ArgumentTypeError(
+            "must be a non-negative EUR amount with at most six decimal places"
+        )
+    return int(micro_eur)
 
 
 def _parse_meta(items: list[str] | None) -> dict:
@@ -7998,6 +8014,8 @@ def cmd_gateway(args: argparse.Namespace) -> int:
             result = service.initialize_install(
                 store.root,
                 litellm_executable=args.litellm_executable,
+                opening_micro_eur=args.opening_micro_eur,
+                opening_evidence=args.opening_evidence,
             )
         elif action == "task-install":
             service.load_install_manifest(store.root)
@@ -8013,7 +8031,6 @@ def cmd_gateway(args: argparse.Namespace) -> int:
                 args.attempt_id,
                 outcome=args.outcome,
                 reason=args.reason,
-                actual_micro_eur=args.actual_micro_eur,
             )
         elif action == "hold":
             result = gateway.SpendLedger().place_hold(reason=args.reason)
@@ -12970,6 +12987,18 @@ def build_parser() -> argparse.ArgumentParser:
     gwsub = pgw.add_subparsers(dest="gateway_action", required=True)
     gw_init = gwsub.add_parser("init", help="One-time ledger/config/token initialization.")
     gw_init.add_argument("--litellm-executable", required=True)
+    gw_init.add_argument(
+        "--opening-eur",
+        dest="opening_micro_eur",
+        type=_micro_eur_arg,
+        required=True,
+        help="Current OVH month-to-date spend in EUR (up to six decimal places).",
+    )
+    gw_init.add_argument(
+        "--opening-evidence",
+        required=True,
+        help="Short source and observed-at description for the opening balance.",
+    )
     gw_init.set_defaults(func=cmd_gateway)
     gw_task = gwsub.add_parser("task-install", help="Install or verify the project task.")
     gw_task.set_defaults(func=cmd_gateway)
@@ -12987,11 +13016,10 @@ def build_parser() -> argparse.ArgumentParser:
     gw_reconcile.add_argument("attempt_id")
     gw_reconcile.add_argument(
         "--outcome",
-        choices=("no-send", "charge-actual", "charge-reserve"),
+        choices=("no-send", "charge-reserve"),
         required=True,
     )
     gw_reconcile.add_argument("--reason", required=True)
-    gw_reconcile.add_argument("--actual-micro-eur", type=int)
     gw_reconcile.set_defaults(func=cmd_gateway)
     gw_hold = gwsub.add_parser("hold", help="Durably block new provider transport.")
     gw_hold.add_argument("--reason", required=True)

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -9858,12 +9858,41 @@ def cmd_wrap(args: argparse.Namespace) -> int:
             try:
                 gateway = gateway_status(store.root)
             except (GatewayConfigError, OSError) as exc:
-                gateway = {"ready": False, "errors": [type(exc).__name__]}
-            if not gateway.get("ready"):
-                reasons = gateway.get("errors")
-                safe_reasons = ",".join(
-                    str(reason) for reason in reasons if isinstance(reason, str)
-                ) if isinstance(reasons, list) else "readiness_unavailable"
+                gateway = {
+                    "ready": False,
+                    "operational_ready": False,
+                    "worker_spend_ready": False,
+                    "errors": [type(exc).__name__],
+                    "worker_spend_errors": ["worker_spend_readiness_unavailable"],
+                }
+            operational_ready = (
+                gateway.get("operational_ready", gateway.get("ready")) is True
+            )
+            worker_spend_ready = gateway.get("worker_spend_ready") is True
+            if not operational_ready or not worker_spend_ready:
+                reasons: list[str] = []
+                if not operational_ready:
+                    operational_errors = gateway.get("errors")
+                    if isinstance(operational_errors, list):
+                        reasons.extend(
+                            reason
+                            for reason in operational_errors
+                            if isinstance(reason, str)
+                        )
+                if not worker_spend_ready:
+                    worker_errors = gateway.get("worker_spend_errors")
+                    safe_worker_errors = (
+                        [reason for reason in worker_errors if isinstance(reason, str)]
+                        if isinstance(worker_errors, list)
+                        else []
+                    )
+                    if safe_worker_errors:
+                        reasons.extend(safe_worker_errors)
+                    else:
+                        reasons.append("worker_spend_readiness_unavailable")
+                if not reasons:
+                    reasons.append("readiness_unavailable")
+                safe_reasons = ",".join(dict.fromkeys(reasons))
                 summary = f"ovh-qwen gateway is not ready ({safe_reasons})"
                 mode = (
                     "lead-loop" if lead_loop else

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2164,45 +2164,6 @@ def _agent_groups(cfg: dict, agent: str) -> list[str]:
             if isinstance(members, list) and agent in members]
 
 
-def _merge_refsets(*refsets: dict) -> dict:
-    merged = {"agents": [], "groups": [], "roles": []}
-    for rs in refsets:
-        for key in merged:
-            merged[key].extend((rs or {}).get(key) or [])
-    return merged
-
-
-def _signoff_domain_refset(store, changed_paths: list[str]) -> dict:
-    """Additive ONLY: the union of matched owned-domain reviewers + matched
-    shared-path default_reviewers for the close's changed paths. Touching a domain
-    never mints a requirement; this only widens an existing set's candidates. Missing
-    registry = empty."""
-    merged = _merge_refsets()
-    if not changed_paths:
-        return merged
-    try:
-        reg = _load_domain_registry(store)
-        data = reg.data
-    except Exception:  # noqa: BLE001 - a broken registry must not crash close check
-        return merged
-    verdicts = dom.check_paths(data, changed_paths)
-    domains = data.get("domains", {})
-    shared = data.get("shared_paths", [])
-    matched_domains: set[str] = set()
-    matched_globs: set[str] = set()
-    for v in verdicts:
-        matched_domains.update(v.get("domains", []))
-        for sm in v.get("shared_paths", []):
-            matched_globs.add(sm.get("glob"))
-    parts = [merged]
-    for did in matched_domains:
-        parts.append(domains.get(did, {}).get("reviewers") or {})
-    for entry in shared:
-        if entry.get("glob") in matched_globs:
-            parts.append(entry.get("default_reviewers") or {})
-    return _merge_refsets(*parts)
-
-
 def _changed_paths_of(record: dict) -> list[str]:
     inv = record.get("risk_inventory") or []
     return sorted({p for e in inv if isinstance(e, dict)
@@ -2228,15 +2189,22 @@ def _build_signoff_eval(store, record: dict):
     cur_inv_hash = close_mod.risk_inventory_hash(inv)
     unmapped = (close_mod.derive_required_signoffs(policy, inv)["unmapped"]
                 if policy else [])
-    domain_refset = _signoff_domain_refset(store, _changed_paths_of(record))
+    domain_refset = close_mod.signoff_domain_refset(
+        store,
+        cfg,
+        _changed_paths_of(record),
+    )
     default_reviewers = ((policy or {}).get("defaults", {}) or {}).get("reviewers") or {}
     resolved: dict[str, list[str]] = {}
     for s in record["required_signoffs"]:
-        merged = _merge_refsets(
-            s.get("candidate_refset") or {},
-            default_reviewers if s.get("use_default_reviewers") else {},
-            domain_refset if s.get("include_domain_reviewers") else {})
-        resolved[s["id"]] = dom.resolve_refset(merged, cfg)
+        resolved[s["id"]] = close_mod.resolve_signoff_candidates(
+            cfg,
+            candidate_refset=s.get("candidate_refset") or {},
+            default_reviewers=default_reviewers,
+            use_default_reviewers=bool(s.get("use_default_reviewers")),
+            domain_refset=domain_refset,
+            include_domain_reviewers=bool(s.get("include_domain_reviewers")),
+        )
     return {"policy_present": policy is not None, "policy_error": None,
             "current_policy_hash": cur_policy_hash,
             "current_risk_inventory_hash": cur_inv_hash,
@@ -2325,15 +2293,18 @@ def _resolve_signoff_audit(store, policy, inv, record) -> dict:
     derived = close_mod.derive_required_signoffs(policy, inv)["signoffs"]
     changed = sorted({p for e in inv if isinstance(e, dict)
                       for p in (e.get("affected_paths") or [])})
-    domain_refset = _signoff_domain_refset(store, changed)
+    domain_refset = close_mod.signoff_domain_refset(store, cfg, changed)
     default_reviewers = ((policy or {}).get("defaults", {}) or {}).get("reviewers") or {}
     audit = {}
     for s in derived:
-        merged = _merge_refsets(
-            s.get("candidate_refset") or {},
-            default_reviewers if s.get("use_default_reviewers") else {},
-            domain_refset if s.get("include_domain_reviewers") else {})
-        audit[s["id"]] = dom.resolve_refset(merged, cfg)
+        audit[s["id"]] = close_mod.resolve_signoff_candidates(
+            cfg,
+            candidate_refset=s.get("candidate_refset") or {},
+            default_reviewers=default_reviewers,
+            use_default_reviewers=bool(s.get("use_default_reviewers")),
+            domain_refset=domain_refset,
+            include_domain_reviewers=bool(s.get("include_domain_reviewers")),
+        )
     return audit
 
 
@@ -8032,6 +8003,11 @@ def cmd_gateway(args: argparse.Namespace) -> int:
                 outcome=args.outcome,
                 reason=args.reason,
             )
+        elif action == "canary-verify":
+            result = gateway.SpendLedger().verify_dashboard_canary(
+                args.attempt_id,
+                observed_delta_micro_eur=args.dashboard_delta_micro_eur,
+            )
         elif action == "hold":
             result = gateway.SpendLedger().place_hold(reason=args.reason)
         elif action == "clear-hold":
@@ -8045,6 +8021,8 @@ def cmd_gateway(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     if action == "status" and not result.get("ready"):
+        return 2
+    if action == "canary-verify" and not result.get("accepted"):
         return 2
     return 0
 
@@ -9918,6 +9896,8 @@ def cmd_wrap(args: argparse.Namespace) -> int:
         backend_profile=backend_profile,
         profile_env=profile_env,
     )
+    if backend_profile == "ovh-qwen":
+        Path(child_env["CLAUDE_CONFIG_DIR"]).mkdir(parents=True, exist_ok=True)
     launch = wrapper_run.preflight_launch_runtime(
         argv, args.cli, launch_cwd, child_env)
     if launch.blocked:
@@ -13021,6 +13001,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     gw_reconcile.add_argument("--reason", required=True)
     gw_reconcile.set_defaults(func=cmd_gateway)
+    gw_canary = gwsub.add_parser(
+        "canary-verify",
+        help="Compare one settled attempt with the operator-observed dashboard delta.",
+    )
+    gw_canary.add_argument("attempt_id")
+    gw_canary.add_argument(
+        "--dashboard-delta-eur",
+        dest="dashboard_delta_micro_eur",
+        type=_micro_eur_arg,
+        required=True,
+    )
+    gw_canary.set_defaults(func=cmd_gateway)
     gw_hold = gwsub.add_parser("hold", help="Durably block new provider transport.")
     gw_hold.add_argument("--reason", required=True)
     gw_hold.set_defaults(func=cmd_gateway)

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -8003,6 +8003,13 @@ def cmd_gateway(args: argparse.Namespace) -> int:
                 outcome=args.outcome,
                 reason=args.reason,
             )
+        elif action == "cap-install":
+            issuer_token = gateway.read_secret_file(
+                gateway.default_front_token_path()
+            )
+            result = gateway.SpendLedger().install_child_caps(
+                issuer_token=issuer_token
+            )
         elif action == "canary-verify":
             result = gateway.SpendLedger().verify_dashboard_canary(
                 args.attempt_id,
@@ -9816,6 +9823,12 @@ def cmd_wrap(args: argparse.Namespace) -> int:
             return 2
         backend_profile = raw_profile
         if backend_profile == "ovh-qwen":
+            if lead_loop:
+                sys.stderr.write(
+                    "agenttalk wrap: ovh-qwen does not support --lead-loop; "
+                    "cadence turns have no immutable inbound budget scope\n"
+                )
+                return 2
             from agenttalk.ovh_gateway import (
                 EXTERNAL_WORKER,
                 GatewayConfigError,
@@ -13030,6 +13043,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     gw_reconcile.add_argument("--reason", required=True)
     gw_reconcile.set_defaults(func=cmd_gateway)
+    gw_cap_install = gwsub.add_parser(
+        "cap-install",
+        help="Durably install or verify fail-closed per-child turn caps.",
+    )
+    gw_cap_install.set_defaults(func=cmd_gateway)
     gw_canary = gwsub.add_parser(
         "canary-verify",
         help="Compare one settled attempt with the operator-observed dashboard delta.",

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -6771,7 +6771,8 @@ def cmd_roster(args: argparse.Namespace) -> int:
                     f"Join as {suggested!r} instead (set $AGENTTALK_SELF to it).\n")
             return 3
         store.add_agent(name, role=getattr(args, "role", None),
-                        groups=getattr(args, "group", None))
+                        groups=getattr(args, "group", None),
+                        trust_class=getattr(args, "trust_class", None))
         if already and active:
             # plain (idempotent) add that re-binds a name a LIVE agent holds:
             # non-fatal warning (catches the rejoin/re-init-misuse path) - the
@@ -6856,6 +6857,16 @@ def cmd_roster(args: argparse.Namespace) -> int:
         store.set_group(args.group, members)
         print(f"roster: group '{args.group}' = {', '.join(members) or '(empty)'}")
         return 0
+    if action == "set-trust-class":
+        value = None if getattr(args, "clear", False) else args.trust_class
+        if value is None and not getattr(args, "clear", False):
+            sys.stderr.write(
+                "agenttalk roster set-trust-class: provide a trust class or --clear\n"
+            )
+            return 2
+        store.set_trust_class(args.name, value)
+        print(f"roster: {args.name} trust_class={value or '(native/default)'}")
+        return 0
     if action == "set-operator-facing":
         # Single-slot designation (#18): "two liaisons" is unrepresentable.
         # Advisory routing metadata only — never authorization (C-007).
@@ -6885,6 +6896,7 @@ def cmd_roster(args: argparse.Namespace) -> int:
     roster = cfg.get("agents", []) or []
     roles = cfg.get("roles", {}) or {}
     groups = cfg.get("groups", {}) or {}
+    trust_classes = cfg.get("trust_classes", {}) or {}
     liaison = store.operator_facing()
     self_name = os.environ.get("AGENTTALK_SELF")
     if self_name not in roster:
@@ -6894,6 +6906,7 @@ def cmd_roster(args: argparse.Namespace) -> int:
             "agents": roster,
             "roles": roles,
             "groups": groups,
+            "trust_classes": trust_classes,
             "operator_facing": liaison,
             "self": self_name,
         }, indent=2))
@@ -6905,7 +6918,8 @@ def cmd_roster(args: argparse.Namespace) -> int:
         member_of = [g for g, ms in groups.items() if a in ms]
         gl = ", ".join(member_of) if member_of else "-"
         of = "  [operator-facing]" if a == liaison else ""
-        print(f"  {a}{you}  role={role}  groups=[{gl}]{of}")
+        trust = trust_classes.get(a) or "native/default"
+        print(f"  {a}{you}  role={role}  trust={trust}  groups=[{gl}]{of}")
     if groups:
         print("groups:")
         for g, ms in groups.items():
@@ -7968,6 +7982,52 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # 2 = error (the user needs to fix something). Exit 1 is reserved
     # for `agenttalk wait` timeout per the published contract.
     if report.overall == "error":
+        return 2
+    return 0
+
+
+def cmd_gateway(args: argparse.Namespace) -> int:
+    """Manage the loopback-only watched OVH/Qwen trial gateway."""
+    from agenttalk import ovh_gateway as gateway
+    from agenttalk import ovh_gateway_service as service
+
+    store = _get_store(args)
+    action = args.gateway_action
+    try:
+        if action == "init":
+            result = service.initialize_install(
+                store.root,
+                litellm_executable=args.litellm_executable,
+            )
+        elif action == "task-install":
+            service.load_install_manifest(store.root)
+            result = service.install_task(store.root)
+        elif action == "start":
+            result = service.start_task(store.root)
+        elif action == "stop":
+            result = service.stop_task(store.root, timeout_seconds=args.timeout)
+        elif action == "run":
+            return service.run_service(store.root)
+        elif action == "reconcile":
+            result = gateway.SpendLedger().reconcile(
+                args.attempt_id,
+                outcome=args.outcome,
+                reason=args.reason,
+                actual_micro_eur=args.actual_micro_eur,
+            )
+        elif action == "hold":
+            result = gateway.SpendLedger().place_hold(reason=args.reason)
+        elif action == "clear-hold":
+            result = gateway.SpendLedger().clear_hold(reason=args.reason)
+        elif action == "status":
+            result = service.gateway_status(store.root)
+        else:
+            raise ValueError(f"unsupported gateway action {action!r}")
+    except (gateway.GatewayError, OSError, ValueError) as exc:
+        sys.stderr.write(f"agenttalk gateway {action}: {exc}\n")
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if action == "status" and not result.get("ready"):
         return 2
     return 0
 
@@ -9366,7 +9426,9 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
                     work_heartbeat: object | None = None,
                     runtime_model: str | None = None,
                     runtime_effort: str | None = None,
-                    runtime_fingerprint: str | None = None) -> int:
+                    runtime_fingerprint: str | None = None,
+                    backend_profile: str | None = None,
+                    profile_env: dict[str, str] | None = None) -> int:
     """The long-running supervised wrapper loop (design C): own the idle bus-wait +
     heartbeat, drive the CLI ONE turn per inbound message in structured-stream mode
     (session continuity owned here), then return to the wait. Runs until killed -
@@ -9480,6 +9542,8 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             health_writer=health_writer,
             work_heartbeat=work_heartbeat,
             wrapper_generation=wrapper_generation,
+            backend_profile=backend_profile,
+            profile_env=profile_env,
             # the lead-loop combined stamp raises _LeadLoopLeaseLost on a lost lease:
             # the ticker treats it as TYPED loss (permanent stop for the turn, status
             # lost_lease, never a bus heartbeat without the lease), while the
@@ -9742,7 +9806,101 @@ def cmd_wrap(args: argparse.Namespace) -> int:
         except lane_mod.LaneError as e:
             sys.stderr.write(f"agenttalk wrap: {e}\n")
             return 2
-    child_env = wrapper_run._child_env(store.root)
+    sup_cfg: dict = {}
+    cfg_agent: dict = {}
+    backend_profile: str | None = None
+    profile_env: dict[str, str] | None = None
+    if getattr(args, "loop", False):
+        sup_cfg = _load_supervisor_config(store)
+        _agents = sup_cfg.get("agents")
+        raw_agent = _agents.get(agent) if isinstance(_agents, dict) else None
+        cfg_agent = raw_agent if isinstance(raw_agent, dict) else {}
+        raw_profile = cfg_agent.get("backend_profile")
+        if raw_profile is not None and not isinstance(raw_profile, str):
+            sys.stderr.write("agenttalk wrap: backend_profile must be a string\n")
+            return 2
+        backend_profile = raw_profile
+        if backend_profile == "ovh-qwen":
+            from agenttalk.ovh_gateway import (
+                EXTERNAL_WORKER,
+                GatewayConfigError,
+                MODEL_ALIAS,
+                default_front_token_path,
+                read_secret_file,
+            )
+            from agenttalk.ovh_gateway_service import gateway_status
+
+            if args.cli != "claude":
+                sys.stderr.write("agenttalk wrap: ovh-qwen requires cli=claude\n")
+                return 2
+            ambient = [key for key in ("OVH_KEY", "ANTHROPIC_API_KEY") if os.environ.get(key)]
+            if ambient:
+                sys.stderr.write(
+                    "agenttalk wrap: ovh-qwen refuses supervisor ambient provider keys: "
+                    + ", ".join(ambient)
+                    + "\n"
+                )
+                return 2
+            if cfg_agent.get("trust_class") != EXTERNAL_WORKER:
+                sys.stderr.write(
+                    "agenttalk wrap: ovh-qwen requires supervisor trust_class=external-worker\n"
+                )
+                return 2
+            if cfg_agent.get("model") != MODEL_ALIAS:
+                sys.stderr.write(
+                    f"agenttalk wrap: ovh-qwen requires model={MODEL_ALIAS}\n"
+                )
+                return 2
+            store_trust = getattr(store, "trust_class", lambda _name: None)(agent)
+            if store_trust != EXTERNAL_WORKER:
+                sys.stderr.write(
+                    "agenttalk wrap: ovh-qwen requires roster trust_class=external-worker\n"
+                )
+                return 2
+            if cfg_agent.get("env"):
+                sys.stderr.write("agenttalk wrap: ovh-qwen forbids literal per-agent env config\n")
+                return 2
+            try:
+                gateway = gateway_status(store.root)
+            except (GatewayConfigError, OSError) as exc:
+                gateway = {"ready": False, "errors": [type(exc).__name__]}
+            if not gateway.get("ready"):
+                reasons = gateway.get("errors")
+                safe_reasons = ",".join(
+                    str(reason) for reason in reasons if isinstance(reason, str)
+                ) if isinstance(reasons, list) else "readiness_unavailable"
+                summary = f"ovh-qwen gateway is not ready ({safe_reasons})"
+                mode = (
+                    "lead-loop" if lead_loop else
+                    "wrapper-one-shot" if args.one_shot else
+                    "wrapper-loop"
+                )
+                return _handle_launch_config_blocked(
+                    store,
+                    agent,
+                    args.cli,
+                    mode=mode,
+                    min_interval=args.min_interval,
+                    summary=summary,
+                )
+            try:
+                front_token = read_secret_file(default_front_token_path())
+            except GatewayConfigError as exc:
+                sys.stderr.write(f"agenttalk wrap: {exc}\n")
+                return 2
+            profile_env = {
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+                "ANTHROPIC_AUTH_TOKEN": front_token,
+                "ANTHROPIC_MODEL": MODEL_ALIAS,
+            }
+        elif backend_profile is not None:
+            sys.stderr.write(f"agenttalk wrap: unsupported backend_profile {backend_profile!r}\n")
+            return 2
+    child_env = wrapper_run._child_env(
+        store.root,
+        backend_profile=backend_profile,
+        profile_env=profile_env,
+    )
     launch = wrapper_run.preflight_launch_runtime(
         argv, args.cli, launch_cwd, child_env)
     if launch.blocked:
@@ -9765,14 +9923,8 @@ def cmd_wrap(args: argparse.Namespace) -> int:
         # dead_letter:{...} config actually takes effect (codex P1 / lead F3). This makes
         # supervisor.resolve_dead_letter_caps the single source of truth.
         from agenttalk import supervisor as _sup
-        sup_cfg = _load_supervisor_config(store)
-        # Coerce to dict only when it IS a dict: a truthy non-dict per-agent entry
-        # (corrupt supervisor.json) must not crash wrapped-controller startup (the
-        # resolver is also hardened, but never feed it a non-dict). Same class as
-        # resolve_timing's extraction.
-        _agents = sup_cfg.get("agents")
-        cfg_agent = _agents.get(agent) if isinstance(_agents, dict) else None
-        cfg_agent = cfg_agent if isinstance(cfg_agent, dict) else {}
+        # sup_cfg/cfg_agent were loaded before preflight so a backend profile can
+        # constrain the exact child environment used by that preflight and launch.
         # Wrapped Claude write-grant fix: session_args is empty for a wrapped agent,
         # so the supervisor never substitutes {PERM_MODE} into the child tail — a
         # supervised wrapped Claude would launch read-only. Apply the same resolved
@@ -9866,7 +10018,9 @@ def cmd_wrap(args: argparse.Namespace) -> int:
                                work_heartbeat=whb_cfg,
                                runtime_model=runtime_model,
                                runtime_effort=runtime_effort,
-                               runtime_fingerprint=runtime_fingerprint)
+                               runtime_fingerprint=runtime_fingerprint,
+                               backend_profile=backend_profile,
+                               profile_env=profile_env)
     try:
         return wrapper_run.run_wrapper(
             cli=args.cli, agent=agent, argv=argv, store=store, sender=sender,
@@ -11125,6 +11279,8 @@ def build_parser() -> argparse.ArgumentParser:
     r_add.add_argument("--role", help="Role label (e.g. implementer, reviewer, lead).")
     r_add.add_argument("--group", action="append",
                        help="Add the agent to this group (repeatable).")
+    r_add.add_argument("--trust-class", choices=("external-worker",),
+                       help="Set opt-in non-authority model trust metadata.")
     r_add.add_argument("--unique", action="store_true",
                        help="Self-join guard: REFUSE (exit 3) if <name> is an "
                             "ACTIVE identity (fresh heartbeat or a live waiter), "
@@ -11187,6 +11343,14 @@ def build_parser() -> argparse.ArgumentParser:
     r_sg.add_argument("group")
     r_sg.add_argument("members", help="Comma-separated agent names.")
     r_sg.set_defaults(func=cmd_roster)
+    r_tc = rsub.add_parser(
+        "set-trust-class",
+        help="Set or clear opt-in non-authority model trust metadata.",
+    )
+    r_tc.add_argument("name")
+    r_tc.add_argument("trust_class", nargs="?", choices=("external-worker",))
+    r_tc.add_argument("--clear", action="store_true")
+    r_tc.set_defaults(func=cmd_roster)
     r_of = rsub.add_parser(
         "set-operator-facing",
         help="Designate the ONE agent the human operator talks to directly "
@@ -12798,6 +12962,48 @@ def build_parser() -> argparse.ArgumentParser:
     pd.add_argument("--json", action="store_true",
                     help="Emit structured JSON instead of human-readable text.")
     pd.set_defaults(func=cmd_doctor)
+
+    pgw = sub.add_parser(
+        "gateway",
+        help="Manage the loopback-only watched OVH/Qwen trial gateway.",
+    )
+    gwsub = pgw.add_subparsers(dest="gateway_action", required=True)
+    gw_init = gwsub.add_parser("init", help="One-time ledger/config/token initialization.")
+    gw_init.add_argument("--litellm-executable", required=True)
+    gw_init.set_defaults(func=cmd_gateway)
+    gw_task = gwsub.add_parser("task-install", help="Install or verify the project task.")
+    gw_task.set_defaults(func=cmd_gateway)
+    gw_start = gwsub.add_parser("start", help="Start the verified managed gateway task.")
+    gw_start.set_defaults(func=cmd_gateway)
+    gw_stop = gwsub.add_parser("stop", help="Gracefully stop the managed gateway task.")
+    gw_stop.add_argument("--timeout", type=_finite_float_arg, default=30.0)
+    gw_stop.set_defaults(func=cmd_gateway)
+    gw_status = gwsub.add_parser("status", help="Show an allowlisted non-secret status.")
+    gw_status.set_defaults(func=cmd_gateway)
+    gw_reconcile = gwsub.add_parser(
+        "reconcile",
+        help="Explicitly resolve one uncertain provider attempt.",
+    )
+    gw_reconcile.add_argument("attempt_id")
+    gw_reconcile.add_argument(
+        "--outcome",
+        choices=("no-send", "charge-actual", "charge-reserve"),
+        required=True,
+    )
+    gw_reconcile.add_argument("--reason", required=True)
+    gw_reconcile.add_argument("--actual-micro-eur", type=int)
+    gw_reconcile.set_defaults(func=cmd_gateway)
+    gw_hold = gwsub.add_parser("hold", help="Durably block new provider transport.")
+    gw_hold.add_argument("--reason", required=True)
+    gw_hold.set_defaults(func=cmd_gateway)
+    gw_clear_hold = gwsub.add_parser(
+        "clear-hold",
+        help="Explicitly clear a service hold after all attempts are reconciled.",
+    )
+    gw_clear_hold.add_argument("--reason", required=True)
+    gw_clear_hold.set_defaults(func=cmd_gateway)
+    gw_run = gwsub.add_parser("run", help=argparse.SUPPRESS)
+    gw_run.set_defaults(func=cmd_gateway)
 
     ph = sub.add_parser(
         "hmac-init",

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -664,6 +664,80 @@ def load_signoff_policy(store) -> tuple[dict | None, str | None]:
         return None, f"malformed signoff policy: {type(e).__name__}: {e}"
 
 
+def merge_candidate_refsets(*refsets: dict) -> dict:
+    """Merge signoff candidate refsets without resolving roster membership."""
+    merged = {"agents": [], "groups": [], "roles": []}
+    for refset in refsets:
+        for key in merged:
+            merged[key].extend((refset or {}).get(key) or [])
+    return merged
+
+
+def signoff_domain_refset(
+    store,
+    cfg: dict,
+    changed_paths: list[str] | None,
+) -> dict:
+    """Resolve matched domain reviewer refsets, or every possible one for a guard.
+
+    ``changed_paths=None`` is the conservative roster-mutation mode: it returns
+    every domain/shared-path reviewer that a future close could count. A concrete
+    path list preserves close evaluation's path-matched behavior.
+    """
+    from agenttalk import domains as domain_mod
+
+    empty = merge_candidate_refsets()
+    if changed_paths == []:
+        return empty
+    try:
+        registry = domain_mod.load_registry(store.dir / domain_mod.FILENAME, cfg)
+    except Exception:  # noqa: BLE001 - preserve close evaluation's empty fallback
+        return empty
+    data = registry.data
+    domains = data.get("domains", {})
+    shared = data.get("shared_paths", [])
+    if changed_paths is None:
+        return merge_candidate_refsets(
+            empty,
+            *(entry.get("reviewers") or {} for entry in domains.values()),
+            *(entry.get("default_reviewers") or {} for entry in shared),
+        )
+    verdicts = domain_mod.check_paths(data, changed_paths)
+    matched_domains: set[str] = set()
+    matched_globs: set[str] = set()
+    for verdict in verdicts:
+        matched_domains.update(verdict.get("domains", []))
+        for match in verdict.get("shared_paths", []):
+            matched_globs.add(match.get("glob"))
+    return merge_candidate_refsets(
+        empty,
+        *(domains.get(domain_id, {}).get("reviewers") or {}
+          for domain_id in matched_domains),
+        *(entry.get("default_reviewers") or {}
+          for entry in shared if entry.get("glob") in matched_globs),
+    )
+
+
+def resolve_signoff_candidates(
+    cfg: dict,
+    *,
+    candidate_refset: dict,
+    default_reviewers: dict,
+    use_default_reviewers: bool,
+    domain_refset: dict,
+    include_domain_reviewers: bool,
+) -> list[str]:
+    """The single candidate merge+resolution contract used by close and roster."""
+    from agenttalk import domains as domain_mod
+
+    merged = merge_candidate_refsets(
+        candidate_refset,
+        default_reviewers if use_default_reviewers else {},
+        domain_refset if include_domain_reviewers else {},
+    )
+    return domain_mod.resolve_refset(merged, cfg)
+
+
 def closes_dir(store):
     return store.dir / DIRNAME
 

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -148,6 +148,9 @@ def run(project_root: Path | None = None) -> Report:
         supervisor_script = _check_supervisor_script_guard(store)
         if supervisor_script is not None:  # additive: absent unless stale/unreadable
             report.checks.append(supervisor_script)
+        qwen_gateway = _check_ovh_qwen_gateway(store)
+        if qwen_gateway is not None:
+            report.checks.append(qwen_gateway)
         holds = _check_config_blocked_holds(store)
         if holds is not None:  # additive: absent unless a valid config-blocked hold exists
             report.checks.append(holds)
@@ -167,6 +170,60 @@ def run(project_root: Path | None = None) -> Report:
         if lead_check is not None:  # additive: absent unless a lead-loop concern exists
             report.checks.append(lead_check)
     return report
+
+
+def _check_ovh_qwen_gateway(store: Store) -> Check | None:
+    path = store.dir / "supervisor.json"
+    if not path.is_file():
+        return None
+    try:
+        config = sup.load_supervisor_config(path)
+    except (OSError, ValueError):
+        return None
+    agents = config.get("agents") if isinstance(config.get("agents"), dict) else {}
+    profile_agents = [
+        name
+        for name, spec in agents.items()
+        if isinstance(spec, dict) and spec.get("backend_profile") == "ovh-qwen"
+    ]
+    if not profile_agents:
+        return None
+    from agenttalk import ovh_gateway_service as service
+
+    try:
+        status = service.gateway_status(store.root)
+    except Exception as exc:  # noqa: BLE001 - doctor must report, never crash
+        status = {
+            "ready": False,
+            "errors": [f"status_unavailable:{type(exc).__name__}"],
+        }
+    problems = list(status.get("errors") or [])
+    config_trust = store.trust_classes()
+    for name in profile_agents:
+        spec = agents[name]
+        if spec.get("trust_class") != "external-worker":
+            problems.append(f"{name}:supervisor_trust_class")
+        if config_trust.get(name) != "external-worker":
+            problems.append(f"{name}:roster_trust_class")
+    if any(os.environ.get(key) for key in ("OVH_KEY", "ANTHROPIC_API_KEY")):
+        problems.append("supervisor_ambient_provider_key")
+    problems = sorted(set(problems))
+    return Check(
+        name="ovh_qwen_gateway",
+        status="error" if problems else "ok",
+        details=(
+            "gateway ready with constrained external-worker profile(s)"
+            if not problems
+            else "gateway/profile check failed: " + ", ".join(problems)
+        ),
+        fix=(
+            "run `agenttalk gateway status`; remove ambient provider keys and repair "
+            "the reported install/task/ledger/trust condition"
+            if problems
+            else ""
+        ),
+        data=status,
+    )
 
 
 def _check_powershell_host(store: Store) -> Check:

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -38,6 +38,7 @@ MAX_CONTEXT_TOKENS = 262_144
 MAX_OUTPUT_TOKENS = 4_096
 TRIAL_CUTOFF_MICRO_EUR = 25_000_000
 SOFT_STOP_MICRO_EUR = 20_000_000
+EXTERNAL_CEILING_MICRO_EUR = 100_000_000
 LEDGER_SCHEMA_VERSION = 1
 INSTALL_MARKER_SCHEMA_VERSION = 1
 BACKEND_PROFILE = "ovh-qwen"
@@ -49,6 +50,7 @@ INTERNAL_PORT = 4001
 MAX_REQUEST_BYTES = 128 * 1024
 DEFAULT_LOCAL_DIRNAME = "agenttalk-ovh"
 DEFAULT_SPEND_DIRNAME = "agenttalk-ovh-spend"
+MAX_OPENING_EVIDENCE_LENGTH = 512
 
 _ATTEMPT_ID_RE = re.compile(r"^[a-f0-9]{32}$")
 _PERIOD_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])$")
@@ -125,6 +127,7 @@ def price_policy() -> dict:
         },
         "trial_cutoff_micro_eur": TRIAL_CUTOFF_MICRO_EUR,
         "soft_stop_micro_eur": SOFT_STOP_MICRO_EUR,
+        "external_ceiling_micro_eur": EXTERNAL_CEILING_MICRO_EUR,
     }
 
 
@@ -336,12 +339,61 @@ class SpendLedger:
             return "absent"
         return "partial"
 
-    def initialize(self, *, generation: str | None = None) -> dict:
+    @staticmethod
+    def _opening_evidence(value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError("opening_evidence must be a string")
+        normalized = value.strip()
+        if (
+            not normalized
+            or len(normalized) > MAX_OPENING_EVIDENCE_LENGTH
+            or "\r" in normalized
+            or "\n" in normalized
+            or any(ord(char) < 32 for char in normalized)
+        ):
+            raise ValueError(
+                "opening_evidence must be a non-empty single line of at most "
+                f"{MAX_OPENING_EVIDENCE_LENGTH} characters"
+            )
+        return normalized
+
+    @staticmethod
+    def _opening_amount(value: object) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError("opening_micro_eur must be a non-negative integer")
+        return value
+
+    @staticmethod
+    def _assert_external_envelope(opening_micro_eur: int) -> None:
+        projected = (
+            opening_micro_eur
+            + TRIAL_CUTOFF_MICRO_EUR
+            + reservation_cost_micro_eur()
+        )
+        if projected > EXTERNAL_CEILING_MICRO_EUR:
+            raise PolicyBlocked(
+                "opening balance plus trial cutoff and one reservation exceeds "
+                "the external account ceiling"
+            )
+
+    def initialize(
+        self,
+        *,
+        opening_micro_eur: int,
+        opening_evidence: str,
+        generation: str | None = None,
+    ) -> dict:
         if self.installation_state() != "absent":
             raise LedgerBlocked(
                 "ledger initialization requires both database and install marker to be absent"
             )
+        opening_micro_eur = self._opening_amount(opening_micro_eur)
+        opening_evidence = self._opening_evidence(opening_evidence)
+        self._assert_external_envelope(opening_micro_eur)
         now = self.now().astimezone(timezone.utc)
+        observed_at = _iso_utc(now)
+        opening_period = _period(now)
+        evidence_hash = hashlib.sha256(opening_evidence.encode("utf-8")).hexdigest()
         generation = generation or uuid.uuid4().hex
         if not _ATTEMPT_ID_RE.fullmatch(generation):
             raise ValueError("generation must be 32 lowercase hexadecimal characters")
@@ -359,9 +411,14 @@ class SpendLedger:
                     "currency": POLICY_CURRENCY,
                     "trial_cutoff_micro_eur": str(TRIAL_CUTOFF_MICRO_EUR),
                     "soft_stop_micro_eur": str(SOFT_STOP_MICRO_EUR),
-                    "initialized_at": _iso_utc(now),
-                    "last_accepted_utc": _iso_utc(now),
-                    "last_accepted_period": _period(now),
+                    "external_ceiling_micro_eur": str(EXTERNAL_CEILING_MICRO_EUR),
+                    "opening_micro_eur": str(opening_micro_eur),
+                    "opening_evidence": opening_evidence,
+                    "opening_observed_at": observed_at,
+                    "opening_period": opening_period,
+                    "initialized_at": observed_at,
+                    "last_accepted_utc": observed_at,
+                    "last_accepted_period": opening_period,
                     "service_hold": "",
                 }
                 conn.execute("BEGIN IMMEDIATE")
@@ -369,8 +426,8 @@ class SpendLedger:
                     "INSERT INTO metadata(key, value) VALUES (?, ?)", values.items()
                 )
                 conn.execute(
-                    "INSERT INTO periods(period, committed_micro_eur) VALUES (?, 0)",
-                    (_period(now),),
+                    "INSERT INTO periods(period, committed_micro_eur) VALUES (?, ?)",
+                    (opening_period, opening_micro_eur),
                 )
                 conn.commit()
             finally:
@@ -382,7 +439,11 @@ class SpendLedger:
                 "ledger_schema_version": LEDGER_SCHEMA_VERSION,
                 "generation": generation,
                 "price_policy_hash": price_policy_hash(),
-                "initialized_at": _iso_utc(now),
+                "opening_micro_eur": opening_micro_eur,
+                "opening_evidence_sha256": evidence_hash,
+                "opening_observed_at": observed_at,
+                "opening_period": opening_period,
+                "initialized_at": observed_at,
             }
             _durable_write_json(self.marker_path, marker)
             return marker
@@ -456,6 +517,22 @@ class SpendLedger:
         generation = marker.get("generation")
         if not isinstance(generation, str) or not _ATTEMPT_ID_RE.fullmatch(generation):
             raise LedgerBlocked("ledger install marker generation is invalid")
+        opening_micro_eur = marker.get("opening_micro_eur")
+        if (
+            not isinstance(opening_micro_eur, int)
+            or isinstance(opening_micro_eur, bool)
+            or opening_micro_eur < 0
+        ):
+            raise LedgerBlocked("ledger install marker opening balance is invalid")
+        evidence_hash = marker.get("opening_evidence_sha256")
+        if (
+            not isinstance(evidence_hash, str)
+            or not re.fullmatch(r"[a-f0-9]{64}", evidence_hash)
+        ):
+            raise LedgerBlocked("ledger install marker opening evidence hash is invalid")
+        _parse_utc(marker.get("opening_observed_at"))
+        if not _PERIOD_RE.fullmatch(str(marker.get("opening_period") or "")):
+            raise LedgerBlocked("ledger install marker opening period is invalid")
         return marker
 
     @contextlib.contextmanager
@@ -499,6 +576,7 @@ class SpendLedger:
             "currency": POLICY_CURRENCY,
             "trial_cutoff_micro_eur": str(TRIAL_CUTOFF_MICRO_EUR),
             "soft_stop_micro_eur": str(SOFT_STOP_MICRO_EUR),
+            "external_ceiling_micro_eur": str(EXTERNAL_CEILING_MICRO_EUR),
         }
         for key, value in expected.items():
             if metadata.get(key) != value:
@@ -507,6 +585,37 @@ class SpendLedger:
         _parse_utc(metadata.get("last_accepted_utc"))
         if not _PERIOD_RE.fullmatch(metadata.get("last_accepted_period", "")):
             raise LedgerBlocked("ledger last accepted period is invalid")
+        raw_opening = metadata.get("opening_micro_eur")
+        try:
+            opening_micro_eur = int(raw_opening or "")
+        except ValueError as exc:
+            raise LedgerBlocked("ledger opening balance is invalid") from exc
+        if str(opening_micro_eur) != raw_opening or opening_micro_eur < 0:
+            raise LedgerBlocked("ledger opening balance is invalid")
+        try:
+            opening_evidence = self._opening_evidence(metadata.get("opening_evidence"))
+            self._assert_external_envelope(opening_micro_eur)
+        except (ValueError, PolicyBlocked) as exc:
+            raise LedgerBlocked("ledger opening balance envelope is invalid") from exc
+        observed_at = metadata.get("opening_observed_at")
+        observed = _parse_utc(observed_at)
+        opening_period = metadata.get("opening_period", "")
+        if not _PERIOD_RE.fullmatch(opening_period) or opening_period != _period(observed):
+            raise LedgerBlocked("ledger opening period is invalid")
+        if (
+            marker.get("opening_micro_eur") != opening_micro_eur
+            or marker.get("opening_observed_at") != observed_at
+            or marker.get("opening_period") != opening_period
+            or marker.get("opening_evidence_sha256")
+            != hashlib.sha256(opening_evidence.encode("utf-8")).hexdigest()
+        ):
+            raise LedgerBlocked("ledger opening balance does not match the install marker")
+        opening_row = conn.execute(
+            "SELECT committed_micro_eur FROM periods WHERE period=?",
+            (opening_period,),
+        ).fetchone()
+        if opening_row is None or int(opening_row[0]) < opening_micro_eur:
+            raise LedgerBlocked("ledger opening balance is not represented in its period")
         return metadata
 
     @staticmethod
@@ -607,7 +716,12 @@ class SpendLedger:
                     raise LedgerBlocked("admission period is missing")
                 unresolved_total = sum(int(item["reserved_micro_eur"]) for item in unresolved)
                 projected = int(row[0]) + unresolved_total + reserve
-                if projected > TRIAL_CUTOFF_MICRO_EUR:
+                opening_allowance = (
+                    int(metadata["opening_micro_eur"])
+                    if period == metadata["opening_period"]
+                    else 0
+                )
+                if projected > opening_allowance + TRIAL_CUTOFF_MICRO_EUR:
                     raise PolicyBlocked("trial spend cutoff would be exceeded")
                 try:
                     conn.execute(
@@ -751,20 +865,13 @@ class SpendLedger:
         *,
         outcome: str,
         reason: str,
-        actual_micro_eur: int | None = None,
         now: datetime | None = None,
     ) -> dict:
         self._validate_attempt_id(attempt_id)
-        if outcome not in {"no-send", "charge-actual", "charge-reserve"}:
-            raise ValueError("outcome must be no-send, charge-actual, or charge-reserve")
+        if outcome not in {"no-send", "charge-reserve"}:
+            raise ValueError("outcome must be no-send or charge-reserve")
         if not isinstance(reason, str) or not reason.strip():
             raise ValueError("a reconciliation reason is required")
-        if outcome == "charge-actual" and (
-            not isinstance(actual_micro_eur, int)
-            or isinstance(actual_micro_eur, bool)
-            or actual_micro_eur < 0
-        ):
-            raise ValueError("charge-actual requires non-negative actual_micro_eur")
         timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
         with self._connect() as conn:
             self._begin(conn)
@@ -781,10 +888,8 @@ class SpendLedger:
                     if already:
                         raise LedgerBlocked("no-send cannot erase an already recorded charge")
                     desired = 0
-                elif outcome == "charge-reserve":
-                    desired = max(already, int(row["reserved_micro_eur"]))
                 else:
-                    desired = max(already, int(actual_micro_eur or 0))
+                    desired = max(already, int(row["reserved_micro_eur"]))
                 incremental = max(0, desired - already)
                 if incremental:
                     conn.execute(
@@ -892,6 +997,10 @@ class SpendLedger:
                 (row for row in periods if row["period"] == current_period),
                 {"committed_micro_eur": 0},
             )
+            opening_micro_eur = int(metadata["opening_micro_eur"])
+            current_opening = (
+                opening_micro_eur if current_period == metadata["opening_period"] else 0
+            )
             return {
                 "schema_version": LEDGER_SCHEMA_VERSION,
                 "generation": metadata["generation"],
@@ -899,8 +1008,17 @@ class SpendLedger:
                 "currency": metadata["currency"],
                 "trial_cutoff_micro_eur": TRIAL_CUTOFF_MICRO_EUR,
                 "soft_stop_micro_eur": SOFT_STOP_MICRO_EUR,
+                "external_ceiling_micro_eur": EXTERNAL_CEILING_MICRO_EUR,
+                "opening_micro_eur": opening_micro_eur,
+                "opening_evidence": metadata["opening_evidence"],
+                "opening_observed_at": metadata["opening_observed_at"],
+                "opening_period": metadata["opening_period"],
                 "current_period": current_period,
                 "current_committed_micro_eur": int(current["committed_micro_eur"]),
+                "current_trial_committed_micro_eur": max(
+                    0,
+                    int(current["committed_micro_eur"]) - current_opening,
+                ),
                 "periods": periods,
                 "unresolved": unresolved,
                 "service_hold": metadata.get("service_hold") or None,

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -27,18 +27,19 @@ from typing import Callable, Iterator
 
 MODEL_ALIAS = "Qwen3.5-397B-A17B"
 POLICY_SOURCE = "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/"
-POLICY_OBSERVED_DATE = "2026-07-15"
+POLICY_OBSERVED_DATE = "2026-07-16"
 POLICY_CURRENCY = "EUR"
 TOKENS_PER_RATE_UNIT = 1_000_000
-INPUT_RATE_MICRO_EUR = 710_000
-OUTPUT_RATE_MICRO_EUR = 4_250_000
-RESERVE_INPUT_RATE_MICRO_EUR = 852_000
-RESERVE_OUTPUT_RATE_MICRO_EUR = 5_100_000
+INPUT_RATE_MICRO_EUR = 600_000
+OUTPUT_RATE_MICRO_EUR = 3_600_000
+RESERVE_INPUT_RATE_MICRO_EUR = 720_000
+RESERVE_OUTPUT_RATE_MICRO_EUR = 4_320_000
 MAX_CONTEXT_TOKENS = 262_144
 MAX_OUTPUT_TOKENS = 4_096
 TRIAL_CUTOFF_MICRO_EUR = 25_000_000
 SOFT_STOP_MICRO_EUR = 20_000_000
 EXTERNAL_CEILING_MICRO_EUR = 100_000_000
+CANARY_TOLERANCE_BPS = 1_000
 LEDGER_SCHEMA_VERSION = 1
 INSTALL_MARKER_SCHEMA_VERSION = 1
 BACKEND_PROFILE = "ovh-qwen"
@@ -128,6 +129,10 @@ def price_policy() -> dict:
         "trial_cutoff_micro_eur": TRIAL_CUTOFF_MICRO_EUR,
         "soft_stop_micro_eur": SOFT_STOP_MICRO_EUR,
         "external_ceiling_micro_eur": EXTERNAL_CEILING_MICRO_EUR,
+        "dashboard_canary": {
+            "requires_nonzero_delta": True,
+            "tolerance_basis_points": CANARY_TOLERANCE_BPS,
+        },
     }
 
 
@@ -448,8 +453,14 @@ class SpendLedger:
             _durable_write_json(self.marker_path, marker)
             return marker
         finally:
-            with contextlib.suppress(FileNotFoundError):
-                temp_db.unlink()
+            for temporary in (
+                temp_db,
+                Path(f"{temp_db}-journal"),
+                Path(f"{temp_db}-wal"),
+                Path(f"{temp_db}-shm"),
+            ):
+                with contextlib.suppress(FileNotFoundError):
+                    temporary.unlink()
 
     @staticmethod
     def _configure(conn: sqlite3.Connection) -> None:
@@ -616,6 +627,55 @@ class SpendLedger:
         ).fetchone()
         if opening_row is None or int(opening_row[0]) < opening_micro_eur:
             raise LedgerBlocked("ledger opening balance is not represented in its period")
+        canary_keys = (
+            "canary_attempt_id",
+            "canary_checked_at",
+            "canary_expected_micro_eur",
+            "canary_observed_micro_eur",
+            "canary_tolerance_micro_eur",
+            "canary_status",
+        )
+        canary_present = [key in metadata for key in canary_keys]
+        if any(canary_present) and not all(canary_present):
+            raise LedgerBlocked("dashboard canary metadata is incomplete")
+        if all(canary_present):
+            attempt_id = metadata["canary_attempt_id"]
+            try:
+                self._validate_attempt_id(attempt_id)
+            except ValueError as exc:
+                raise LedgerBlocked("dashboard canary attempt id is invalid") from exc
+            _parse_utc(metadata["canary_checked_at"])
+            try:
+                expected = int(metadata["canary_expected_micro_eur"])
+                observed = int(metadata["canary_observed_micro_eur"])
+                tolerance = int(metadata["canary_tolerance_micro_eur"])
+            except ValueError as exc:
+                raise LedgerBlocked("dashboard canary amount is invalid") from exc
+            if (
+                str(expected) != metadata["canary_expected_micro_eur"]
+                or str(observed) != metadata["canary_observed_micro_eur"]
+                or str(tolerance) != metadata["canary_tolerance_micro_eur"]
+                or expected <= 0
+                or observed < 0
+                or tolerance <= 0
+            ):
+                raise LedgerBlocked("dashboard canary amount is invalid")
+            status = metadata["canary_status"]
+            mathematically_accepted = observed > 0 and abs(observed - expected) <= tolerance
+            if status not in {"accepted", "mismatch"} or (
+                (status == "accepted") != mathematically_accepted
+            ):
+                raise LedgerBlocked("dashboard canary status is invalid")
+            canary_attempt = conn.execute(
+                "SELECT state, actual_micro_eur FROM attempts WHERE attempt_id=?",
+                (attempt_id,),
+            ).fetchone()
+            if (
+                canary_attempt is None
+                or canary_attempt["state"] != "settled"
+                or int(canary_attempt["actual_micro_eur"] or 0) != expected
+            ):
+                raise LedgerBlocked("dashboard canary attempt binding is invalid")
         return metadata
 
     @staticmethod
@@ -626,11 +686,14 @@ class SpendLedger:
             raise LedgerBlocked("ledger writer lock could not be acquired") from exc
 
     def _commit(self, conn: sqlite3.Connection) -> None:
+        # PRAGMA synchronous=FULL makes SQLite's successful commit return the
+        # sole durability authority for ledger transactions. A second file
+        # flush after commit can fail after the terminal row is already visible,
+        # falsely reporting failure while leaving the ledger ready.
         try:
             conn.commit()
-            self._durability_barrier(self.db_path)
-        except (OSError, sqlite3.Error) as exc:
-            raise LedgerBlocked("ledger durability barrier failed") from exc
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger transaction commit failed") from exc
 
     @staticmethod
     def _rollback(conn: sqlite3.Connection) -> None:
@@ -723,6 +786,17 @@ class SpendLedger:
                 )
                 if projected > opening_allowance + TRIAL_CUTOFF_MICRO_EUR:
                     raise PolicyBlocked("trial spend cutoff would be exceeded")
+                cumulative_row = conn.execute(
+                    "SELECT COALESCE(SUM(committed_micro_eur), 0) FROM periods"
+                ).fetchone()
+                # The opening balance is seeded into the opening period, so the
+                # SUM already includes it. Adding metadata.opening_micro_eur
+                # again would double-count the operator-observed balance.
+                cumulative_projected = (
+                    int(cumulative_row[0]) + unresolved_total + reserve
+                )
+                if cumulative_projected > EXTERNAL_CEILING_MICRO_EUR:
+                    raise PolicyBlocked("external ceiling would be exceeded")
                 try:
                     conn.execute(
                         """
@@ -985,6 +1059,84 @@ class SpendLedger:
                 raise
         return {"held": False, "prior_hold": prior or None, "cleared_at": timestamp}
 
+    def verify_dashboard_canary(
+        self,
+        attempt_id: str,
+        *,
+        observed_delta_micro_eur: int,
+        now: datetime | None = None,
+    ) -> dict:
+        """Persist a fail-closed live dashboard comparison for one settled call."""
+        self._validate_attempt_id(attempt_id)
+        if (
+            not isinstance(observed_delta_micro_eur, int)
+            or isinstance(observed_delta_micro_eur, bool)
+            or observed_delta_micro_eur < 0
+        ):
+            raise ValueError("observed dashboard delta must be non-negative micro-EUR")
+        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                row = conn.execute(
+                    "SELECT * FROM attempts WHERE attempt_id=?", (attempt_id,)
+                ).fetchone()
+                if row is None:
+                    raise LedgerBlocked("attempt does not exist")
+                expected = int(row["actual_micro_eur"] or 0)
+                if (
+                    row["state"] != "settled"
+                    or row["model"] != MODEL_ALIAS
+                    or row["policy_hash"] != price_policy_hash()
+                    or expected <= 0
+                ):
+                    raise LedgerBlocked(
+                        "dashboard canary requires a positive policy-matched settled attempt"
+                    )
+                tolerance = max(
+                    1,
+                    (
+                        expected * CANARY_TOLERANCE_BPS
+                        + 10_000
+                        - 1
+                    )
+                    // 10_000,
+                )
+                accepted = (
+                    observed_delta_micro_eur > 0
+                    and abs(observed_delta_micro_eur - expected) <= tolerance
+                )
+                values = {
+                    "canary_attempt_id": attempt_id,
+                    "canary_checked_at": timestamp,
+                    "canary_expected_micro_eur": str(expected),
+                    "canary_observed_micro_eur": str(observed_delta_micro_eur),
+                    "canary_tolerance_micro_eur": str(tolerance),
+                    "canary_status": "accepted" if accepted else "mismatch",
+                }
+                conn.executemany(
+                    "INSERT OR REPLACE INTO metadata(key, value) VALUES (?, ?)",
+                    values.items(),
+                )
+                if not accepted:
+                    conn.execute(
+                        "UPDATE metadata SET value='dashboard_canary_mismatch' "
+                        "WHERE key='service_hold'"
+                    )
+                self._commit(conn)
+                return {
+                    "attempt_id": attempt_id,
+                    "accepted": accepted,
+                    "expected_micro_eur": expected,
+                    "observed_delta_micro_eur": observed_delta_micro_eur,
+                    "tolerance_micro_eur": tolerance,
+                    "held": not accepted,
+                    "checked_at": timestamp,
+                }
+            except Exception:
+                self._rollback(conn)
+                raise
+
     def status(self) -> dict:
         with self._connect() as conn:
             marker = self._marker()
@@ -1022,6 +1174,24 @@ class SpendLedger:
                 "periods": periods,
                 "unresolved": unresolved,
                 "service_hold": metadata.get("service_hold") or None,
+                "dashboard_canary": (
+                    {
+                        "attempt_id": metadata["canary_attempt_id"],
+                        "checked_at": metadata["canary_checked_at"],
+                        "expected_micro_eur": int(
+                            metadata["canary_expected_micro_eur"]
+                        ),
+                        "observed_delta_micro_eur": int(
+                            metadata["canary_observed_micro_eur"]
+                        ),
+                        "tolerance_micro_eur": int(
+                            metadata["canary_tolerance_micro_eur"]
+                        ),
+                        "status": metadata["canary_status"],
+                    }
+                    if metadata.get("canary_attempt_id")
+                    else None
+                ),
                 "ready": not unresolved and not metadata.get("service_hold"),
             }
 

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -1,0 +1,979 @@
+"""Watched-trial OVH/Qwen gateway policy and durable spend accounting.
+
+This module deliberately has no LiteLLM dependency.  The public front reserves
+money here before it sends a byte to the loopback LiteLLM process, then settles
+from the completed Anthropic response stream.  LiteLLM callbacks are not an
+accounting authority.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import sqlite3
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterator
+
+
+MODEL_ALIAS = "Qwen3.5-397B-A17B"
+POLICY_SOURCE = "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/"
+POLICY_OBSERVED_DATE = "2026-07-15"
+POLICY_CURRENCY = "EUR"
+TOKENS_PER_RATE_UNIT = 1_000_000
+INPUT_RATE_MICRO_EUR = 710_000
+OUTPUT_RATE_MICRO_EUR = 4_250_000
+RESERVE_INPUT_RATE_MICRO_EUR = 852_000
+RESERVE_OUTPUT_RATE_MICRO_EUR = 5_100_000
+MAX_CONTEXT_TOKENS = 262_144
+MAX_OUTPUT_TOKENS = 4_096
+TRIAL_CUTOFF_MICRO_EUR = 25_000_000
+SOFT_STOP_MICRO_EUR = 20_000_000
+LEDGER_SCHEMA_VERSION = 1
+INSTALL_MARKER_SCHEMA_VERSION = 1
+BACKEND_PROFILE = "ovh-qwen"
+EXTERNAL_WORKER = "external-worker"
+PUBLIC_HOST = "127.0.0.1"
+PUBLIC_PORT = 4000
+INTERNAL_HOST = "127.0.0.1"
+INTERNAL_PORT = 4001
+MAX_REQUEST_BYTES = 128 * 1024
+DEFAULT_LOCAL_DIRNAME = "agenttalk-ovh"
+DEFAULT_SPEND_DIRNAME = "agenttalk-ovh-spend"
+
+_ATTEMPT_ID_RE = re.compile(r"^[a-f0-9]{32}$")
+_PERIOD_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])$")
+_TERMINAL_ATTEMPT_STATES = frozenset({"settled", "reconciled"})
+_UNRESOLVED_ATTEMPT_STATES = frozenset({"reserved", "uncertain"})
+
+
+class GatewayError(RuntimeError):
+    """Base class for stable gateway failures."""
+
+
+class GatewayConfigError(GatewayError):
+    """Static configuration is invalid or incomplete."""
+
+
+class LedgerError(GatewayError):
+    """The durable ledger could not prove a safe accounting state."""
+
+
+class LedgerBlocked(LedgerError):
+    """Accounting failed closed before transport."""
+
+
+class LedgerHold(LedgerError):
+    """An unresolved or explicitly held attempt blocks further transport."""
+
+
+class PolicyBlocked(LedgerError):
+    """The configured trial cutoff refuses a new reservation."""
+
+
+def _ceil_cost(tokens: int, rate_micro_eur: int) -> int:
+    if not isinstance(tokens, int) or isinstance(tokens, bool) or tokens < 0:
+        raise ValueError("token counts must be non-negative integers")
+    return (tokens * rate_micro_eur + TOKENS_PER_RATE_UNIT - 1) // TOKENS_PER_RATE_UNIT
+
+
+def settlement_cost_micro_eur(input_tokens: int, output_tokens: int) -> int:
+    """Exact fixed-point settlement cost, rounded upward per component."""
+    return (
+        _ceil_cost(input_tokens, INPUT_RATE_MICRO_EUR)
+        + _ceil_cost(output_tokens, OUTPUT_RATE_MICRO_EUR)
+    )
+
+
+def reservation_cost_micro_eur() -> int:
+    """Conservative one-attempt hold at full context and bounded output."""
+    return (
+        _ceil_cost(MAX_CONTEXT_TOKENS, RESERVE_INPUT_RATE_MICRO_EUR)
+        + _ceil_cost(MAX_OUTPUT_TOKENS, RESERVE_OUTPUT_RATE_MICRO_EUR)
+    )
+
+
+def price_policy() -> dict:
+    """Canonical non-secret policy object whose digest binds persisted state."""
+    return {
+        "schema_version": 1,
+        "model": MODEL_ALIAS,
+        "source": POLICY_SOURCE,
+        "observed_date": POLICY_OBSERVED_DATE,
+        "billing_currency": POLICY_CURRENCY,
+        "tokens_per_rate_unit": TOKENS_PER_RATE_UNIT,
+        "settlement": {
+            "input_micro_eur": INPUT_RATE_MICRO_EUR,
+            "output_micro_eur": OUTPUT_RATE_MICRO_EUR,
+        },
+        "reservation": {
+            "input_micro_eur": RESERVE_INPUT_RATE_MICRO_EUR,
+            "output_micro_eur": RESERVE_OUTPUT_RATE_MICRO_EUR,
+            "margin_percent": 20,
+            "max_context_tokens": MAX_CONTEXT_TOKENS,
+            "max_output_tokens": MAX_OUTPUT_TOKENS,
+            "worst_case_micro_eur": reservation_cost_micro_eur(),
+        },
+        "trial_cutoff_micro_eur": TRIAL_CUTOFF_MICRO_EUR,
+        "soft_stop_micro_eur": SOFT_STOP_MICRO_EUR,
+    }
+
+
+def price_policy_hash() -> str:
+    encoded = json.dumps(
+        price_policy(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _local_appdata() -> Path:
+    raw = os.environ.get("LOCALAPPDATA")
+    if raw:
+        return Path(raw)
+    return Path.home() / ".local" / "share"
+
+
+def default_secret_dir() -> Path:
+    return _local_appdata() / DEFAULT_LOCAL_DIRNAME
+
+
+def default_spend_dir() -> Path:
+    return _local_appdata() / DEFAULT_SPEND_DIRNAME
+
+
+def default_key_path() -> Path:
+    return default_secret_dir() / "api_key.txt"
+
+
+def default_front_token_path() -> Path:
+    return default_secret_dir() / "front_token.txt"
+
+
+def default_internal_token_path() -> Path:
+    return default_secret_dir() / "internal_token.txt"
+
+
+def default_ledger_path() -> Path:
+    return default_spend_dir() / "ledger.sqlite3"
+
+
+def default_install_marker_path() -> Path:
+    return default_spend_dir() / "install.json"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso_utc(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("a timezone-aware UTC datetime is required")
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _parse_utc(value: object) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise LedgerBlocked("ledger timestamp is missing")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise LedgerBlocked("ledger timestamp is invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LedgerBlocked("ledger timestamp lacks a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def _period(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m")
+
+
+def _next_period(value: str) -> str:
+    if not _PERIOD_RE.fullmatch(value):
+        raise LedgerBlocked("ledger period is invalid")
+    year, month = (int(part) for part in value.split("-", 1))
+    if month == 12:
+        return f"{year + 1:04d}-01"
+    return f"{year:04d}-{month + 1:02d}"
+
+
+def _flush_file(path: Path) -> None:
+    # CPython's Windows fsync delegates to _commit(), which rejects a
+    # read-only CRT descriptor. The ledger and its journal are service-owned
+    # writable files, so open read/write before the required FlushFileBuffers.
+    flags = os.O_RDWR if os.name == "nt" else os.O_RDONLY
+    fd = os.open(path, flags)
+    try:
+        os.fsync(fd)
+        if os.name == "nt":
+            import msvcrt
+
+            handle = ctypes.c_void_p(msvcrt.get_osfhandle(fd))
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.FlushFileBuffers.argtypes = [ctypes.c_void_p]
+            kernel32.FlushFileBuffers.restype = ctypes.c_int
+            if not kernel32.FlushFileBuffers(handle):
+                raise OSError(ctypes.get_last_error(), "FlushFileBuffers failed")
+    finally:
+        os.close(fd)
+
+
+def _flush_parent(path: Path) -> None:
+    if os.name == "nt":
+        return
+    fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _durable_replace(source: Path, target: Path) -> None:
+    _flush_file(source)
+    if os.name == "nt":
+        move_file = ctypes.WinDLL("kernel32", use_last_error=True).MoveFileExW
+        move_file.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint]
+        move_file.restype = ctypes.c_int
+        replace_existing = 0x1
+        write_through = 0x8
+        if not move_file(str(source), str(target), replace_existing | write_through):
+            raise OSError(ctypes.get_last_error(), "MoveFileExW durable replace failed")
+        return
+    os.replace(source, target)
+    _flush_parent(target)
+
+
+def _durable_write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(raw)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        _durable_replace(tmp, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+
+
+def _durable_write_bytes(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(raw)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        _durable_replace(tmp, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+
+
+def _strict_json_object(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise LedgerBlocked(f"cannot read {path.name}") from exc
+    if not isinstance(value, dict):
+        raise LedgerBlocked(f"{path.name} must contain a JSON object")
+    return value
+
+
+@dataclass(frozen=True)
+class Reservation:
+    attempt_id: str
+    period: str
+    reserved_micro_eur: int
+    admitted_at: str
+
+
+class SpendLedger:
+    """Fail-closed monthly accounting with durable unresolved reservations."""
+
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        marker_path: Path | None = None,
+        *,
+        now: Callable[[], datetime] = _utc_now,
+        busy_timeout_seconds: float = 5.0,
+        durability_barrier: Callable[[Path], None] | None = None,
+    ) -> None:
+        self.db_path = Path(db_path or default_ledger_path()).resolve()
+        self.marker_path = Path(marker_path or default_install_marker_path()).resolve()
+        self.now = now
+        self.busy_timeout_seconds = max(0.05, float(busy_timeout_seconds))
+        self._durability_barrier = durability_barrier or self._default_barrier
+
+    @staticmethod
+    def _default_barrier(db_path: Path) -> None:
+        _flush_file(db_path)
+        journal = Path(f"{db_path}-journal")
+        if journal.exists():
+            _flush_file(journal)
+
+    def installation_state(self) -> str:
+        db_exists = self.db_path.exists()
+        marker_exists = self.marker_path.exists()
+        if db_exists and marker_exists:
+            return "complete"
+        if not db_exists and not marker_exists:
+            return "absent"
+        return "partial"
+
+    def initialize(self, *, generation: str | None = None) -> dict:
+        if self.installation_state() != "absent":
+            raise LedgerBlocked(
+                "ledger initialization requires both database and install marker to be absent"
+            )
+        now = self.now().astimezone(timezone.utc)
+        generation = generation or uuid.uuid4().hex
+        if not _ATTEMPT_ID_RE.fullmatch(generation):
+            raise ValueError("generation must be 32 lowercase hexadecimal characters")
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_db = self.db_path.with_name(f".{self.db_path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            conn = sqlite3.connect(temp_db)
+            try:
+                self._configure(conn)
+                self._create_schema(conn)
+                values = {
+                    "schema_version": str(LEDGER_SCHEMA_VERSION),
+                    "generation": generation,
+                    "price_policy_hash": price_policy_hash(),
+                    "currency": POLICY_CURRENCY,
+                    "trial_cutoff_micro_eur": str(TRIAL_CUTOFF_MICRO_EUR),
+                    "soft_stop_micro_eur": str(SOFT_STOP_MICRO_EUR),
+                    "initialized_at": _iso_utc(now),
+                    "last_accepted_utc": _iso_utc(now),
+                    "last_accepted_period": _period(now),
+                    "service_hold": "",
+                }
+                conn.execute("BEGIN IMMEDIATE")
+                conn.executemany(
+                    "INSERT INTO metadata(key, value) VALUES (?, ?)", values.items()
+                )
+                conn.execute(
+                    "INSERT INTO periods(period, committed_micro_eur) VALUES (?, 0)",
+                    (_period(now),),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            self._durability_barrier(temp_db)
+            _durable_replace(temp_db, self.db_path)
+            marker = {
+                "schema_version": INSTALL_MARKER_SCHEMA_VERSION,
+                "ledger_schema_version": LEDGER_SCHEMA_VERSION,
+                "generation": generation,
+                "price_policy_hash": price_policy_hash(),
+                "initialized_at": _iso_utc(now),
+            }
+            _durable_write_json(self.marker_path, marker)
+            return marker
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                temp_db.unlink()
+
+    @staticmethod
+    def _configure(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=PERSIST")
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute("PRAGMA fullfsync=ON")
+        conn.execute("PRAGMA checkpoint_fullfsync=ON")
+        conn.execute("PRAGMA foreign_keys=ON")
+
+    @staticmethod
+    def _create_schema(conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE periods (
+                period TEXT PRIMARY KEY,
+                committed_micro_eur INTEGER NOT NULL CHECK (committed_micro_eur >= 0)
+            );
+            CREATE TABLE attempts (
+                attempt_id TEXT PRIMARY KEY,
+                period TEXT NOT NULL REFERENCES periods(period),
+                model TEXT NOT NULL,
+                policy_hash TEXT NOT NULL,
+                reserved_micro_eur INTEGER NOT NULL CHECK (reserved_micro_eur >= 0),
+                state TEXT NOT NULL CHECK (
+                    state IN ('reserved', 'uncertain', 'settled', 'reconciled')
+                ),
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                actual_micro_eur INTEGER,
+                admitted_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                reason TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE reconciliations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                attempt_id TEXT NOT NULL REFERENCES attempts(attempt_id),
+                outcome TEXT NOT NULL,
+                prior_state TEXT NOT NULL,
+                charged_micro_eur INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                reconciled_at TEXT NOT NULL
+            );
+            """
+        )
+
+    def _marker(self) -> dict:
+        state = self.installation_state()
+        if state == "absent":
+            raise LedgerBlocked("ledger is not initialized; run explicit ledger init")
+        if state == "partial":
+            raise LedgerBlocked("ledger installation is partial; explicit recovery is required")
+        marker = _strict_json_object(self.marker_path)
+        expected = {
+            "schema_version": INSTALL_MARKER_SCHEMA_VERSION,
+            "ledger_schema_version": LEDGER_SCHEMA_VERSION,
+            "price_policy_hash": price_policy_hash(),
+        }
+        for key, value in expected.items():
+            if marker.get(key) != value:
+                raise LedgerBlocked(f"ledger install marker {key} mismatch")
+        generation = marker.get("generation")
+        if not isinstance(generation, str) or not _ATTEMPT_ID_RE.fullmatch(generation):
+            raise LedgerBlocked("ledger install marker generation is invalid")
+        return marker
+
+    @contextlib.contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        marker = self._marker()
+        try:
+            conn = sqlite3.connect(
+                f"{self.db_path.as_uri()}?mode=rw",
+                uri=True,
+                timeout=self.busy_timeout_seconds,
+            )
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger database cannot be opened") from exc
+        conn.row_factory = sqlite3.Row
+        try:
+            self._configure(conn)
+            conn.execute(f"PRAGMA busy_timeout={int(self.busy_timeout_seconds * 1000)}")
+            self._verify_metadata(conn, marker)
+            yield conn
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger database operation failed") from exc
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _metadata(conn: sqlite3.Connection) -> dict[str, str]:
+        return {row["key"]: row["value"] for row in conn.execute("SELECT key, value FROM metadata")}
+
+    def _verify_metadata(self, conn: sqlite3.Connection, marker: dict) -> dict[str, str]:
+        try:
+            integrity = conn.execute("PRAGMA quick_check(1)").fetchone()
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger integrity check failed") from exc
+        if not integrity or integrity[0] != "ok":
+            raise LedgerBlocked("ledger integrity check is not ok")
+        metadata = self._metadata(conn)
+        expected = {
+            "schema_version": str(LEDGER_SCHEMA_VERSION),
+            "generation": marker["generation"],
+            "price_policy_hash": price_policy_hash(),
+            "currency": POLICY_CURRENCY,
+            "trial_cutoff_micro_eur": str(TRIAL_CUTOFF_MICRO_EUR),
+            "soft_stop_micro_eur": str(SOFT_STOP_MICRO_EUR),
+        }
+        for key, value in expected.items():
+            if metadata.get(key) != value:
+                raise LedgerBlocked(f"ledger metadata {key} mismatch")
+        _parse_utc(metadata.get("initialized_at"))
+        _parse_utc(metadata.get("last_accepted_utc"))
+        if not _PERIOD_RE.fullmatch(metadata.get("last_accepted_period", "")):
+            raise LedgerBlocked("ledger last accepted period is invalid")
+        return metadata
+
+    @staticmethod
+    def _begin(conn: sqlite3.Connection) -> None:
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger writer lock could not be acquired") from exc
+
+    def _commit(self, conn: sqlite3.Connection) -> None:
+        try:
+            conn.commit()
+            self._durability_barrier(self.db_path)
+        except (OSError, sqlite3.Error) as exc:
+            raise LedgerBlocked("ledger durability barrier failed") from exc
+
+    @staticmethod
+    def _rollback(conn: sqlite3.Connection) -> None:
+        with contextlib.suppress(sqlite3.Error):
+            conn.rollback()
+
+    @staticmethod
+    def _unresolved(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+        return list(
+            conn.execute(
+                """
+                SELECT * FROM attempts
+                WHERE state IN (?, ?)
+                ORDER BY admitted_at
+                """,
+                ("reserved", "uncertain"),
+            )
+        )
+
+    @staticmethod
+    def _validate_attempt_id(attempt_id: str) -> None:
+        if not isinstance(attempt_id, str) or not _ATTEMPT_ID_RE.fullmatch(attempt_id):
+            raise ValueError("attempt_id must be 32 lowercase hexadecimal characters")
+
+    def _advance_period_if_valid(
+        self,
+        conn: sqlite3.Connection,
+        metadata: dict[str, str],
+        now: datetime,
+    ) -> str:
+        admitted_period = self._validate_clock(metadata, now)
+        if admitted_period == metadata["last_accepted_period"]:
+            return admitted_period
+        conn.execute(
+            "INSERT OR IGNORE INTO periods(period, committed_micro_eur) VALUES (?, 0)",
+            (admitted_period,),
+        )
+        return admitted_period
+
+    @staticmethod
+    def _validate_clock(metadata: dict[str, str], now: datetime) -> str:
+        admitted_period = _period(now)
+        prior_period = metadata["last_accepted_period"]
+        prior_time = _parse_utc(metadata["last_accepted_utc"])
+        if now < prior_time:
+            raise LedgerHold("clock rollback detected; explicit reconciliation is required")
+        if now - prior_time > timedelta(days=40):
+            raise LedgerHold("clock or billing period jumped implausibly; explicit advance required")
+        if admitted_period == prior_period:
+            return admitted_period
+        if admitted_period != _next_period(prior_period):
+            raise LedgerHold("billing period skipped or moved backward; explicit advance required")
+        return admitted_period
+
+    def reserve(
+        self,
+        attempt_id: str,
+        *,
+        model: str = MODEL_ALIAS,
+        now: datetime | None = None,
+    ) -> Reservation:
+        self._validate_attempt_id(attempt_id)
+        if model != MODEL_ALIAS:
+            raise PolicyBlocked("model alias is not allowed by the price policy")
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
+        reserve = reservation_cost_micro_eur()
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                marker = self._marker()
+                metadata = self._verify_metadata(conn, marker)
+                if metadata.get("service_hold"):
+                    raise LedgerHold("gateway has a durable accounting hold")
+                unresolved = self._unresolved(conn)
+                if unresolved:
+                    raise LedgerHold("an unresolved provider attempt blocks new transport")
+                period = self._advance_period_if_valid(conn, metadata, current)
+                row = conn.execute(
+                    "SELECT committed_micro_eur FROM periods WHERE period=?", (period,)
+                ).fetchone()
+                if row is None:
+                    raise LedgerBlocked("admission period is missing")
+                unresolved_total = sum(int(item["reserved_micro_eur"]) for item in unresolved)
+                projected = int(row[0]) + unresolved_total + reserve
+                if projected > TRIAL_CUTOFF_MICRO_EUR:
+                    raise PolicyBlocked("trial spend cutoff would be exceeded")
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO attempts(
+                            attempt_id, period, model, policy_hash, reserved_micro_eur,
+                            state, admitted_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, 'reserved', ?, ?)
+                        """,
+                        (
+                            attempt_id,
+                            period,
+                            model,
+                            price_policy_hash(),
+                            reserve,
+                            timestamp,
+                            timestamp,
+                        ),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    raise LedgerBlocked("attempt_id already exists") from exc
+                conn.execute(
+                    "UPDATE metadata SET value=? WHERE key='last_accepted_utc'", (timestamp,)
+                )
+                conn.execute(
+                    "UPDATE metadata SET value=? WHERE key='last_accepted_period'", (period,)
+                )
+                self._commit(conn)
+                return Reservation(attempt_id, period, reserve, timestamp)
+            except Exception:
+                self._rollback(conn)
+                raise
+
+    def mark_uncertain(self, attempt_id: str, *, reason: str, now: datetime | None = None) -> None:
+        self._validate_attempt_id(attempt_id)
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("an uncertainty reason is required")
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                row = conn.execute(
+                    "SELECT state FROM attempts WHERE attempt_id=?", (attempt_id,)
+                ).fetchone()
+                if row is None:
+                    raise LedgerBlocked("attempt does not exist")
+                if row["state"] in _TERMINAL_ATTEMPT_STATES:
+                    return
+                conn.execute(
+                    """
+                    UPDATE attempts SET state='uncertain', reason=?, updated_at=?
+                    WHERE attempt_id=?
+                    """,
+                    (reason.strip()[:512], timestamp, attempt_id),
+                )
+                self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+
+    def settle(
+        self,
+        attempt_id: str,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        now: datetime | None = None,
+    ) -> dict:
+        self._validate_attempt_id(attempt_id)
+        if model != MODEL_ALIAS:
+            self.mark_uncertain(attempt_id, reason="response model mismatch", now=now)
+            raise LedgerHold("response model does not match the price policy")
+        if (
+            not isinstance(input_tokens, int)
+            or isinstance(input_tokens, bool)
+            or input_tokens <= 0
+            or not isinstance(output_tokens, int)
+            or isinstance(output_tokens, bool)
+            or output_tokens <= 0
+        ):
+            self.mark_uncertain(attempt_id, reason="invalid or missing usage", now=now)
+            raise LedgerHold("response usage is invalid")
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
+        actual = settlement_cost_micro_eur(input_tokens, output_tokens)
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                row = conn.execute(
+                    "SELECT * FROM attempts WHERE attempt_id=?", (attempt_id,)
+                ).fetchone()
+                if row is None:
+                    raise LedgerBlocked("attempt does not exist")
+                if row["state"] != "reserved":
+                    raise LedgerHold("only a reserved attempt can settle automatically")
+                marker = self._marker()
+                metadata = self._verify_metadata(conn, marker)
+                self._validate_clock(metadata, current)
+                over_limit = (
+                    input_tokens > MAX_CONTEXT_TOKENS
+                    or output_tokens > MAX_OUTPUT_TOKENS
+                    or actual > int(row["reserved_micro_eur"])
+                )
+                conn.execute(
+                    "UPDATE periods SET committed_micro_eur=committed_micro_eur+? WHERE period=?",
+                    (actual, row["period"]),
+                )
+                state = "uncertain" if over_limit else "settled"
+                reason = "reported usage exceeded reserved policy" if over_limit else ""
+                conn.execute(
+                    """
+                    UPDATE attempts
+                    SET state=?, input_tokens=?, output_tokens=?, actual_micro_eur=?,
+                        updated_at=?, reason=?
+                    WHERE attempt_id=?
+                    """,
+                    (state, input_tokens, output_tokens, actual, timestamp, reason, attempt_id),
+                )
+                if over_limit:
+                    conn.execute(
+                        "UPDATE metadata SET value=? WHERE key='service_hold'",
+                        (f"attempt {attempt_id} exceeded the reserved policy",),
+                    )
+                self._commit(conn)
+                return {
+                    "attempt_id": attempt_id,
+                    "state": state,
+                    "period": row["period"],
+                    "actual_micro_eur": actual,
+                    "held": over_limit,
+                }
+            except Exception:
+                self._rollback(conn)
+                raise
+
+    def reconcile(
+        self,
+        attempt_id: str,
+        *,
+        outcome: str,
+        reason: str,
+        actual_micro_eur: int | None = None,
+        now: datetime | None = None,
+    ) -> dict:
+        self._validate_attempt_id(attempt_id)
+        if outcome not in {"no-send", "charge-actual", "charge-reserve"}:
+            raise ValueError("outcome must be no-send, charge-actual, or charge-reserve")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("a reconciliation reason is required")
+        if outcome == "charge-actual" and (
+            not isinstance(actual_micro_eur, int)
+            or isinstance(actual_micro_eur, bool)
+            or actual_micro_eur < 0
+        ):
+            raise ValueError("charge-actual requires non-negative actual_micro_eur")
+        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                row = conn.execute(
+                    "SELECT * FROM attempts WHERE attempt_id=?", (attempt_id,)
+                ).fetchone()
+                if row is None:
+                    raise LedgerBlocked("attempt does not exist")
+                if row["state"] not in _UNRESOLVED_ATTEMPT_STATES:
+                    raise LedgerBlocked("attempt is not unresolved")
+                already = int(row["actual_micro_eur"] or 0)
+                if outcome == "no-send":
+                    if already:
+                        raise LedgerBlocked("no-send cannot erase an already recorded charge")
+                    desired = 0
+                elif outcome == "charge-reserve":
+                    desired = max(already, int(row["reserved_micro_eur"]))
+                else:
+                    desired = max(already, int(actual_micro_eur or 0))
+                incremental = max(0, desired - already)
+                if incremental:
+                    conn.execute(
+                        "UPDATE periods SET committed_micro_eur=committed_micro_eur+? WHERE period=?",
+                        (incremental, row["period"]),
+                    )
+                conn.execute(
+                    """
+                    UPDATE attempts SET state='reconciled', actual_micro_eur=?,
+                        reason=?, updated_at=? WHERE attempt_id=?
+                    """,
+                    (desired, reason.strip()[:512], timestamp, attempt_id),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO reconciliations(
+                        attempt_id, outcome, prior_state, charged_micro_eur,
+                        reason, reconciled_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        attempt_id,
+                        outcome,
+                        row["state"],
+                        incremental,
+                        reason.strip()[:512],
+                        timestamp,
+                    ),
+                )
+                remaining = self._unresolved(conn)
+                metadata = self._metadata(conn)
+                if (
+                    not remaining
+                    and metadata.get("service_hold", "").startswith(
+                        f"attempt {attempt_id} "
+                    )
+                ):
+                    conn.execute("UPDATE metadata SET value='' WHERE key='service_hold'")
+                self._commit(conn)
+                return {
+                    "attempt_id": attempt_id,
+                    "state": "reconciled",
+                    "outcome": outcome,
+                    "charged_micro_eur": incremental,
+                    "total_actual_micro_eur": desired,
+                }
+            except Exception:
+                self._rollback(conn)
+                raise
+
+    def place_hold(self, *, reason: str, now: datetime | None = None) -> dict:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("a hold reason is required")
+        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        value = "manual: " + reason.strip()[:500]
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                conn.execute("UPDATE metadata SET value=? WHERE key='service_hold'", (value,))
+                conn.execute(
+                    "INSERT OR REPLACE INTO metadata(key, value) VALUES ('hold_set_at', ?)",
+                    (timestamp,),
+                )
+                self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+        return {"held": True, "reason": value, "held_at": timestamp}
+
+    def clear_hold(self, *, reason: str, now: datetime | None = None) -> dict:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("a clear-hold reason is required")
+        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                if self._unresolved(conn):
+                    raise LedgerHold("unresolved attempts must be reconciled before clearing hold")
+                metadata = self._metadata(conn)
+                prior = metadata.get("service_hold") or ""
+                conn.execute("UPDATE metadata SET value='' WHERE key='service_hold'")
+                conn.execute(
+                    "INSERT OR REPLACE INTO metadata(key, value) VALUES ('hold_cleared_at', ?)",
+                    (timestamp,),
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO metadata(key, value) VALUES ('hold_clear_reason', ?)",
+                    (reason.strip()[:512],),
+                )
+                self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+        return {"held": False, "prior_hold": prior or None, "cleared_at": timestamp}
+
+    def status(self) -> dict:
+        with self._connect() as conn:
+            marker = self._marker()
+            metadata = self._verify_metadata(conn, marker)
+            self._validate_clock(metadata, self.now().astimezone(timezone.utc))
+            periods = [dict(row) for row in conn.execute("SELECT * FROM periods ORDER BY period")]
+            unresolved = [dict(row) for row in self._unresolved(conn)]
+            current_period = metadata["last_accepted_period"]
+            current = next(
+                (row for row in periods if row["period"] == current_period),
+                {"committed_micro_eur": 0},
+            )
+            return {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "generation": metadata["generation"],
+                "policy_hash": metadata["price_policy_hash"],
+                "currency": metadata["currency"],
+                "trial_cutoff_micro_eur": TRIAL_CUTOFF_MICRO_EUR,
+                "soft_stop_micro_eur": SOFT_STOP_MICRO_EUR,
+                "current_period": current_period,
+                "current_committed_micro_eur": int(current["committed_micro_eur"]),
+                "periods": periods,
+                "unresolved": unresolved,
+                "service_hold": metadata.get("service_hold") or None,
+                "ready": not unresolved and not metadata.get("service_hold"),
+            }
+
+
+def generate_token() -> str:
+    return "atgw-" + secrets.token_urlsafe(32)
+
+
+def write_secret_file(path: Path, value: str) -> None:
+    if not isinstance(value, str) or not value or "\n" in value or "\r" in value:
+        raise ValueError("secret value must be a single non-empty line")
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise GatewayConfigError(f"refusing to replace existing secret file {path}")
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        os.write(fd, (value + "\n").encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    _flush_parent(path)
+
+
+def read_secret_file(path: Path) -> str:
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise GatewayConfigError(f"required secret file is unavailable: {Path(path).name}") from exc
+    value = raw.rstrip("\r\n")
+    if not value or "\n" in value or "\r" in value:
+        raise GatewayConfigError(f"required secret file is malformed: {Path(path).name}")
+    return value
+
+
+def token_matches(header: str | None, expected: str) -> bool:
+    if not isinstance(header, str) or not header.startswith("Bearer "):
+        return False
+    return hmac.compare_digest(header[7:], expected)
+
+
+def render_litellm_config(*, api_base: str) -> str:
+    """Render the single-model, callback-free LiteLLM trial configuration."""
+    if not isinstance(api_base, str) or not api_base.startswith(("https://", "http://")):
+        raise ValueError("api_base must be an explicit HTTP(S) URL")
+    return (
+        "model_list:\n"
+        f"  - model_name: {MODEL_ALIAS}\n"
+        "    litellm_params:\n"
+        f"      model: openai/{MODEL_ALIAS}\n"
+        f"      api_base: {api_base}\n"
+        "      api_key: os.environ/OVH_KEY\n"
+        "      store: false\n"
+        "      extra_body:\n"
+        "        store: false\n"
+        "      max_retries: 0\n"
+        "litellm_settings:\n"
+        "  drop_params: true\n"
+        "  num_retries: 0\n"
+        "  telemetry: false\n"
+        "  use_chat_completions_url_for_anthropic_messages: true\n"
+        "router_settings:\n"
+        "  num_retries: 0\n"
+        "general_settings:\n"
+        "  master_key: os.environ/LITELLM_MASTER_KEY\n"
+    )
+
+
+def policy_summary() -> dict:
+    return {
+        **price_policy(),
+        "price_policy_hash": price_policy_hash(),
+    }

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -40,8 +40,12 @@ TRIAL_CUTOFF_MICRO_EUR = 25_000_000
 SOFT_STOP_MICRO_EUR = 20_000_000
 EXTERNAL_CEILING_MICRO_EUR = 100_000_000
 CANARY_TOLERANCE_BPS = 1_000
-LEDGER_SCHEMA_VERSION = 1
+LEDGER_SCHEMA_VERSION = 2
 INSTALL_MARKER_SCHEMA_VERSION = 1
+CHILD_CAP_SCHEMA_VERSION = 1
+CHILD_TURN_MAX_CALLS = 8
+CHILD_TURN_MAX_MICRO_EUR = 500_000
+CHILD_TURN_MAX_SECONDS = 300
 BACKEND_PROFILE = "ovh-qwen"
 EXTERNAL_WORKER = "external-worker"
 PUBLIC_HOST = "127.0.0.1"
@@ -57,6 +61,13 @@ _ATTEMPT_ID_RE = re.compile(r"^[a-f0-9]{32}$")
 _PERIOD_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])$")
 _TERMINAL_ATTEMPT_STATES = frozenset({"settled", "reconciled"})
 _UNRESOLVED_ATTEMPT_STATES = frozenset({"reserved", "uncertain"})
+_FRONT_TOKEN_RE = re.compile(r"^atgw-[A-Za-z0-9_-]{43}$")
+_CHILD_CAPABILITY_RE = re.compile(r"^atgw-child-[A-Za-z0-9_-]{43}$")
+_CHILD_CAP_TABLES = (
+    "child_turns",
+    "child_capabilities",
+    "child_attempts",
+)
 
 
 class GatewayError(RuntimeError):
@@ -81,6 +92,14 @@ class LedgerHold(LedgerError):
 
 class PolicyBlocked(LedgerError):
     """The configured trial cutoff refuses a new reservation."""
+
+
+class ChildTurnCapBlocked(LedgerBlocked):
+    """A request lacks a valid durable child-turn capability."""
+
+
+class ChildTurnCapExceeded(ChildTurnCapBlocked):
+    """A durable child-turn budget has reached a hard gateway ceiling."""
 
 
 def _ceil_cost(tokens: int, rate_micro_eur: int) -> int:
@@ -139,6 +158,24 @@ def price_policy() -> dict:
 def price_policy_hash() -> str:
     encoded = json.dumps(
         price_policy(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def child_cap_policy() -> dict:
+    """Canonical separately-versioned child-turn admission policy."""
+    return {
+        "schema_version": CHILD_CAP_SCHEMA_VERSION,
+        "max_calls": CHILD_TURN_MAX_CALLS,
+        "max_micro_eur": CHILD_TURN_MAX_MICRO_EUR,
+        "max_seconds": CHILD_TURN_MAX_SECONDS,
+        "reservation_micro_eur": reservation_cost_micro_eur(),
+    }
+
+
+def child_cap_policy_hash() -> str:
+    encoded = json.dumps(
+        child_cap_policy(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
@@ -310,6 +347,14 @@ class Reservation:
     admitted_at: str
 
 
+@dataclass(frozen=True)
+class ChildTurnCredential:
+    token: str
+    agent: str
+    message_id: str
+    expires_at: str
+
+
 class SpendLedger:
     """Fail-closed monthly accounting with durable unresolved reservations."""
 
@@ -387,6 +432,7 @@ class SpendLedger:
         opening_micro_eur: int,
         opening_evidence: str,
         generation: str | None = None,
+        child_cap_issuer_token: str | None = None,
     ) -> dict:
         if self.installation_state() != "absent":
             raise LedgerBlocked(
@@ -394,6 +440,7 @@ class SpendLedger:
             )
         opening_micro_eur = self._opening_amount(opening_micro_eur)
         opening_evidence = self._opening_evidence(opening_evidence)
+        issuer_hash = self._child_cap_issuer_hash(child_cap_issuer_token)
         self._assert_external_envelope(opening_micro_eur)
         now = self.now().astimezone(timezone.utc)
         observed_at = _iso_utc(now)
@@ -425,6 +472,9 @@ class SpendLedger:
                     "last_accepted_utc": observed_at,
                     "last_accepted_period": opening_period,
                     "service_hold": "",
+                    "child_cap_schema_version": str(CHILD_CAP_SCHEMA_VERSION),
+                    "child_cap_policy_hash": child_cap_policy_hash(),
+                    "child_cap_issuer_sha256": issuer_hash,
                 }
                 conn.execute("BEGIN IMMEDIATE")
                 conn.executemany(
@@ -509,8 +559,48 @@ class SpendLedger:
             );
             """
         )
+        SpendLedger._create_child_cap_schema(conn)
 
-    def _marker(self) -> dict:
+    @staticmethod
+    def _create_child_cap_schema(conn: sqlite3.Connection) -> None:
+        statements = (
+            """CREATE TABLE child_turns (
+                agent TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                request_id TEXT NOT NULL,
+                state TEXT NOT NULL CHECK (
+                    state IN ('open', 'capped', 'expired')
+                ),
+                max_calls INTEGER NOT NULL CHECK (max_calls > 0),
+                max_micro_eur INTEGER NOT NULL CHECK (max_micro_eur > 0),
+                opened_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                reason TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY(agent, message_id)
+            )""",
+            """CREATE TABLE child_capabilities (
+                token_sha256 TEXT PRIMARY KEY,
+                agent TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                issued_at TEXT NOT NULL,
+                FOREIGN KEY(agent, message_id)
+                    REFERENCES child_turns(agent, message_id)
+            )""",
+            """CREATE TABLE child_attempts (
+                attempt_id TEXT PRIMARY KEY REFERENCES attempts(attempt_id),
+                agent TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+                FOREIGN KEY(agent, message_id)
+                    REFERENCES child_turns(agent, message_id),
+                UNIQUE(agent, message_id, ordinal)
+            )""",
+        )
+        for statement in statements:
+            conn.execute(statement)
+
+    def _marker(self, *, ledger_schema_version: int | None = None) -> dict:
         state = self.installation_state()
         if state == "absent":
             raise LedgerBlocked("ledger is not initialized; run explicit ledger init")
@@ -519,7 +609,11 @@ class SpendLedger:
         marker = _strict_json_object(self.marker_path)
         expected = {
             "schema_version": INSTALL_MARKER_SCHEMA_VERSION,
-            "ledger_schema_version": LEDGER_SCHEMA_VERSION,
+            "ledger_schema_version": (
+                LEDGER_SCHEMA_VERSION
+                if ledger_schema_version is None
+                else ledger_schema_version
+            ),
             "price_policy_hash": price_policy_hash(),
         }
         for key, value in expected.items():
@@ -572,7 +666,13 @@ class SpendLedger:
     def _metadata(conn: sqlite3.Connection) -> dict[str, str]:
         return {row["key"]: row["value"] for row in conn.execute("SELECT key, value FROM metadata")}
 
-    def _verify_metadata(self, conn: sqlite3.Connection, marker: dict) -> dict[str, str]:
+    def _verify_metadata(
+        self,
+        conn: sqlite3.Connection,
+        marker: dict,
+        *,
+        ledger_schema_version: int | None = None,
+    ) -> dict[str, str]:
         try:
             integrity = conn.execute("PRAGMA quick_check(1)").fetchone()
         except sqlite3.Error as exc:
@@ -581,7 +681,11 @@ class SpendLedger:
             raise LedgerBlocked("ledger integrity check is not ok")
         metadata = self._metadata(conn)
         expected = {
-            "schema_version": str(LEDGER_SCHEMA_VERSION),
+            "schema_version": str(
+                LEDGER_SCHEMA_VERSION
+                if ledger_schema_version is None
+                else ledger_schema_version
+            ),
             "generation": marker["generation"],
             "price_policy_hash": price_policy_hash(),
             "currency": POLICY_CURRENCY,
@@ -682,6 +786,224 @@ class SpendLedger:
         return metadata
 
     @staticmethod
+    def _child_cap_table_names(conn: sqlite3.Connection) -> set[str]:
+        return {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'child_%'"
+            )
+        }
+
+    def _child_cap_feature_state(
+        self,
+        conn: sqlite3.Connection,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        metadata = metadata or self._metadata(conn)
+        schema_value = metadata.get("child_cap_schema_version")
+        policy_value = metadata.get("child_cap_policy_hash")
+        issuer_value = metadata.get("child_cap_issuer_sha256")
+        tables = self._child_cap_table_names(conn)
+        expected_tables = set(_CHILD_CAP_TABLES)
+        if (
+            schema_value is None
+            and policy_value is None
+            and issuer_value is None
+            and not (tables & expected_tables)
+        ):
+            return "absent"
+        if schema_value != str(CHILD_CAP_SCHEMA_VERSION):
+            raise LedgerBlocked("child cap schema version is missing or mismatched")
+        if policy_value != child_cap_policy_hash():
+            raise LedgerBlocked("child cap policy hash is missing or mismatched")
+        if not isinstance(issuer_value, str) or not re.fullmatch(
+            r"[a-f0-9]{64}", issuer_value
+        ):
+            raise LedgerBlocked("child cap issuer authority is missing or invalid")
+        if not expected_tables <= tables:
+            raise LedgerBlocked("child cap schema is partial")
+        expected_columns = {
+            "child_turns": (
+                "agent",
+                "message_id",
+                "request_id",
+                "state",
+                "max_calls",
+                "max_micro_eur",
+                "opened_at",
+                "expires_at",
+                "updated_at",
+                "reason",
+            ),
+            "child_capabilities": (
+                "token_sha256",
+                "agent",
+                "message_id",
+                "issued_at",
+            ),
+            "child_attempts": (
+                "attempt_id",
+                "agent",
+                "message_id",
+                "ordinal",
+            ),
+        }
+        for table, expected in expected_columns.items():
+            observed = tuple(
+                str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")
+            )
+            if observed != expected:
+                raise LedgerBlocked(f"child cap table {table} has an unexpected shape")
+        invalid_turn = conn.execute(
+            """
+            SELECT 1 FROM child_turns
+            WHERE state NOT IN ('open', 'capped', 'expired')
+               OR max_calls != ? OR max_micro_eur != ?
+            LIMIT 1
+            """,
+            (CHILD_TURN_MAX_CALLS, CHILD_TURN_MAX_MICRO_EUR),
+        ).fetchone()
+        if invalid_turn is not None:
+            raise LedgerBlocked("child cap turn policy binding is invalid")
+        for row in conn.execute(
+            "SELECT opened_at, expires_at, updated_at FROM child_turns"
+        ):
+            opened = _parse_utc(row["opened_at"])
+            expires = _parse_utc(row["expires_at"])
+            _parse_utc(row["updated_at"])
+            if expires - opened != timedelta(seconds=CHILD_TURN_MAX_SECONDS):
+                raise LedgerBlocked("child cap turn expiry binding is invalid")
+        for row in conn.execute(
+            "SELECT token_sha256, issued_at FROM child_capabilities"
+        ):
+            if not re.fullmatch(r"[a-f0-9]{64}", str(row["token_sha256"])):
+                raise LedgerBlocked("child cap capability hash is invalid")
+            _parse_utc(row["issued_at"])
+        return "ready"
+
+    def install_child_caps(self, *, issuer_token: str | None = None) -> dict:
+        """Migrate a v1 ledger to the downgrade-fenced child-cap schema."""
+        issuer_hash = self._child_cap_issuer_hash(issuer_token)
+        if self.installation_state() != "complete":
+            raise LedgerBlocked(
+                "child cap install requires a complete existing ledger"
+            )
+        raw_marker = _strict_json_object(self.marker_path)
+        marker_version = raw_marker.get("ledger_schema_version")
+        if marker_version == LEDGER_SCHEMA_VERSION:
+            with self._connect() as conn:
+                metadata = self._verify_metadata(conn, self._marker())
+                if self._child_cap_feature_state(conn, metadata) != "ready":
+                    raise LedgerBlocked(
+                        "current ledger schema is missing the child cap feature"
+                    )
+                if not hmac.compare_digest(
+                    metadata["child_cap_issuer_sha256"], issuer_hash
+                ):
+                    raise ChildTurnCapBlocked(
+                        "child turn issuer credential is invalid"
+                    )
+            return {
+                "installed": False,
+                "schema_version": CHILD_CAP_SCHEMA_VERSION,
+                "policy_hash": child_cap_policy_hash(),
+            }
+        if marker_version != 1:
+            raise LedgerBlocked("child cap install requires ledger schema v1 or v2")
+
+        # Commit the database version first. During the small marker-update
+        # window, old code sees metadata v2 and new code sees marker v1, so both
+        # fail closed. A retry recognizes that transitional pair and finishes
+        # the durable marker projection.
+        marker = self._marker(ledger_schema_version=1)
+        try:
+            conn = sqlite3.connect(
+                f"{self.db_path.as_uri()}?mode=rw",
+                uri=True,
+                timeout=self.busy_timeout_seconds,
+            )
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger database cannot be opened") from exc
+        conn.row_factory = sqlite3.Row
+        try:
+            self._configure(conn)
+            conn.execute(
+                f"PRAGMA busy_timeout={int(self.busy_timeout_seconds * 1000)}"
+            )
+            self._begin(conn)
+            try:
+                raw_metadata = self._metadata(conn)
+                database_version = raw_metadata.get("schema_version")
+                if database_version == "1":
+                    metadata = self._verify_metadata(
+                        conn, marker, ledger_schema_version=1
+                    )
+                    if self._unresolved(conn):
+                        raise LedgerHold(
+                            "child cap install requires all provider attempts reconciled"
+                        )
+                    state = self._child_cap_feature_state(conn, metadata)
+                    if state == "absent":
+                        self._create_child_cap_schema(conn)
+                        conn.executemany(
+                            "INSERT INTO metadata(key, value) VALUES (?, ?)",
+                            (
+                                (
+                                    "child_cap_schema_version",
+                                    str(CHILD_CAP_SCHEMA_VERSION),
+                                ),
+                                ("child_cap_policy_hash", child_cap_policy_hash()),
+                                ("child_cap_issuer_sha256", issuer_hash),
+                            ),
+                        )
+                    else:
+                        if not hmac.compare_digest(
+                            metadata["child_cap_issuer_sha256"], issuer_hash
+                        ):
+                            raise ChildTurnCapBlocked(
+                                "child turn issuer credential is invalid"
+                            )
+                    conn.execute(
+                        "UPDATE metadata SET value=? WHERE key='schema_version'",
+                        (str(LEDGER_SCHEMA_VERSION),),
+                    )
+                elif database_version == str(LEDGER_SCHEMA_VERSION):
+                    metadata = self._verify_metadata(
+                        conn, marker, ledger_schema_version=LEDGER_SCHEMA_VERSION
+                    )
+                    if self._child_cap_feature_state(conn, metadata) != "ready":
+                        raise LedgerBlocked(
+                            "migrated ledger is missing the child cap feature"
+                        )
+                    if not hmac.compare_digest(
+                        metadata["child_cap_issuer_sha256"], issuer_hash
+                    ):
+                        raise ChildTurnCapBlocked(
+                            "child turn issuer credential is invalid"
+                        )
+                else:
+                    raise LedgerBlocked(
+                        "ledger schema cannot be migrated to the child cap feature"
+                    )
+                self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+        except sqlite3.Error as exc:
+            raise LedgerBlocked("ledger database operation failed") from exc
+        finally:
+            conn.close()
+
+        migrated_marker = dict(marker)
+        migrated_marker["ledger_schema_version"] = LEDGER_SCHEMA_VERSION
+        _durable_write_json(self.marker_path, migrated_marker)
+        return {
+            "installed": True,
+            "schema_version": CHILD_CAP_SCHEMA_VERSION,
+            "policy_hash": child_cap_policy_hash(),
+        }
+
+    @staticmethod
     def _begin(conn: sqlite3.Connection) -> None:
         try:
             conn.execute("BEGIN IMMEDIATE")
@@ -717,9 +1039,201 @@ class SpendLedger:
         )
 
     @staticmethod
+    def _validate_child_cap_clock(
+        conn: sqlite3.Connection, current: datetime
+    ) -> None:
+        observations = [
+            _parse_utc(row[0])
+            for row in conn.execute("SELECT updated_at FROM child_turns")
+        ]
+        if observations and current < max(observations):
+            raise LedgerHold(
+                "child turn clock rollback detected; explicit reconciliation is required"
+            )
+
+    def _observe_child_attempt_clock(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        attempt_id: str,
+        current: datetime,
+        timestamp: str,
+    ) -> None:
+        self._validate_child_cap_clock(conn, current)
+        child = conn.execute(
+            """
+            SELECT agent, message_id FROM child_attempts WHERE attempt_id=?
+            """,
+            (attempt_id,),
+        ).fetchone()
+        if child is not None:
+            conn.execute(
+                """
+                UPDATE child_turns SET updated_at=?
+                WHERE agent=? AND message_id=?
+                """,
+                (timestamp, child["agent"], child["message_id"]),
+            )
+
+    @staticmethod
     def _validate_attempt_id(attempt_id: str) -> None:
         if not isinstance(attempt_id, str) or not _ATTEMPT_ID_RE.fullmatch(attempt_id):
             raise ValueError("attempt_id must be 32 lowercase hexadecimal characters")
+
+    @staticmethod
+    def _validate_child_scope(value: object, *, name: str, limit: int) -> str:
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > limit
+            or any(ord(char) < 32 or ord(char) == 127 for char in value)
+        ):
+            raise ValueError(f"{name} must be a non-empty printable string of at most {limit} characters")
+        return value
+
+    @staticmethod
+    def _capability_hash(capability: object) -> str:
+        if not isinstance(capability, str) or not _CHILD_CAPABILITY_RE.fullmatch(capability):
+            raise ChildTurnCapBlocked("child turn capability is missing or malformed")
+        return hashlib.sha256(capability.encode("ascii")).hexdigest()
+
+    @staticmethod
+    def _child_cap_issuer_hash(issuer_token: object) -> str:
+        if not isinstance(issuer_token, str) or not _FRONT_TOKEN_RE.fullmatch(
+            issuer_token
+        ):
+            raise ChildTurnCapBlocked(
+                "child turn issuer credential is missing or malformed"
+            )
+        return hashlib.sha256(issuer_token.encode("ascii")).hexdigest()
+
+    def verify_child_cap_issuer(self, issuer_token: str | None) -> None:
+        """Fail closed unless the current front token owns child-cap minting."""
+        issuer_hash = self._child_cap_issuer_hash(issuer_token)
+        with self._connect() as conn:
+            metadata = self._verify_metadata(conn, self._marker())
+            if self._child_cap_feature_state(conn, metadata) != "ready":
+                raise ChildTurnCapBlocked("child turn cap feature is not installed")
+            if not hmac.compare_digest(
+                metadata["child_cap_issuer_sha256"], issuer_hash
+            ):
+                raise ChildTurnCapBlocked(
+                    "front token does not match the child turn issuer authority"
+                )
+
+    def open_child_turn(
+        self,
+        *,
+        agent: str,
+        message_id: str,
+        request_id: str = "",
+        issuer_token: str | None = None,
+        now: datetime | None = None,
+    ) -> ChildTurnCredential:
+        """Issue an opaque capability bound to one durable wrapper message."""
+        agent = self._validate_child_scope(agent, name="agent", limit=128)
+        message_id = self._validate_child_scope(
+            message_id, name="message_id", limit=256
+        )
+        if request_id:
+            request_id = self._validate_child_scope(
+                request_id, name="request_id", limit=256
+            )
+        elif not isinstance(request_id, str):
+            raise ValueError("request_id must be a string")
+        current = (now or self.now()).astimezone(timezone.utc)
+        issuer_hash = self._child_cap_issuer_hash(issuer_token)
+        timestamp = _iso_utc(current)
+        expires_at = _iso_utc(current + timedelta(seconds=CHILD_TURN_MAX_SECONDS))
+        token = "atgw-child-" + secrets.token_urlsafe(32)
+        token_hash = self._capability_hash(token)
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                marker = self._marker()
+                metadata = self._verify_metadata(conn, marker)
+                if self._child_cap_feature_state(conn, metadata) != "ready":
+                    raise ChildTurnCapBlocked("child turn cap feature is not installed")
+                if not hmac.compare_digest(
+                    metadata["child_cap_issuer_sha256"], issuer_hash
+                ):
+                    raise ChildTurnCapBlocked("child turn issuer credential is invalid")
+                self._validate_child_cap_clock(conn, current)
+                self._validate_clock(metadata, current)
+                row = conn.execute(
+                    "SELECT * FROM child_turns WHERE agent=? AND message_id=?",
+                    (agent, message_id),
+                ).fetchone()
+                if row is None:
+                    conn.execute(
+                        """
+                        INSERT INTO child_turns(
+                            agent, message_id, request_id, state, max_calls,
+                            max_micro_eur, opened_at, expires_at, updated_at
+                        ) VALUES (?, ?, ?, 'open', ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            agent,
+                            message_id,
+                            request_id,
+                            CHILD_TURN_MAX_CALLS,
+                            CHILD_TURN_MAX_MICRO_EUR,
+                            timestamp,
+                            expires_at,
+                            timestamp,
+                        ),
+                    )
+                else:
+                    if row["request_id"] != request_id:
+                        raise ChildTurnCapBlocked(
+                            "child turn request binding changed for an immutable message"
+                        )
+                    latest_observation = _parse_utc(row["updated_at"])
+                    if current < latest_observation:
+                        raise LedgerHold(
+                            "child turn clock rollback detected; explicit reconciliation "
+                            "is required"
+                        )
+                    expiry = _parse_utc(row["expires_at"])
+                    if row["state"] != "open" or current >= expiry:
+                        if row["state"] == "open":
+                            conn.execute(
+                                """
+                                UPDATE child_turns
+                                SET state='expired', reason='wall-time ceiling exceeded',
+                                    updated_at=?
+                                WHERE agent=? AND message_id=?
+                                """,
+                                (timestamp, agent, message_id),
+                            )
+                            self._commit(conn)
+                        raise ChildTurnCapExceeded(
+                            str(row["reason"] or "child turn wall-time ceiling exceeded")
+                        )
+                    expires_at = row["expires_at"]
+                    conn.execute(
+                        """
+                        UPDATE child_turns SET updated_at=?
+                        WHERE agent=? AND message_id=?
+                        """,
+                        (timestamp, agent, message_id),
+                    )
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO child_capabilities(
+                            token_sha256, agent, message_id, issued_at
+                        ) VALUES (?, ?, ?, ?)
+                        """,
+                        (token_hash, agent, message_id, timestamp),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    raise LedgerBlocked("child turn capability collision") from exc
+                self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+        return ChildTurnCredential(token, agent, message_id, expires_at)
 
     def _advance_period_if_valid(
         self,
@@ -751,6 +1265,81 @@ class SpendLedger:
             raise LedgerHold("billing period skipped or moved backward; explicit advance required")
         return admitted_period
 
+    def _reserve_locked(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        attempt_id: str,
+        model: str,
+        current: datetime,
+        timestamp: str,
+        reserve: int,
+        metadata: dict[str, str],
+        child_scope: tuple[str, str, int] | None = None,
+    ) -> Reservation:
+        if metadata.get("service_hold"):
+            raise LedgerHold("gateway has a durable accounting hold")
+        unresolved = self._unresolved(conn)
+        if unresolved:
+            raise LedgerHold("an unresolved provider attempt blocks new transport")
+        period = self._advance_period_if_valid(conn, metadata, current)
+        row = conn.execute(
+            "SELECT committed_micro_eur FROM periods WHERE period=?", (period,)
+        ).fetchone()
+        if row is None:
+            raise LedgerBlocked("admission period is missing")
+        unresolved_total = sum(int(item["reserved_micro_eur"]) for item in unresolved)
+        projected = int(row[0]) + unresolved_total + reserve
+        opening_allowance = (
+            int(metadata["opening_micro_eur"])
+            if period == metadata["opening_period"]
+            else 0
+        )
+        if projected > opening_allowance + TRIAL_CUTOFF_MICRO_EUR:
+            raise PolicyBlocked("trial spend cutoff would be exceeded")
+        cumulative_row = conn.execute(
+            "SELECT COALESCE(SUM(committed_micro_eur), 0) FROM periods"
+        ).fetchone()
+        cumulative_projected = int(cumulative_row[0]) + unresolved_total + reserve
+        if cumulative_projected > EXTERNAL_CEILING_MICRO_EUR:
+            raise PolicyBlocked("external ceiling would be exceeded")
+        try:
+            conn.execute(
+                """
+                INSERT INTO attempts(
+                    attempt_id, period, model, policy_hash, reserved_micro_eur,
+                    state, admitted_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'reserved', ?, ?)
+                """,
+                (
+                    attempt_id,
+                    period,
+                    model,
+                    price_policy_hash(),
+                    reserve,
+                    timestamp,
+                    timestamp,
+                ),
+            )
+            if child_scope is not None:
+                child_agent, child_message_id, ordinal = child_scope
+                conn.execute(
+                    """
+                    INSERT INTO child_attempts(attempt_id, agent, message_id, ordinal)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (attempt_id, child_agent, child_message_id, ordinal),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise LedgerBlocked("attempt_id or child turn ordinal already exists") from exc
+        conn.execute(
+            "UPDATE metadata SET value=? WHERE key='last_accepted_utc'", (timestamp,)
+        )
+        conn.execute(
+            "UPDATE metadata SET value=? WHERE key='last_accepted_period'", (period,)
+        )
+        return Reservation(attempt_id, period, reserve, timestamp)
+
     def reserve(
         self,
         attempt_id: str,
@@ -769,68 +1358,135 @@ class SpendLedger:
             try:
                 marker = self._marker()
                 metadata = self._verify_metadata(conn, marker)
-                if metadata.get("service_hold"):
-                    raise LedgerHold("gateway has a durable accounting hold")
-                unresolved = self._unresolved(conn)
-                if unresolved:
-                    raise LedgerHold("an unresolved provider attempt blocks new transport")
-                period = self._advance_period_if_valid(conn, metadata, current)
-                row = conn.execute(
-                    "SELECT committed_micro_eur FROM periods WHERE period=?", (period,)
-                ).fetchone()
-                if row is None:
-                    raise LedgerBlocked("admission period is missing")
-                unresolved_total = sum(int(item["reserved_micro_eur"]) for item in unresolved)
-                projected = int(row[0]) + unresolved_total + reserve
-                opening_allowance = (
-                    int(metadata["opening_micro_eur"])
-                    if period == metadata["opening_period"]
-                    else 0
-                )
-                if projected > opening_allowance + TRIAL_CUTOFF_MICRO_EUR:
-                    raise PolicyBlocked("trial spend cutoff would be exceeded")
-                cumulative_row = conn.execute(
-                    "SELECT COALESCE(SUM(committed_micro_eur), 0) FROM periods"
-                ).fetchone()
-                # The opening balance is seeded into the opening period, so the
-                # SUM already includes it. Adding metadata.opening_micro_eur
-                # again would double-count the operator-observed balance.
-                cumulative_projected = (
-                    int(cumulative_row[0]) + unresolved_total + reserve
-                )
-                if cumulative_projected > EXTERNAL_CEILING_MICRO_EUR:
-                    raise PolicyBlocked("external ceiling would be exceeded")
-                try:
-                    conn.execute(
-                        """
-                        INSERT INTO attempts(
-                            attempt_id, period, model, policy_hash, reserved_micro_eur,
-                            state, admitted_at, updated_at
-                        ) VALUES (?, ?, ?, ?, ?, 'reserved', ?, ?)
-                        """,
-                        (
-                            attempt_id,
-                            period,
-                            model,
-                            price_policy_hash(),
-                            reserve,
-                            timestamp,
-                            timestamp,
-                        ),
-                    )
-                except sqlite3.IntegrityError as exc:
-                    raise LedgerBlocked("attempt_id already exists") from exc
-                conn.execute(
-                    "UPDATE metadata SET value=? WHERE key='last_accepted_utc'", (timestamp,)
-                )
-                conn.execute(
-                    "UPDATE metadata SET value=? WHERE key='last_accepted_period'", (period,)
+                reservation = self._reserve_locked(
+                    conn,
+                    attempt_id=attempt_id,
+                    model=model,
+                    current=current,
+                    timestamp=timestamp,
+                    reserve=reserve,
+                    metadata=metadata,
                 )
                 self._commit(conn)
-                return Reservation(attempt_id, period, reserve, timestamp)
+                return reservation
             except Exception:
                 self._rollback(conn)
                 raise
+
+    def reserve_for_child(
+        self,
+        attempt_id: str,
+        *,
+        capability: str,
+        model: str = MODEL_ALIAS,
+        now: datetime | None = None,
+    ) -> Reservation:
+        """Atomically consume a child-turn slot and reserve provider exposure."""
+        self._validate_attempt_id(attempt_id)
+        capability_hash = self._capability_hash(capability)
+        if model != MODEL_ALIAS:
+            raise PolicyBlocked("model alias is not allowed by the price policy")
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
+        reserve = reservation_cost_micro_eur()
+        denial: str | None = None
+        reservation: Reservation | None = None
+        with self._connect() as conn:
+            self._begin(conn)
+            try:
+                marker = self._marker()
+                metadata = self._verify_metadata(conn, marker)
+                if self._child_cap_feature_state(conn, metadata) != "ready":
+                    raise ChildTurnCapBlocked("child turn cap feature is not installed")
+                self._validate_child_cap_clock(conn, current)
+                row = conn.execute(
+                    """
+                    SELECT turn.*
+                    FROM child_capabilities AS capability
+                    JOIN child_turns AS turn
+                      ON turn.agent=capability.agent
+                     AND turn.message_id=capability.message_id
+                    WHERE capability.token_sha256=?
+                    """,
+                    (capability_hash,),
+                ).fetchone()
+                if row is None:
+                    raise ChildTurnCapBlocked("child turn capability is unknown")
+                opened = _parse_utc(row["opened_at"])
+                latest_observation = _parse_utc(row["updated_at"])
+                expiry = _parse_utc(row["expires_at"])
+                if current < opened or current < latest_observation:
+                    raise LedgerHold(
+                        "child turn clock rollback detected; explicit reconciliation is required"
+                    )
+                if row["state"] != "open":
+                    denial = str(row["reason"] or "child turn is no longer open")
+                elif current >= expiry:
+                    denial = "child turn wall-time ceiling exceeded"
+                counts = conn.execute(
+                    """
+                    SELECT COUNT(*) AS attempt_count,
+                           COALESCE(SUM(
+                               CASE
+                                   WHEN attempt.actual_micro_eur IS NOT NULL
+                                   THEN attempt.actual_micro_eur
+                                   ELSE attempt.reserved_micro_eur
+                               END
+                           ), 0) AS exposure_micro_eur
+                    FROM child_attempts AS child
+                    JOIN attempts AS attempt ON attempt.attempt_id=child.attempt_id
+                    WHERE child.agent=? AND child.message_id=?
+                    """,
+                    (row["agent"], row["message_id"]),
+                ).fetchone()
+                attempt_count = int(counts["attempt_count"])
+                exposure = int(counts["exposure_micro_eur"])
+                if denial is None and attempt_count >= int(row["max_calls"]):
+                    denial = "child turn call ceiling exceeded"
+                if denial is None and exposure + reserve > int(row["max_micro_eur"]):
+                    denial = "child turn cost ceiling exceeded"
+                if denial is not None:
+                    state = "expired" if current >= expiry else "capped"
+                    conn.execute(
+                        """
+                        UPDATE child_turns
+                        SET state=?, reason=?, updated_at=?
+                        WHERE agent=? AND message_id=?
+                        """,
+                        (state, denial, timestamp, row["agent"], row["message_id"]),
+                    )
+                    self._commit(conn)
+                else:
+                    conn.execute(
+                        """
+                        UPDATE child_turns SET updated_at=?
+                        WHERE agent=? AND message_id=?
+                        """,
+                        (timestamp, row["agent"], row["message_id"]),
+                    )
+                    reservation = self._reserve_locked(
+                        conn,
+                        attempt_id=attempt_id,
+                        model=model,
+                        current=current,
+                        timestamp=timestamp,
+                        reserve=reserve,
+                        metadata=metadata,
+                        child_scope=(
+                            str(row["agent"]),
+                            str(row["message_id"]),
+                            attempt_count + 1,
+                        ),
+                    )
+                    self._commit(conn)
+            except Exception:
+                self._rollback(conn)
+                raise
+        if denial is not None:
+            raise ChildTurnCapExceeded(denial)
+        if reservation is None:
+            raise LedgerBlocked("child turn reservation did not reach a terminal state")
+        return reservation
 
     def mark_uncertain(self, attempt_id: str, *, reason: str, now: datetime | None = None) -> None:
         self._validate_attempt_id(attempt_id)
@@ -848,6 +1504,12 @@ class SpendLedger:
                     raise LedgerBlocked("attempt does not exist")
                 if row["state"] in _TERMINAL_ATTEMPT_STATES:
                     return
+                self._observe_child_attempt_clock(
+                    conn,
+                    attempt_id=attempt_id,
+                    current=current,
+                    timestamp=timestamp,
+                )
                 conn.execute(
                     """
                     UPDATE attempts SET state='uncertain', reason=?, updated_at=?
@@ -899,6 +1561,12 @@ class SpendLedger:
                 marker = self._marker()
                 metadata = self._verify_metadata(conn, marker)
                 self._validate_clock(metadata, current)
+                self._observe_child_attempt_clock(
+                    conn,
+                    attempt_id=attempt_id,
+                    current=current,
+                    timestamp=timestamp,
+                )
                 over_limit = (
                     input_tokens > MAX_CONTEXT_TOKENS
                     or output_tokens > MAX_OUTPUT_TOKENS
@@ -949,7 +1617,8 @@ class SpendLedger:
             raise ValueError("outcome must be no-send or charge-reserve")
         if not isinstance(reason, str) or not reason.strip():
             raise ValueError("a reconciliation reason is required")
-        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
         with self._connect() as conn:
             self._begin(conn)
             try:
@@ -960,6 +1629,12 @@ class SpendLedger:
                     raise LedgerBlocked("attempt does not exist")
                 if row["state"] not in _UNRESOLVED_ATTEMPT_STATES:
                     raise LedgerBlocked("attempt is not unresolved")
+                self._observe_child_attempt_clock(
+                    conn,
+                    attempt_id=attempt_id,
+                    current=current,
+                    timestamp=timestamp,
+                )
                 already = int(row["actual_micro_eur"] or 0)
                 if outcome == "no-send":
                     if already:
@@ -1020,7 +1695,8 @@ class SpendLedger:
     def place_hold(self, *, reason: str, now: datetime | None = None) -> dict:
         if not isinstance(reason, str) or not reason.strip():
             raise ValueError("a hold reason is required")
-        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
         value = "manual: " + reason.strip()[:500]
         with self._connect() as conn:
             self._begin(conn)
@@ -1039,7 +1715,8 @@ class SpendLedger:
     def clear_hold(self, *, reason: str, now: datetime | None = None) -> dict:
         if not isinstance(reason, str) or not reason.strip():
             raise ValueError("a clear-hold reason is required")
-        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
         with self._connect() as conn:
             self._begin(conn)
             try:
@@ -1077,7 +1754,8 @@ class SpendLedger:
             or observed_delta_micro_eur < 0
         ):
             raise ValueError("observed dashboard delta must be non-negative micro-EUR")
-        timestamp = _iso_utc((now or self.now()).astimezone(timezone.utc))
+        current = (now or self.now()).astimezone(timezone.utc)
+        timestamp = _iso_utc(current)
         with self._connect() as conn:
             self._begin(conn)
             try:
@@ -1096,6 +1774,12 @@ class SpendLedger:
                     raise LedgerBlocked(
                         "dashboard canary requires a positive policy-matched settled attempt"
                     )
+                self._observe_child_attempt_clock(
+                    conn,
+                    attempt_id=attempt_id,
+                    current=current,
+                    timestamp=timestamp,
+                )
                 tolerance = max(
                     1,
                     (
@@ -1144,7 +1828,11 @@ class SpendLedger:
         with self._connect() as conn:
             marker = self._marker()
             metadata = self._verify_metadata(conn, marker)
-            self._validate_clock(metadata, self.now().astimezone(timezone.utc))
+            current = self.now().astimezone(timezone.utc)
+            self._validate_clock(metadata, current)
+            child_cap_state = self._child_cap_feature_state(conn, metadata)
+            if child_cap_state == "ready":
+                self._validate_child_cap_clock(conn, current)
             periods = [dict(row) for row in conn.execute("SELECT * FROM periods ORDER BY period")]
             unresolved = [dict(row) for row in self._unresolved(conn)]
             current_period = metadata["last_accepted_period"]
@@ -1180,6 +1868,36 @@ class SpendLedger:
                 worker_spend_errors.append("dashboard_canary_absent")
             elif dashboard_canary["status"] != "accepted":
                 worker_spend_errors.append("dashboard_canary_mismatch")
+            if child_cap_state != "ready":
+                worker_spend_errors.append("child_cap_unavailable")
+            active_child_turns = []
+            if child_cap_state == "ready":
+                active_child_turns = [
+                    dict(row)
+                    for row in conn.execute(
+                        """
+                        SELECT turn.agent, turn.message_id, turn.request_id,
+                               turn.state, turn.opened_at, turn.expires_at,
+                               turn.reason,
+                               COUNT(child.attempt_id) AS attempt_count,
+                               COALESCE(SUM(
+                                   CASE
+                                       WHEN attempt.actual_micro_eur IS NOT NULL
+                                       THEN attempt.actual_micro_eur
+                                       ELSE attempt.reserved_micro_eur
+                                   END
+                               ), 0) AS exposure_micro_eur
+                        FROM child_turns AS turn
+                        LEFT JOIN child_attempts AS child
+                          ON child.agent=turn.agent
+                         AND child.message_id=turn.message_id
+                        LEFT JOIN attempts AS attempt
+                          ON attempt.attempt_id=child.attempt_id
+                        GROUP BY turn.agent, turn.message_id
+                        ORDER BY turn.opened_at, turn.agent, turn.message_id
+                        """
+                    )
+                ]
             return {
                 "schema_version": LEDGER_SCHEMA_VERSION,
                 "generation": metadata["generation"],
@@ -1202,6 +1920,17 @@ class SpendLedger:
                 "unresolved": unresolved,
                 "service_hold": metadata.get("service_hold") or None,
                 "dashboard_canary": dashboard_canary,
+                "child_cap_ready": child_cap_state == "ready",
+                "child_cap_schema_version": (
+                    CHILD_CAP_SCHEMA_VERSION if child_cap_state == "ready" else None
+                ),
+                "child_cap_policy_hash": (
+                    child_cap_policy_hash() if child_cap_state == "ready" else None
+                ),
+                "child_turn_max_calls": CHILD_TURN_MAX_CALLS,
+                "child_turn_max_micro_eur": CHILD_TURN_MAX_MICRO_EUR,
+                "child_turn_max_seconds": CHILD_TURN_MAX_SECONDS,
+                "active_child_turns": active_child_turns,
                 "ready": accounting_ready,
                 "worker_spend_ready": not worker_spend_errors,
                 "worker_spend_errors": worker_spend_errors,
@@ -1243,6 +1972,13 @@ def token_matches(header: str | None, expected: str) -> bool:
     if not isinstance(header, str) or not header.startswith("Bearer "):
         return False
     return hmac.compare_digest(header[7:], expected)
+
+
+def child_capability_from_header(header: str | None) -> str | None:
+    if not isinstance(header, str) or not header.startswith("Bearer "):
+        return None
+    token = header[7:]
+    return token if _CHILD_CAPABILITY_RE.fullmatch(token) else None
 
 
 def render_litellm_config(*, api_base: str) -> str:

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -667,13 +667,16 @@ class SpendLedger:
             ):
                 raise LedgerBlocked("dashboard canary status is invalid")
             canary_attempt = conn.execute(
-                "SELECT state, actual_micro_eur FROM attempts WHERE attempt_id=?",
+                "SELECT state, actual_micro_eur, model, policy_hash "
+                "FROM attempts WHERE attempt_id=?",
                 (attempt_id,),
             ).fetchone()
             if (
                 canary_attempt is None
                 or canary_attempt["state"] != "settled"
                 or int(canary_attempt["actual_micro_eur"] or 0) != expected
+                or canary_attempt["model"] != MODEL_ALIAS
+                or canary_attempt["policy_hash"] != price_policy_hash()
             ):
                 raise LedgerBlocked("dashboard canary attempt binding is invalid")
         return metadata
@@ -1153,6 +1156,30 @@ class SpendLedger:
             current_opening = (
                 opening_micro_eur if current_period == metadata["opening_period"] else 0
             )
+            dashboard_canary = (
+                {
+                    "attempt_id": metadata["canary_attempt_id"],
+                    "checked_at": metadata["canary_checked_at"],
+                    "expected_micro_eur": int(metadata["canary_expected_micro_eur"]),
+                    "observed_delta_micro_eur": int(
+                        metadata["canary_observed_micro_eur"]
+                    ),
+                    "tolerance_micro_eur": int(
+                        metadata["canary_tolerance_micro_eur"]
+                    ),
+                    "status": metadata["canary_status"],
+                }
+                if metadata.get("canary_attempt_id")
+                else None
+            )
+            accounting_ready = not unresolved and not metadata.get("service_hold")
+            worker_spend_errors: list[str] = []
+            if not accounting_ready:
+                worker_spend_errors.append("ledger_not_ready")
+            if dashboard_canary is None:
+                worker_spend_errors.append("dashboard_canary_absent")
+            elif dashboard_canary["status"] != "accepted":
+                worker_spend_errors.append("dashboard_canary_mismatch")
             return {
                 "schema_version": LEDGER_SCHEMA_VERSION,
                 "generation": metadata["generation"],
@@ -1174,25 +1201,10 @@ class SpendLedger:
                 "periods": periods,
                 "unresolved": unresolved,
                 "service_hold": metadata.get("service_hold") or None,
-                "dashboard_canary": (
-                    {
-                        "attempt_id": metadata["canary_attempt_id"],
-                        "checked_at": metadata["canary_checked_at"],
-                        "expected_micro_eur": int(
-                            metadata["canary_expected_micro_eur"]
-                        ),
-                        "observed_delta_micro_eur": int(
-                            metadata["canary_observed_micro_eur"]
-                        ),
-                        "tolerance_micro_eur": int(
-                            metadata["canary_tolerance_micro_eur"]
-                        ),
-                        "status": metadata["canary_status"],
-                    }
-                    if metadata.get("canary_attempt_id")
-                    else None
-                ),
-                "ready": not unresolved and not metadata.get("service_hold"),
+                "dashboard_canary": dashboard_canary,
+                "ready": accounting_ready,
+                "worker_spend_ready": not worker_spend_errors,
+                "worker_spend_errors": worker_spend_errors,
             }
 
 

--- a/src/agenttalk/ovh_gateway_front.py
+++ b/src/agenttalk/ovh_gateway_front.py
@@ -21,12 +21,14 @@ from .ovh_gateway import (
     MODEL_ALIAS,
     PUBLIC_HOST,
     PUBLIC_PORT,
+    ChildTurnCapBlocked,
+    ChildTurnCapExceeded,
     GatewayConfigError,
     LedgerBlocked,
     LedgerHold,
     PolicyBlocked,
     SpendLedger,
-    token_matches,
+    child_capability_from_header,
 )
 
 
@@ -37,6 +39,7 @@ LEDGER_BLOCKED_CODE = "ATGW_LEDGER_BLOCKED"
 CONFIG_ERROR_CODE = "ATGW_CONFIG_ERROR"
 INFRA_ERROR_CODE = "ATGW_INFRA_UNAVAILABLE"
 BUSY_CODE = "ATGW_INFRA_BUSY"
+CHILD_TURN_CAP_EXCEEDED_CODE = "ATGW_CHILD_TURN_CAP_EXCEEDED"
 FORBIDDEN_REQUEST_KEYS = frozenset({
     "api_base",
     "api_key",
@@ -250,7 +253,8 @@ class GatewayFront:
                 if len(authorization_values) != 1:
                     self._stable_error(400, CONFIG_ERROR_CODE)
                     return
-                if not token_matches(authorization_values[0], front.config.public_token):
+                capability = child_capability_from_header(authorization_values[0])
+                if capability is None:
                     self._stable_error(401, CONFIG_ERROR_CODE)
                     return
                 content_type_values = self.headers.get_all("Content-Type") or []
@@ -305,7 +309,7 @@ class GatewayFront:
                     self._stable_error(429, BUSY_CODE)
                     return
                 try:
-                    front._proxy(self, body)
+                    front._proxy(self, body, capability=capability)
                 finally:
                     front._permit.release()
 
@@ -319,11 +323,23 @@ class GatewayFront:
             # explanatory update cannot be committed.
             return
 
-    def _proxy(self, handler: BaseHTTPRequestHandler, body: bytes) -> None:
+    def _proxy(
+        self,
+        handler: BaseHTTPRequestHandler,
+        body: bytes,
+        *,
+        capability: str,
+    ) -> None:
         attempt_id = uuid.uuid4().hex
         public_response_started = False
         try:
-            self.ledger.reserve(attempt_id)
+            self.ledger.reserve_for_child(attempt_id, capability=capability)
+        except ChildTurnCapExceeded:
+            handler._stable_error(403, CHILD_TURN_CAP_EXCEEDED_CODE)  # type: ignore[attr-defined]
+            return
+        except ChildTurnCapBlocked:
+            handler._stable_error(403, CHILD_TURN_CAP_EXCEEDED_CODE)  # type: ignore[attr-defined]
+            return
         except PolicyBlocked:
             handler._stable_error(429, POLICY_BLOCKED_CODE)  # type: ignore[attr-defined]
             return

--- a/src/agenttalk/ovh_gateway_front.py
+++ b/src/agenttalk/ovh_gateway_front.py
@@ -1,0 +1,426 @@
+"""Default-deny loopback front for the watched OVH/Qwen trial gateway."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import socket
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+
+from .ovh_gateway import (
+    INTERNAL_HOST,
+    INTERNAL_PORT,
+    MAX_CONTEXT_TOKENS,
+    MAX_OUTPUT_TOKENS,
+    MAX_REQUEST_BYTES,
+    MODEL_ALIAS,
+    PUBLIC_HOST,
+    PUBLIC_PORT,
+    GatewayConfigError,
+    LedgerBlocked,
+    LedgerHold,
+    PolicyBlocked,
+    SpendLedger,
+    token_matches,
+)
+
+
+PUBLIC_ROUTE = "/v1/messages"
+INTERNAL_LIVELINESS_ROUTE = "/health/liveliness"
+POLICY_BLOCKED_CODE = "ATGW_POLICY_BLOCKED"
+LEDGER_BLOCKED_CODE = "ATGW_LEDGER_BLOCKED"
+CONFIG_ERROR_CODE = "ATGW_CONFIG_ERROR"
+INFRA_ERROR_CODE = "ATGW_INFRA_UNAVAILABLE"
+BUSY_CODE = "ATGW_INFRA_BUSY"
+FORBIDDEN_REQUEST_KEYS = frozenset({
+    "api_base",
+    "api_key",
+    "base_url",
+    "custom_llm_provider",
+    "deployment_id",
+    "extra_headers",
+    "fallbacks",
+    "headers",
+    "max_retries",
+    "model_list",
+    "num_retries",
+    "router_settings",
+})
+
+
+@dataclass(frozen=True)
+class FrontConfig:
+    public_token: str
+    internal_token: str
+    public_host: str = PUBLIC_HOST
+    public_port: int = PUBLIC_PORT
+    internal_host: str = INTERNAL_HOST
+    internal_port: int = INTERNAL_PORT
+    request_timeout_seconds: float = 120.0
+    max_request_bytes: int = MAX_REQUEST_BYTES
+
+    def validate(self) -> None:
+        if self.public_host != PUBLIC_HOST or self.internal_host != INTERNAL_HOST:
+            raise GatewayConfigError("both gateway listeners must use literal IPv4 loopback")
+        if not (1 <= self.public_port <= 65535 and 1 <= self.internal_port <= 65535):
+            raise GatewayConfigError("gateway ports must be in the TCP port range")
+        if self.public_port == self.internal_port:
+            raise GatewayConfigError("public and internal gateway ports must differ")
+        if not self.public_token or not self.internal_token:
+            raise GatewayConfigError("gateway tokens are required")
+        if self.max_request_bytes <= 0 or self.max_request_bytes > MAX_REQUEST_BYTES:
+            raise GatewayConfigError("request body limit exceeds the trial policy")
+        if self.request_timeout_seconds <= 0:
+            raise GatewayConfigError("request timeout must be positive")
+
+    @property
+    def public_host_header(self) -> str:
+        return f"{self.public_host}:{self.public_port}"
+
+
+class StreamUsage:
+    """Extract authoritative usage from Anthropic JSON or SSE responses."""
+
+    def __init__(self) -> None:
+        self.model: str | None = None
+        self.input_tokens: int | None = None
+        self.output_tokens: int | None = None
+        self.complete = False
+        self._buffer = bytearray()
+        self._body = bytearray()
+        self._saw_sse = False
+
+    @staticmethod
+    def _valid_count(value: object) -> int | None:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
+
+    def _consume_object(self, value: object) -> None:
+        if not isinstance(value, dict):
+            return
+        value_type = value.get("type")
+        if value_type == "message_start":
+            message = value.get("message")
+            if isinstance(message, dict):
+                if isinstance(message.get("model"), str):
+                    self.model = message["model"]
+                usage = message.get("usage")
+                if isinstance(usage, dict):
+                    count = self._valid_count(usage.get("input_tokens"))
+                    if count is not None:
+                        self.input_tokens = count
+        elif value_type == "message_delta":
+            usage = value.get("usage")
+            if isinstance(usage, dict):
+                count = self._valid_count(usage.get("input_tokens"))
+                if count is not None:
+                    self.input_tokens = count
+                count = self._valid_count(usage.get("output_tokens"))
+                if count is not None:
+                    self.output_tokens = count
+        elif value_type == "message_stop":
+            self.complete = True
+        elif value_type == "message":
+            if isinstance(value.get("model"), str):
+                self.model = value["model"]
+            usage = value.get("usage")
+            if isinstance(usage, dict):
+                self.input_tokens = self._valid_count(usage.get("input_tokens"))
+                self.output_tokens = self._valid_count(usage.get("output_tokens"))
+            self.complete = True
+
+    def feed(self, chunk: bytes) -> None:
+        self._body.extend(chunk)
+        self._buffer.extend(chunk)
+        while b"\n" in self._buffer:
+            raw, _, remaining = self._buffer.partition(b"\n")
+            self._buffer = bytearray(remaining)
+            line = raw.rstrip(b"\r")
+            if not line.startswith(b"data:"):
+                continue
+            self._saw_sse = True
+            payload = line[5:].strip()
+            if not payload or payload == b"[DONE]":
+                continue
+            try:
+                self._consume_object(json.loads(payload.decode("utf-8")))
+            except (UnicodeDecodeError, ValueError):
+                continue
+
+    def finish(self) -> tuple[str, int, int]:
+        if not self._saw_sse:
+            try:
+                self._consume_object(json.loads(self._body.decode("utf-8")))
+            except (UnicodeDecodeError, ValueError):
+                pass
+        if (
+            not self.complete
+            or self.model is None
+            or self.input_tokens is None
+            or self.output_tokens is None
+            or self.input_tokens <= 0
+            or self.output_tokens <= 0
+        ):
+            raise LedgerHold("completed response lacks authoritative usage")
+        return self.model, self.input_tokens, self.output_tokens
+
+
+class GatewayFront:
+    """Own one public listener and one conservative provider-attempt permit."""
+
+    def __init__(
+        self,
+        config: FrontConfig,
+        ledger: SpendLedger,
+        *,
+        connection_factory: Callable[..., http.client.HTTPConnection] = http.client.HTTPConnection,
+    ) -> None:
+        config.validate()
+        self.config = config
+        self.ledger = ledger
+        self.connection_factory = connection_factory
+        self._permit = threading.BoundedSemaphore(1)
+        self._server: ThreadingHTTPServer | None = None
+
+    def _stable_body(self, code: str) -> bytes:
+        return json.dumps(
+            {"type": "error", "error": {"type": code, "message": code}},
+            separators=(",", ":"),
+        ).encode("ascii")
+
+    def _handler_type(self) -> type[BaseHTTPRequestHandler]:
+        front = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+            server_version = "agenttalk-qwen-front"
+            sys_version = ""
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def _stable_error(self, status: int, code: str) -> None:
+                body = front._stable_body(code)
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                self.close_connection = True
+
+            def _reject_default(self) -> None:
+                self._stable_error(404, CONFIG_ERROR_CODE)
+
+            do_GET = _reject_default
+            do_PUT = _reject_default
+            do_DELETE = _reject_default
+            do_PATCH = _reject_default
+            do_OPTIONS = _reject_default
+            do_HEAD = _reject_default
+
+            def do_POST(self) -> None:
+                if self.path != PUBLIC_ROUTE:
+                    self._reject_default()
+                    return
+                if self.headers.get("Host") != front.config.public_host_header:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                if "Origin" in self.headers:
+                    self._stable_error(403, CONFIG_ERROR_CODE)
+                    return
+                if not token_matches(self.headers.get("Authorization"), front.config.public_token):
+                    self._stable_error(401, CONFIG_ERROR_CODE)
+                    return
+                raw_length = self.headers.get("Content-Length")
+                try:
+                    length = int(raw_length or "")
+                except ValueError:
+                    self._stable_error(411, CONFIG_ERROR_CODE)
+                    return
+                if length <= 0 or length > front.config.max_request_bytes:
+                    self._stable_error(413, CONFIG_ERROR_CODE)
+                    return
+                try:
+                    body = self.rfile.read(length)
+                except OSError:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                if len(body) != length:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                try:
+                    request = json.loads(body.decode("utf-8"))
+                except (UnicodeDecodeError, ValueError):
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                if not isinstance(request, dict) or request.get("model") != MODEL_ALIAS:
+                    self._stable_error(422, CONFIG_ERROR_CODE)
+                    return
+                if any(str(key).casefold() in FORBIDDEN_REQUEST_KEYS for key in request):
+                    self._stable_error(422, CONFIG_ERROR_CODE)
+                    return
+                max_tokens = request.get("max_tokens")
+                if (
+                    not isinstance(max_tokens, int)
+                    or isinstance(max_tokens, bool)
+                    or max_tokens < 1
+                    or max_tokens > MAX_OUTPUT_TOKENS
+                    or length > MAX_CONTEXT_TOKENS
+                ):
+                    self._stable_error(422, CONFIG_ERROR_CODE)
+                    return
+                if not front._permit.acquire(blocking=False):
+                    self._stable_error(429, BUSY_CODE)
+                    return
+                try:
+                    front._proxy(self, body)
+                finally:
+                    front._permit.release()
+
+        return Handler
+
+    def _mark_uncertain(self, attempt_id: str, reason: str) -> None:
+        try:
+            self.ledger.mark_uncertain(attempt_id, reason=reason)
+        except Exception:
+            # The original durable reservation remains unresolved even when the
+            # explanatory update cannot be committed.
+            return
+
+    def _proxy(self, handler: BaseHTTPRequestHandler, body: bytes) -> None:
+        attempt_id = uuid.uuid4().hex
+        public_response_started = False
+        try:
+            self.ledger.reserve(attempt_id)
+        except PolicyBlocked:
+            handler._stable_error(429, POLICY_BLOCKED_CODE)  # type: ignore[attr-defined]
+            return
+        except (LedgerBlocked, LedgerHold):
+            handler._stable_error(503, LEDGER_BLOCKED_CODE)  # type: ignore[attr-defined]
+            return
+
+        conn: http.client.HTTPConnection | None = None
+        try:
+            conn = self.connection_factory(
+                self.config.internal_host,
+                self.config.internal_port,
+                timeout=self.config.request_timeout_seconds,
+            )
+            conn.request(
+                "POST",
+                PUBLIC_ROUTE,
+                body=body,
+                headers={
+                    "Authorization": f"Bearer {self.config.internal_token}",
+                    "Content-Type": "application/json",
+                    "Host": f"{self.config.internal_host}:{self.config.internal_port}",
+                },
+            )
+            response = conn.getresponse()
+            if response.status != 200:
+                response.read(MAX_REQUEST_BYTES)
+                self._mark_uncertain(attempt_id, f"internal status {response.status}")
+                handler._stable_error(502, INFRA_ERROR_CODE)  # type: ignore[attr-defined]
+                return
+            content_type = response.getheader("Content-Type") or "text/event-stream"
+            handler.send_response(200)
+            handler.send_header("Content-Type", content_type)
+            handler.send_header("Cache-Control", "no-store")
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+            public_response_started = True
+            usage = StreamUsage()
+            while True:
+                chunk = response.read(16 * 1024)
+                if not chunk:
+                    break
+                usage.feed(chunk)
+                handler.wfile.write(chunk)
+                handler.wfile.flush()
+            model, input_tokens, output_tokens = usage.finish()
+            self.ledger.settle(
+                attempt_id,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        except (BrokenPipeError, ConnectionResetError, TimeoutError, socket.timeout):
+            self._mark_uncertain(attempt_id, "stream disconnect or timeout")
+            if not public_response_started and not handler.wfile.closed:
+                try:
+                    handler._stable_error(502, INFRA_ERROR_CODE)  # type: ignore[attr-defined]
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+        except (OSError, http.client.HTTPException, LedgerBlocked, LedgerHold):
+            self._mark_uncertain(attempt_id, "transport or settlement failure")
+            if not public_response_started and not handler.wfile.closed:
+                try:
+                    handler._stable_error(502, INFRA_ERROR_CODE)  # type: ignore[attr-defined]
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+        finally:
+            if conn is not None:
+                conn.close()
+            handler.close_connection = True
+
+    def make_server(self) -> ThreadingHTTPServer:
+        if self._server is not None:
+            raise GatewayConfigError("front server already exists")
+
+        class Server(ThreadingHTTPServer):
+            allow_reuse_address = False
+            daemon_threads = True
+
+            def server_bind(self) -> None:
+                if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+                    self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+                super().server_bind()
+
+        self._server = Server(
+            (self.config.public_host, self.config.public_port),
+            self._handler_type(),
+        )
+        return self._server
+
+    def internal_liveliness(self) -> bool:
+        conn: http.client.HTTPConnection | None = None
+        try:
+            conn = self.connection_factory(
+                self.config.internal_host,
+                self.config.internal_port,
+                timeout=min(5.0, self.config.request_timeout_seconds),
+            )
+            conn.request(
+                "GET",
+                INTERNAL_LIVELINESS_ROUTE,
+                headers={
+                    "Authorization": f"Bearer {self.config.internal_token}",
+                    "Host": f"{self.config.internal_host}:{self.config.internal_port}",
+                },
+            )
+            response = conn.getresponse()
+            response.read(MAX_REQUEST_BYTES)
+            return response.status == 200
+        except (OSError, http.client.HTTPException):
+            return False
+        finally:
+            if conn is not None:
+                conn.close()
+
+    def drain(self, timeout_seconds: float) -> bool:
+        """Wait until the sole request permit is idle without starting work."""
+        deadline = time.monotonic() + max(0.0, timeout_seconds)
+        while time.monotonic() < deadline:
+            if self._permit.acquire(blocking=False):
+                self._permit.release()
+                return True
+            time.sleep(0.05)
+        return False

--- a/src/agenttalk/ovh_gateway_front.py
+++ b/src/agenttalk/ovh_gateway_front.py
@@ -227,24 +227,48 @@ class GatewayFront:
             do_HEAD = _reject_default
 
             def do_POST(self) -> None:
-                if self.path != PUBLIC_ROUTE:
+                request_line = self.requestline.split(" ")
+                if (
+                    len(request_line) != 3
+                    or request_line[0] != "POST"
+                    or request_line[1] != PUBLIC_ROUTE
+                    or self.path != PUBLIC_ROUTE
+                ):
                     self._reject_default()
                     return
-                if self.headers.get("Host") != front.config.public_host_header:
+                host_values = self.headers.get_all("Host") or []
+                if len(host_values) != 1 or host_values[0] != front.config.public_host_header:
                     self._stable_error(400, CONFIG_ERROR_CODE)
                     return
-                if "Origin" in self.headers:
+                if self.headers.get_all("Origin"):
                     self._stable_error(403, CONFIG_ERROR_CODE)
                     return
-                if not token_matches(self.headers.get("Authorization"), front.config.public_token):
+                if self.headers.get_all("Transfer-Encoding"):
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                authorization_values = self.headers.get_all("Authorization") or []
+                if len(authorization_values) != 1:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                if not token_matches(authorization_values[0], front.config.public_token):
                     self._stable_error(401, CONFIG_ERROR_CODE)
                     return
-                raw_length = self.headers.get("Content-Length")
-                try:
-                    length = int(raw_length or "")
-                except ValueError:
+                content_type_values = self.headers.get_all("Content-Type") or []
+                if len(content_type_values) > 1:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                length_values = self.headers.get_all("Content-Length") or []
+                if not length_values:
                     self._stable_error(411, CONFIG_ERROR_CODE)
                     return
+                if len(length_values) != 1:
+                    self._stable_error(400, CONFIG_ERROR_CODE)
+                    return
+                raw_length = length_values[0]
+                if not raw_length or any(char < "0" or char > "9" for char in raw_length):
+                    self._stable_error(411, CONFIG_ERROR_CODE)
+                    return
+                length = int(raw_length)
                 if length <= 0 or length > front.config.max_request_bytes:
                     self._stable_error(413, CONFIG_ERROR_CODE)
                     return

--- a/src/agenttalk/ovh_gateway_front.py
+++ b/src/agenttalk/ovh_gateway_front.py
@@ -32,6 +32,15 @@ from .ovh_gateway import (
 
 
 PUBLIC_ROUTE = "/v1/messages"
+# Allowlisted content types the front will echo from the internal upstream into
+# the public response header (defense-in-depth vs CodeQL py/http-response-splitting;
+# the internal upstream only ever returns SSE or JSON). Anything else -> SSE default.
+_ALLOWED_RESPONSE_CONTENT_TYPES = frozenset({
+    "text/event-stream",
+    "text/event-stream; charset=utf-8",
+    "application/json",
+    "application/json; charset=utf-8",
+})
 INTERNAL_LIVELINESS_ROUTE = "/health/liveliness"
 POLICY_BLOCKED_CODE = "ATGW_POLICY_BLOCKED"
 LEDGER_BLOCKED_CODE = "ATGW_LEDGER_BLOCKED"
@@ -367,9 +376,19 @@ class GatewayFront:
                 self.config.internal_port,
                 timeout=self.config.request_timeout_seconds,
             )
+            # Defense-in-depth (CodeQL py/partial-ssrf): forward only an
+            # allowlisted LITERAL route to the fixed internal host, never the
+            # caller-derived string. _public_request_target already rejects
+            # anything but these two exact targets with 404; re-deriving a
+            # literal here breaks the taint path and keeps the invariant local.
+            forward_target = (
+                f"{PUBLIC_ROUTE}?beta=true"
+                if request_target == f"{PUBLIC_ROUTE}?beta=true"
+                else PUBLIC_ROUTE
+            )
             conn.request(
                 "POST",
-                request_target,
+                forward_target,
                 body=body,
                 headers={
                     "Authorization": f"Bearer {self.config.internal_token}",
@@ -383,7 +402,16 @@ class GatewayFront:
                 self._mark_uncertain(attempt_id, f"internal status {response.status}")
                 handler._stable_error(502, INFRA_ERROR_CODE)  # type: ignore[attr-defined]
                 return
-            content_type = response.getheader("Content-Type") or "text/event-stream"
+            # Defense-in-depth (CodeQL py/http-response-splitting): never echo a
+            # raw upstream header value into the public response — collapse to an
+            # allowlisted literal content type (the internal upstream only ever
+            # returns SSE or JSON); anything else falls back to the SSE default.
+            upstream_content_type = response.getheader("Content-Type") or "text/event-stream"
+            content_type = (
+                upstream_content_type
+                if upstream_content_type in _ALLOWED_RESPONSE_CONTENT_TYPES
+                else "text/event-stream"
+            )
             handler.send_response(200)
             handler.send_header("Content-Type", content_type)
             handler.send_header("Cache-Control", "no-store")

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -296,6 +296,8 @@ def initialize_install(
     root: str | os.PathLike[str],
     *,
     litellm_executable: str | os.PathLike[str],
+    opening_micro_eur: int,
+    opening_evidence: str,
     api_base: str = DEFAULT_API_BASE,
     ledger: SpendLedger | None = None,
     front_token_path: Path | None = None,
@@ -321,7 +323,10 @@ def initialize_install(
             "refusing partial or replacement gateway initialization: " + ", ".join(existing)
         )
     ledger = ledger or SpendLedger()
-    marker = ledger.initialize()
+    marker = ledger.initialize(
+        opening_micro_eur=opening_micro_eur,
+        opening_evidence=opening_evidence,
+    )
     _durable_write_bytes(
         config_path,
         render_litellm_config(api_base=api_base).encode("utf-8"),
@@ -345,6 +350,8 @@ def initialize_install(
         "initialized": True,
         "ledger_generation": marker["generation"],
         "price_policy_hash": marker["price_policy_hash"],
+        "opening_micro_eur": marker["opening_micro_eur"],
+        "opening_observed_at": marker["opening_observed_at"],
         "config_path": str(config_path),
         "config_sha256": config_hash,
         "litellm_executable": str(executable),

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -759,6 +759,8 @@ def gateway_status(
         "task_identity_ok": False,
         "runtime_marker_present": False,
         "runtime": None,
+        "worker_spend_ready": False,
+        "worker_spend_errors": ["ledger_unavailable"],
         "errors": [],
     }
     manifest: dict | None = None
@@ -771,6 +773,10 @@ def gateway_status(
     try:
         result["ledger"] = ledger.status()
         result["ledger_ok"] = True
+        result["worker_spend_ready"] = result["ledger"]["worker_spend_ready"]
+        result["worker_spend_errors"] = list(
+            result["ledger"]["worker_spend_errors"]
+        )
     except (LedgerBlocked, LedgerHold):
         result["errors"].append("ledger_blocked")
     try:
@@ -832,5 +838,6 @@ def gateway_status(
     if not result["ambient_provider_keys_absent"]:
         result["errors"].append("supervisor_ambient_provider_key")
     result["errors"] = sorted(set(result["errors"]))
-    result["ready"] = not result["errors"]
+    result["operational_ready"] = not result["errors"]
+    result["ready"] = result["operational_ready"]
     return result

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -30,6 +30,7 @@ from .ovh_gateway import (
     SpendLedger,
     _durable_write_bytes,
     _durable_write_json,
+    child_cap_policy_hash,
     default_front_token_path,
     default_internal_token_path,
     default_key_path,
@@ -45,7 +46,7 @@ from .redaction import redact_diagnostic_text
 
 
 TASK_SCHEMA_VERSION = 1
-RUNTIME_SCHEMA_VERSION = 1
+RUNTIME_SCHEMA_VERSION = 2
 DEFAULT_API_BASE = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
 STOP_TIMEOUT_SECONDS = 30.0
 LITELLM_READINESS_TIMEOUT_SECONDS = 120.0
@@ -422,10 +423,12 @@ def initialize_install(
         raise GatewayConfigError(
             "refusing partial or replacement gateway initialization: " + ", ".join(existing)
         )
+    front_token = generate_token()
     ledger = ledger or SpendLedger()
     marker = ledger.initialize(
         opening_micro_eur=opening_micro_eur,
         opening_evidence=opening_evidence,
+        child_cap_issuer_token=front_token,
     )
     _durable_write_bytes(
         config_path,
@@ -444,7 +447,7 @@ def initialize_install(
             "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
         },
     )
-    write_secret_file(front_path, generate_token())
+    write_secret_file(front_path, front_token)
     write_secret_file(internal_path, generate_token())
     return {
         "initialized": True,
@@ -577,6 +580,7 @@ def _runtime_projection(root: Path, manifest: dict, *, front_token_sha256: str) 
         "schema_version": RUNTIME_SCHEMA_VERSION,
         "task_name": project_task_name(root),
         "price_policy_hash": price_policy_hash(),
+        "child_cap_policy_hash": child_cap_policy_hash(),
         "config_sha256": manifest["litellm_config_sha256"],
         "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
         "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
@@ -602,6 +606,7 @@ def _runtime_projection(root: Path, manifest: dict, *, front_token_sha256: str) 
             "litellm_start",
             "task_name",
             "price_policy_hash",
+            "child_cap_policy_hash",
             "config_sha256",
             "public_bind",
             "internal_bind",
@@ -728,12 +733,14 @@ def run_service(
     if not actions_enabled(root):
         raise GatewayConfigError("gateway.kill is present; actions are disabled")
     ledger = ledger or SpendLedger()
-    if not ledger.status()["ready"]:
-        raise LedgerBlocked("ledger has an unresolved reservation or service hold")
+    ledger_status = ledger.status()
+    if not ledger_status["ready"] or not ledger_status["child_cap_ready"]:
+        raise LedgerBlocked("ledger or child turn cap is not ready")
     exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
     exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
     ovh_key = read_secret_file(key_path or default_key_path())
     front_token = read_secret_file(front_token_path or default_front_token_path())
+    ledger.verify_child_cap_issuer(front_token)
     internal_token = read_secret_file(internal_token_path or default_internal_token_path())
     manifest = load_install_manifest(root)
     configured_executable = str(Path(manifest["litellm_executable"]).resolve())
@@ -800,6 +807,7 @@ def run_service(
                 "litellm_start": _process_start_token(int(process.pid)),
                 "task_name": project_task_name(root),
                 "price_policy_hash": price_policy_hash(),
+                "child_cap_policy_hash": child_cap_policy_hash(),
                 "config_sha256": manifest["litellm_config_sha256"],
                 "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
                 "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
@@ -884,8 +892,9 @@ def start_task(
     root = canonical_project_root(root)
     load_install_manifest(root)
     ledger = ledger or SpendLedger()
-    if not ledger.status()["ready"]:
-        raise LedgerBlocked("gateway ledger is not ready")
+    ledger_status = ledger.status()
+    if not ledger_status["ready"] or not ledger_status["child_cap_ready"]:
+        raise LedgerBlocked("gateway ledger or child turn cap is not ready")
     identity = expected_task_identity(root)
     existing = commands.query_xml(identity.task_name)
     if existing is None:
@@ -893,6 +902,10 @@ def start_task(
     if not task_xml_matches(existing, identity):
         raise GatewayConfigError("refusing to start a foreign or mismatched gateway task")
     current = gateway_status(root, commands=commands, ledger=ledger)
+    if {"child_cap_issuer_mismatch", "front_token_unavailable"} & set(
+        current["errors"]
+    ):
+        raise LedgerBlocked("front token cannot authorize child turn issuance")
     if current["ready"]:
         return {"started": False, "ready": True, "task_name": identity.task_name}
     kill_switch_path(root).unlink(missing_ok=True)
@@ -928,6 +941,7 @@ def gateway_status(
         "project_root": str(root),
         "task_name": project_task_name(root),
         "price_policy_hash": price_policy_hash(),
+        "child_cap_policy_hash": child_cap_policy_hash(),
         "ambient_provider_keys_absent": not any(
             os.environ.get(key) for key in ("OVH_KEY", "ANTHROPIC_API_KEY")
         ),
@@ -976,8 +990,14 @@ def gateway_status(
     try:
         front_token = read_secret_file(front_token_path or default_front_token_path())
         front_token_hash = hashlib.sha256(front_token.encode("utf-8")).hexdigest()
+        ledger.verify_child_cap_issuer(front_token)
     except GatewayConfigError:
         result["errors"].append("front_token_unavailable")
+    except (LedgerBlocked, LedgerHold):
+        result["errors"].append("child_cap_issuer_mismatch")
+        result["worker_spend_ready"] = False
+        if "child_cap_issuer_mismatch" not in result["worker_spend_errors"]:
+            result["worker_spend_errors"].append("child_cap_issuer_mismatch")
     if (
         runtime_marker_path(root).is_file()
         and manifest is not None

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -1,0 +1,829 @@
+"""Windows-first managed lifecycle for the watched OVH/Qwen gateway."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import html
+import http.client
+import json
+import os
+import socket
+import subprocess  # nosec B404 - fixed schtasks/LiteLLM argv lists; shell is never used
+import sys
+import threading
+import time
+import xml.etree.ElementTree as ET  # nosec B405 - bounded local Task Scheduler XML
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from .ovh_gateway import (
+    INTERNAL_HOST,
+    INTERNAL_PORT,
+    PUBLIC_HOST,
+    PUBLIC_PORT,
+    GatewayConfigError,
+    LedgerBlocked,
+    LedgerHold,
+    SpendLedger,
+    _durable_write_bytes,
+    _durable_write_json,
+    default_front_token_path,
+    default_internal_token_path,
+    default_key_path,
+    generate_token,
+    price_policy_hash,
+    read_secret_file,
+    render_litellm_config,
+    write_secret_file,
+)
+from .ovh_gateway_front import CONFIG_ERROR_CODE, PUBLIC_ROUTE, FrontConfig, GatewayFront
+
+
+TASK_SCHEMA_VERSION = 1
+RUNTIME_SCHEMA_VERSION = 1
+DEFAULT_API_BASE = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
+STOP_TIMEOUT_SECONDS = 30.0
+MAX_TASK_RESTARTS = 3
+TASK_RESTART_INTERVAL = "PT1M"
+TASK_PREFIX = "agenttalk-qwen-gateway"
+_TASK_NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+
+
+@dataclass(frozen=True)
+class TaskIdentity:
+    schema_version: int
+    task_name: str
+    project_root: str
+    execute: str
+    arguments: str
+    working_directory: str
+    principal: str
+    public_host: str
+    public_port: int
+    internal_host: str
+    internal_port: int
+    price_policy_hash: str
+
+
+def canonical_project_root(root: str | os.PathLike[str]) -> Path:
+    return Path(root).resolve()
+
+
+def project_task_name(root: str | os.PathLike[str]) -> str:
+    canonical = str(canonical_project_root(root)).replace("\\", "/").casefold()
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"{TASK_PREFIX}-{digest}"
+
+
+def gateway_state_dir(root: str | os.PathLike[str]) -> Path:
+    return canonical_project_root(root) / ".agenttalk" / "gateway"
+
+
+def task_identity_path(root: str | os.PathLike[str]) -> Path:
+    return gateway_state_dir(root) / "task-identity.json"
+
+
+def runtime_marker_path(root: str | os.PathLike[str]) -> Path:
+    return gateway_state_dir(root) / "runtime.json"
+
+
+def kill_switch_path(root: str | os.PathLike[str]) -> Path:
+    return gateway_state_dir(root) / "gateway.kill"
+
+
+def litellm_config_path(root: str | os.PathLike[str]) -> Path:
+    return gateway_state_dir(root) / "litellm.yaml"
+
+
+def install_manifest_path(root: str | os.PathLike[str]) -> Path:
+    return gateway_state_dir(root) / "install-manifest.json"
+
+
+def _task_arguments(root: Path) -> str:
+    return f'-m agenttalk --root "{root}" gateway run'
+
+
+def expected_task_identity(
+    root: str | os.PathLike[str],
+    *,
+    execute: str | os.PathLike[str] = sys.executable,
+    principal: str | None = None,
+) -> TaskIdentity:
+    project = canonical_project_root(root)
+    resolved_execute = str(Path(execute).resolve())
+    principal = principal or f"{os.environ.get('USERDOMAIN', '.')}\\{os.environ.get('USERNAME', '')}"
+    return TaskIdentity(
+        schema_version=TASK_SCHEMA_VERSION,
+        task_name=project_task_name(project),
+        project_root=str(project),
+        execute=resolved_execute,
+        arguments=_task_arguments(project),
+        working_directory=str(project),
+        principal=principal,
+        public_host=PUBLIC_HOST,
+        public_port=PUBLIC_PORT,
+        internal_host=INTERNAL_HOST,
+        internal_port=INTERNAL_PORT,
+        price_policy_hash=price_policy_hash(),
+    )
+
+
+def render_task_xml(identity: TaskIdentity) -> str:
+    command = html.escape(identity.execute, quote=True)
+    arguments = html.escape(identity.arguments, quote=True)
+    working_directory = html.escape(identity.working_directory, quote=True)
+    principal = html.escape(identity.principal, quote=True)
+    return f"""<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="{_TASK_NS}">
+  <RegistrationInfo><Description>agenttalk watched Qwen gateway</Description></RegistrationInfo>
+  <Triggers><LogonTrigger><Enabled>true</Enabled><UserId>{principal}</UserId></LogonTrigger></Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>{principal}</UserId><LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <RestartOnFailure><Interval>{TASK_RESTART_INTERVAL}</Interval><Count>{MAX_TASK_RESTARTS}</Count></RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>{command}</Command><Arguments>{arguments}</Arguments>
+      <WorkingDirectory>{working_directory}</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+
+def _task_xml_action(xml_text: str) -> tuple[str, str, str, str]:
+    if len(xml_text) > 256 * 1024:
+        raise GatewayConfigError("registered gateway task XML is too large")
+    try:
+        # ElementTree does not resolve external entities. Input is additionally
+        # bounded and comes only from the local Task Scheduler query.
+        root = ET.fromstring(xml_text)  # nosec B314  # noqa: S314
+    except ET.ParseError as exc:
+        raise GatewayConfigError("registered gateway task XML is malformed") from exc
+    ns = {"t": _TASK_NS}
+    actions = root.findall(".//t:Actions/t:Exec", ns)
+    principals = root.findall(".//t:Principals/t:Principal/t:UserId", ns)
+    if len(actions) != 1 or len(principals) != 1:
+        raise GatewayConfigError("registered gateway task has an ambiguous action or principal")
+    action = actions[0]
+
+    def text(name: str) -> str:
+        element = action.find(f"t:{name}", ns)
+        if element is None or not isinstance(element.text, str):
+            raise GatewayConfigError(f"registered gateway task lacks {name}")
+        return element.text
+
+    return text("Command"), text("Arguments"), text("WorkingDirectory"), principals[0].text or ""
+
+
+def task_xml_matches(xml_text: str, identity: TaskIdentity) -> bool:
+    try:
+        action = _task_xml_action(xml_text)
+    except GatewayConfigError:
+        return False
+    return action == (
+        identity.execute,
+        identity.arguments,
+        identity.working_directory,
+        identity.principal,
+    )
+
+
+def exclusive_bind_probe(host: str, port: int) -> None:
+    if host != "127.0.0.1":
+        raise GatewayConfigError("gateway bind probe requires literal IPv4 loopback")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        sock.bind((host, port))
+    except OSError as exc:
+        raise GatewayConfigError(f"gateway port {host}:{port} is already occupied") from exc
+    finally:
+        sock.close()
+
+
+class TaskCommands:
+    """Narrow injectable wrapper around the Windows Task Scheduler CLI."""
+
+    def run(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(  # nosec B603  # noqa: S603
+                argv,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise GatewayConfigError("gateway Task Scheduler command failed") from exc
+
+    def query_xml(self, task_name: str) -> str | None:
+        result = self.run(["schtasks.exe", "/Query", "/TN", task_name, "/XML"])
+        if result.returncode == 1:
+            return None
+        if result.returncode != 0:
+            raise GatewayConfigError("gateway task query failed")
+        return result.stdout
+
+    def install(self, task_name: str, xml_path: Path) -> None:
+        result = self.run(
+            ["schtasks.exe", "/Create", "/TN", task_name, "/XML", str(xml_path)]
+        )
+        if result.returncode != 0:
+            raise GatewayConfigError("gateway task registration failed")
+
+    def start(self, task_name: str) -> None:
+        result = self.run(["schtasks.exe", "/Run", "/TN", task_name])
+        if result.returncode != 0:
+            raise GatewayConfigError("gateway task start failed")
+
+    def stop(self, task_name: str) -> None:
+        result = self.run(["schtasks.exe", "/End", "/TN", task_name])
+        if result.returncode not in {0, 1}:
+            raise GatewayConfigError("gateway task stop failed")
+
+
+def install_task(
+    root: str | os.PathLike[str],
+    *,
+    commands: TaskCommands | None = None,
+    execute: str | os.PathLike[str] = sys.executable,
+    principal: str | None = None,
+) -> dict:
+    commands = commands or TaskCommands()
+    identity = expected_task_identity(root, execute=execute, principal=principal)
+    existing = commands.query_xml(identity.task_name)
+    if existing is not None:
+        if not task_xml_matches(existing, identity):
+            raise GatewayConfigError("refusing to replace a foreign or mismatched gateway task")
+        _durable_write_json(task_identity_path(root), asdict(identity))
+        return {"installed": True, "changed": False, **asdict(identity)}
+    state_dir = gateway_state_dir(root)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    xml_path = state_dir / "task.xml"
+    task_xml = render_task_xml(identity).replace("\n", "\r\n").encode("utf-16")
+    _durable_write_bytes(xml_path, task_xml)
+    try:
+        commands.install(identity.task_name, xml_path)
+    except GatewayConfigError:
+        # A concurrent exact installer may win between query and create. Never
+        # overwrite: accept only the now-registered byte-equivalent authority.
+        raced = commands.query_xml(identity.task_name)
+        if raced is None or not task_xml_matches(raced, identity):
+            raise
+        _durable_write_json(task_identity_path(root), asdict(identity))
+        return {"installed": True, "changed": False, **asdict(identity)}
+    registered = commands.query_xml(identity.task_name)
+    if registered is None or not task_xml_matches(registered, identity):
+        raise GatewayConfigError("registered gateway task failed identity verification")
+    _durable_write_json(task_identity_path(root), asdict(identity))
+    return {"installed": True, "changed": True, **asdict(identity)}
+
+
+def initialize_install(
+    root: str | os.PathLike[str],
+    *,
+    litellm_executable: str | os.PathLike[str],
+    api_base: str = DEFAULT_API_BASE,
+    ledger: SpendLedger | None = None,
+    front_token_path: Path | None = None,
+    internal_token_path: Path | None = None,
+) -> dict:
+    """One-time state setup. It intentionally does not activate a task or key."""
+    root = canonical_project_root(root)
+    if api_base != DEFAULT_API_BASE:
+        raise GatewayConfigError("gateway install requires the pinned OVH API base")
+    config_path = litellm_config_path(root)
+    executable = Path(litellm_executable).resolve()
+    if not executable.is_file():
+        raise GatewayConfigError("LiteLLM executable is missing")
+    front_path = front_token_path or default_front_token_path()
+    internal_path = internal_token_path or default_internal_token_path()
+    existing = [
+        path.name
+        for path in (config_path, install_manifest_path(root), front_path, internal_path)
+        if path.exists()
+    ]
+    if existing:
+        raise GatewayConfigError(
+            "refusing partial or replacement gateway initialization: " + ", ".join(existing)
+        )
+    ledger = ledger or SpendLedger()
+    marker = ledger.initialize()
+    _durable_write_bytes(
+        config_path,
+        render_litellm_config(api_base=api_base).encode("utf-8"),
+    )
+    config_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+    _durable_write_json(
+        install_manifest_path(root),
+        {
+            "schema_version": 1,
+            "litellm_executable": str(executable),
+            "litellm_config": str(config_path),
+            "litellm_config_sha256": config_hash,
+            "price_policy_hash": price_policy_hash(),
+            "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
+            "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
+        },
+    )
+    write_secret_file(front_path, generate_token())
+    write_secret_file(internal_path, generate_token())
+    return {
+        "initialized": True,
+        "ledger_generation": marker["generation"],
+        "price_policy_hash": marker["price_policy_hash"],
+        "config_path": str(config_path),
+        "config_sha256": config_hash,
+        "litellm_executable": str(executable),
+        "front_token_path": str(front_path),
+        "internal_token_path": str(internal_path),
+    }
+
+
+def _safe_gateway_environment(ovh_key: str, internal_token: str) -> dict[str, str]:
+    allowed = (
+        "PATH",
+        "SystemRoot",
+        "windir",
+        "TEMP",
+        "TMP",
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
+    )
+    env = {key: os.environ[key] for key in allowed if key in os.environ}
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["OVH_KEY"] = ovh_key
+    env["LITELLM_MASTER_KEY"] = internal_token
+    return env
+
+
+def load_install_manifest(root: str | os.PathLike[str]) -> dict:
+    path = install_manifest_path(root)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GatewayConfigError("gateway install manifest is unreadable") from exc
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise GatewayConfigError("gateway install manifest schema mismatch")
+    if value.get("price_policy_hash") != price_policy_hash():
+        raise GatewayConfigError("gateway install manifest price policy mismatch")
+    expected_binds = {
+        "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
+        "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
+    }
+    for key, expected in expected_binds.items():
+        if value.get(key) != expected:
+            raise GatewayConfigError(f"gateway install manifest {key} mismatch")
+    executable = Path(str(value.get("litellm_executable") or "")).resolve()
+    config = Path(str(value.get("litellm_config") or "")).resolve()
+    if config != litellm_config_path(root).resolve():
+        raise GatewayConfigError("gateway install manifest config path mismatch")
+    if not executable.is_file() or not config.is_file():
+        raise GatewayConfigError("gateway install manifest references a missing artifact")
+    digest = hashlib.sha256(config.read_bytes()).hexdigest()
+    if digest != value.get("litellm_config_sha256"):
+        raise GatewayConfigError("LiteLLM config hash mismatch")
+    return value
+
+
+def _process_start_token(pid: int) -> str:
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except OSError as exc:
+            raise GatewayConfigError("gateway process is not running") from exc
+        return str(pid)
+    import ctypes
+    from ctypes import wintypes
+
+    query_limited = 0x1000
+    handle = ctypes.windll.kernel32.OpenProcess(query_limited, False, pid)
+    if not handle:
+        raise GatewayConfigError("cannot query gateway process identity")
+    try:
+        creation = wintypes.FILETIME()
+        exit_time = wintypes.FILETIME()
+        kernel = wintypes.FILETIME()
+        user = wintypes.FILETIME()
+        if not ctypes.windll.kernel32.GetProcessTimes(
+            handle,
+            ctypes.byref(creation),
+            ctypes.byref(exit_time),
+            ctypes.byref(kernel),
+            ctypes.byref(user),
+        ):
+            raise GatewayConfigError("cannot query gateway process creation time")
+        return f"{creation.dwHighDateTime:08x}{creation.dwLowDateTime:08x}"
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)
+
+
+def actions_enabled(root: str | os.PathLike[str]) -> bool:
+    return not kill_switch_path(root).exists()
+
+
+def _both_sockets_free() -> bool:
+    try:
+        exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
+        exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
+    except GatewayConfigError:
+        return False
+    return True
+
+
+def _service_absent(root: str | os.PathLike[str]) -> bool:
+    root = canonical_project_root(root)
+    sockets_free = _both_sockets_free()
+    marker = runtime_marker_path(root)
+    if sockets_free and marker.exists() and not actions_enabled(root):
+        # Task Scheduler can terminate the runner without executing Python's
+        # finally block. With actions disabled and both exact sockets free, the
+        # marker is stale state, not process authority.
+        with contextlib.suppress(OSError):
+            marker.unlink()
+    return sockets_free and not marker.exists()
+
+
+def _runtime_projection(root: Path, manifest: dict, *, front_token_sha256: str) -> dict:
+    path = runtime_marker_path(root)
+    try:
+        marker = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GatewayConfigError("gateway runtime marker is unreadable") from exc
+    if not isinstance(marker, dict):
+        raise GatewayConfigError("gateway runtime marker must be an object")
+    expected = {
+        "schema_version": RUNTIME_SCHEMA_VERSION,
+        "task_name": project_task_name(root),
+        "price_policy_hash": price_policy_hash(),
+        "config_sha256": manifest["litellm_config_sha256"],
+        "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
+        "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
+        "front_token_sha256": front_token_sha256,
+    }
+    for key, value in expected.items():
+        if marker.get(key) != value:
+            raise GatewayConfigError(f"gateway runtime marker {key} mismatch")
+    for prefix in ("runner", "litellm"):
+        pid = marker.get(f"{prefix}_pid")
+        start = marker.get(f"{prefix}_start")
+        if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+            raise GatewayConfigError(f"gateway runtime marker {prefix}_pid is invalid")
+        if not isinstance(start, str) or _process_start_token(pid) != start:
+            raise GatewayConfigError(f"gateway runtime marker {prefix} identity mismatch")
+    return {
+        key: marker[key]
+        for key in (
+            "schema_version",
+            "runner_pid",
+            "runner_start",
+            "litellm_pid",
+            "litellm_start",
+            "task_name",
+            "price_policy_hash",
+            "config_sha256",
+            "public_bind",
+            "internal_bind",
+        )
+    }
+
+
+def _wait_liveliness(front: GatewayFront, process: subprocess.Popen, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise GatewayConfigError("LiteLLM exited before readiness")
+        if front.internal_liveliness():
+            return
+        time.sleep(0.25)
+    raise GatewayConfigError("LiteLLM readiness timed out")
+
+
+def _public_front_attested(timeout_seconds: float = 5.0) -> bool:
+    """Recognize the public front without disclosing its real bearer token."""
+    conn: http.client.HTTPConnection | None = None
+    try:
+        conn = http.client.HTTPConnection(PUBLIC_HOST, PUBLIC_PORT, timeout=timeout_seconds)
+        body = b"{}"
+        conn.request(
+            "POST",
+            PUBLIC_ROUTE,
+            body=body,
+            headers={
+                "Authorization": "Bearer atgw-status-probe-not-a-secret",
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+                "Host": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
+            },
+        )
+        response = conn.getresponse()
+        payload = response.read(4097)
+        if response.status != 401 or len(payload) > 4096:
+            return False
+        value = json.loads(payload.decode("ascii"))
+        return (
+            isinstance(value, dict)
+            and isinstance(value.get("error"), dict)
+            and value["error"].get("type") == CONFIG_ERROR_CODE
+            and value["error"].get("message") == CONFIG_ERROR_CODE
+        )
+    except (OSError, ValueError, UnicodeDecodeError, http.client.HTTPException):
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def run_service(
+    root: str | os.PathLike[str],
+    *,
+    litellm_executable: str | os.PathLike[str] | None = None,
+    ledger: SpendLedger | None = None,
+    key_path: Path | None = None,
+    front_token_path: Path | None = None,
+    internal_token_path: Path | None = None,
+    popen=subprocess.Popen,
+) -> int:
+    """Run LiteLLM plus the public front. Called only by the managed task."""
+    root = canonical_project_root(root)
+    if not actions_enabled(root):
+        raise GatewayConfigError("gateway.kill is present; actions are disabled")
+    ledger = ledger or SpendLedger()
+    if not ledger.status()["ready"]:
+        raise LedgerBlocked("ledger has an unresolved reservation or service hold")
+    exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
+    exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
+    ovh_key = read_secret_file(key_path or default_key_path())
+    front_token = read_secret_file(front_token_path or default_front_token_path())
+    internal_token = read_secret_file(internal_token_path or default_internal_token_path())
+    manifest = load_install_manifest(root)
+    configured_executable = str(Path(manifest["litellm_executable"]).resolve())
+    if (
+        litellm_executable is not None
+        and str(Path(litellm_executable).resolve()) != configured_executable
+    ):
+        raise GatewayConfigError("requested LiteLLM executable differs from installed manifest")
+    executable = configured_executable
+    config_path = litellm_config_path(root)
+    if not config_path.is_file():
+        raise GatewayConfigError("LiteLLM config is missing")
+    argv = [
+        executable,
+        "--config",
+        str(config_path),
+        "--host",
+        INTERNAL_HOST,
+        "--port",
+        str(INTERNAL_PORT),
+        "--num_workers",
+        "1",
+    ]
+    process = popen(
+        argv,
+        cwd=str(root),
+        env=_safe_gateway_environment(ovh_key, internal_token),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    front = GatewayFront(
+        FrontConfig(public_token=front_token, internal_token=internal_token),
+        ledger,
+    )
+    server = None
+    monitor_stop = threading.Event()
+    try:
+        _wait_liveliness(front, process)
+        server = front.make_server()
+        _durable_write_json(
+            runtime_marker_path(root),
+            {
+                "schema_version": RUNTIME_SCHEMA_VERSION,
+                "runner_pid": os.getpid(),
+                "runner_start": _process_start_token(os.getpid()),
+                "litellm_pid": int(process.pid),
+                "litellm_start": _process_start_token(int(process.pid)),
+                "task_name": project_task_name(root),
+                "price_policy_hash": price_policy_hash(),
+                "config_sha256": manifest["litellm_config_sha256"],
+                "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
+                "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
+                "front_token_sha256": hashlib.sha256(front_token.encode("utf-8")).hexdigest(),
+            },
+        )
+
+        def monitor() -> None:
+            while not monitor_stop.wait(0.25):
+                if not actions_enabled(root) or process.poll() is not None:
+                    server.shutdown()
+                    return
+
+        monitor_thread = threading.Thread(target=monitor, daemon=True)
+        monitor_thread.start()
+        server.serve_forever(poll_interval=0.25)
+        front.drain(STOP_TIMEOUT_SECONDS)
+        monitor_stop.set()
+        monitor_thread.join(timeout=2)
+        return 0 if process.poll() is None or not actions_enabled(root) else 1
+    finally:
+        monitor_stop.set()
+        if server is not None:
+            server.server_close()
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        with contextlib.suppress(FileNotFoundError):
+            runtime_marker_path(root).unlink()
+
+
+def stop_task(
+    root: str | os.PathLike[str],
+    *,
+    commands: TaskCommands | None = None,
+    timeout_seconds: float = STOP_TIMEOUT_SECONDS,
+) -> dict:
+    commands = commands or TaskCommands()
+    root = canonical_project_root(root)
+    identity = expected_task_identity(root)
+    existing = commands.query_xml(identity.task_name)
+    if existing is None:
+        if _service_absent(root):
+            return {"stopped": True, "task_present": False}
+        raise GatewayConfigError(
+            "gateway task is absent but runtime state or a loopback port remains occupied"
+        )
+    if not task_xml_matches(existing, identity):
+        raise GatewayConfigError("refusing to stop a foreign or mismatched gateway task")
+    kill = kill_switch_path(root)
+    kill.parent.mkdir(parents=True, exist_ok=True)
+    kill.write_text("operator-stop\n", encoding="ascii")
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while time.monotonic() < deadline:
+        if _service_absent(root):
+            return {"stopped": True, "forced": False, "task_present": True}
+        time.sleep(0.25)
+    commands.stop(identity.task_name)
+    verify_deadline = time.monotonic() + 5.0
+    while time.monotonic() < verify_deadline:
+        if _service_absent(root):
+            return {"stopped": True, "forced": True, "task_present": True}
+        time.sleep(0.25)
+    raise GatewayConfigError("gateway task ended but its loopback sockets remain occupied")
+
+
+def start_task(
+    root: str | os.PathLike[str],
+    *,
+    commands: TaskCommands | None = None,
+    ledger: SpendLedger | None = None,
+    readiness_timeout_seconds: float = 30.0,
+) -> dict:
+    commands = commands or TaskCommands()
+    root = canonical_project_root(root)
+    load_install_manifest(root)
+    ledger = ledger or SpendLedger()
+    if not ledger.status()["ready"]:
+        raise LedgerBlocked("gateway ledger is not ready")
+    identity = expected_task_identity(root)
+    existing = commands.query_xml(identity.task_name)
+    if existing is None:
+        raise GatewayConfigError("gateway task is not installed")
+    if not task_xml_matches(existing, identity):
+        raise GatewayConfigError("refusing to start a foreign or mismatched gateway task")
+    current = gateway_status(root, commands=commands, ledger=ledger)
+    if current["ready"]:
+        return {"started": False, "ready": True, "task_name": identity.task_name}
+    kill_switch_path(root).unlink(missing_ok=True)
+    exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
+    exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
+    commands.start(identity.task_name)
+    deadline = time.monotonic() + max(0.0, readiness_timeout_seconds)
+    last_errors: list[str] = []
+    while time.monotonic() < deadline:
+        status = gateway_status(root, commands=commands, ledger=ledger)
+        if status["ready"]:
+            return {"started": True, "ready": True, "task_name": identity.task_name}
+        last_errors = list(status["errors"])
+        time.sleep(0.25)
+    detail = ",".join(last_errors) or "readiness_timeout"
+    raise GatewayConfigError(f"gateway task did not become ready: {detail}")
+
+
+def gateway_status(
+    root: str | os.PathLike[str],
+    *,
+    commands: TaskCommands | None = None,
+    ledger: SpendLedger | None = None,
+    front_token_path: Path | None = None,
+    internal_token_path: Path | None = None,
+) -> dict:
+    """Return an allowlisted, non-secret service projection."""
+    commands = commands or TaskCommands()
+    root = canonical_project_root(root)
+    ledger = ledger or SpendLedger()
+    result = {
+        "schema_version": 1,
+        "project_root": str(root),
+        "task_name": project_task_name(root),
+        "price_policy_hash": price_policy_hash(),
+        "ambient_provider_keys_absent": not any(
+            os.environ.get(key) for key in ("OVH_KEY", "ANTHROPIC_API_KEY")
+        ),
+        "install_manifest_ok": False,
+        "ledger_ok": False,
+        "task_identity_ok": False,
+        "runtime_marker_present": False,
+        "runtime": None,
+        "errors": [],
+    }
+    manifest: dict | None = None
+    try:
+        manifest = load_install_manifest(root)
+        result["install_manifest_ok"] = True
+        result["config_sha256"] = manifest["litellm_config_sha256"]
+    except GatewayConfigError:
+        result["errors"].append("install_manifest_invalid")
+    try:
+        result["ledger"] = ledger.status()
+        result["ledger_ok"] = True
+    except (LedgerBlocked, LedgerHold):
+        result["errors"].append("ledger_blocked")
+    try:
+        identity = expected_task_identity(root)
+        task_xml = commands.query_xml(identity.task_name)
+        try:
+            stored_identity = json.loads(task_identity_path(root).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            stored_identity = None
+        result["task_identity_ok"] = (
+            task_xml is not None
+            and task_xml_matches(task_xml, identity)
+            and stored_identity == asdict(identity)
+        )
+        if not result["task_identity_ok"]:
+            result["errors"].append("task_identity_invalid")
+    except (GatewayConfigError, OSError):
+        result["errors"].append("task_query_failed")
+    front_token_hash: str | None = None
+    try:
+        front_token = read_secret_file(front_token_path or default_front_token_path())
+        front_token_hash = hashlib.sha256(front_token.encode("utf-8")).hexdigest()
+    except GatewayConfigError:
+        result["errors"].append("front_token_unavailable")
+    if (
+        runtime_marker_path(root).is_file()
+        and manifest is not None
+        and front_token_hash is not None
+    ):
+        try:
+            result["runtime"] = _runtime_projection(
+                root,
+                manifest,
+                front_token_sha256=front_token_hash,
+            )
+            result["runtime_marker_present"] = True
+        except GatewayConfigError:
+            result["errors"].append("runtime_marker_invalid")
+    else:
+        result["errors"].append("runtime_marker_missing")
+    try:
+        exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
+    except GatewayConfigError:
+        result["public_listener_present"] = True
+    else:
+        result["public_listener_present"] = False
+        result["errors"].append("public_listener_missing")
+    result["public_front_attested"] = _public_front_attested()
+    if not result["public_front_attested"]:
+        result["errors"].append("public_front_attestation_failed")
+    try:
+        token = read_secret_file(internal_token_path or default_internal_token_path())
+        front = GatewayFront(FrontConfig(public_token=token, internal_token=token), ledger)
+        result["internal_liveliness"] = front.internal_liveliness()
+    except GatewayConfigError:
+        result["internal_liveliness"] = False
+    if not result["internal_liveliness"]:
+        result["errors"].append("internal_liveliness_failed")
+    if not result["ambient_provider_keys_absent"]:
+        result["errors"].append("supervisor_ambient_provider_key")
+    result["errors"] = sorted(set(result["errors"]))
+    result["ready"] = not result["errors"]
+    return result

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -7,6 +7,8 @@ import hashlib
 import html
 import http.client
 import json
+import logging
+from logging.handlers import RotatingFileHandler
 import os
 import socket
 import subprocess  # nosec B404 - fixed schtasks/LiteLLM argv lists; shell is never used
@@ -31,6 +33,7 @@ from .ovh_gateway import (
     default_front_token_path,
     default_internal_token_path,
     default_key_path,
+    default_secret_dir,
     generate_token,
     price_policy_hash,
     read_secret_file,
@@ -38,12 +41,17 @@ from .ovh_gateway import (
     write_secret_file,
 )
 from .ovh_gateway_front import CONFIG_ERROR_CODE, PUBLIC_ROUTE, FrontConfig, GatewayFront
+from .redaction import redact_diagnostic_text
 
 
 TASK_SCHEMA_VERSION = 1
 RUNTIME_SCHEMA_VERSION = 1
 DEFAULT_API_BASE = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
 STOP_TIMEOUT_SECONDS = 30.0
+LITELLM_READINESS_TIMEOUT_SECONDS = 120.0
+LITELLM_LOG_MAX_BYTES = 1024 * 1024
+LITELLM_LOG_BACKUP_COUNT = 2
+LITELLM_LOG_RECORD_MAX_BYTES = 64 * 1024
 MAX_TASK_RESTARTS = 3
 TASK_RESTART_INTERVAL = "PT1M"
 TASK_PREFIX = "agenttalk-qwen-gateway"
@@ -98,6 +106,10 @@ def litellm_config_path(root: str | os.PathLike[str]) -> Path:
 
 def install_manifest_path(root: str | os.PathLike[str]) -> Path:
     return gateway_state_dir(root) / "install-manifest.json"
+
+
+def default_litellm_log_path() -> Path:
+    return default_secret_dir() / "gateway" / "litellm.log"
 
 
 def _task_arguments(root: Path) -> str:
@@ -187,17 +199,105 @@ def _task_xml_action(xml_text: str) -> tuple[str, str, str, str]:
     return text("Command"), text("Arguments"), text("WorkingDirectory"), principals[0].text or ""
 
 
+def _canonical_sid(value: str) -> str | None:
+    parts = value.strip().split("-")
+    if len(parts) < 4 or parts[0].casefold() != "s" or any(not part.isdecimal() for part in parts[1:]):
+        return None
+    numbers = [int(part) for part in parts[1:]]
+    revision, authority, *subauthorities = numbers
+    if (
+        revision > 0xFF
+        or authority > 0xFFFFFFFFFFFF
+        or len(subauthorities) > 15
+        or any(part > 0xFFFFFFFF for part in subauthorities)
+    ):
+        return None
+    return "S-" + "-".join(str(part) for part in numbers)
+
+
+def _binary_sid_to_string(value: bytes) -> str | None:
+    if len(value) < 8:
+        return None
+    revision = value[0]
+    count = value[1]
+    required = 8 + (count * 4)
+    if count > 15 or len(value) < required:
+        return None
+    authority = int.from_bytes(value[2:8], "big")
+    subauthorities = [
+        int.from_bytes(value[offset : offset + 4], "little")
+        for offset in range(8, required, 4)
+    ]
+    return "S-" + "-".join(str(part) for part in (revision, authority, *subauthorities))
+
+
+def _resolve_principal_sid(principal: str) -> str | None:
+    canonical = _canonical_sid(principal)
+    if canonical is not None:
+        return canonical
+    if os.name != "nt":
+        return None
+
+    import ctypes
+    from ctypes import wintypes
+
+    lookup_account_name = ctypes.WinDLL("advapi32", use_last_error=True).LookupAccountNameW
+    lookup_account_name.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.LPVOID,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    lookup_account_name.restype = wintypes.BOOL
+    sid_size = wintypes.DWORD()
+    domain_size = wintypes.DWORD()
+    sid_type = wintypes.DWORD()
+    lookup_account_name(
+        None,
+        principal,
+        None,
+        ctypes.byref(sid_size),
+        None,
+        ctypes.byref(domain_size),
+        ctypes.byref(sid_type),
+    )
+    if ctypes.get_last_error() != 122 or sid_size.value == 0:
+        return None
+    sid = ctypes.create_string_buffer(sid_size.value)
+    domain = ctypes.create_unicode_buffer(max(1, domain_size.value))
+    if not lookup_account_name(
+        None,
+        principal,
+        sid,
+        ctypes.byref(sid_size),
+        domain,
+        ctypes.byref(domain_size),
+        ctypes.byref(sid_type),
+    ):
+        return None
+    return _binary_sid_to_string(sid.raw[: sid_size.value])
+
+
 def task_xml_matches(xml_text: str, identity: TaskIdentity) -> bool:
     try:
         action = _task_xml_action(xml_text)
     except GatewayConfigError:
         return False
-    return action == (
+    if action[:3] != (
         identity.execute,
         identity.arguments,
         identity.working_directory,
-        identity.principal,
-    )
+    ):
+        return False
+    actual_principal = action[3]
+    if actual_principal == identity.principal:
+        return True
+    actual_sid = _resolve_principal_sid(actual_principal)
+    expected_sid = _resolve_principal_sid(identity.principal)
+    return actual_sid is not None and actual_sid == expected_sid
 
 
 def exclusive_bind_probe(host: str, port: int) -> None:
@@ -509,7 +609,11 @@ def _runtime_projection(root: Path, manifest: dict, *, front_token_sha256: str) 
     }
 
 
-def _wait_liveliness(front: GatewayFront, process: subprocess.Popen, timeout: float = 30.0) -> None:
+def _wait_liveliness(
+    front: GatewayFront,
+    process: subprocess.Popen,
+    timeout: float = LITELLM_READINESS_TIMEOUT_SECONDS,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
@@ -518,6 +622,59 @@ def _wait_liveliness(front: GatewayFront, process: subprocess.Popen, timeout: fl
             return
         time.sleep(0.25)
     raise GatewayConfigError("LiteLLM readiness timed out")
+
+
+def _open_litellm_log(path: Path) -> RotatingFileHandler:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        path,
+        maxBytes=LITELLM_LOG_MAX_BYTES,
+        backupCount=LITELLM_LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    os.chmod(path, 0o600)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    return handler
+
+
+def _redact_litellm_output(value: object, secrets: tuple[str, ...]) -> str:
+    text = str(value or "").rstrip("\r\n")
+    for secret in secrets:
+        if secret:
+            text = text.replace(secret, "[REDACTED]")
+    clean = redact_diagnostic_text(text)
+    budget = min(LITELLM_LOG_RECORD_MAX_BYTES, max(64, LITELLM_LOG_MAX_BYTES // 2))
+    encoded = clean.encode("utf-8", "replace")
+    if len(encoded) <= budget:
+        return clean
+    marker = b" [truncated]"
+    prefix = encoded[: max(0, budget - len(marker))].decode("utf-8", "ignore")
+    return prefix + marker.decode("ascii")
+
+
+def _pump_litellm_output(
+    stream,
+    handler: RotatingFileHandler,
+    secrets: tuple[str, ...],
+) -> None:
+    try:
+        for line in stream:
+            clean = _redact_litellm_output(line, secrets)
+            if not clean:
+                continue
+            record = logging.LogRecord(
+                "agenttalk.ovh_gateway.litellm",
+                logging.INFO,
+                __file__,
+                0,
+                clean,
+                (),
+                None,
+            )
+            handler.handle(record)
+    finally:
+        with contextlib.suppress(OSError, ValueError):
+            stream.close()
 
 
 def _public_front_attested(timeout_seconds: float = 5.0) -> bool:
@@ -563,6 +720,7 @@ def run_service(
     key_path: Path | None = None,
     front_token_path: Path | None = None,
     internal_token_path: Path | None = None,
+    child_log_path: Path | None = None,
     popen=subprocess.Popen,
 ) -> int:
     """Run LiteLLM plus the public front. Called only by the managed task."""
@@ -599,21 +757,37 @@ def run_service(
         "--num_workers",
         "1",
     ]
-    process = popen(
-        argv,
-        cwd=str(root),
-        env=_safe_gateway_environment(ovh_key, internal_token),
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    front = GatewayFront(
-        FrontConfig(public_token=front_token, internal_token=internal_token),
-        ledger,
-    )
+    log_handler = _open_litellm_log(Path(child_log_path or default_litellm_log_path()))
+    process = None
+    pump_thread = None
     server = None
     monitor_stop = threading.Event()
     try:
+        process = popen(
+            argv,
+            cwd=str(root),
+            env=_safe_gateway_environment(ovh_key, internal_token),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        if process.stdout is None:
+            raise GatewayConfigError("LiteLLM diagnostic pipe is unavailable")
+        pump_thread = threading.Thread(
+            target=_pump_litellm_output,
+            args=(process.stdout, log_handler, (ovh_key, front_token, internal_token)),
+            daemon=True,
+            name="agenttalk-litellm-log",
+        )
+        pump_thread.start()
+        front = GatewayFront(
+            FrontConfig(public_token=front_token, internal_token=internal_token),
+            ledger,
+        )
         _wait_liveliness(front, process)
         server = front.make_server()
         _durable_write_json(
@@ -650,13 +824,16 @@ def run_service(
         monitor_stop.set()
         if server is not None:
             server.server_close()
-        if process.poll() is None:
+        if process is not None and process.poll() is None:
             process.terminate()
             try:
                 process.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=5)
+        if pump_thread is not None:
+            pump_thread.join(timeout=5)
+        log_handler.close()
         with contextlib.suppress(FileNotFoundError):
             runtime_marker_path(root).unlink()
 

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -15,7 +15,7 @@ import subprocess  # nosec B404 - fixed schtasks/LiteLLM argv lists; shell is ne
 import sys
 import threading
 import time
-import xml.etree.ElementTree as ET  # nosec B405 - bounded local Task Scheduler XML
+import xml.etree.ElementTree as ET  # nosec B405 - bounded local Task Scheduler XML  # nosemgrep
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -180,8 +180,10 @@ def _task_xml_action(xml_text: str) -> tuple[str, str, str, str]:
         raise GatewayConfigError("registered gateway task XML is too large")
     try:
         # ElementTree does not resolve external entities. Input is additionally
-        # bounded and comes only from the local Task Scheduler query.
-        root = ET.fromstring(xml_text)  # nosec B314  # noqa: S314
+        # bounded and comes only from the local Task Scheduler query (schtasks
+        # /Query /XML) or our own render_task_xml — never untrusted external XML,
+        # so the defusedxml XXE class does not apply (nosemgrep: use-defused-xml).
+        root = ET.fromstring(xml_text)  # nosec B314  # noqa: S314  # nosemgrep
     except ET.ParseError as exc:
         raise GatewayConfigError("registered gateway task XML is malformed") from exc
     ns = {"t": _TASK_NS}

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -667,6 +667,29 @@ def validate_roles(roles: dict, roster: list[str]) -> dict:
     return roles
 
 
+TRUST_CLASS_EXTERNAL_WORKER = "external-worker"
+KNOWN_TRUST_CLASSES = frozenset({TRUST_CLASS_EXTERNAL_WORKER})
+
+
+def validate_trust_classes(trust_classes: dict, roster: list[str]) -> dict:
+    """Validate opt-in model trust metadata for active roster identities."""
+    if not isinstance(trust_classes, dict):
+        raise ValueError(
+            f"'trust_classes' must be a dict, got {type(trust_classes).__name__}"
+        )
+    rset = set(roster)
+    for agent, trust_class in trust_classes.items():
+        if agent not in rset:
+            raise ValueError(
+                f"trust class key {agent!r} is not in the roster {sorted(rset)}"
+            )
+        if trust_class not in KNOWN_TRUST_CLASSES:
+            raise ValueError(
+                f"trust class for {agent!r} must be one of {sorted(KNOWN_TRUST_CLASSES)}"
+            )
+    return trust_classes
+
+
 def validate_managed_lead_loop(managed: object, roster: list[str]) -> dict:
     """Validate the ``{agent: {enabled, ttl_seconds, cadence_seconds}}`` map.
 
@@ -1120,6 +1143,11 @@ class Store:
                 validate_roles(cfg["roles"], agents)
             except ValueError as e:
                 raise ValueError(f"corrupt config at {self.config_path}: {e}.") from e
+        if cfg.get("trust_classes") is not None:
+            try:
+                validate_trust_classes(cfg["trust_classes"], agents)
+            except ValueError as e:
+                raise ValueError(f"corrupt config at {self.config_path}: {e}.") from e
         # Identity registry tombstones (0.16.0, #19 Phase A). Absent OR null ⇒
         # no retirements (full 0.15.0 behavior). Validated fail-closed so a
         # corrupt registry can't alias an active name or smuggle an unsafe one.
@@ -1495,6 +1523,13 @@ class Store:
         """Return the ``{agent: role}`` map ({} if none defined)."""
         return self.load_config().get("roles", {}) or {}
 
+    def trust_classes(self) -> dict[str, str]:
+        return self.load_config().get("trust_classes", {}) or {}
+
+    def trust_class(self, name: str) -> str | None:
+        value = self.trust_classes().get(name)
+        return value if value in KNOWN_TRUST_CLASSES else None
+
     def avatar_preferences(self) -> dict[str, str]:
         """Return sanitized display-avatar preferences.
 
@@ -1608,8 +1643,65 @@ class Store:
             )
         return out
 
+    @staticmethod
+    def _agent_matches_refset(cfg: dict, agent: str, refset: dict) -> bool:
+        if agent in (refset.get("agents") or []):
+            return True
+        role = (cfg.get("roles") or {}).get(agent)
+        if role in (refset.get("roles") or []):
+            return True
+        groups = cfg.get("groups") or {}
+        return any(agent in (groups.get(group) or []) for group in (refset.get("groups") or []))
+
+    def _assert_external_worker_authority_safe(self, cfg: dict) -> None:
+        """Prevent accidental authority assignment at roster mutation time.
+
+        This is deliberately the narrow watched-trial guard. Broader hostile-
+        model enforcement at close/release time remains a production follow-up.
+        """
+        external = {
+            agent
+            for agent, value in (cfg.get("trust_classes") or {}).items()
+            if value == TRUST_CLASS_EXTERNAL_WORKER
+        }
+        if not external:
+            return
+        roles = cfg.get("roles") or {}
+        for agent in sorted(external):
+            if isinstance(roles.get(agent), str) and roles[agent].casefold() == "lead":
+                raise ValueError(
+                    f"external-worker {agent!r} cannot hold the lead role"
+                )
+            if cfg.get("operator_facing") == agent:
+                raise ValueError(
+                    f"external-worker {agent!r} cannot be operator-facing"
+                )
+
+        from agenttalk import close as _close
+
+        policy, error = _close.load_signoff_policy(self)
+        if error:
+            raise ValueError(
+                "cannot prove external-worker signoff exclusion while "
+                f"signoffs.json is invalid: {error}"
+            )
+        if policy is None:
+            return
+        refsets = [policy["defaults"]["reviewers"]]
+        for sets in policy["risk_policies"].values():
+            for signoff_set in sets:
+                refsets.append(signoff_set["candidates"])
+                if signoff_set["use_default_reviewers"]:
+                    refsets.append(policy["defaults"]["reviewers"])
+        for agent in sorted(external):
+            if any(self._agent_matches_refset(cfg, agent, refset) for refset in refsets):
+                raise ValueError(
+                    f"external-worker {agent!r} cannot be a signoff candidate"
+                )
+
     def add_agent(self, name: str, *, role: str | None = None,
-                  groups: list[str] | None = None) -> dict:
+                  groups: list[str] | None = None,
+                  trust_class: str | None = None) -> dict:
         """Add an agent to the roster (idempotent) and optionally set its
         role / group memberships. A deliberate local admin op — NOT a
         security boundary and NOT process supervision."""
@@ -1648,6 +1740,11 @@ class Store:
                     if name not in members:
                         members.append(name)
                 validate_groups(g, roster)
+            if trust_class is not None:
+                trust_classes = self._cfg_dict(cfg, "trust_classes")
+                trust_classes[name] = trust_class
+                validate_trust_classes(trust_classes, roster)
+            self._assert_external_worker_authority_safe(cfg)
             # All validation passed — only now perform side effects, so a bad
             # role/group never orphans a freshly-written cursor file.
             self._write_config(cfg)
@@ -1677,6 +1774,24 @@ class Store:
                 cfg["managed_lead_loop"].pop(name, None)
             if isinstance(cfg.get("avatars"), dict):
                 cfg["avatars"].pop(name, None)
+            if isinstance(cfg.get("trust_classes"), dict):
+                cfg["trust_classes"].pop(name, None)
+            self._write_config(cfg)
+        return cfg
+
+    def set_trust_class(self, name: str, trust_class: str | None) -> dict:
+        with self._config_lock():
+            cfg = self.load_config()
+            roster = cfg.get("agents", []) or []
+            if name not in roster:
+                raise ValueError(f"agent {name!r} is not in the roster {sorted(roster)}")
+            values = self._cfg_dict(cfg, "trust_classes")
+            if trust_class is None:
+                values.pop(name, None)
+            else:
+                values[name] = trust_class
+            validate_trust_classes(values, roster)
+            self._assert_external_worker_authority_safe(cfg)
             self._write_config(cfg)
         return cfg
 
@@ -1703,6 +1818,7 @@ class Store:
             roles = self._cfg_dict(cfg, "roles")
             demoted = self._assign_role_enforcing_lead(roles, name, role)
             validate_roles(roles, roster)
+            self._assert_external_worker_authority_safe(cfg)
             self._write_config(cfg)
         return demoted
 
@@ -1767,6 +1883,7 @@ class Store:
             groups = self._cfg_dict(cfg, "groups")
             groups[group] = list(dict.fromkeys(members))  # de-dupe, preserve order
             validate_groups(groups, roster)
+            self._assert_external_worker_authority_safe(cfg)
             self._write_config(cfg)
         return cfg
 
@@ -2046,6 +2163,7 @@ class Store:
                         f"agent {name!r} is not in the roster {sorted(roster)}"
                     )
                 cfg["operator_facing"] = name
+            self._assert_external_worker_authority_safe(cfg)
             self._write_config(cfg)
         return cfg
 
@@ -2084,6 +2202,9 @@ class Store:
         avatars = cfg.get("avatars")
         if isinstance(avatars, dict):
             avatars.pop(name, None)
+        trust_classes = cfg.get("trust_classes")
+        if isinstance(trust_classes, dict):
+            trust_classes.pop(name, None)
 
     def set_avatar(self, name: str, avatar_id: str) -> dict:
         """Set an active roster member's display-avatar preference."""
@@ -2209,6 +2330,7 @@ class Store:
                           if old in members]
             was_liaison = cfg.get("operator_facing") == old
             old_managed = (cfg.get("managed_lead_loop") or {}).get(old)
+            old_trust_class = (cfg.get("trust_classes") or {}).get(old)
             avatars = cfg.get("avatars")
             old_avatar = avatars.get(old) if isinstance(avatars, dict) else None
             # Retire old -> tombstone(renamed_to=new), then activate new + carryover.
@@ -2241,6 +2363,8 @@ class Store:
             # rename would SILENTLY DROP the managed flag.
             if old_managed is not None:
                 self._cfg_dict(cfg, "managed_lead_loop")[new] = old_managed
+            if old_trust_class is not None:
+                self._cfg_dict(cfg, "trust_classes")[new] = old_trust_class
             avatar_id = _avatars.normalize_avatar_id(old_avatar)
             if avatar_id is not None:
                 self._cfg_dict(cfg, "avatars")[new] = avatar_id
@@ -2253,6 +2377,9 @@ class Store:
                 validate_groups(cfg["groups"], roster)
             if cfg.get("managed_lead_loop"):
                 validate_managed_lead_loop(cfg["managed_lead_loop"], roster)
+            if cfg.get("trust_classes"):
+                validate_trust_classes(cfg["trust_classes"], roster)
+            self._assert_external_worker_authority_safe(cfg)
             self._write_config(cfg)
             cur = self.state_dir / f"{new}.cursor"
             if not cur.exists():

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -1643,16 +1643,6 @@ class Store:
             )
         return out
 
-    @staticmethod
-    def _agent_matches_refset(cfg: dict, agent: str, refset: dict) -> bool:
-        if agent in (refset.get("agents") or []):
-            return True
-        role = (cfg.get("roles") or {}).get(agent)
-        if role in (refset.get("roles") or []):
-            return True
-        groups = cfg.get("groups") or {}
-        return any(agent in (groups.get(group) or []) for group in (refset.get("groups") or []))
-
     def _assert_external_worker_authority_safe(self, cfg: dict) -> None:
         """Prevent accidental authority assignment at roster mutation time.
 
@@ -1678,6 +1668,7 @@ class Store:
                 )
 
         from agenttalk import close as _close
+        from agenttalk import domains as _domains
 
         policy, error = _close.load_signoff_policy(self)
         if error:
@@ -1694,7 +1685,7 @@ class Store:
                 if signoff_set["use_default_reviewers"]:
                     refsets.append(policy["defaults"]["reviewers"])
         for agent in sorted(external):
-            if any(self._agent_matches_refset(cfg, agent, refset) for refset in refsets):
+            if any(agent in _domains.resolve_refset(refset, cfg) for refset in refsets):
                 raise ValueError(
                     f"external-worker {agent!r} cannot be a signoff candidate"
                 )

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -941,6 +941,7 @@ class Store:
         # re-validatable tombstone; only a config damaged beyond JSON-parse has
         # nothing recoverable to carry.
         retired_carry: list = []
+        external_carry: set[str] = set()
         if self.initialized():
             try:
                 raw = json.loads(self.config_path.read_text(encoding="utf-8"))
@@ -975,6 +976,42 @@ class Store:
                         "reason": (e.get("reason")
                                    if isinstance(e.get("reason"), str) else None),
                     })
+            raw_trust = raw.get("trust_classes") if isinstance(raw, dict) else None
+            if isinstance(raw_trust, dict):
+                for name, trust_class in raw_trust.items():
+                    if trust_class != TRUST_CLASS_EXTERNAL_WORKER:
+                        continue
+                    try:
+                        validate_agent_name(name)
+                    except (TypeError, ValueError):
+                        continue
+                    external_carry.add(name)
+        retired_keys = {
+            e["name"].casefold()
+            for e in retired_carry
+            if isinstance(e, dict) and isinstance(e.get("name"), str)
+        }
+        active_external: list[str] = []
+        for historical_name in sorted(external_carry):
+            matches = [
+                name for name in agents
+                if name.casefold() == historical_name.casefold()
+            ]
+            if matches:
+                if matches[0] != historical_name:
+                    raise ValueError(
+                        f"cannot init with case-variant {matches[0]!r} of historical "
+                        f"external-worker {historical_name!r}; identities are non-rebindable"
+                    )
+                active_external.append(historical_name)
+            elif historical_name.casefold() not in retired_keys:
+                retired_carry.append({
+                    "name": historical_name,
+                    "retired_at": _now_iso(),
+                    "renamed_to": None,
+                    "reason": "external-worker omitted by force init",
+                })
+                retired_keys.add(historical_name.casefold())
         if retired_carry:
             tomb_keys = {
                 e["name"].casefold() for e in retired_carry
@@ -1003,6 +1040,10 @@ class Store:
         }
         if retired_carry:
             cfg["retired"] = retired_carry  # tombstones survive a force re-init
+        if active_external:
+            cfg["trust_classes"] = dict.fromkeys(
+                active_external, TRUST_CLASS_EXTERNAL_WORKER
+            )
         _atomic_write_text(self.config_path, json.dumps(cfg, indent=2))
         for a in agents:
             cur = self.state_dir / f"{a}.cursor"
@@ -1668,7 +1709,6 @@ class Store:
                 )
 
         from agenttalk import close as _close
-        from agenttalk import domains as _domains
 
         policy, error = _close.load_signoff_policy(self)
         if error:
@@ -1678,14 +1718,32 @@ class Store:
             )
         if policy is None:
             return
-        refsets = [policy["defaults"]["reviewers"]]
+        default_reviewers = policy["defaults"]["reviewers"]
+        all_domain_reviewers = _close.signoff_domain_refset(self, cfg, None)
+        candidate_sets = [
+            _close.resolve_signoff_candidates(
+                cfg,
+                candidate_refset=default_reviewers,
+                default_reviewers={},
+                use_default_reviewers=False,
+                domain_refset={},
+                include_domain_reviewers=False,
+            )
+        ]
         for sets in policy["risk_policies"].values():
             for signoff_set in sets:
-                refsets.append(signoff_set["candidates"])
-                if signoff_set["use_default_reviewers"]:
-                    refsets.append(policy["defaults"]["reviewers"])
+                candidate_sets.append(
+                    _close.resolve_signoff_candidates(
+                        cfg,
+                        candidate_refset=signoff_set["candidates"],
+                        default_reviewers=default_reviewers,
+                        use_default_reviewers=signoff_set["use_default_reviewers"],
+                        domain_refset=all_domain_reviewers,
+                        include_domain_reviewers=signoff_set["include_domain_reviewers"],
+                    )
+                )
         for agent in sorted(external):
-            if any(agent in _domains.resolve_refset(refset, cfg) for refset in refsets):
+            if any(agent in candidates for candidates in candidate_sets):
                 raise ValueError(
                     f"external-worker {agent!r} cannot be a signoff candidate"
                 )
@@ -1747,10 +1805,16 @@ class Store:
 
     def remove_agent(self, name: str) -> dict:
         """Remove an agent from the roster, its role, and all group
-        memberships. Leaves its cursor/messages as historical record."""
+        memberships. External workers become permanent tombstones; ordinary
+        force-removed identities retain the historical re-addable behavior."""
         with self._retirement_lock(), self._config_lock():
             cfg = self.load_config()
             roster = list(cfg.get("agents", []))
+            was_external = (
+                name in roster
+                and (cfg.get("trust_classes") or {}).get(name)
+                == TRUST_CLASS_EXTERNAL_WORKER
+            )
             if name in roster:
                 roster.remove(name)
                 cfg["agents"] = roster
@@ -1767,6 +1831,18 @@ class Store:
                 cfg["avatars"].pop(name, None)
             if isinstance(cfg.get("trust_classes"), dict):
                 cfg["trust_classes"].pop(name, None)
+            if was_external:
+                retired = cfg.get("retired")
+                if not isinstance(retired, list):
+                    retired = []
+                retired.append({
+                    "name": name,
+                    "retired_at": _now_iso(),
+                    "renamed_to": None,
+                    "reason": "removed external-worker identity",
+                })
+                cfg["retired"] = retired
+                validate_retired(retired, roster)
             self._write_config(cfg)
         return cfg
 
@@ -1777,6 +1853,14 @@ class Store:
             if name not in roster:
                 raise ValueError(f"agent {name!r} is not in the roster {sorted(roster)}")
             values = self._cfg_dict(cfg, "trust_classes")
+            if (
+                values.get(name) == TRUST_CLASS_EXTERNAL_WORKER
+                and trust_class != TRUST_CLASS_EXTERNAL_WORKER
+            ):
+                raise ValueError(
+                    f"external-worker trust for {name!r} cannot be cleared or reclassified; "
+                    "retire the identity instead"
+                )
             if trust_class is None:
                 values.pop(name, None)
             else:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -3474,6 +3474,44 @@ def bootstrap_check(store: Store, *, now_epoch: float,
                            f"{cli_name} agent configured", agent=name,
                            facts={"cli": cli_name})
 
+        backend_profile = cfg_agent.get("backend_profile")
+        if backend_profile is not None:
+            if backend_profile != "ovh-qwen":
+                _bootstrap_add(
+                    checks,
+                    "supervisor_backend_profile_unsupported",
+                    "error",
+                    "backend_profile must be ovh-qwen when present",
+                    agent=name,
+                )
+            else:
+                trust_class = cfg_agent.get("trust_class")
+                roster_trust = (cfg.get("trust_classes") or {}).get(name)
+                errors = []
+                if cli_name != "claude":
+                    errors.append("cli must be claude")
+                if cfg_agent.get("wrapped") is not True:
+                    errors.append("wrapped must be true")
+                if cfg_agent.get("model") != "Qwen3.5-397B-A17B":
+                    errors.append("model must be Qwen3.5-397B-A17B")
+                if trust_class != "external-worker" or roster_trust != "external-worker":
+                    errors.append("supervisor and roster trust_class must be external-worker")
+                if cfg_agent.get("env"):
+                    errors.append("literal per-agent env is forbidden")
+                ambient = [
+                    key for key in ("OVH_KEY", "ANTHROPIC_API_KEY") if os.environ.get(key)
+                ]
+                if ambient:
+                    errors.append("supervisor ambient provider keys must be absent")
+                _bootstrap_add(
+                    checks,
+                    "supervisor_ovh_qwen_profile",
+                    "error" if errors else "ok",
+                    "; ".join(errors) if errors else "ovh-qwen profile is constrained",
+                    agent=name,
+                    facts={"backend_profile": backend_profile, "trust_class": trust_class},
+                )
+
         if cfg_agent.get("auto_restart") is True:
             _bootstrap_add(checks, "supervisor_agent_restart_enabled", "ok",
                            "auto_restart is enabled", agent=name)
@@ -5411,6 +5449,16 @@ function Preflight($name, $plan, $file, $codexHome) {
 function Launch($name, $plan, $codexHome) {
   if (-not (Assert-ActionsEnabled ("launch {0}" -f $name))) { return $null }
   $a = $cfg.agents.$name
+  if ($a.backend_profile -eq 'ovh-qwen') {
+    if ($env:OVH_KEY -or $env:ANTHROPIC_API_KEY) {
+      Write-Warning "supervisor: agent '$name': ovh-qwen refuses ambient OVH_KEY/ANTHROPIC_API_KEY; NOT launching"
+      return $null
+    }
+    if ($a.env) {
+      Write-Warning "supervisor: agent '$name': ovh-qwen forbids literal per-agent env; NOT launching"
+      return $null
+    }
+  }
   $file = $a.launch.windows_file
   if (-not $file -or $file -like 'REPLACE:*') {
     Write-Warning "supervisor: agent '$name' has no real launch.windows_file (the agent EXECUTABLE) - fill supervisor.json"; return $null

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -3498,6 +3498,16 @@ def bootstrap_check(store: Store, *, now_epoch: float,
                     errors.append("supervisor and roster trust_class must be external-worker")
                 if cfg_agent.get("env"):
                     errors.append("literal per-agent env is forbidden")
+                profile_launch = cfg_agent.get("launch")
+                profile_args = (
+                    profile_launch.get("windows_args")
+                    if isinstance(profile_launch, dict)
+                    else None
+                )
+                if isinstance(profile_args, list) and "--lead-loop" in profile_args:
+                    errors.append(
+                        "lead-loop is unsupported because cadence has no immutable budget scope"
+                    )
                 ambient = [
                     key for key in ("OVH_KEY", "ANTHROPIC_API_KEY") if os.environ.get(key)
                 ]

--- a/src/agenttalk/wrapper/claude_adapter.py
+++ b/src/agenttalk/wrapper/claude_adapter.py
@@ -24,6 +24,26 @@ from .events import Event, EventType
 CLI = "claude"
 
 
+def _result_error_text(obj: dict) -> str:
+    result = obj.get("result")
+    if result not in (None, ""):
+        return str(result)
+
+    errors = obj.get("errors")
+    if isinstance(errors, str) and errors:
+        return errors
+    if isinstance(errors, list):
+        for item in errors:
+            if isinstance(item, str) and item:
+                return item
+            if isinstance(item, dict):
+                message = item.get("message")
+                if message not in (None, ""):
+                    return str(message)
+
+    return str(obj.get("subtype") or "error")
+
+
 def map_event(obj: object) -> list[Event]:
     """Map ONE parsed Claude stream-json object to normalized events."""
     if not isinstance(obj, dict):
@@ -39,7 +59,7 @@ def map_event(obj: object) -> list[Event]:
         # success: message_stop already emitted turn_finished; the result is a
         # terminal summary. An error result is a terminal adapter_error.
         if obj.get("is_error"):
-            text = str(obj.get("result") or obj.get("subtype") or "error")
+            text = _result_error_text(obj)
             return [Event(EventType.ADAPTER_ERROR, text=text, retryable=False, raw=obj)]
         return []
     if t == "rate_limit_event":

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -491,6 +491,7 @@ def _child_env(
         injected["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = (
             OVH_QWEN_CLAUDE_MAX_OUTPUT
         )
+        injected["MAX_THINKING_TOKENS"] = "0"
         # The front token is a controller-only mint credential. It must not
         # reach executable preflight or the model child. A paid child receives
         # only the scoped capability minted immediately before its spawn.

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -430,12 +430,62 @@ def _child_env(
     *,
     wrapper_generation: str | None = None,
     inbound_request_id: str | None = None,
+    backend_profile: str | None = None,
+    profile_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in {LEAD_LOOP_LEASE_ENV, WRAPPER_GENERATION_ENV, INBOUND_REQUEST_ID_ENV}
-    }
+    if backend_profile == "ovh-qwen":
+        allowed_names = {
+            "path",
+            "systemroot",
+            "windir",
+            "temp",
+            "tmp",
+            "pythonutf8",
+            "pythonioencoding",
+        }
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key.casefold() in allowed_names or key.upper().startswith("AGENTTALK_")
+        }
+        injected = dict(profile_env or {})
+        allowed_injected = {
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_MODEL",
+        }
+        unexpected = set(injected) - allowed_injected
+        if unexpected:
+            raise ValueError(f"ovh-qwen profile env contains unsupported keys: {sorted(unexpected)}")
+        if injected.get("ANTHROPIC_BASE_URL") != "http://127.0.0.1:4000":
+            raise ValueError("ovh-qwen requires the pinned loopback gateway URL")
+        if not injected.get("ANTHROPIC_AUTH_TOKEN"):
+            raise ValueError("ovh-qwen requires an injected front token")
+        if injected.get("ANTHROPIC_MODEL") not in {None, "Qwen3.5-397B-A17B"}:
+            raise ValueError("ovh-qwen requires the pinned model alias")
+        injected["ANTHROPIC_MODEL"] = "Qwen3.5-397B-A17B"
+        # Never inherit provider credentials or an ambient Claude token. The
+        # front token is the only Anthropic credential injected below.
+        for key in list(env):
+            if key.casefold() in {
+                "anthropic_api_key",
+                "anthropic_auth_token",
+                "ovh_key",
+            }:
+                env.pop(key, None)
+        for key in (LEAD_LOOP_LEASE_ENV, WRAPPER_GENERATION_ENV, INBOUND_REQUEST_ID_ENV):
+            env.pop(key, None)
+        env.update(injected)
+    elif backend_profile is not None:
+        raise ValueError(f"unsupported backend_profile {backend_profile!r}")
+    else:
+        # Preserve the historical environment byte-for-byte for every ordinary
+        # backend; the restrictive profile is intentionally opt-in.
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {LEAD_LOOP_LEASE_ENV, WRAPPER_GENERATION_ENV, INBOUND_REQUEST_ID_ENV}
+        }
     workspace = Path(workspace_root).resolve() if workspace_root else _workspace_root()
     env["AGENTTALK_PY"] = _agenttalk_py()
     env["AGENTTALK_ROOT"] = str(workspace)
@@ -1466,7 +1516,21 @@ class _ProcStream:
             _ = exc
 
 
-def _classify_drive_failure(sig: dict) -> tuple[str, str]:
+def _ovh_qwen_failure_text(sig: dict) -> str:
+    values = [sig.get("error"), sig.get("terminal_text"), sig.get("config_blocked_text")]
+    tail = sig.get("child_output_tail")
+    if isinstance(tail, dict):
+        for row in tail.get("lines") or []:
+            if isinstance(row, dict):
+                values.append(row.get("text"))
+    return " ".join(str(value) for value in values if value).casefold()
+
+
+def _classify_drive_failure(
+    sig: dict,
+    *,
+    backend_profile: str | None = None,
+) -> tuple[str, str]:
     """Map failed-turn signals to the wrapper dead-letter/resume taxonomy."""
     from .loop import (
         CLASS_AMBIGUOUS,
@@ -1474,6 +1538,33 @@ def _classify_drive_failure(sig: dict) -> tuple[str, str]:
         CLASS_INFRA,
         CLASS_POISON,
     )
+
+    if backend_profile == "ovh-qwen":
+        text = _ovh_qwen_failure_text(sig)
+        if "atgw_policy_blocked" in text or "atgw_ledger_blocked" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH trial policy or accounting hold"
+        if "atgw_config_error" in text or "status code: 422" in text or "http 422" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH gateway route or configuration error"
+        infra_markers = (
+            "atgw_infra_unavailable",
+            "atgw_infra_busy",
+            "connection refused",
+            "actively refused",
+            "connect timeout",
+            "connection timeout",
+            "status code: 429",
+            "http 429",
+            "status code: 500",
+            "status code: 502",
+            "status code: 503",
+            "status code: 504",
+            "http 500",
+            "http 502",
+            "http 503",
+            "http 504",
+        )
+        if any(marker in text for marker in infra_markers):
+            return CLASS_INFRA, "OVH gateway transport is unavailable"
 
     wd = sig.get("watchdog")
     if wd:
@@ -1536,6 +1627,8 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                health_writer: WrapperHealthWriter | None = None,
                work_heartbeat=None,
                wrapper_generation: str | None = None,
+               backend_profile: str | None = None,
+               profile_env: dict[str, str] | None = None,
                lease_lost_exceptions: tuple = ()) -> Callable[[dict], object]:
     """Build the per-turn ``drive(record)`` callback for loop.run_loop. Each call
     drives ONE real CLI turn and returns a :class:`loop.DriveOutcome` (ok + a failure
@@ -1664,6 +1757,8 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 store.root,
                 wrapper_generation=wrapper_generation,
                 inbound_request_id=active_parent_request_id,
+                backend_profile=backend_profile,
+                profile_env=profile_env,
             )
             return _ProcStream(argv, stdin_text, watchdog=turn_watchdog,
                                watchdog_snapshot_fn=watchdog_snapshot_fn,
@@ -1806,7 +1901,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         return sig
 
     def _classify(sig: dict) -> tuple[str, str]:
-        return _classify_drive_failure(sig)
+        return _classify_drive_failure(sig, backend_profile=backend_profile)
 
     def drive(record: dict) -> DriveOutcome:
         nonlocal active_parent_request_id

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -425,6 +425,17 @@ def _agenttalk_py() -> str:
     return str(Path(sys.executable).resolve())
 
 
+def _ovh_qwen_claude_config_dir(workspace: Path) -> str:
+    profile = (workspace / ".agenttalk" / "gateway" / "claude-profile").resolve()
+    try:
+        profile.relative_to(workspace)
+    except ValueError as exc:
+        raise ValueError(
+            "ovh-qwen Claude profile must resolve inside the project workspace"
+        ) from exc
+    return str(profile)
+
+
 def _child_env(
     workspace_root: str | os.PathLike[str] | None = None,
     *,
@@ -433,6 +444,7 @@ def _child_env(
     backend_profile: str | None = None,
     profile_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
+    workspace = Path(workspace_root).resolve() if workspace_root else _workspace_root()
     if backend_profile == "ovh-qwen":
         allowed_names = {
             "path",
@@ -476,6 +488,11 @@ def _child_env(
         for key in (LEAD_LOOP_LEASE_ENV, WRAPPER_GENERATION_ENV, INBOUND_REQUEST_ID_ENV):
             env.pop(key, None)
         env.update(injected)
+        # Claude Code must not discover the operator's normal ~/.claude profile
+        # through the same-user OS home fallback. This workspace-scoped profile
+        # is disposable with the watched-trial clone and contains no operator
+        # credentials or history.
+        env["CLAUDE_CONFIG_DIR"] = _ovh_qwen_claude_config_dir(workspace)
     elif backend_profile is not None:
         raise ValueError(f"unsupported backend_profile {backend_profile!r}")
     else:
@@ -486,7 +503,6 @@ def _child_env(
             for k, v in os.environ.items()
             if k not in {LEAD_LOOP_LEASE_ENV, WRAPPER_GENERATION_ENV, INBOUND_REQUEST_ID_ENV}
         }
-    workspace = Path(workspace_root).resolve() if workspace_root else _workspace_root()
     env["AGENTTALK_PY"] = _agenttalk_py()
     env["AGENTTALK_ROOT"] = str(workspace)
     if isinstance(wrapper_generation, str) and wrapper_generation:

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -56,6 +56,10 @@ WRAPPER_GENERATION_ENV = "AGENTTALK_WRAPPER_GENERATION"
 INBOUND_REQUEST_ID_ENV = "AGENTTALK_INBOUND_REQUEST_ID"
 _BENIGN_PIPE_TEARDOWN_ERRNOS = {errno.EINVAL, errno.EPIPE}
 
+
+class _GatewayChildCapUnavailable(RuntimeError):
+    """The wrapper could not durably issue a scoped paid-child credential."""
+
 # Legacy infra-like text markers. These are low-confidence hints only; they deliberately
 # no longer classify known_global_infra without a structured CLI status/rate-limit fact.
 # NOTE: bare "blocked" is DELIBERATELY excluded - it would shadow the content-policy
@@ -443,6 +447,7 @@ def _child_env(
     inbound_request_id: str | None = None,
     backend_profile: str | None = None,
     profile_env: dict[str, str] | None = None,
+    gateway_capability: str | None = None,
 ) -> dict[str, str]:
     workspace = Path(workspace_root).resolve() if workspace_root else _workspace_root()
     if backend_profile == "ovh-qwen":
@@ -476,8 +481,19 @@ def _child_env(
         if injected.get("ANTHROPIC_MODEL") not in {None, "Qwen3.5-397B-A17B"}:
             raise ValueError("ovh-qwen requires the pinned model alias")
         injected["ANTHROPIC_MODEL"] = "Qwen3.5-397B-A17B"
+        # The front token is a controller-only mint credential. It must not
+        # reach executable preflight or the model child. A paid child receives
+        # only the scoped capability minted immediately before its spawn.
+        injected.pop("ANTHROPIC_AUTH_TOKEN")
+        if gateway_capability is not None:
+            from agenttalk.ovh_gateway import child_capability_from_header
+
+            if child_capability_from_header(f"Bearer {gateway_capability}") is None:
+                raise ValueError("ovh-qwen child turn capability is malformed")
+            injected["ANTHROPIC_AUTH_TOKEN"] = gateway_capability
         # Never inherit provider credentials or an ambient Claude token. The
-        # front token is the only Anthropic credential injected below.
+        # controller starts with the issuer token; the real paid child gets
+        # only its message-scoped capability instead.
         for key in list(env):
             if key.casefold() in {
                 "anthropic_api_key",
@@ -1557,6 +1573,8 @@ def _classify_drive_failure(
 
     if backend_profile == "ovh-qwen":
         text = _ovh_qwen_failure_text(sig)
+        if "atgw_child_turn_cap_exceeded" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH child turn budget exhausted"
         if "atgw_policy_blocked" in text or "atgw_ledger_blocked" in text:
             return CLASS_CONFIG_BLOCKED, "OVH trial policy or accounting hold"
         if "atgw_config_error" in text or "status code: 422" in text or "http 422" in text:
@@ -1752,6 +1770,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         min_interval=min_interval,
     )
     active_parent_request_id: str | None = None
+    active_message_id: str | None = None
     if spawn is not None:
         spawner = spawn                     # tests inject their own (argv, stdin) spawner
     else:
@@ -1769,12 +1788,35 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             # Bind the per-turn watchdog onto the real spawner. When turn_watchdog is None
             # or disabled, _ProcStream starts no thread (zero overhead, behavior unchanged).
             # Same for a disabled/invalid work_heartbeat config.
+            gateway_capability = None
+            if backend_profile == "ovh-qwen":
+                from agenttalk.ovh_gateway import GatewayError, SpendLedger
+
+                if not active_message_id:
+                    raise _GatewayChildCapUnavailable(
+                        "immutable inbound message id is unavailable"
+                    )
+                try:
+                    gateway_capability = SpendLedger().open_child_turn(
+                        agent=agent,
+                        message_id=active_message_id,
+                        request_id=active_parent_request_id or "",
+                        issuer_token=str(
+                            (profile_env or {}).get("ANTHROPIC_AUTH_TOKEN") or ""
+                        ),
+                    ).token
+                except (GatewayError, OSError, ValueError) as exc:
+                    raise _GatewayChildCapUnavailable(
+                        "durable child turn capability unavailable: "
+                        f"{type(exc).__name__}"
+                    ) from exc
             child_env = _child_env(
                 store.root,
                 wrapper_generation=wrapper_generation,
                 inbound_request_id=active_parent_request_id,
                 backend_profile=backend_profile,
                 profile_env=profile_env,
+                gateway_capability=gateway_capability,
             )
             return _ProcStream(argv, stdin_text, watchdog=turn_watchdog,
                                watchdog_snapshot_fn=watchdog_snapshot_fn,
@@ -1885,6 +1927,13 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             sig["setup_failure"] = setup_failure
                     health_writer.event(ev)
                     engine.process(ev, clock())
+        except _GatewayChildCapUnavailable as e:
+            _capture_child_output("stderr", f"{type(e).__name__}: {e}")
+            _finalize_child_output()
+            sig["config_blocked"] = True
+            sig["config_blocked_text"] = str(e)
+            sig["error"] = str(e)
+            return sig
         except OSError as e:
             _capture_child_output("stderr", f"{type(e).__name__}: {e}")
             _finalize_child_output()
@@ -1920,10 +1969,12 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         return _classify_drive_failure(sig, backend_profile=backend_profile)
 
     def drive(record: dict) -> DriveOutcome:
-        nonlocal active_parent_request_id
+        nonlocal active_message_id, active_parent_request_id
         meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
         parent = meta.get("request_id")
         active_parent_request_id = parent if isinstance(parent, str) and parent else None
+        message_id = record.get("id")
+        active_message_id = message_id if isinstance(message_id, str) and message_id else None
         lesson_selection = _lesson_context.select_for_record(store, record)
         lesson_prompt = _lesson_context.render_prompt_section(lesson_selection)
         lesson_turn_id = f"turn-{uuid.uuid4().hex[:12]}"

--- a/src/agenttalk/wrapper/session.py
+++ b/src/agenttalk/wrapper/session.py
@@ -198,6 +198,7 @@ def resume_failure_is_session_attributable(failure_class: str | None,
     broken_terms = (
         "no session",
         "session not found",
+        "no conversation found with session id",
         "invalid session",
         "expired session",
         "broken session",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from agenttalk import cli, doctor, install_skills as iskl, signing
+from agenttalk import cli, doctor, install_skills as iskl, ovh_gateway_service, signing
 from agenttalk.store import Store
 
 
@@ -38,6 +38,61 @@ def test_doctor_on_initialized_project_includes_all_check_categories(
     assert "codex_config" in names
     assert "heartbeat.alpha" in names
     assert "heartbeat.beta" in names
+
+
+def test_doctor_ovh_qwen_gateway_is_allowlisted_and_checks_ambient_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+    store.set_role("lead", "lead")
+    store.set_operator_facing("lead")
+    store.set_trust_class("qwen-dev-1", "external-worker")
+    (store.dir / "supervisor.json").write_text(
+        json.dumps({
+            "schema_version": 2,
+            "agents": {
+                "qwen-dev-1": {
+                    "backend_profile": "ovh-qwen",
+                    "trust_class": "external-worker",
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        ovh_gateway_service,
+        "gateway_status",
+        lambda _root: {
+            "ready": True,
+            "errors": [],
+            "price_policy_hash": "a" * 64,
+            "committed_micro_eur": 123,
+            "unresolved_count": 0,
+        },
+    )
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    check = doctor._check_ovh_qwen_gateway(store)
+
+    assert check is not None
+    assert check.status == "ok"
+    assert set(check.data or {}) == {
+        "ready",
+        "errors",
+        "price_policy_hash",
+        "committed_micro_eur",
+        "unresolved_count",
+    }
+
+    monkeypatch.setenv("OVH_KEY", "must-not-be-reported")
+    check = doctor._check_ovh_qwen_gateway(store)
+    assert check is not None
+    assert check.status == "error"
+    assert "supervisor_ambient_provider_key" in check.details
+    assert "must-not-be-reported" not in json.dumps(check.data)
 
 
 # ----- hmac check status mapping (review C*: doctor must NOT report a

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -98,12 +98,23 @@ def test_doctor_ovh_qwen_gateway_is_allowlisted_and_checks_ambient_keys(
     assert check.data["ledger"]["opening_micro_eur"] == 580_000
     assert "OVH AI Endpoints dashboard" in check.data["ledger"]["opening_evidence"]
 
-    monkeypatch.setenv("OVH_KEY", "must-not-be-reported")
+    ovh_secret = "must-not-be-reported-ovh-secret"
+    anthropic_secret = "must-not-be-reported-anthropic-secret"
+    monkeypatch.setenv("OVH_KEY", ovh_secret)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", anthropic_secret)
     check = doctor._check_ovh_qwen_gateway(store)
     assert check is not None
     assert check.status == "error"
     assert "supervisor_ambient_provider_key" in check.details
-    assert "must-not-be-reported" not in json.dumps(check.data)
+    rendered = json.dumps({
+        "details": check.details,
+        "fix": check.fix,
+        "data": check.data,
+    })
+    assert ovh_secret not in rendered
+    assert anthropic_secret not in rendered
+    assert "OVH_KEY" not in rendered
+    assert "ANTHROPIC_API_KEY" not in rendered
 
 
 # ----- hmac check status mapping (review C*: doctor must NOT report a

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -70,6 +70,14 @@ def test_doctor_ovh_qwen_gateway_is_allowlisted_and_checks_ambient_keys(
             "price_policy_hash": "a" * 64,
             "committed_micro_eur": 123,
             "unresolved_count": 0,
+            "ledger": {
+                "opening_micro_eur": 580_000,
+                "opening_evidence": (
+                    "OVH AI Endpoints dashboard, observed 2026-07-16 morning"
+                ),
+                "opening_observed_at": "2026-07-16T08:00:00.000000Z",
+                "opening_period": "2026-07",
+            },
         },
     )
     monkeypatch.delenv("OVH_KEY", raising=False)
@@ -85,7 +93,10 @@ def test_doctor_ovh_qwen_gateway_is_allowlisted_and_checks_ambient_keys(
         "price_policy_hash",
         "committed_micro_eur",
         "unresolved_count",
+        "ledger",
     }
+    assert check.data["ledger"]["opening_micro_eur"] == 580_000
+    assert "OVH AI Endpoints dashboard" in check.data["ledger"]["opening_evidence"]
 
     monkeypatch.setenv("OVH_KEY", "must-not-be-reported")
     check = doctor._check_ovh_qwen_gateway(store)

--- a/tests/test_external_worker_trust.py
+++ b/tests/test_external_worker_trust.py
@@ -132,7 +132,7 @@ def test_add_agent_group_path_uses_same_candidate_guard(tmp_path) -> None:
     assert "qwen" not in store.active_agents()
 
 
-def test_rename_carries_external_worker_metadata_and_remove_clears_it(tmp_path) -> None:
+def test_rename_carries_external_worker_metadata_and_remove_tombstones_it(tmp_path) -> None:
     store = make_store(tmp_path)
     store.set_trust_class("worker", "external-worker")
     store.rename_agent("worker", "qwen-worker")
@@ -140,3 +140,75 @@ def test_rename_carries_external_worker_metadata_and_remove_clears_it(tmp_path) 
     assert "worker" not in store.trust_classes()
     store.remove_agent("qwen-worker")
     assert "qwen-worker" not in store.trust_classes()
+    assert "qwen-worker" in store.retired_agents()
+    with pytest.raises(ValueError, match="retired tombstone"):
+        store.add_agent("qwen-worker", role="reviewer")
+
+
+def test_external_worker_trust_is_sticky_and_survives_force_init(tmp_path) -> None:
+    store = make_store(tmp_path)
+    store.set_trust_class("worker", "external-worker")
+
+    with pytest.raises(ValueError, match="cannot be cleared"):
+        store.set_trust_class("worker", None)
+
+    store.init(["lead", "worker", "reviewer"], force=True)
+    assert store.trust_class("worker") == "external-worker"
+
+    store.init(["lead", "reviewer"], force=True)
+    assert "worker" in store.retired_agents()
+    with pytest.raises(ValueError, match="retired tombstone"):
+        store.add_agent("worker")
+
+
+def test_force_init_recovers_external_trust_from_a_partly_malformed_config(
+    tmp_path,
+) -> None:
+    store = make_store(tmp_path)
+    store.set_trust_class("worker", "external-worker")
+    raw = json.loads(store.config_path.read_text(encoding="utf-8"))
+    raw["agents"] = "malformed-but-trust-record-is-recoverable"
+    store.config_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    store.init(["lead", "worker", "reviewer"], force=True)
+
+    assert store.trust_class("worker") == "external-worker"
+
+
+def test_domain_reviewer_cannot_be_reclassified_as_external_worker(tmp_path) -> None:
+    store = make_store(tmp_path)
+    (store.dir / "signoffs.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "defaults": {"reviewers": {}},
+            "risk_policies": {
+                "security": [{
+                    "id": "domain-security",
+                    "required_count": 1,
+                    "candidates": {},
+                    "include_domain_reviewers": True,
+                }],
+            },
+        }),
+        encoding="utf-8",
+    )
+    (store.dir / "domains.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "domains": {
+                "auth": {
+                    "title": "Auth",
+                    "owners": {"agents": ["lead"]},
+                    "reviewers": {"agents": ["worker"]},
+                    "owned_globs": ["src/auth/**"],
+                },
+            },
+            "shared_paths": [],
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.set_trust_class("worker", "external-worker")
+
+    assert store.trust_class("worker") is None

--- a/tests/test_external_worker_trust.py
+++ b/tests/test_external_worker_trust.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agenttalk import cli
+from agenttalk.store import Store
+
+
+def make_store(tmp_path) -> Store:
+    store = Store(tmp_path)
+    store.init(["lead", "worker", "reviewer"])
+    store.set_role("lead", "lead")
+    return store
+
+
+def write_signoff_policy(store: Store, reviewers: dict) -> None:
+    (store.dir / "signoffs.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "defaults": {"reviewers": reviewers},
+                "risk_policies": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_external_worker_metadata_is_opt_in_and_load_validated(tmp_path) -> None:
+    store = make_store(tmp_path)
+    store.set_trust_class("worker", "external-worker")
+    assert store.trust_class("worker") == "external-worker"
+    assert store.trust_class("reviewer") is None
+
+    cfg = store.load_config()
+    cfg["trust_classes"]["worker"] = "unknown"
+    store.config_path.write_text(json.dumps(cfg), encoding="utf-8")
+    with pytest.raises(ValueError, match="trust class"):
+        store.load_config()
+
+
+def test_roster_cli_add_and_show_external_worker_metadata(tmp_path, capsys) -> None:
+    store = make_store(tmp_path)
+    assert cli.main([
+        "--root",
+        str(tmp_path),
+        "roster",
+        "add",
+        "qwen-dev-1",
+        "--trust-class",
+        "external-worker",
+    ]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["--root", str(tmp_path), "roster", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["trust_classes"]["qwen-dev-1"] == "external-worker"
+    assert store.trust_class("qwen-dev-1") == "external-worker"
+
+
+def test_external_worker_cannot_be_added_or_mutated_to_lead(tmp_path) -> None:
+    store = make_store(tmp_path)
+    with pytest.raises(ValueError, match="cannot hold the lead role"):
+        store.add_agent("qwen", role="lead", trust_class="external-worker")
+    assert "qwen" not in store.active_agents()
+
+    store.set_trust_class("worker", "external-worker")
+    with pytest.raises(ValueError, match="cannot hold the lead role"):
+        store.set_role("worker", "lead")
+    assert store.roles().get("worker") != "lead"
+
+
+def test_external_worker_cannot_be_operator_facing(tmp_path) -> None:
+    store = make_store(tmp_path)
+    store.set_trust_class("worker", "external-worker")
+    with pytest.raises(ValueError, match="cannot be operator-facing"):
+        store.set_operator_facing("worker")
+    assert store.operator_facing() is None
+
+
+@pytest.mark.parametrize(
+    "reviewers",
+    [
+        {"agents": ["worker"]},
+        {"roles": ["reviewer"]},
+        {"groups": ["gating-reviewers"]},
+    ],
+)
+def test_external_worker_cannot_become_signoff_candidate(tmp_path, reviewers) -> None:
+    store = make_store(tmp_path)
+    write_signoff_policy(store, reviewers)
+    if reviewers.get("roles"):
+        store.set_role("worker", "reviewer")
+    if reviewers.get("groups"):
+        store.set_group("gating-reviewers", ["worker"])
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.set_trust_class("worker", "external-worker")
+    assert store.trust_class("worker") is None
+
+
+def test_group_mutation_cannot_make_running_external_worker_countable(tmp_path) -> None:
+    store = make_store(tmp_path)
+    write_signoff_policy(store, {"groups": ["gating-reviewers"]})
+    store.set_trust_class("worker", "external-worker")
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.set_group("gating-reviewers", ["worker", "reviewer"])
+    assert "gating-reviewers" not in store.groups()
+
+
+def test_role_mutation_cannot_make_running_external_worker_countable(tmp_path) -> None:
+    store = make_store(tmp_path)
+    write_signoff_policy(store, {"roles": ["reviewer"]})
+    store.set_trust_class("worker", "external-worker")
+
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.set_role("worker", "reviewer")
+
+    assert store.roles().get("worker") != "reviewer"
+
+
+def test_add_agent_group_path_uses_same_candidate_guard(tmp_path) -> None:
+    store = make_store(tmp_path)
+    write_signoff_policy(store, {"groups": ["gating-reviewers"]})
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.add_agent(
+            "qwen",
+            groups=["gating-reviewers"],
+            trust_class="external-worker",
+        )
+    assert "qwen" not in store.active_agents()
+
+
+def test_rename_carries_external_worker_metadata_and_remove_clears_it(tmp_path) -> None:
+    store = make_store(tmp_path)
+    store.set_trust_class("worker", "external-worker")
+    store.rename_agent("worker", "qwen-worker")
+    assert store.trust_class("qwen-worker") == "external-worker"
+    assert "worker" not in store.trust_classes()
+    store.remove_agent("qwen-worker")
+    assert "qwen-worker" not in store.trust_classes()

--- a/tests/test_external_worker_trust.py
+++ b/tests/test_external_worker_trust.py
@@ -212,3 +212,45 @@ def test_domain_reviewer_cannot_be_reclassified_as_external_worker(tmp_path) -> 
         store.set_trust_class("worker", "external-worker")
 
     assert store.trust_class("worker") is None
+
+
+def test_domain_referenced_rename_cannot_make_external_worker_countable(tmp_path) -> None:
+    store = make_store(tmp_path)
+    (store.dir / "signoffs.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "defaults": {"reviewers": {}},
+            "risk_policies": {
+                "security": [{
+                    "id": "domain-security",
+                    "required_count": 1,
+                    "candidates": {},
+                    "include_domain_reviewers": True,
+                }],
+            },
+        }),
+        encoding="utf-8",
+    )
+    (store.dir / "domains.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "domains": {
+                "auth": {
+                    "title": "Auth",
+                    "owners": {"agents": ["lead"]},
+                    "reviewers": {"agents": ["qwen-worker"]},
+                    "owned_globs": ["src/auth/**"],
+                },
+            },
+            "shared_paths": [],
+        }),
+        encoding="utf-8",
+    )
+    store.set_trust_class("worker", "external-worker")
+
+    with pytest.raises(ValueError, match="cannot be a signoff candidate"):
+        store.rename_agent("worker", "qwen-worker")
+
+    assert "worker" in store.active_agents()
+    assert "qwen-worker" not in store.active_agents()
+    assert store.trust_class("worker") == "external-worker"

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from agenttalk.ovh_gateway import (
+    CANARY_TOLERANCE_BPS,
     EXTERNAL_CEILING_MICRO_EUR,
     INPUT_RATE_MICRO_EUR,
     MAX_CONTEXT_TOKENS,
@@ -62,17 +63,18 @@ def make_ledger(tmp_path, clock: Clock | None = None) -> SpendLedger:
 
 def test_exact_price_policy_and_charge_fixture() -> None:
     assert POLICY_CURRENCY == "EUR"
-    assert INPUT_RATE_MICRO_EUR == 710_000
-    assert OUTPUT_RATE_MICRO_EUR == 4_250_000
-    assert RESERVE_INPUT_RATE_MICRO_EUR == 852_000
-    assert RESERVE_OUTPUT_RATE_MICRO_EUR == 5_100_000
+    assert INPUT_RATE_MICRO_EUR == 600_000
+    assert OUTPUT_RATE_MICRO_EUR == 3_600_000
+    assert RESERVE_INPUT_RATE_MICRO_EUR == 720_000
+    assert RESERVE_OUTPUT_RATE_MICRO_EUR == 4_320_000
     assert MAX_CONTEXT_TOKENS == 262_144
     assert MAX_OUTPUT_TOKENS == 4_096
     assert TRIAL_CUTOFF_MICRO_EUR == 25_000_000
     assert SOFT_STOP_MICRO_EUR == 20_000_000
     assert EXTERNAL_CEILING_MICRO_EUR == 100_000_000
-    assert settlement_cost_micro_eur(1_000, 100) == 1_135
-    assert reservation_cost_micro_eur() == 244_237
+    assert CANARY_TOLERANCE_BPS == 1_000
+    assert settlement_cost_micro_eur(1_000, 100) == 960
+    assert reservation_cost_micro_eur() == 206_439
     assert len(price_policy_hash()) == 64
 
 
@@ -130,6 +132,21 @@ def test_initialize_durability_failure_never_creates_complete_install(tmp_path) 
     assert ledger.installation_state() == "absent"
 
 
+def test_initialize_removes_temporary_persist_journal(tmp_path) -> None:
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence=TEST_OPENING_EVIDENCE,
+        generation="a" * 32,
+    )
+
+    assert not [
+        path.name
+        for path in tmp_path.iterdir()
+        if path.name.startswith(".ledger.sqlite3.")
+    ]
+
+
 def test_corrupt_marker_or_database_fails_closed(tmp_path) -> None:
     ledger = make_ledger(tmp_path)
     ledger.marker_path.write_text("not-json", encoding="utf-8")
@@ -175,8 +192,8 @@ def test_opening_balance_is_bound_seeded_and_surfaced(tmp_path) -> None:
         output_tokens=100,
     )
     status = ledger.status()
-    assert status["current_committed_micro_eur"] == 581_135
-    assert status["current_trial_committed_micro_eur"] == 1_135
+    assert status["current_committed_micro_eur"] == 580_960
+    assert status["current_trial_committed_micro_eur"] == 960
 
 
 def test_opening_balance_external_envelope_blocks_init_and_readiness(tmp_path) -> None:
@@ -218,7 +235,7 @@ def test_opening_balance_external_envelope_blocks_init_and_readiness(tmp_path) -
 def test_reserve_then_settle_commits_exact_actual(tmp_path) -> None:
     ledger = make_ledger(tmp_path)
     reservation = ledger.reserve("1" * 32)
-    assert reservation.reserved_micro_eur == 244_237
+    assert reservation.reserved_micro_eur == 206_439
     assert ledger.status()["ready"] is False
 
     result = ledger.settle(
@@ -227,14 +244,14 @@ def test_reserve_then_settle_commits_exact_actual(tmp_path) -> None:
         input_tokens=1_000,
         output_tokens=100,
     )
-    assert result["actual_micro_eur"] == 1_135
+    assert result["actual_micro_eur"] == 960
     status = ledger.status()
     assert status["ready"] is True
-    assert status["current_committed_micro_eur"] == 1_135
+    assert status["current_committed_micro_eur"] == 960
     assert status["unresolved"] == []
 
 
-def test_reservation_barrier_failure_never_allows_transport_and_remains_held(tmp_path) -> None:
+def test_sqlite_full_commit_is_the_reservation_durability_authority(tmp_path) -> None:
     ledger = make_ledger(tmp_path)
 
     def fail_barrier(_path) -> None:
@@ -246,11 +263,76 @@ def test_reservation_barrier_failure_never_allows_transport_and_remains_held(tmp
         now=ledger.now,
         durability_barrier=fail_barrier,
     )
-    with pytest.raises(LedgerBlocked, match="durability barrier"):
-        failing.reserve("1" * 32)
+    failing.reserve("1" * 32)
     status = ledger.status()
     assert status["ready"] is False
     assert status["unresolved"][0]["attempt_id"] == "1" * 32
+
+
+def test_settle_does_not_depend_on_a_fallible_post_commit_barrier(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+
+    def fail_barrier(_path) -> None:
+        raise OSError("post-commit barrier must not run")
+
+    failing = SpendLedger(
+        ledger.db_path,
+        ledger.marker_path,
+        now=ledger.now,
+        durability_barrier=fail_barrier,
+    )
+    result = failing.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+
+    assert result["actual_micro_eur"] == 960
+    assert ledger.status()["ready"] is True
+
+
+def test_reconcile_does_not_depend_on_a_fallible_post_commit_barrier(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+
+    def fail_barrier(_path) -> None:
+        raise OSError("post-commit barrier must not run")
+
+    failing = SpendLedger(
+        ledger.db_path,
+        ledger.marker_path,
+        now=ledger.now,
+        durability_barrier=fail_barrier,
+    )
+    result = failing.reconcile(
+        "1" * 32,
+        outcome="no-send",
+        reason="provider proves transport never started",
+    )
+
+    assert result["total_actual_micro_eur"] == 0
+    assert ledger.status()["ready"] is True
+
+
+def test_clear_hold_does_not_depend_on_a_fallible_post_commit_barrier(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.place_hold(reason="dashboard mismatch")
+
+    def fail_barrier(_path) -> None:
+        raise OSError("post-commit barrier must not run")
+
+    failing = SpendLedger(
+        ledger.db_path,
+        ledger.marker_path,
+        now=ledger.now,
+        durability_barrier=fail_barrier,
+    )
+    result = failing.clear_hold(reason="operator completed reconciliation")
+
+    assert result["held"] is False
+    assert ledger.status()["ready"] is True
 
 
 def test_unresolved_attempt_blocks_restart_until_explicit_reconcile(tmp_path) -> None:
@@ -268,7 +350,7 @@ def test_unresolved_attempt_blocks_restart_until_explicit_reconcile(tmp_path) ->
         outcome="charge-reserve",
         reason="operator could not prove no-send",
     )
-    assert result["total_actual_micro_eur"] == 244_237
+    assert result["total_actual_micro_eur"] == reservation_cost_micro_eur()
     restarted.reserve("2" * 32)
 
 
@@ -399,6 +481,67 @@ def test_cutoff_counts_committed_and_the_new_worst_case_reservation(tmp_path) ->
         )
     with pytest.raises(PolicyBlocked, match="cutoff"):
         ledger.reserve("1" * 32)
+
+
+def test_running_external_ceiling_counts_committed_across_all_periods(tmp_path) -> None:
+    clock = Clock(datetime(2026, 11, 1, 0, 1, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute("DELETE FROM periods")
+        conn.executemany(
+            "INSERT INTO periods(period, committed_micro_eur) VALUES (?, ?)",
+            [
+                ("2026-07", TRIAL_CUTOFF_MICRO_EUR),
+                ("2026-08", TRIAL_CUTOFF_MICRO_EUR),
+                ("2026-09", TRIAL_CUTOFF_MICRO_EUR),
+                ("2026-10", TRIAL_CUTOFF_MICRO_EUR),
+                ("2026-11", 0),
+            ],
+        )
+        conn.execute(
+            "UPDATE metadata SET value='2026-11' WHERE key='last_accepted_period'"
+        )
+        conn.execute(
+            "UPDATE metadata SET value=? WHERE key='last_accepted_utc'",
+            ("2026-11-01T00:00:00.000000Z",),
+        )
+
+    with pytest.raises(PolicyBlocked, match="external ceiling"):
+        ledger.reserve("1" * 32)
+
+
+def test_dashboard_canary_enforces_nonzero_delta_and_numeric_tolerance(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+
+    accepted = ledger.verify_dashboard_canary(
+        "1" * 32,
+        observed_delta_micro_eur=1_056,
+    )
+    assert accepted["accepted"] is True
+    assert accepted["expected_micro_eur"] == 960
+    assert accepted["tolerance_micro_eur"] == 96
+
+    other = make_ledger(tmp_path / "zero")
+    other.reserve("2" * 32)
+    other.settle(
+        "2" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    rejected = other.verify_dashboard_canary(
+        "2" * 32,
+        observed_delta_micro_eur=0,
+    )
+    assert rejected["accepted"] is False
+    assert other.status()["service_hold"] == "dashboard_canary_mismatch"
 
 
 def test_begin_immediate_serializes_concurrent_admission(tmp_path) -> None:

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from agenttalk.ovh_gateway import (
+    INPUT_RATE_MICRO_EUR,
+    MAX_CONTEXT_TOKENS,
+    MAX_OUTPUT_TOKENS,
+    MODEL_ALIAS,
+    OUTPUT_RATE_MICRO_EUR,
+    POLICY_CURRENCY,
+    RESERVE_INPUT_RATE_MICRO_EUR,
+    RESERVE_OUTPUT_RATE_MICRO_EUR,
+    SOFT_STOP_MICRO_EUR,
+    TRIAL_CUTOFF_MICRO_EUR,
+    LedgerBlocked,
+    LedgerHold,
+    PolicyBlocked,
+    SpendLedger,
+    price_policy_hash,
+    render_litellm_config,
+    reservation_cost_micro_eur,
+    settlement_cost_micro_eur,
+)
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+def make_ledger(tmp_path, clock: Clock | None = None) -> SpendLedger:
+    clock = clock or Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = SpendLedger(
+        tmp_path / "ledger.sqlite3",
+        tmp_path / "install.json",
+        now=clock,
+    )
+    ledger.initialize(generation="a" * 32)
+    return ledger
+
+
+def test_exact_price_policy_and_charge_fixture() -> None:
+    assert POLICY_CURRENCY == "EUR"
+    assert INPUT_RATE_MICRO_EUR == 710_000
+    assert OUTPUT_RATE_MICRO_EUR == 4_250_000
+    assert RESERVE_INPUT_RATE_MICRO_EUR == 852_000
+    assert RESERVE_OUTPUT_RATE_MICRO_EUR == 5_100_000
+    assert MAX_CONTEXT_TOKENS == 262_144
+    assert MAX_OUTPUT_TOKENS == 4_096
+    assert TRIAL_CUTOFF_MICRO_EUR == 25_000_000
+    assert SOFT_STOP_MICRO_EUR == 20_000_000
+    assert settlement_cost_micro_eur(1_000, 100) == 1_135
+    assert reservation_cost_micro_eur() == 244_237
+    assert len(price_policy_hash()) == 64
+
+
+def test_litellm_config_is_single_model_callback_free_and_chat_completions() -> None:
+    rendered = render_litellm_config(api_base="http://127.0.0.1:18080/v1")
+    assert rendered.count("model_name:") == 1
+    assert MODEL_ALIAS in rendered
+    assert rendered.count("store: false") == 2
+    assert "max_retries: 0" in rendered
+    assert "num_retries: 0" in rendered
+    litellm_settings = rendered.split("litellm_settings:\n", 1)[1].split(
+        "router_settings:\n", 1
+    )[0]
+    assert "use_chat_completions_url_for_anthropic_messages: true" in litellm_settings
+    assert "callback" not in rendered
+    assert "/v1/responses" not in rendered
+
+
+def test_initialize_is_explicit_and_partial_or_missing_state_fails_closed(tmp_path) -> None:
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    with pytest.raises(LedgerBlocked, match="not initialized"):
+        ledger.status()
+    marker = ledger.initialize(generation="b" * 32)
+    assert marker["price_policy_hash"] == price_policy_hash()
+    with pytest.raises(LedgerBlocked, match="requires both"):
+        ledger.initialize()
+
+    (tmp_path / "install.json").unlink()
+    with pytest.raises(LedgerBlocked, match="partial"):
+        ledger.status()
+
+
+def test_initialize_durability_failure_never_creates_complete_install(tmp_path) -> None:
+    def fail_barrier(_path) -> None:
+        raise OSError("fake flush failure")
+
+    ledger = SpendLedger(
+        tmp_path / "ledger.sqlite3",
+        tmp_path / "install.json",
+        durability_barrier=fail_barrier,
+    )
+    with pytest.raises(OSError, match="flush failure"):
+        ledger.initialize(generation="a" * 32)
+    assert ledger.installation_state() == "absent"
+
+
+def test_corrupt_marker_or_database_fails_closed(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.marker_path.write_text("not-json", encoding="utf-8")
+    with pytest.raises(LedgerBlocked, match="cannot read"):
+        ledger.reserve("1" * 32)
+
+    ledger = make_ledger(tmp_path / "other")
+    ledger.db_path.write_bytes(b"not sqlite")
+    with pytest.raises(LedgerBlocked):
+        ledger.status()
+
+
+def test_reserve_then_settle_commits_exact_actual(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    reservation = ledger.reserve("1" * 32)
+    assert reservation.reserved_micro_eur == 244_237
+    assert ledger.status()["ready"] is False
+
+    result = ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    assert result["actual_micro_eur"] == 1_135
+    status = ledger.status()
+    assert status["ready"] is True
+    assert status["current_committed_micro_eur"] == 1_135
+    assert status["unresolved"] == []
+
+
+def test_reservation_barrier_failure_never_allows_transport_and_remains_held(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+
+    def fail_barrier(_path) -> None:
+        raise OSError("fake flush failure")
+
+    failing = SpendLedger(
+        ledger.db_path,
+        ledger.marker_path,
+        now=ledger.now,
+        durability_barrier=fail_barrier,
+    )
+    with pytest.raises(LedgerBlocked, match="durability barrier"):
+        failing.reserve("1" * 32)
+    status = ledger.status()
+    assert status["ready"] is False
+    assert status["unresolved"][0]["attempt_id"] == "1" * 32
+
+
+def test_unresolved_attempt_blocks_restart_until_explicit_reconcile(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    restarted = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)
+    with pytest.raises(LedgerHold, match="unresolved"):
+        restarted.reserve("2" * 32)
+    restarted.mark_uncertain("1" * 32, reason="process killed after send")
+    with pytest.raises(LedgerHold, match="unresolved"):
+        restarted.reserve("2" * 32)
+
+    result = restarted.reconcile(
+        "1" * 32,
+        outcome="charge-reserve",
+        reason="operator could not prove no-send",
+    )
+    assert result["total_actual_micro_eur"] == 244_237
+    restarted.reserve("2" * 32)
+
+
+def test_process_exit_after_durable_reserve_retains_global_restart_hold(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    source_root = str((Path(__file__).resolve().parents[1] / "src"))
+    code = (
+        "import os,sys; from datetime import datetime,timezone; from pathlib import Path; "
+        "from agenttalk.ovh_gateway import SpendLedger; "
+        "now=lambda: datetime(2026,7,15,12,tzinfo=timezone.utc); "
+        "SpendLedger(Path(sys.argv[1]),Path(sys.argv[2]),now=now).reserve('1'*32); "
+        "os._exit(0)"
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = source_root
+
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code, str(ledger.db_path), str(ledger.marker_path)],
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0
+    restarted = SpendLedger(ledger.db_path, ledger.marker_path, now=clock)
+    status = restarted.status()
+    assert status["ready"] is False
+    assert status["unresolved"][0]["attempt_id"] == "1" * 32
+    with pytest.raises(LedgerHold, match="unresolved"):
+        restarted.reserve("2" * 32)
+
+
+def test_manual_price_mismatch_hold_requires_explicit_clear(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    placed = ledger.place_hold(reason="live dashboard price mismatch")
+    assert placed["held"] is True
+    with pytest.raises(LedgerHold, match="durable accounting hold"):
+        ledger.reserve("1" * 32)
+    assert ledger.status()["service_hold"] == "manual: live dashboard price mismatch"
+
+    cleared = ledger.clear_hold(reason="operator approved corrected price policy")
+    assert cleared["held"] is False
+    ledger.reserve("1" * 32)
+
+
+def test_attempt_reconcile_does_not_clear_independent_manual_hold(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    ledger.place_hold(reason="dashboard mismatch")
+    ledger.reconcile("1" * 32, outcome="charge-reserve", reason="unknown disposition")
+    assert ledger.status()["service_hold"] == "manual: dashboard mismatch"
+
+
+def test_missing_or_invalid_usage_retains_reservation_and_sets_hold(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    with pytest.raises(LedgerHold, match="usage is invalid"):
+        ledger.settle(
+            "1" * 32,
+            model=MODEL_ALIAS,
+            input_tokens=0,
+            output_tokens=0,
+        )
+    status = ledger.status()
+    assert status["unresolved"][0]["state"] == "uncertain"
+    assert status["current_committed_micro_eur"] == 0
+
+
+@pytest.mark.parametrize(("input_tokens", "output_tokens"), [(0, 1), (1, 0)])
+def test_zero_component_usage_is_not_authoritative(
+    tmp_path,
+    input_tokens,
+    output_tokens,
+) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    with pytest.raises(LedgerHold, match="usage is invalid"):
+        ledger.settle(
+            "1" * 32,
+            model=MODEL_ALIAS,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    assert ledger.status()["unresolved"][0]["state"] == "uncertain"
+
+
+def test_usage_over_reservation_is_charged_and_holds_service(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    result = ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=MAX_CONTEXT_TOKENS + 1,
+        output_tokens=MAX_OUTPUT_TOKENS,
+    )
+    assert result["held"] is True
+    status = ledger.status()
+    assert status["service_hold"]
+    assert status["unresolved"][0]["state"] == "uncertain"
+
+
+def test_cutoff_counts_committed_and_the_new_worst_case_reservation(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute(
+            "UPDATE periods SET committed_micro_eur=?",
+            (TRIAL_CUTOFF_MICRO_EUR - reservation_cost_micro_eur() + 1,),
+        )
+    with pytest.raises(PolicyBlocked, match="cutoff"):
+        ledger.reserve("1" * 32)
+
+
+def test_begin_immediate_serializes_concurrent_admission(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    outcomes: list[str] = []
+    barrier = threading.Barrier(3)
+
+    def reserve(attempt_id: str) -> None:
+        barrier.wait()
+        try:
+            ledger.reserve(attempt_id)
+            outcomes.append("reserved")
+        except LedgerHold:
+            outcomes.append("held")
+
+    threads = [
+        threading.Thread(target=reserve, args=("1" * 32,)),
+        threading.Thread(target=reserve, args=("2" * 32,)),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+    assert sorted(outcomes) == ["held", "reserved"]
+    assert len(ledger.status()["unresolved"]) == 1
+
+
+def test_begin_immediate_serializes_cross_process_admission(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    start = tmp_path / "start"
+    outputs = [tmp_path / "one.out", tmp_path / "two.out"]
+    source_root = str(Path(__file__).resolve().parents[1] / "src")
+    code = """
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from agenttalk.ovh_gateway import SpendLedger
+
+start = Path(sys.argv[3])
+while not start.exists():
+    time.sleep(0.01)
+now = lambda: datetime(2026, 7, 15, 12, tzinfo=timezone.utc)
+ledger = SpendLedger(Path(sys.argv[1]), Path(sys.argv[2]), now=now)
+out = Path(sys.argv[5])
+try:
+    ledger.reserve(sys.argv[4])
+except Exception as exc:
+    out.write_text(type(exc).__name__, encoding="ascii")
+else:
+    out.write_text("reserved", encoding="ascii")
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = source_root
+    children = [
+        subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-c",
+                code,
+                str(ledger.db_path),
+                str(ledger.marker_path),
+                str(start),
+                attempt,
+                str(output),
+            ],
+            env=env,
+        )
+        for attempt, output in zip(("1" * 32, "2" * 32), outputs, strict=True)
+    ]
+    start.write_text("go", encoding="ascii")
+    for child in children:
+        assert child.wait(timeout=30) == 0
+
+    assert sorted(output.read_text(encoding="ascii") for output in outputs) == [
+        "LedgerHold",
+        "reserved",
+    ]
+    assert len(ledger.status()["unresolved"]) == 1
+
+
+def test_period_is_pinned_at_admission_across_rollover(tmp_path) -> None:
+    clock = Clock(datetime(2026, 12, 31, 23, 59, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    reservation = ledger.reserve("1" * 32)
+    assert reservation.period == "2026-12"
+    clock.value = datetime(2027, 1, 1, 0, 1, tzinfo=timezone.utc)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=100,
+        output_tokens=10,
+    )
+    periods = {row["period"]: row["committed_micro_eur"] for row in ledger.status()["periods"]}
+    assert periods["2026-12"] == settlement_cost_micro_eur(100, 10)
+    assert "2027-01" not in periods
+
+
+def test_clock_rollback_and_impossible_jump_fail_closed(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    clock.value -= timedelta(seconds=1)
+    with pytest.raises(LedgerHold, match="rollback"):
+        ledger.reserve("1" * 32)
+
+    clock.value = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    with pytest.raises(LedgerHold, match="jumped implausibly"):
+        ledger.reserve("2" * 32)
+
+
+def test_clock_rollback_blocks_status_and_service_restart(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    clock.value -= timedelta(microseconds=1)
+    with pytest.raises(LedgerHold, match="rollback"):
+        ledger.status()
+
+
+def test_policy_hash_tamper_blocks_all_calls(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    marker["price_policy_hash"] = "0" * 64
+    ledger.marker_path.write_text(json.dumps(marker), encoding="utf-8")
+    with pytest.raises(LedgerBlocked, match="price_policy_hash mismatch"):
+        ledger.status()

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -544,6 +544,64 @@ def test_dashboard_canary_enforces_nonzero_delta_and_numeric_tolerance(tmp_path)
     assert other.status()["service_hold"] == "dashboard_canary_mismatch"
 
 
+def test_dashboard_canary_gates_worker_spend_readiness_until_accepted(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    initial = ledger.status()
+    assert initial["ready"] is True
+    assert initial["worker_spend_ready"] is False
+    assert initial["worker_spend_errors"] == ["dashboard_canary_absent"]
+
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=0)
+    mismatched = ledger.status()
+    assert mismatched["ready"] is False
+    assert mismatched["worker_spend_ready"] is False
+    assert mismatched["worker_spend_errors"] == [
+        "ledger_not_ready",
+        "dashboard_canary_mismatch",
+    ]
+
+    ledger.clear_hold(reason="operator inspected mismatch")
+    cleared = ledger.status()
+    assert cleared["ready"] is True
+    assert cleared["dashboard_canary"]["status"] == "mismatch"
+    assert cleared["worker_spend_ready"] is False
+    assert cleared["worker_spend_errors"] == ["dashboard_canary_mismatch"]
+
+    ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=960)
+    accepted = ledger.status()
+    assert accepted["ready"] is True
+    assert accepted["dashboard_canary"]["status"] == "accepted"
+    assert accepted["worker_spend_ready"] is True
+    assert accepted["worker_spend_errors"] == []
+
+
+def test_dashboard_canary_readiness_rejects_stale_attempt_policy_binding(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=960)
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute(
+            "UPDATE attempts SET policy_hash='stale' WHERE attempt_id=?",
+            ("1" * 32,),
+        )
+
+    with pytest.raises(LedgerBlocked, match="canary attempt binding"):
+        ledger.status()
+
+
 def test_begin_immediate_serializes_concurrent_admission(tmp_path) -> None:
     ledger = make_ledger(tmp_path)
     outcomes: list[str] = []

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from agenttalk.ovh_gateway import (
+    EXTERNAL_CEILING_MICRO_EUR,
     INPUT_RATE_MICRO_EUR,
     MAX_CONTEXT_TOKENS,
     MAX_OUTPUT_TOKENS,
@@ -33,6 +34,9 @@ from agenttalk.ovh_gateway import (
 )
 
 
+TEST_OPENING_EVIDENCE = "test dashboard, observed 2026-07-15T12:00:00Z"
+
+
 class Clock:
     def __init__(self, value: datetime) -> None:
         self.value = value
@@ -48,7 +52,11 @@ def make_ledger(tmp_path, clock: Clock | None = None) -> SpendLedger:
         tmp_path / "install.json",
         now=clock,
     )
-    ledger.initialize(generation="a" * 32)
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence=TEST_OPENING_EVIDENCE,
+        generation="a" * 32,
+    )
     return ledger
 
 
@@ -62,6 +70,7 @@ def test_exact_price_policy_and_charge_fixture() -> None:
     assert MAX_OUTPUT_TOKENS == 4_096
     assert TRIAL_CUTOFF_MICRO_EUR == 25_000_000
     assert SOFT_STOP_MICRO_EUR == 20_000_000
+    assert EXTERNAL_CEILING_MICRO_EUR == 100_000_000
     assert settlement_cost_micro_eur(1_000, 100) == 1_135
     assert reservation_cost_micro_eur() == 244_237
     assert len(price_policy_hash()) == 64
@@ -86,10 +95,17 @@ def test_initialize_is_explicit_and_partial_or_missing_state_fails_closed(tmp_pa
     ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
     with pytest.raises(LedgerBlocked, match="not initialized"):
         ledger.status()
-    marker = ledger.initialize(generation="b" * 32)
+    marker = ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence=TEST_OPENING_EVIDENCE,
+        generation="b" * 32,
+    )
     assert marker["price_policy_hash"] == price_policy_hash()
     with pytest.raises(LedgerBlocked, match="requires both"):
-        ledger.initialize()
+        ledger.initialize(
+            opening_micro_eur=0,
+            opening_evidence=TEST_OPENING_EVIDENCE,
+        )
 
     (tmp_path / "install.json").unlink()
     with pytest.raises(LedgerBlocked, match="partial"):
@@ -106,7 +122,11 @@ def test_initialize_durability_failure_never_creates_complete_install(tmp_path) 
         durability_barrier=fail_barrier,
     )
     with pytest.raises(OSError, match="flush failure"):
-        ledger.initialize(generation="a" * 32)
+        ledger.initialize(
+            opening_micro_eur=0,
+            opening_evidence=TEST_OPENING_EVIDENCE,
+            generation="a" * 32,
+        )
     assert ledger.installation_state() == "absent"
 
 
@@ -119,6 +139,79 @@ def test_corrupt_marker_or_database_fails_closed(tmp_path) -> None:
     ledger = make_ledger(tmp_path / "other")
     ledger.db_path.write_bytes(b"not sqlite")
     with pytest.raises(LedgerBlocked):
+        ledger.status()
+
+
+def test_opening_balance_is_bound_seeded_and_surfaced(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 16, 8, 0, tzinfo=timezone.utc))
+    ledger = SpendLedger(
+        tmp_path / "ledger.sqlite3",
+        tmp_path / "install.json",
+        now=clock,
+    )
+    evidence = "OVH AI Endpoints dashboard, observed 2026-07-16 morning"
+
+    marker = ledger.initialize(
+        opening_micro_eur=580_000,
+        opening_evidence=evidence,
+        generation="b" * 32,
+    )
+
+    assert marker["opening_micro_eur"] == 580_000
+    status = ledger.status()
+    assert status["opening_micro_eur"] == 580_000
+    assert status["opening_evidence"] == evidence
+    assert status["opening_observed_at"] == "2026-07-16T08:00:00.000000Z"
+    assert status["opening_period"] == "2026-07"
+    assert status["current_committed_micro_eur"] == 580_000
+    assert status["current_trial_committed_micro_eur"] == 0
+    assert status["external_ceiling_micro_eur"] == 100_000_000
+
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    status = ledger.status()
+    assert status["current_committed_micro_eur"] == 581_135
+    assert status["current_trial_committed_micro_eur"] == 1_135
+
+
+def test_opening_balance_external_envelope_blocks_init_and_readiness(tmp_path) -> None:
+    unsafe_opening = (
+        EXTERNAL_CEILING_MICRO_EUR
+        - TRIAL_CUTOFF_MICRO_EUR
+        - reservation_cost_micro_eur()
+        + 1
+    )
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    with pytest.raises(PolicyBlocked, match="external account ceiling"):
+        ledger.initialize(
+            opening_micro_eur=unsafe_opening,
+            opening_evidence=TEST_OPENING_EVIDENCE,
+        )
+    assert ledger.installation_state() == "absent"
+
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence=TEST_OPENING_EVIDENCE,
+        generation="a" * 32,
+    )
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    marker["opening_micro_eur"] = unsafe_opening
+    ledger.marker_path.write_text(json.dumps(marker), encoding="utf-8")
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute(
+            "UPDATE metadata SET value=? WHERE key='opening_micro_eur'",
+            (str(unsafe_opening),),
+        )
+        conn.execute(
+            "UPDATE periods SET committed_micro_eur=? WHERE period='2026-07'",
+            (unsafe_opening,),
+        )
+    with pytest.raises(LedgerBlocked, match="opening balance envelope"):
         ledger.status()
 
 
@@ -177,6 +270,25 @@ def test_unresolved_attempt_blocks_restart_until_explicit_reconcile(tmp_path) ->
     )
     assert result["total_actual_micro_eur"] == 244_237
     restarted.reserve("2" * 32)
+
+
+def test_reconcile_never_accepts_a_caller_supplied_actual_cost(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)
+
+    with pytest.raises(ValueError, match="no-send or charge-reserve"):
+        ledger.reconcile(
+            "1" * 32,
+            outcome="charge-actual",
+            reason="caller supplied dashboard value",
+        )
+
+    result = ledger.reconcile(
+        "1" * 32,
+        outcome="charge-reserve",
+        reason="provider disposition remains ambiguous",
+    )
+    assert result["total_actual_micro_eur"] == reservation_cost_micro_eur()
 
 
 def test_process_exit_after_durable_reserve_retains_global_restart_hold(tmp_path) -> None:

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from agenttalk import ovh_gateway as gateway
 from agenttalk.ovh_gateway import (
     CANARY_TOLERANCE_BPS,
     EXTERNAL_CEILING_MICRO_EUR,
@@ -36,6 +37,7 @@ from agenttalk.ovh_gateway import (
 
 
 TEST_OPENING_EVIDENCE = "test dashboard, observed 2026-07-15T12:00:00Z"
+TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
 
 
 class Clock:
@@ -57,8 +59,31 @@ def make_ledger(tmp_path, clock: Clock | None = None) -> SpendLedger:
         opening_micro_eur=0,
         opening_evidence=TEST_OPENING_EVIDENCE,
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     return ledger
+
+
+def downgrade_to_v1_without_child_caps(ledger: SpendLedger) -> None:
+    """Build the exact pre-cap ledger shape exercised by the migration."""
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute("DROP TABLE child_attempts")
+        conn.execute("DROP TABLE child_capabilities")
+        conn.execute("DROP TABLE child_turns")
+        conn.execute(
+            "DELETE FROM metadata WHERE key IN (?, ?, ?)",
+            (
+                "child_cap_schema_version",
+                "child_cap_policy_hash",
+                "child_cap_issuer_sha256",
+            ),
+        )
+        conn.execute(
+            "UPDATE metadata SET value='1' WHERE key='schema_version'"
+        )
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    marker["ledger_schema_version"] = 1
+    ledger.marker_path.write_text(json.dumps(marker), encoding="utf-8")
 
 
 def test_exact_price_policy_and_charge_fixture() -> None:
@@ -76,6 +101,14 @@ def test_exact_price_policy_and_charge_fixture() -> None:
     assert settlement_cost_micro_eur(1_000, 100) == 960
     assert reservation_cost_micro_eur() == 206_439
     assert len(price_policy_hash()) == 64
+    assert gateway.child_cap_policy() == {
+        "schema_version": 1,
+        "max_calls": 8,
+        "max_micro_eur": 500_000,
+        "max_seconds": 300,
+        "reservation_micro_eur": 206_439,
+    }
+    assert len(gateway.child_cap_policy_hash()) == 64
 
 
 def test_litellm_config_is_single_model_callback_free_and_chat_completions() -> None:
@@ -101,12 +134,14 @@ def test_initialize_is_explicit_and_partial_or_missing_state_fails_closed(tmp_pa
         opening_micro_eur=0,
         opening_evidence=TEST_OPENING_EVIDENCE,
         generation="b" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     assert marker["price_policy_hash"] == price_policy_hash()
     with pytest.raises(LedgerBlocked, match="requires both"):
         ledger.initialize(
             opening_micro_eur=0,
             opening_evidence=TEST_OPENING_EVIDENCE,
+            child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
         )
 
     (tmp_path / "install.json").unlink()
@@ -128,6 +163,7 @@ def test_initialize_durability_failure_never_creates_complete_install(tmp_path) 
             opening_micro_eur=0,
             opening_evidence=TEST_OPENING_EVIDENCE,
             generation="a" * 32,
+            child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
         )
     assert ledger.installation_state() == "absent"
 
@@ -138,6 +174,7 @@ def test_initialize_removes_temporary_persist_journal(tmp_path) -> None:
         opening_micro_eur=0,
         opening_evidence=TEST_OPENING_EVIDENCE,
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
 
     assert not [
@@ -172,6 +209,7 @@ def test_opening_balance_is_bound_seeded_and_surfaced(tmp_path) -> None:
         opening_micro_eur=580_000,
         opening_evidence=evidence,
         generation="b" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
 
     assert marker["opening_micro_eur"] == 580_000
@@ -208,6 +246,7 @@ def test_opening_balance_external_envelope_blocks_init_and_readiness(tmp_path) -
         ledger.initialize(
             opening_micro_eur=unsafe_opening,
             opening_evidence=TEST_OPENING_EVIDENCE,
+            child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
         )
     assert ledger.installation_state() == "absent"
 
@@ -215,6 +254,7 @@ def test_opening_balance_external_envelope_blocks_init_and_readiness(tmp_path) -
         opening_micro_eur=0,
         opening_evidence=TEST_OPENING_EVIDENCE,
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
     marker["opening_micro_eur"] = unsafe_opening
@@ -249,6 +289,415 @@ def test_reserve_then_settle_commits_exact_actual(tmp_path) -> None:
     assert status["ready"] is True
     assert status["current_committed_micro_eur"] == 960
     assert status["unresolved"] == []
+
+
+def test_child_turn_call_cap_is_durable_and_fail_closed(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="20260719-120000-000000-test",
+        request_id="q-child-cap",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    assert credential.expires_at == "2026-07-15T12:05:00.000000Z"
+
+    for ordinal in range(gateway.CHILD_TURN_MAX_CALLS):
+        attempt_id = f"{ordinal + 1:032x}"
+        ledger.reserve_for_child(attempt_id, capability=credential.token)
+        ledger.settle(
+            attempt_id,
+            model=MODEL_ALIAS,
+            input_tokens=1_000,
+            output_tokens=100,
+        )
+
+    restarted = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)
+    replay = restarted.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="20260719-120000-000000-test",
+        request_id="q-child-cap",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    with pytest.raises(gateway.ChildTurnCapExceeded, match="call ceiling"):
+        restarted.reserve_for_child("f" * 32, capability=replay.token)
+
+    status = restarted.status()
+    assert status["child_cap_ready"] is True
+    assert status["active_child_turns"][0]["attempt_count"] == (
+        gateway.CHILD_TURN_MAX_CALLS
+    )
+    assert all(row["attempt_id"] != "f" * 32 for row in status["unresolved"])
+
+
+def test_child_turn_mint_requires_non_inherited_controller_issuer(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    untrusted_child = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)
+
+    with pytest.raises(gateway.ChildTurnCapBlocked, match="issuer"):
+        untrusted_child.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="invented-fresh-scope",
+            request_id="q-bypass",
+        )
+    with pytest.raises(gateway.ChildTurnCapBlocked, match="issuer"):
+        untrusted_child.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="invented-fresh-scope",
+            request_id="q-bypass",
+            issuer_token="atgw-" + "x" * 43,
+        )
+
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM child_turns").fetchone()[0] == 0
+
+
+def test_child_turn_cost_cap_and_scope_isolation(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    first = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-a",
+        request_id="same-request",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    for ordinal in range(2):
+        attempt_id = f"{ordinal + 1:032x}"
+        ledger.reserve_for_child(attempt_id, capability=first.token)
+        ledger.settle(
+            attempt_id,
+            model=MODEL_ALIAS,
+            input_tokens=MAX_CONTEXT_TOKENS,
+            output_tokens=MAX_OUTPUT_TOKENS,
+        )
+    with pytest.raises(gateway.ChildTurnCapExceeded, match="cost ceiling"):
+        ledger.reserve_for_child("3" * 32, capability=first.token)
+
+    # A different immutable inbound message gets an independent bucket even when
+    # request_id repeats; another child is independent too.
+    second_message = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-b",
+        request_id="same-request",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    other_child = ledger.open_child_turn(
+        agent="qwen-review-1",
+        message_id="message-a",
+        request_id="same-request",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    ledger.reserve_for_child("4" * 32, capability=second_message.token)
+    ledger.settle(
+        "4" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    ledger.reserve_for_child("5" * 32, capability=other_child.token)
+
+
+def test_child_turn_expiry_and_forged_capability_block_before_reserve(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-a",
+        request_id="q-expiry",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+
+    with pytest.raises(gateway.ChildTurnCapBlocked, match="capability"):
+        ledger.reserve_for_child("1" * 32, capability="atgw-child-forged")
+    assert ledger.status()["unresolved"] == []
+
+    clock.value += timedelta(seconds=gateway.CHILD_TURN_MAX_SECONDS + 1)
+    with pytest.raises(gateway.ChildTurnCapExceeded, match="wall-time"):
+        ledger.reserve_for_child("2" * 32, capability=credential.token)
+    assert ledger.status()["unresolved"] == []
+
+
+def test_child_turn_clock_rollback_cannot_extend_wall_time(tmp_path) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    clock.value += timedelta(hours=1)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-clock-rollback",
+        request_id="q-clock-rollback",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+
+    # This is still later than the ledger initialization clock, but earlier than
+    # the durable turn opening. It must not extend the turn's wall-time budget.
+    clock.value -= timedelta(minutes=59)
+    with pytest.raises(LedgerHold, match="clock rollback"):
+        ledger.reserve_for_child("1" * 32, capability=credential.token)
+
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM attempts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM child_attempts").fetchone()[0] == 0
+
+
+def test_child_turn_clock_rollback_after_capability_reissue_blocks_reserve(
+    tmp_path,
+) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-reissued-clock",
+        request_id="q-reissued-clock",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    clock.value += timedelta(minutes=4)
+    replay = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-reissued-clock",
+        request_id="q-reissued-clock",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+
+    clock.value -= timedelta(minutes=3)
+    with pytest.raises(LedgerHold, match="clock rollback"):
+        ledger.reserve_for_child("1" * 32, capability=replay.token)
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM attempts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM child_attempts").fetchone()[0] == 0
+
+
+def test_child_turn_clock_rollback_after_settlement_blocks_more_transport(
+    tmp_path,
+) -> None:
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-settlement-clock",
+        request_id="q-settlement-clock",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    ledger.reserve_for_child("1" * 32, capability=credential.token)
+    clock.value += timedelta(minutes=4)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+
+    clock.value -= timedelta(minutes=3)
+    with pytest.raises(LedgerHold, match="clock rollback"):
+        ledger.reserve_for_child("2" * 32, capability=credential.token)
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM attempts WHERE attempt_id=?", ("2" * 32,)
+        ).fetchone()[0] == 0
+
+
+def test_child_cap_install_migrates_old_ledger_atomically_under_hold(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.place_hold(reason="install cap before any more paid work")
+    downgrade_to_v1_without_child_caps(ledger)
+
+    with pytest.raises(LedgerBlocked, match="marker ledger_schema_version mismatch"):
+        ledger.status()
+    installed = ledger.install_child_caps(issuer_token=TEST_CHILD_CAP_ISSUER)
+    repeated = ledger.install_child_caps(issuer_token=TEST_CHILD_CAP_ISSUER)
+
+    assert installed["installed"] is True
+    assert repeated["installed"] is False
+    after = ledger.status()
+    assert after["child_cap_ready"] is True
+    assert after["service_hold"] == "manual: install cap before any more paid work"
+    assert after["worker_spend_ready"] is False
+
+
+def test_child_cap_migration_fences_old_static_token_ledger_code(
+    tmp_path, monkeypatch
+) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.place_hold(reason="migration fence")
+    downgrade_to_v1_without_child_caps(ledger)
+
+    assert ledger.install_child_caps(
+        issuer_token=TEST_CHILD_CAP_ISSUER
+    )["installed"] is True
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    assert marker["ledger_schema_version"] == 2
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute(
+            "SELECT value FROM metadata WHERE key='schema_version'"
+        ).fetchone()[0] == "2"
+
+    # The pre-cap front calls the old ledger's reserve() directly. Its v1
+    # marker/schema authority must reject this migrated install before reserve.
+    monkeypatch.setattr(gateway, "LEDGER_SCHEMA_VERSION", 1)
+    old_ledger = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)
+    with pytest.raises(LedgerBlocked, match="marker ledger_schema_version mismatch"):
+        old_ledger.reserve("f" * 32)
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM attempts").fetchone()[0] == 0
+
+
+def test_child_cap_migration_refuses_unresolved_attempt_without_partial_upgrade(
+    tmp_path,
+) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("a" * 32)
+    downgrade_to_v1_without_child_caps(ledger)
+
+    with pytest.raises(LedgerHold, match="all provider attempts reconciled"):
+        ledger.install_child_caps(issuer_token=TEST_CHILD_CAP_ISSUER)
+
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    assert marker["ledger_schema_version"] == 1
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute(
+            "SELECT value FROM metadata WHERE key='schema_version'"
+        ).fetchone()[0] == "1"
+        child_tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'child_%'"
+        ).fetchall()
+        assert child_tables == []
+
+
+def test_child_cap_migration_recovers_after_marker_projection_failure(
+    tmp_path, monkeypatch
+) -> None:
+    ledger = make_ledger(tmp_path)
+    ledger.place_hold(reason="migration recovery")
+    downgrade_to_v1_without_child_caps(ledger)
+    durable_write = gateway._durable_write_json
+
+    def fail_marker_projection(_path, _value) -> None:
+        raise OSError("injected marker projection failure")
+
+    monkeypatch.setattr(gateway, "_durable_write_json", fail_marker_projection)
+    with pytest.raises(OSError, match="projection failure"):
+        ledger.install_child_caps(issuer_token=TEST_CHILD_CAP_ISSUER)
+
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    assert marker["ledger_schema_version"] == 1
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute(
+            "SELECT value FROM metadata WHERE key='schema_version'"
+        ).fetchone()[0] == "2"
+    with pytest.raises(LedgerBlocked, match="marker ledger_schema_version mismatch"):
+        ledger.status()
+
+    monkeypatch.setattr(gateway, "_durable_write_json", durable_write)
+    assert ledger.install_child_caps(
+        issuer_token=TEST_CHILD_CAP_ISSUER
+    )["installed"] is True
+    assert ledger.status()["child_cap_ready"] is True
+
+
+def test_partial_child_cap_schema_fails_closed(tmp_path) -> None:
+    ledger = make_ledger(tmp_path)
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute("DROP TABLE child_attempts")
+
+    with pytest.raises(LedgerBlocked, match="partial"):
+        ledger.status()
+
+
+def test_child_capability_is_hash_only_and_global_rejection_consumes_no_slot(
+    tmp_path,
+) -> None:
+    ledger = make_ledger(tmp_path)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-a",
+        request_id="q-atomic",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    assert credential.token.encode("ascii") not in ledger.db_path.read_bytes()
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute(
+            "UPDATE periods SET committed_micro_eur=? WHERE period='2026-07'",
+            (TRIAL_CUTOFF_MICRO_EUR,),
+        )
+
+    with pytest.raises(PolicyBlocked, match="trial spend cutoff"):
+        ledger.reserve_for_child("1" * 32, capability=credential.token)
+
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM child_attempts").fetchone()[0] == 0
+        conn.execute(
+            "UPDATE periods SET committed_micro_eur=0 WHERE period='2026-07'"
+        )
+    ledger.reserve_for_child("2" * 32, capability=credential.token)
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute(
+            "SELECT ordinal FROM child_attempts WHERE attempt_id=?", ("2" * 32,)
+        ).fetchone()[0] == 1
+
+
+def test_child_turn_last_slot_race_never_exceeds_ceiling(
+    tmp_path, monkeypatch
+) -> None:
+    ledger = make_ledger(tmp_path)
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="message-race",
+        request_id="q-race",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    for ordinal in range(gateway.CHILD_TURN_MAX_CALLS - 1):
+        attempt_id = f"{ordinal + 1:032x}"
+        ledger.reserve_for_child(attempt_id, capability=credential.token)
+        ledger.settle(
+            attempt_id,
+            model=MODEL_ALIAS,
+            input_tokens=1_000,
+            output_tokens=100,
+        )
+
+    # Isolate the child-cap CAS from the separate single-unresolved-attempt
+    # safety gate, so the losing writer must observe the durable call ceiling.
+    monkeypatch.setattr(
+        SpendLedger, "_unresolved", staticmethod(lambda _conn: [])
+    )
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str]] = []
+
+    def reserve_last(attempt_id: str) -> None:
+        contender = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)
+        barrier.wait(timeout=5)
+        try:
+            contender.reserve_for_child(attempt_id, capability=credential.token)
+        except gateway.ChildTurnCapExceeded:
+            results.append(("blocked", attempt_id))
+        else:
+            results.append(("reserved", attempt_id))
+
+    workers = [
+        threading.Thread(target=reserve_last, args=("a" * 32,)),
+        threading.Thread(target=reserve_last, args=("b" * 32,)),
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert sorted(state for state, _attempt_id in results) == ["blocked", "reserved"]
+    blocked_id = next(
+        attempt_id for state, attempt_id in results if state == "blocked"
+    )
+    with sqlite3.connect(ledger.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM child_attempts").fetchone()[0] == (
+            gateway.CHILD_TURN_MAX_CALLS
+        )
+        assert conn.execute(
+            "SELECT COALESCE(MAX(ordinal), 0) FROM child_attempts"
+        ).fetchone()[0] == gateway.CHILD_TURN_MAX_CALLS
+        assert conn.execute(
+            "SELECT COUNT(*) FROM attempts WHERE attempt_id=?", (blocked_id,)
+        ).fetchone()[0] == 0
+        turn = conn.execute(
+            "SELECT state, reason FROM child_turns WHERE message_id='message-race'"
+        ).fetchone()
+        assert turn == ("capped", "child turn call ceiling exceeded")
 
 
 def test_sqlite_full_commit_is_the_reservation_durability_authority(tmp_path) -> None:

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -9,6 +9,7 @@ from agenttalk import cli
 from agenttalk import ovh_gateway
 from agenttalk import ovh_gateway_service
 from agenttalk.ovh_gateway import SpendLedger, default_install_marker_path, default_ledger_path
+from agenttalk.ovh_gateway import MODEL_ALIAS
 from agenttalk.store import Store
 
 
@@ -66,6 +67,26 @@ def test_gateway_cli_initializes_once_and_controls_manual_hold(
     cleared = json.loads(capsys.readouterr().out)
     assert cleared["held"] is False
     assert ledger.status()["service_hold"] is None
+
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    assert cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "canary-verify",
+        "1" * 32,
+        "--dashboard-delta-eur",
+        "0.00096",
+    ]) == 0
+    canary = json.loads(capsys.readouterr().out)
+    assert canary["accepted"] is True
+    assert canary["expected_micro_eur"] == 960
 
 
 def test_gateway_cli_rejects_caller_supplied_actual_reconciliation(

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import sys
 
 import pytest
@@ -12,6 +13,9 @@ from agenttalk.ovh_gateway import SpendLedger, default_install_marker_path, defa
 from agenttalk.ovh_gateway import MODEL_ALIAS
 from agenttalk.wrapper import run as wrapper_run
 from agenttalk.store import Store
+
+
+TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
 
 
 def _make_qwen_wrap_store(tmp_path) -> Store:
@@ -148,6 +152,48 @@ def test_gateway_cli_rejects_caller_supplied_actual_reconciliation(
     assert "invalid choice" in capsys.readouterr().err
 
 
+def test_gateway_cli_atomically_installs_child_caps_on_existing_ledger(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    ledger = SpendLedger(default_ledger_path(), default_install_marker_path())
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    with sqlite3.connect(ledger.db_path) as conn:
+        conn.execute("DROP TABLE child_attempts")
+        conn.execute("DROP TABLE child_capabilities")
+        conn.execute("DROP TABLE child_turns")
+        conn.execute(
+            "DELETE FROM metadata WHERE key IN (?, ?, ?)",
+            (
+                "child_cap_schema_version",
+                "child_cap_policy_hash",
+                "child_cap_issuer_sha256",
+            ),
+        )
+        conn.execute("UPDATE metadata SET value='1' WHERE key='schema_version'")
+    marker = json.loads(ledger.marker_path.read_text(encoding="utf-8"))
+    marker["ledger_schema_version"] = 1
+    ledger.marker_path.write_text(json.dumps(marker), encoding="utf-8")
+    ovh_gateway.write_secret_file(
+        ovh_gateway.default_front_token_path(), TEST_CHILD_CAP_ISSUER
+    )
+
+    assert cli.main(["--root", str(root), "gateway", "cap-install"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["installed"] is True
+    assert ledger.status()["child_cap_ready"] is True
+
+
 def test_gateway_status_not_ready_uses_operational_error_exit(tmp_path, monkeypatch) -> None:
     root = tmp_path / "project"
     Store(root).init(["lead"])
@@ -195,6 +241,34 @@ def test_qwen_wrap_requires_authenticated_gateway_readiness_before_token_read(
     assert "internal_liveliness_failed" in hold["summary"]
 
 
+def test_qwen_wrap_rejects_uncapped_lead_loop_cadence(
+    tmp_path,
+    capsys,
+) -> None:
+    store = _make_qwen_wrap_store(tmp_path)
+    store.set_managed_lead_loop("qwen-dev-1")
+
+    rc = cli.main([
+        "--root",
+        str(tmp_path),
+        "wrap",
+        "--for",
+        "qwen-dev-1",
+        "--cli",
+        "claude",
+        "--loop",
+        "--lead-loop",
+        "--",
+        sys.executable,
+        "-c",
+        "pass",
+    ])
+
+    assert rc == 2
+    assert "does not support --lead-loop" in capsys.readouterr().err
+    assert store.read_lead_loop_lease("qwen-dev-1") is None
+
+
 @pytest.mark.parametrize(
     ("canary_state", "expected_reason"),
     [
@@ -215,6 +289,7 @@ def test_qwen_wrap_worker_spend_preflight_blocks_unaccepted_canary_before_token_
         opening_micro_eur=0,
         opening_evidence="test dashboard, observed 2026-07-16",
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     if canary_state != "absent":
         ledger.reserve("1" * 32)
@@ -271,6 +346,7 @@ def test_qwen_wrap_worker_spend_preflight_allows_accepted_canary(
         opening_micro_eur=0,
         opening_evidence="test dashboard, observed 2026-07-16",
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     ledger.reserve("1" * 32)
     ledger.settle(

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from agenttalk import cli
 from agenttalk import ovh_gateway
 from agenttalk import ovh_gateway_service
@@ -28,11 +30,16 @@ def test_gateway_cli_initializes_once_and_controls_manual_hold(
         "init",
         "--litellm-executable",
         str(executable),
+        "--opening-eur",
+        "0.58",
+        "--opening-evidence",
+        "OVH AI Endpoints dashboard, observed 2026-07-16 morning",
     ])
 
     assert rc == 0
     initialized = json.loads(capsys.readouterr().out)
     assert initialized["initialized"] is True
+    assert initialized["opening_micro_eur"] == 580_000
     assert "atgw-" not in json.dumps(initialized)
 
     assert cli.main([
@@ -59,6 +66,30 @@ def test_gateway_cli_initializes_once_and_controls_manual_hold(
     cleared = json.loads(capsys.readouterr().out)
     assert cleared["held"] is False
     assert ledger.status()["service_hold"] is None
+
+
+def test_gateway_cli_rejects_caller_supplied_actual_reconciliation(
+    tmp_path,
+    capsys,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main([
+            "--root",
+            str(root),
+            "gateway",
+            "reconcile",
+            "1" * 32,
+            "--outcome",
+            "charge-actual",
+            "--reason",
+            "caller supplied value",
+        ])
+
+    assert exc_info.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
 
 
 def test_gateway_status_not_ready_uses_operational_error_exit(tmp_path, monkeypatch) -> None:

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -10,7 +10,42 @@ from agenttalk import ovh_gateway
 from agenttalk import ovh_gateway_service
 from agenttalk.ovh_gateway import SpendLedger, default_install_marker_path, default_ledger_path
 from agenttalk.ovh_gateway import MODEL_ALIAS
+from agenttalk.wrapper import run as wrapper_run
 from agenttalk.store import Store
+
+
+def _make_qwen_wrap_store(tmp_path) -> Store:
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+    store.set_role("lead", "lead")
+    store.set_operator_facing("lead")
+    store.set_trust_class("qwen-dev-1", "external-worker")
+    (store.dir / "supervisor.json").write_text(
+        json.dumps({
+            "agents": {
+                "qwen-dev-1": {
+                    "backend_profile": "ovh-qwen",
+                    "cli": "claude",
+                    "model": "Qwen3.5-397B-A17B",
+                    "trust_class": "external-worker",
+                    "wrapped": True,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    return store
+
+
+def _worker_gateway_projection(ledger: SpendLedger) -> dict:
+    ledger_status = ledger.status()
+    return {
+        "ready": True,
+        "operational_ready": True,
+        "errors": [],
+        "worker_spend_ready": ledger_status["worker_spend_ready"],
+        "worker_spend_errors": ledger_status["worker_spend_errors"],
+    }
 
 
 def test_gateway_cli_initializes_once_and_controls_manual_hold(
@@ -125,25 +160,7 @@ def test_qwen_wrap_requires_authenticated_gateway_readiness_before_token_read(
     tmp_path,
     monkeypatch,
 ) -> None:
-    store = Store(tmp_path)
-    store.init(["lead", "qwen-dev-1"])
-    store.set_role("lead", "lead")
-    store.set_operator_facing("lead")
-    store.set_trust_class("qwen-dev-1", "external-worker")
-    (store.dir / "supervisor.json").write_text(
-        json.dumps({
-            "agents": {
-                "qwen-dev-1": {
-                    "backend_profile": "ovh-qwen",
-                    "cli": "claude",
-                    "model": "Qwen3.5-397B-A17B",
-                    "trust_class": "external-worker",
-                    "wrapped": True,
-                },
-            },
-        }),
-        encoding="utf-8",
-    )
+    store = _make_qwen_wrap_store(tmp_path)
     monkeypatch.delenv("OVH_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(
@@ -176,3 +193,128 @@ def test_qwen_wrap_requires_authenticated_gateway_readiness_before_token_read(
     hold = store.read_config_blocked_hold("qwen-dev-1")
     assert hold is not None
     assert "internal_liveliness_failed" in hold["summary"]
+
+
+@pytest.mark.parametrize(
+    ("canary_state", "expected_reason"),
+    [
+        ("absent", "dashboard_canary_absent"),
+        ("mismatch", "dashboard_canary_mismatch"),
+        ("mismatch-cleared", "dashboard_canary_mismatch"),
+    ],
+)
+def test_qwen_wrap_worker_spend_preflight_blocks_unaccepted_canary_before_token_read(
+    tmp_path,
+    monkeypatch,
+    canary_state,
+    expected_reason,
+) -> None:
+    store = _make_qwen_wrap_store(tmp_path)
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        generation="a" * 32,
+    )
+    if canary_state != "absent":
+        ledger.reserve("1" * 32)
+        ledger.settle(
+            "1" * 32,
+            model=MODEL_ALIAS,
+            input_tokens=1_000,
+            output_tokens=100,
+        )
+        ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=0)
+    if canary_state == "mismatch-cleared":
+        ledger.clear_hold(reason="operator inspected mismatch")
+
+    def status_projection(_root):
+        return _worker_gateway_projection(ledger)
+
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(ovh_gateway_service, "gateway_status", status_projection)
+
+    def token_must_not_be_read(_path):
+        raise AssertionError("front token read before worker/spend readiness")
+
+    monkeypatch.setattr(ovh_gateway, "read_secret_file", token_must_not_be_read)
+
+    rc = cli.main([
+        "--root",
+        str(tmp_path),
+        "wrap",
+        "--for",
+        "qwen-dev-1",
+        "--cli",
+        "claude",
+        "--loop",
+        "--",
+        sys.executable,
+        "-c",
+        "pass",
+    ])
+
+    assert rc == 1
+    hold = store.read_config_blocked_hold("qwen-dev-1")
+    assert hold is not None
+    assert expected_reason in hold["summary"]
+
+
+def test_qwen_wrap_worker_spend_preflight_allows_accepted_canary(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _make_qwen_wrap_store(tmp_path)
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        generation="a" * 32,
+    )
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=960)
+
+    def status_projection(_root):
+        return _worker_gateway_projection(ledger)
+
+    token_reads: list[str] = []
+
+    def read_front_token(path):
+        token_reads.append(str(path))
+        return "front-token"
+
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(ovh_gateway_service, "gateway_status", status_projection)
+    monkeypatch.setattr(ovh_gateway, "read_secret_file", read_front_token)
+    monkeypatch.setattr(
+        wrapper_run,
+        "preflight_launch_runtime",
+        lambda argv, _cli, _root, _env: wrapper_run.LaunchPreflightResult(list(argv)),
+    )
+    monkeypatch.setattr(cli, "_wrap_loop_mode", lambda *_args, **_kwargs: 0)
+
+    rc = cli.main([
+        "--root",
+        str(tmp_path),
+        "wrap",
+        "--for",
+        "qwen-dev-1",
+        "--cli",
+        "claude",
+        "--loop",
+        "--",
+        sys.executable,
+        "-c",
+        "pass",
+    ])
+
+    assert rc == 0
+    assert len(token_reads) == 1

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from agenttalk import cli
+from agenttalk import ovh_gateway
+from agenttalk import ovh_gateway_service
+from agenttalk.ovh_gateway import SpendLedger, default_install_marker_path, default_ledger_path
+from agenttalk.store import Store
+
+
+def test_gateway_cli_initializes_once_and_controls_manual_hold(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+
+    rc = cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "init",
+        "--litellm-executable",
+        str(executable),
+    ])
+
+    assert rc == 0
+    initialized = json.loads(capsys.readouterr().out)
+    assert initialized["initialized"] is True
+    assert "atgw-" not in json.dumps(initialized)
+
+    assert cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "hold",
+        "--reason",
+        "dashboard mismatch",
+    ]) == 0
+    held = json.loads(capsys.readouterr().out)
+    assert held["held"] is True
+    ledger = SpendLedger(default_ledger_path(), default_install_marker_path())
+    assert ledger.status()["service_hold"] == "manual: dashboard mismatch"
+
+    assert cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "clear-hold",
+        "--reason",
+        "operator approved",
+    ]) == 0
+    cleared = json.loads(capsys.readouterr().out)
+    assert cleared["held"] is False
+    assert ledger.status()["service_hold"] is None
+
+
+def test_gateway_status_not_ready_uses_operational_error_exit(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert cli.main(["--root", str(root), "gateway", "status"]) == 2
+
+
+def test_qwen_wrap_requires_authenticated_gateway_readiness_before_token_read(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+    store.set_role("lead", "lead")
+    store.set_operator_facing("lead")
+    store.set_trust_class("qwen-dev-1", "external-worker")
+    (store.dir / "supervisor.json").write_text(
+        json.dumps({
+            "agents": {
+                "qwen-dev-1": {
+                    "backend_profile": "ovh-qwen",
+                    "cli": "claude",
+                    "model": "Qwen3.5-397B-A17B",
+                    "trust_class": "external-worker",
+                    "wrapped": True,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(
+        ovh_gateway_service,
+        "gateway_status",
+        lambda _root: {"ready": False, "errors": ["internal_liveliness_failed"]},
+    )
+
+    def token_must_not_be_read(_path):
+        raise AssertionError("front token read before gateway readiness")
+
+    monkeypatch.setattr(ovh_gateway, "read_secret_file", token_must_not_be_read)
+
+    rc = cli.main([
+        "--root",
+        str(tmp_path),
+        "wrap",
+        "--for",
+        "qwen-dev-1",
+        "--cli",
+        "claude",
+        "--loop",
+        "--",
+        sys.executable,
+        "-c",
+        "pass",
+    ])
+
+    assert rc == 1
+    hold = store.read_config_blocked_hold("qwen-dev-1")
+    assert hold is not None
+    assert "internal_liveliness_failed" in hold["summary"]

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from agenttalk.ovh_gateway import MODEL_ALIAS, SpendLedger, settlement_cost_micro_eur
+from agenttalk.ovh_gateway_front import (
+    CONFIG_ERROR_CODE,
+    INFRA_ERROR_CODE,
+    LEDGER_BLOCKED_CODE,
+    PUBLIC_ROUTE,
+    FrontConfig,
+    GatewayFront,
+    StreamUsage,
+)
+
+
+def _listen_port() -> int:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    try:
+        return int(server.server_address[1])
+    finally:
+        server.server_close()
+
+
+class FakeUpstream:
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        response: bytes | None = None,
+        entered: threading.Event | None = None,
+        release: threading.Event | None = None,
+    ) -> None:
+        self.status = status
+        self.response = response or (
+            b'event: message_start\n'
+            b'data: {"type":"message_start","message":{"model":"'
+            + MODEL_ALIAS.encode("ascii")
+            + b'","usage":{"input_tokens":100}}}\n\n'
+            b'event: content_block_delta\n'
+            b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n\n'
+            b'event: message_delta\n'
+            b'data: {"type":"message_delta","usage":{"output_tokens":10}}\n\n'
+            b'event: message_stop\n'
+            b'data: {"type":"message_stop"}\n\n'
+        )
+        self.requests: list[dict] = []
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_GET(self) -> None:
+                if self.path == "/health/liveliness":
+                    self.send_response(200)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                self.send_error(404)
+
+            def do_POST(self) -> None:
+                length = int(self.headers["Content-Length"])
+                body = self.rfile.read(length)
+                owner.requests.append(
+                    {
+                        "method": "POST",
+                        "path": self.path,
+                        "authorization": self.headers.get("Authorization"),
+                        "host": self.headers.get("Host"),
+                        "body": json.loads(body),
+                    }
+                )
+                if entered is not None:
+                    entered.set()
+                if release is not None:
+                    release.wait(timeout=10)
+                self.send_response(owner.status)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(owner.response)))
+                self.end_headers()
+                self.wfile.write(owner.response)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.port = int(self.server.server_address[1])
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> FakeUpstream:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+class RunningFront:
+    def __init__(self, tmp_path, upstream: FakeUpstream) -> None:
+        self.ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+        self.ledger.initialize(generation="a" * 32)
+        public_port = _listen_port()
+        self.config = FrontConfig(
+            public_token="front-secret",
+            internal_token="internal-secret",
+            public_port=public_port,
+            internal_port=upstream.port,
+            request_timeout_seconds=5,
+        )
+        self.front = GatewayFront(self.config, self.ledger)
+        self.server = self.front.make_server()
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> RunningFront:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def request(
+        self,
+        method: str = "POST",
+        path: str = PUBLIC_ROUTE,
+        *,
+        body: dict | bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes]:
+        if body is None:
+            body = {
+                "model": MODEL_ALIAS,
+                "max_tokens": 256,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        encoded = json.dumps(body).encode("utf-8") if isinstance(body, dict) else body
+        request_headers = {
+            "Host": self.config.public_host_header,
+            "Authorization": "Bearer front-secret",
+            "Content-Type": "application/json",
+        }
+        request_headers.update(headers or {})
+        conn = http.client.HTTPConnection("127.0.0.1", self.config.public_port, timeout=5)
+        try:
+            conn.request(method, path, body=encoded, headers=request_headers)
+            response = conn.getresponse()
+            return response.status, response.read()
+        finally:
+            conn.close()
+
+
+def test_stream_usage_accepts_complete_sse_and_json() -> None:
+    parser = StreamUsage()
+    parser.feed(
+        b'data: {"type":"message_start","message":{"model":"'
+        + MODEL_ALIAS.encode()
+        + b'","usage":{"input_tokens":5}}}\n'
+        b'data: {"type":"message_delta","usage":{"output_tokens":2}}\n'
+        b'data: {"type":"message_stop"}\n'
+    )
+    assert parser.finish() == (MODEL_ALIAS, 5, 2)
+
+    parser = StreamUsage()
+    parser.feed(
+        json.dumps(
+            {
+                "type": "message",
+                "model": MODEL_ALIAS,
+                "usage": {"input_tokens": 8, "output_tokens": 3},
+            }
+        ).encode()
+    )
+    assert parser.finish() == (MODEL_ALIAS, 8, 3)
+
+    parser = StreamUsage()
+    parser.feed(
+        b'data: {"type":"message_start","message":{"model":"'
+        + MODEL_ALIAS.encode()
+        + b'","usage":{"input_tokens":0}}}\n'
+        b'data: {"type":"message_delta","usage":{"input_tokens":5,"output_tokens":2}}\n'
+        b'data: {"type":"message_stop"}\n'
+    )
+    assert parser.finish() == (MODEL_ALIAS, 5, 2)
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "headers", "expected"),
+    [
+        ("GET", PUBLIC_ROUTE, {}, 404),
+        ("POST", "/", {}, 404),
+        ("POST", "/v1/models", {}, 404),
+        ("POST", "/v1/chat/completions", {}, 404),
+        ("POST", "/health", {}, 404),
+        ("POST", PUBLIC_ROUTE, {"Host": "localhost:4000"}, 400),
+        ("POST", PUBLIC_ROUTE, {"Host": ""}, 400),
+        ("POST", PUBLIC_ROUTE, {"Origin": "https://example.invalid"}, 403),
+        ("POST", PUBLIC_ROUTE, {"Authorization": "Bearer wrong"}, 401),
+    ],
+)
+def test_front_is_exact_default_deny(tmp_path, method, path, headers, expected) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        status, response = front.request(method, path, headers=headers)
+        assert status == expected
+        assert CONFIG_ERROR_CODE.encode() in response
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
+def test_success_reserves_before_one_internal_attempt_then_settles(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        assert front.front.internal_liveliness() is True
+        status, body = front.request()
+        assert status == 200
+        assert b"message_stop" in body
+        assert len(upstream.requests) == 1
+        request = upstream.requests[0]
+        assert request["path"] == PUBLIC_ROUTE
+        assert request["authorization"] == "Bearer internal-secret"
+        assert request["host"] == f"127.0.0.1:{upstream.port}"
+        assert request["body"]["model"] == MODEL_ALIAS
+        ledger = front.ledger.status()
+        assert ledger["unresolved"] == []
+        assert ledger["current_committed_micro_eur"] == settlement_cost_micro_eur(100, 10)
+
+
+@pytest.mark.parametrize("upstream_status", [429, 500])
+def test_internal_failure_never_echoes_raw_error_and_holds_next_call(
+    tmp_path,
+    upstream_status,
+) -> None:
+    raw = b'Authorization: Bearer internal-secret OVH_KEY=provider-secret raw-body'
+    with FakeUpstream(
+        status=upstream_status,
+        response=raw,
+    ) as upstream, RunningFront(tmp_path, upstream) as front:
+        status, body = front.request()
+        assert status == 502
+        assert INFRA_ERROR_CODE.encode() in body
+        assert b"internal-secret" not in body
+        assert b"provider-secret" not in body
+        assert len(upstream.requests) == 1
+        assert front.ledger.status()["unresolved"][0]["state"] == "uncertain"
+
+        status, body = front.request()
+        assert status == 503
+        assert LEDGER_BLOCKED_CODE.encode() in body
+        assert len(upstream.requests) == 1
+
+
+def test_request_policy_rejects_wrong_model_and_output_limit_before_reserve(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        status, _ = front.request(body={"model": "other", "max_tokens": 10})
+        assert status == 422
+        status, _ = front.request(body={"model": MODEL_ALIAS, "max_tokens": 4_097})
+        assert status == 422
+        status, _ = front.request(body={
+            "model": MODEL_ALIAS,
+            "max_tokens": 10,
+            "api_base": "http://127.0.0.1:1/v1",
+            "max_retries": 9,
+        })
+        assert status == 422
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
+def test_single_permit_covers_transport_through_settlement(tmp_path) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    with FakeUpstream(entered=entered, release=release) as upstream, RunningFront(
+        tmp_path,
+        upstream,
+    ) as front:
+        first: list[tuple[int, bytes]] = []
+        worker = threading.Thread(target=lambda: first.append(front.request()))
+        worker.start()
+        assert entered.wait(timeout=5)
+
+        status, body = front.request()
+
+        assert status == 429
+        assert b"ATGW_INFRA_BUSY" in body
+        assert len(upstream.requests) == 1
+        release.set()
+        worker.join(timeout=10)
+        assert first and first[0][0] == 200
+        assert front.ledger.status()["ready"] is True
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def getheader(self, _name: str) -> str:
+        return "text/event-stream"
+
+    def read(self, _size: int = -1) -> bytes:
+        body, self.body = self.body, b""
+        return body
+
+
+class _FakeConnection:
+    def __init__(
+        self,
+        response: _FakeResponse | None = None,
+        *,
+        failure: BaseException | None = None,
+    ) -> None:
+        self.response = response
+        self.failure = failure
+        self.request_count = 0
+
+    def request(self, *_args, **_kwargs) -> None:
+        self.request_count += 1
+        if self.failure is not None:
+            raise self.failure
+
+    def getresponse(self) -> _FakeResponse:
+        assert self.response is not None
+        return self.response
+
+    def close(self) -> None:
+        return
+
+
+class _DisconnectingWriter:
+    closed = False
+
+    def write(self, _body: bytes) -> None:
+        raise BrokenPipeError("fake client disconnect")
+
+    def flush(self) -> None:
+        return
+
+
+class _FakeHandler:
+    def __init__(self, *, disconnect: bool = False) -> None:
+        self.wfile = _DisconnectingWriter() if disconnect else io.BytesIO()
+        self.close_connection = False
+        self.status: int | None = None
+        self.error_code: str | None = None
+
+    def send_response(self, status: int) -> None:
+        self.status = status
+
+    def send_header(self, _name: str, _value: str) -> None:
+        return
+
+    def end_headers(self) -> None:
+        return
+
+    def _stable_error(self, status: int, code: str) -> None:
+        self.status = status
+        self.error_code = code
+
+
+def _direct_front(tmp_path, connection: _FakeConnection) -> GatewayFront:
+    ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+    ledger.initialize(generation="a" * 32)
+    return GatewayFront(
+        FrontConfig(public_token="front", internal_token="internal"),
+        ledger,
+        connection_factory=lambda *_args, **_kwargs: connection,
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [socket.timeout("fake timeout"), ConnectionResetError("fake reset")],
+)
+def test_internal_transport_failure_retains_reservation_and_returns_stable_infra(
+    tmp_path,
+    failure,
+) -> None:
+    connection = _FakeConnection(failure=failure)
+    front = _direct_front(tmp_path, connection)
+    handler = _FakeHandler()
+
+    front._proxy(handler, b"{}")
+
+    assert connection.request_count == 1
+    assert handler.status == 502
+    assert handler.error_code == INFRA_ERROR_CODE
+    assert front.ledger.status()["unresolved"][0]["state"] == "uncertain"
+
+
+def test_client_disconnect_retains_reservation_after_one_internal_attempt(tmp_path) -> None:
+    body = (
+        b'data: {"type":"message_start","message":{"model":"'
+        + MODEL_ALIAS.encode("ascii")
+        + b'","usage":{"input_tokens":5}}}\n\n'
+        b'data: {"type":"message_delta","usage":{"output_tokens":2}}\n\n'
+        b'data: {"type":"message_stop"}\n\n'
+    )
+    connection = _FakeConnection(_FakeResponse(body))
+    front = _direct_front(tmp_path, connection)
+    handler = _FakeHandler(disconnect=True)
+
+    front._proxy(handler, b"{}")
+
+    assert connection.request_count == 1
+    assert front.ledger.status()["unresolved"][0]["state"] == "uncertain"

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -75,6 +75,7 @@ class FakeUpstream:
                         "path": self.path,
                         "authorization": self.headers.get("Authorization"),
                         "host": self.headers.get("Host"),
+                        "headers": dict(self.headers.items()),
                         "body": json.loads(body),
                     }
                 )
@@ -105,7 +106,11 @@ class FakeUpstream:
 class RunningFront:
     def __init__(self, tmp_path, upstream: FakeUpstream) -> None:
         self.ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
-        self.ledger.initialize(generation="a" * 32)
+        self.ledger.initialize(
+            opening_micro_eur=0,
+            opening_evidence="fake front fixture, observed 2026-07-16",
+            generation="a" * 32,
+        )
         public_port = _listen_port()
         self.config = FrontConfig(
             public_token="front-secret",
@@ -156,6 +161,19 @@ class RunningFront:
             return response.status, response.read()
         finally:
             conn.close()
+
+    def raw_request(self, request: bytes) -> tuple[int, bytes]:
+        with socket.create_connection(
+            ("127.0.0.1", self.config.public_port), timeout=5
+        ) as connection:
+            connection.sendall(request)
+            connection.shutdown(socket.SHUT_WR)
+            chunks: list[bytes] = []
+            while chunk := connection.recv(16 * 1024):
+                chunks.append(chunk)
+        response = b"".join(chunks)
+        status = int(response.split(b" ", 2)[1])
+        return status, response
 
 
 def test_stream_usage_accepts_complete_sse_and_json() -> None:
@@ -215,10 +233,72 @@ def test_front_is_exact_default_deny(tmp_path, method, path, headers, expected) 
         assert front.ledger.status()["unresolved"] == []
 
 
+@pytest.mark.parametrize(
+    "raw_request",
+    [
+        (
+            b"POST /v1/messages HTTP/1.1\r\n"
+            b"Host: {HOST}\r\nHost: {HOST}\r\n"
+            b"Authorization: Bearer front-secret\r\nContent-Length: 2\r\n\r\n{}"
+        ),
+        (
+            b"POST /v1/messages HTTP/1.1\r\nHost: {HOST}\r\n"
+            b"Authorization: Bearer front-secret\r\n"
+            b"Authorization: Bearer front-secret\r\nContent-Length: 2\r\n\r\n{}"
+        ),
+        (
+            b"POST /v1/messages HTTP/1.1\r\nHost: {HOST}\r\n"
+            b"Authorization: Bearer front-secret\r\n"
+            b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}"
+        ),
+        (
+            b"POST /v1/messages HTTP/1.1\r\nHost: {HOST}\r\n"
+            b"Authorization: Bearer front-secret\r\n"
+            b"Content-Type: application/json\r\nContent-Type: application/json\r\n"
+            b"Content-Length: 2\r\n\r\n{}"
+        ),
+        (
+            b"POST /v1/messages HTTP/1.1\r\nHost: {HOST}\r\n"
+            b"Authorization: Bearer front-secret\r\nTransfer-Encoding: chunked\r\n"
+            b"Content-Length: 2\r\n\r\n{}"
+        ),
+    ],
+)
+def test_front_rejects_duplicate_or_ambiguous_request_framing(
+    tmp_path, raw_request
+) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        raw_request = raw_request.replace(
+            b"{HOST}", front.config.public_host_header.encode("ascii")
+        )
+        status, response = front.raw_request(raw_request)
+
+        assert status == 400
+        assert CONFIG_ERROR_CODE.encode() in response
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
+def test_front_rejects_absolute_form_request_target(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        host = front.config.public_host_header.encode("ascii")
+        request = (
+            b"POST http://" + host + b"/v1/messages HTTP/1.1\r\n"
+            b"Host: " + host + b"\r\nAuthorization: Bearer front-secret\r\n"
+            b"Content-Length: 2\r\n\r\n{}"
+        )
+        status, response = front.raw_request(request)
+
+        assert status == 404
+        assert CONFIG_ERROR_CODE.encode() in response
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
 def test_success_reserves_before_one_internal_attempt_then_settles(tmp_path) -> None:
     with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
         assert front.front.internal_liveliness() is True
-        status, body = front.request()
+        status, body = front.request(headers={"X-Front-Only": "must-not-forward"})
         assert status == 200
         assert b"message_stop" in body
         assert len(upstream.requests) == 1
@@ -227,6 +307,15 @@ def test_success_reserves_before_one_internal_attempt_then_settles(tmp_path) -> 
         assert request["authorization"] == "Bearer internal-secret"
         assert request["host"] == f"127.0.0.1:{upstream.port}"
         assert request["body"]["model"] == MODEL_ALIAS
+        downstream_headers = {name.casefold() for name in request["headers"]}
+        assert "x-front-only" not in downstream_headers
+        assert downstream_headers <= {
+            "accept-encoding",
+            "authorization",
+            "content-length",
+            "content-type",
+            "host",
+        }
         ledger = front.ledger.status()
         assert ledger["unresolved"] == []
         assert ledger["current_committed_micro_eur"] == settlement_cost_micro_eur(100, 10)
@@ -367,7 +456,11 @@ class _FakeHandler:
 
 def _direct_front(tmp_path, connection: _FakeConnection) -> GatewayFront:
     ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
-    ledger.initialize(generation="a" * 32)
+    ledger.initialize(
+        opening_micro_eur=0,
+        opening_evidence="fake front fixture, observed 2026-07-16",
+        generation="a" * 32,
+    )
     return GatewayFront(
         FrontConfig(public_token="front", internal_token="internal"),
         ledger,

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -9,6 +9,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+from agenttalk import ovh_gateway as gateway
 from agenttalk.ovh_gateway import MODEL_ALIAS, SpendLedger, settlement_cost_micro_eur
 from agenttalk.ovh_gateway_front import (
     CONFIG_ERROR_CODE,
@@ -19,6 +20,9 @@ from agenttalk.ovh_gateway_front import (
     GatewayFront,
     StreamUsage,
 )
+
+
+TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
 
 
 def _listen_port() -> int:
@@ -110,6 +114,13 @@ class RunningFront:
             opening_micro_eur=0,
             opening_evidence="fake front fixture, observed 2026-07-16",
             generation="a" * 32,
+            child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
+        )
+        self.credential = self.ledger.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="front-fixture-message",
+            request_id="q-front-fixture",
+            issuer_token=TEST_CHILD_CAP_ISSUER,
         )
         public_port = _listen_port()
         self.config = FrontConfig(
@@ -150,7 +161,7 @@ class RunningFront:
         encoded = json.dumps(body).encode("utf-8") if isinstance(body, dict) else body
         request_headers = {
             "Host": self.config.public_host_header,
-            "Authorization": "Bearer front-secret",
+            "Authorization": f"Bearer {self.credential.token}",
             "Content-Type": "application/json",
         }
         request_headers.update(headers or {})
@@ -271,6 +282,9 @@ def test_front_rejects_duplicate_or_ambiguous_request_framing(
         raw_request = raw_request.replace(
             b"{HOST}", front.config.public_host_header.encode("ascii")
         )
+        raw_request = raw_request.replace(
+            b"front-secret", front.credential.token.encode("ascii")
+        )
         status, response = front.raw_request(raw_request)
 
         assert status == 400
@@ -319,6 +333,44 @@ def test_success_reserves_before_one_internal_attempt_then_settles(tmp_path) -> 
         ledger = front.ledger.status()
         assert ledger["unresolved"] == []
         assert ledger["current_committed_micro_eur"] == settlement_cost_micro_eur(100, 10)
+
+
+def test_static_front_token_is_not_a_paid_transport_bypass(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        status, body = front.request(
+            headers={"Authorization": "Bearer front-secret"},
+        )
+
+        assert status == 401
+        assert CONFIG_ERROR_CODE.encode() in body
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
+def test_forged_well_formed_child_capability_never_reaches_provider(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        status, body = front.request(
+            headers={"Authorization": "Bearer atgw-child-" + "z" * 43},
+        )
+
+        assert status == 403
+        assert b"ATGW_CHILD_TURN_CAP_EXCEEDED" in body
+        assert upstream.requests == []
+        assert front.ledger.status()["unresolved"] == []
+
+
+def test_front_refuses_ninth_child_call_without_provider_transport(tmp_path) -> None:
+    with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
+        for _ in range(gateway.CHILD_TURN_MAX_CALLS):
+            status, _ = front.request()
+            assert status == 200
+
+        status, body = front.request()
+
+        assert status == 403
+        assert b"ATGW_CHILD_TURN_CAP_EXCEEDED" in body
+        assert len(upstream.requests) == gateway.CHILD_TURN_MAX_CALLS
+        assert front.ledger.status()["unresolved"] == []
 
 
 @pytest.mark.parametrize("upstream_status", [429, 500])
@@ -460,12 +512,22 @@ def _direct_front(tmp_path, connection: _FakeConnection) -> GatewayFront:
         opening_micro_eur=0,
         opening_evidence="fake front fixture, observed 2026-07-16",
         generation="a" * 32,
+        child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
     )
     return GatewayFront(
         FrontConfig(public_token="front", internal_token="internal"),
         ledger,
         connection_factory=lambda *_args, **_kwargs: connection,
     )
+
+
+def _direct_capability(front: GatewayFront) -> str:
+    return front.ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="direct-front-message",
+        request_id="q-direct-front",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    ).token
 
 
 @pytest.mark.parametrize(
@@ -480,7 +542,7 @@ def test_internal_transport_failure_retains_reservation_and_returns_stable_infra
     front = _direct_front(tmp_path, connection)
     handler = _FakeHandler()
 
-    front._proxy(handler, b"{}")
+    front._proxy(handler, b"{}", capability=_direct_capability(front))
 
     assert connection.request_count == 1
     assert handler.status == 502
@@ -500,7 +562,7 @@ def test_client_disconnect_retains_reservation_after_one_internal_attempt(tmp_pa
     front = _direct_front(tmp_path, connection)
     handler = _FakeHandler(disconnect=True)
 
-    front._proxy(handler, b"{}")
+    front._proxy(handler, b"{}", capability=_direct_capability(front))
 
     assert connection.request_count == 1
     assert front.ledger.status()["unresolved"][0]["state"] == "uncertain"

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -158,11 +158,15 @@ def test_one_time_install_writes_nonsecret_config_and_tokens_outside_project(tmp
     result = initialize_install(
         tmp_path / "project",
         litellm_executable=executable,
+        opening_micro_eur=580_000,
+        opening_evidence="test dashboard, observed 2026-07-16",
         ledger=ledger,
         front_token_path=front_token,
         internal_token_path=internal_token,
     )
     assert result["price_policy_hash"] == price_policy_hash()
+    assert result["opening_micro_eur"] == 580_000
+    assert result["opening_observed_at"]
     config = litellm_config_path(tmp_path / "project").read_text(encoding="utf-8")
     assert "use_chat_completions_url_for_anthropic_messages: true" in config
     assert "store: false" in config
@@ -174,6 +178,8 @@ def test_one_time_install_writes_nonsecret_config_and_tokens_outside_project(tmp
         initialize_install(
             tmp_path / "project",
             litellm_executable=executable,
+            opening_micro_eur=580_000,
+            opening_evidence="test dashboard, observed 2026-07-16",
             ledger=ledger,
             front_token_path=front_token,
             internal_token_path=internal_token,
@@ -208,6 +214,8 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
     initialize_install(
         root,
         litellm_executable=executable,
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
         ledger=ledger,
         front_token_path=front_token,
         internal_token_path=internal_token,
@@ -356,6 +364,8 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     initialize_install(
         root,
         litellm_executable=executable,
+        opening_micro_eur=580_000,
+        opening_evidence="test dashboard, observed 2026-07-16",
         ledger=ledger,
         front_token_path=front_token,
         internal_token_path=internal_token,
@@ -399,6 +409,11 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     )
 
     assert status["ready"] is True
+    assert status["ledger"]["opening_micro_eur"] == 580_000
+    assert status["ledger"]["current_committed_micro_eur"] == 580_000
+    assert status["ledger"]["opening_evidence"] == (
+        "test dashboard, observed 2026-07-16"
+    )
     encoded = str(status)
     assert "atgw-" not in encoded
     assert "provider-key" not in encoded
@@ -423,6 +438,8 @@ def test_start_waits_for_attested_readiness(tmp_path, monkeypatch) -> None:
     initialize_install(
         root,
         litellm_executable=executable,
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
         ledger=ledger,
         front_token_path=tmp_path / "secrets" / "front.txt",
         internal_token_path=tmp_path / "secrets" / "internal.txt",
@@ -458,6 +475,8 @@ def test_start_is_idempotent_when_attested_service_is_already_ready(
     initialize_install(
         root,
         litellm_executable=executable,
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
         ledger=ledger,
         front_token_path=tmp_path / "secrets" / "front.txt",
         internal_token_path=tmp_path / "secrets" / "internal.txt",

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+from pathlib import Path
+
+import pytest
+
+from agenttalk import ovh_gateway_service as service
+from agenttalk.ovh_gateway import GatewayConfigError, SpendLedger, price_policy_hash
+from agenttalk.ovh_gateway_service import (
+    MAX_TASK_RESTARTS,
+    TaskCommands,
+    _safe_gateway_environment,
+    expected_task_identity,
+    exclusive_bind_probe,
+    gateway_status,
+    initialize_install,
+    install_task,
+    kill_switch_path,
+    litellm_config_path,
+    project_task_name,
+    render_task_xml,
+    run_service,
+    runtime_marker_path,
+    start_task,
+    stop_task,
+    task_identity_path,
+    task_xml_matches,
+)
+
+
+class FakeCommands(TaskCommands):
+    def __init__(self) -> None:
+        self.tasks: dict[str, str] = {}
+        self.stopped: list[str] = []
+        self.started: list[str] = []
+
+    def query_xml(self, task_name: str) -> str | None:
+        return self.tasks.get(task_name)
+
+    def install(self, task_name: str, xml_path: Path) -> None:
+        self.tasks[task_name] = xml_path.read_text(encoding="utf-16")
+
+    def stop(self, task_name: str) -> None:
+        self.stopped.append(task_name)
+
+    def start(self, task_name: str) -> None:
+        self.started.append(task_name)
+
+
+class RacingInstallCommands(FakeCommands):
+    def __init__(self, identity) -> None:
+        super().__init__()
+        self.identity = identity
+
+    def install(self, task_name: str, _xml_path: Path) -> None:
+        self.tasks[task_name] = render_task_xml(self.identity)
+        raise GatewayConfigError("concurrent installer won")
+
+
+def test_project_task_name_is_canonical_and_collision_resistant(tmp_path) -> None:
+    first = project_task_name(tmp_path / "Project")
+    same = project_task_name(tmp_path / "Project" / ".." / "Project")
+    other = project_task_name(tmp_path / "Other")
+    assert first == same
+    assert first != other
+    assert first.startswith("agenttalk-qwen-gateway-")
+
+
+def test_task_xml_pins_one_least_privilege_action_and_bounded_restart(tmp_path) -> None:
+    identity = expected_task_identity(
+        tmp_path,
+        execute=tmp_path / "python.exe",
+        principal="DOMAIN\\operator",
+    )
+    xml = render_task_xml(identity)
+    assert task_xml_matches(xml, identity)
+    assert xml.count("<Exec>") == 1
+    assert "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>" in xml
+    assert "<RunLevel>LeastPrivilege</RunLevel>" in xml
+    assert f"<Count>{MAX_TASK_RESTARTS}</Count>" in xml
+    assert "OVH_KEY" not in xml
+    assert "api_key" not in xml
+
+
+def test_install_is_idempotent_and_refuses_foreign_task(tmp_path) -> None:
+    commands = FakeCommands()
+    execute = tmp_path / "python.exe"
+    execute.write_bytes(b"")
+    identity = expected_task_identity(tmp_path, execute=execute, principal="D\\u")
+
+    result = install_task(
+        tmp_path,
+        commands=commands,
+        execute=execute,
+        principal="D\\u",
+    )
+    assert result["changed"] is True
+    assert task_identity_path(tmp_path).is_file()
+    result = install_task(
+        tmp_path,
+        commands=commands,
+        execute=execute,
+        principal="D\\u",
+    )
+    assert result["changed"] is False
+
+    commands.tasks[identity.task_name] = render_task_xml(
+        expected_task_identity(tmp_path, execute=tmp_path / "other.exe", principal="D\\u")
+    )
+    with pytest.raises(GatewayConfigError, match="foreign or mismatched"):
+        install_task(
+            tmp_path,
+            commands=commands,
+            execute=execute,
+            principal="D\\u",
+        )
+
+
+def test_concurrent_exact_task_installer_converges_without_overwrite(tmp_path) -> None:
+    execute = tmp_path / "python.exe"
+    execute.write_bytes(b"")
+    identity = expected_task_identity(tmp_path, execute=execute, principal="D\\u")
+    commands = RacingInstallCommands(identity)
+
+    result = install_task(
+        tmp_path,
+        commands=commands,
+        execute=execute,
+        principal="D\\u",
+    )
+
+    assert result["installed"] is True
+    assert result["changed"] is False
+    assert task_xml_matches(commands.tasks[identity.task_name], identity)
+
+
+def test_exclusive_bind_probe_refuses_occupied_listener() -> None:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    port = int(listener.getsockname()[1])
+    try:
+        with pytest.raises(GatewayConfigError, match="occupied"):
+            exclusive_bind_probe("127.0.0.1", port)
+    finally:
+        listener.close()
+    exclusive_bind_probe("127.0.0.1", port)
+
+
+def test_one_time_install_writes_nonsecret_config_and_tokens_outside_project(tmp_path) -> None:
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json")
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    result = initialize_install(
+        tmp_path / "project",
+        litellm_executable=executable,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    assert result["price_policy_hash"] == price_policy_hash()
+    config = litellm_config_path(tmp_path / "project").read_text(encoding="utf-8")
+    assert "use_chat_completions_url_for_anthropic_messages: true" in config
+    assert "store: false" in config
+    assert "callback" not in config
+    assert "atgw-" not in config
+    assert front_token.read_text(encoding="utf-8").startswith("atgw-")
+    assert internal_token.read_text(encoding="utf-8").startswith("atgw-")
+    with pytest.raises(GatewayConfigError, match="replacement gateway initialization"):
+        initialize_install(
+            tmp_path / "project",
+            litellm_executable=executable,
+            ledger=ledger,
+            front_token_path=front_token,
+            internal_token_path=internal_token,
+        )
+
+
+def test_gateway_process_environment_is_allowlisted_and_secrets_are_env_only(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-pass")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "must-not-pass")
+    monkeypatch.setenv("UNRELATED_SECRET", "must-not-pass")
+    monkeypatch.setenv("PATH", "safe-path")
+    env = _safe_gateway_environment("provider-key", "internal-token")
+    assert env["PATH"] == "safe-path"
+    assert env["OVH_KEY"] == "provider-key"
+    assert env["LITELLM_MASTER_KEY"] == "internal-token"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "UNRELATED_SECRET" not in env
+
+
+def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json")
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    key = tmp_path / "secrets" / "provider.txt"
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    key.write_text("provider-secret\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = os.getpid()
+
+        def poll(self):
+            return None
+
+        def terminate(self) -> None:
+            return
+
+        def kill(self) -> None:
+            return
+
+        def wait(self, timeout=None) -> int:
+            return 0
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(kwargs["env"])
+        return FakeProcess()
+
+    class FakeServer:
+        def serve_forever(self, **_kwargs) -> None:
+            return
+
+        def shutdown(self) -> None:
+            return
+
+        def server_close(self) -> None:
+            return
+
+    class FakeFront:
+        def __init__(self, _config, _ledger) -> None:
+            return
+
+        def make_server(self):
+            return FakeServer()
+
+        def drain(self, _timeout) -> bool:
+            return True
+
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+    monkeypatch.setattr(service, "_wait_liveliness", lambda _front, _process: None)
+    monkeypatch.setattr(service, "GatewayFront", FakeFront)
+
+    rc = run_service(
+        root,
+        ledger=ledger,
+        key_path=key,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+        popen=fake_popen,
+    )
+
+    assert rc == 0
+    argv = captured["argv"]
+    encoded_argv = " ".join(argv)
+    assert "provider-secret" not in encoded_argv
+    assert "atgw-" not in encoded_argv
+    assert argv[-2:] == ["--num_workers", "1"]
+    assert ["--host", "127.0.0.1", "--port", "4001"] == argv[3:7]
+    env = captured["env"]
+    assert env["OVH_KEY"] == "provider-secret"
+    assert env["LITELLM_MASTER_KEY"].startswith("atgw-")
+    assert not runtime_marker_path(root).exists()
+
+
+def test_operator_stop_uses_gateway_kill_switch_before_bounded_task_end(tmp_path) -> None:
+    commands = FakeCommands()
+    identity = expected_task_identity(tmp_path)
+    commands.tasks[identity.task_name] = render_task_xml(identity)
+    result = stop_task(tmp_path, commands=commands, timeout_seconds=0)
+    assert result == {"stopped": True, "forced": True, "task_present": True}
+    assert kill_switch_path(tmp_path).read_text(encoding="ascii") == "operator-stop\n"
+    assert commands.stopped == [identity.task_name]
+
+
+def test_task_action_and_status_artifacts_contain_no_secret_values(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("OVH_KEY", "provider-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    identity = expected_task_identity(tmp_path)
+    text = render_task_xml(identity)
+    assert "provider-key" not in text
+    assert "anthropic-key" not in text
+    assert os.environ["OVH_KEY"] not in identity.arguments
+
+
+def test_public_front_attestation_uses_only_a_nonsecret_negative_auth_probe(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    class Response:
+        status = 401
+
+        @staticmethod
+        def read(limit: int) -> bytes:
+            assert limit == 4097
+            return b'{"type":"error","error":{"type":"ATGW_CONFIG_ERROR","message":"ATGW_CONFIG_ERROR"}}'
+
+    class Connection:
+        def request(self, method, path, *, body, headers) -> None:
+            captured.update(method=method, path=path, body=body, headers=headers)
+
+        @staticmethod
+        def getresponse():
+            return Response()
+
+        @staticmethod
+        def close() -> None:
+            return
+
+    monkeypatch.setattr(
+        service.http.client,
+        "HTTPConnection",
+        lambda host, port, *, timeout: (
+            captured.update(host=host, port=port, timeout=timeout) or Connection()
+        ),
+    )
+
+    assert service._public_front_attested() is True
+    assert captured["headers"]["Authorization"] == (
+        "Bearer atgw-status-probe-not-a-secret"
+    )
+    assert "front" not in captured["headers"]["Authorization"]
+
+
+def test_status_requires_attested_runtime_front_and_internal_liveliness(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    root = tmp_path / "project"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json")
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    commands = FakeCommands()
+    install_task(root, commands=commands)
+    manifest = service.load_install_manifest(root)
+    start = service._process_start_token(os.getpid())
+    service._durable_write_json(
+        runtime_marker_path(root),
+        {
+            "schema_version": 1,
+            "runner_pid": os.getpid(),
+            "runner_start": start,
+            "litellm_pid": os.getpid(),
+            "litellm_start": start,
+            "task_name": project_task_name(root),
+            "price_policy_hash": price_policy_hash(),
+            "config_sha256": manifest["litellm_config_sha256"],
+            "public_bind": "127.0.0.1:4000",
+            "internal_bind": "127.0.0.1:4001",
+            "front_token_sha256": hashlib.sha256(
+                front_token.read_text(encoding="utf-8").strip().encode("utf-8")
+            ).hexdigest(),
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "exclusive_bind_probe",
+        lambda _host, _port: (_ for _ in ()).throw(GatewayConfigError("occupied")),
+    )
+    monkeypatch.setattr(service.GatewayFront, "internal_liveliness", lambda _self: True)
+    monkeypatch.setattr(service, "_public_front_attested", lambda: True)
+
+    status = gateway_status(
+        root,
+        commands=commands,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+
+    assert status["ready"] is True
+    encoded = str(status)
+    assert "atgw-" not in encoded
+    assert "provider-key" not in encoded
+
+    front_token.write_text("replacement-token\n", encoding="utf-8")
+    replaced = gateway_status(
+        root,
+        commands=commands,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    assert replaced["ready"] is False
+    assert "runtime_marker_invalid" in replaced["errors"]
+
+
+def test_start_waits_for_attested_readiness(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json")
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        ledger=ledger,
+        front_token_path=tmp_path / "secrets" / "front.txt",
+        internal_token_path=tmp_path / "secrets" / "internal.txt",
+    )
+    commands = FakeCommands()
+    install_task(root, commands=commands)
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+    statuses = iter([
+        {"ready": False, "errors": ["runtime_marker_missing"]},
+        {"ready": True, "errors": []},
+    ])
+    monkeypatch.setattr(service, "gateway_status", lambda *_args, **_kwargs: next(statuses))
+
+    result = start_task(
+        root,
+        commands=commands,
+        ledger=ledger,
+        readiness_timeout_seconds=1,
+    )
+
+    assert result["ready"] is True
+    assert commands.started == [project_task_name(root)]
+
+
+def test_start_is_idempotent_when_attested_service_is_already_ready(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json")
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        ledger=ledger,
+        front_token_path=tmp_path / "secrets" / "front.txt",
+        internal_token_path=tmp_path / "secrets" / "internal.txt",
+    )
+    commands = FakeCommands()
+    install_task(root, commands=commands)
+    monkeypatch.setattr(
+        service,
+        "gateway_status",
+        lambda *_args, **_kwargs: {"ready": True, "errors": []},
+    )
+
+    result = start_task(root, commands=commands, ledger=ledger)
+
+    assert result == {
+        "started": False,
+        "ready": True,
+        "task_name": project_task_name(root),
+    }
+    assert commands.started == []
+
+
+def test_forced_stop_removes_only_stale_marker_after_both_sockets_are_free(tmp_path) -> None:
+    commands = FakeCommands()
+    identity = expected_task_identity(tmp_path)
+    commands.tasks[identity.task_name] = render_task_xml(identity)
+    runtime_marker_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    runtime_marker_path(tmp_path).write_text("stale", encoding="utf-8")
+
+    result = stop_task(tmp_path, commands=commands, timeout_seconds=0)
+
+    assert result["stopped"] is True
+    assert result["forced"] is True
+    assert not runtime_marker_path(tmp_path).exists()
+
+
+def test_stop_refuses_unknown_listener_when_task_is_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: False)
+
+    with pytest.raises(GatewayConfigError, match="task is absent"):
+        stop_task(tmp_path, commands=FakeCommands(), timeout_seconds=0)

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from agenttalk import ovh_gateway_service as service
-from agenttalk.ovh_gateway import GatewayConfigError, SpendLedger, price_policy_hash
+from agenttalk.ovh_gateway import GatewayConfigError, MODEL_ALIAS, SpendLedger, price_policy_hash
 from agenttalk.ovh_gateway_service import (
     MAX_TASK_RESTARTS,
     TaskCommands,
@@ -409,6 +409,9 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     )
 
     assert status["ready"] is True
+    assert status["operational_ready"] is True
+    assert status["worker_spend_ready"] is False
+    assert status["worker_spend_errors"] == ["dashboard_canary_absent"]
     assert status["ledger"]["opening_micro_eur"] == 580_000
     assert status["ledger"]["current_committed_micro_eur"] == 580_000
     assert status["ledger"]["opening_evidence"] == (
@@ -417,6 +420,25 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     encoded = str(status)
     assert "atgw-" not in encoded
     assert "provider-key" not in encoded
+
+    ledger.reserve("1" * 32)
+    ledger.settle(
+        "1" * 32,
+        model=MODEL_ALIAS,
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+    ledger.verify_dashboard_canary("1" * 32, observed_delta_micro_eur=960)
+    accepted = gateway_status(
+        root,
+        commands=commands,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    assert accepted["operational_ready"] is True
+    assert accepted["worker_spend_ready"] is True
+    assert accepted["worker_spend_errors"] == []
 
     front_token.write_text("replacement-token\n", encoding="utf-8")
     replaced = gateway_status(

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import socket
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -83,6 +85,41 @@ def test_task_xml_pins_one_least_privilege_action_and_bounded_restart(tmp_path) 
     assert f"<Count>{MAX_TASK_RESTARTS}</Count>" in xml
     assert "OVH_KEY" not in xml
     assert "api_key" not in xml
+
+
+def test_task_xml_matches_sid_normalized_scheduler_fixture(tmp_path, monkeypatch) -> None:
+    identity = expected_task_identity(
+        tmp_path,
+        execute=tmp_path / "python.exe",
+        principal="DOMAIN\\operator",
+    )
+    sid = "S-1-5-21-111-222-333-1001"
+    scheduler_xml = render_task_xml(identity).replace(
+        "<UserId>DOMAIN\\operator</UserId>",
+        f"<UserId>{sid}</UserId>",
+    )
+    monkeypatch.setattr(
+        service,
+        "_resolve_principal_sid",
+        lambda principal: sid if principal in {identity.principal, sid} else None,
+        raising=False,
+    )
+
+    assert task_xml_matches(scheduler_xml, identity)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows account SID lookup")
+def test_current_windows_principal_round_trips_as_scheduler_sid(tmp_path) -> None:
+    identity = expected_task_identity(tmp_path)
+    sid = service._resolve_principal_sid(identity.principal)
+    assert sid is not None
+    assert sid.startswith("S-1-")
+    scheduler_xml = render_task_xml(identity).replace(
+        f"<UserId>{identity.principal}</UserId>",
+        f"<UserId>{sid}</UserId>",
+    )
+
+    assert task_xml_matches(scheduler_xml, identity)
 
 
 def test_install_is_idempotent_and_refuses_foreign_task(tmp_path) -> None:
@@ -226,6 +263,9 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
     class FakeProcess:
         pid = os.getpid()
 
+        def __init__(self, output: str) -> None:
+            self.stdout = io.StringIO(output)
+
         def poll(self):
             return None
 
@@ -241,7 +281,15 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
     def fake_popen(argv, **kwargs):
         captured["argv"] = list(argv)
         captured["env"] = dict(kwargs["env"])
-        return FakeProcess()
+        captured["stdout"] = kwargs["stdout"]
+        captured["stderr"] = kwargs["stderr"]
+        output = (
+            "oversized diagnostic " + "x" * 2_048 + "\n"
+            + "bounded startup diagnostic\n" * 80
+            + f"raw provider {kwargs['env']['OVH_KEY']}\n"
+            f"Authorization: Bearer {kwargs['env']['LITELLM_MASTER_KEY']}\n"
+        )
+        return FakeProcess(output)
 
     class FakeServer:
         def serve_forever(self, **_kwargs) -> None:
@@ -266,6 +314,9 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
     monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
     monkeypatch.setattr(service, "_wait_liveliness", lambda _front, _process: None)
     monkeypatch.setattr(service, "GatewayFront", FakeFront)
+    monkeypatch.setattr(service, "LITELLM_LOG_MAX_BYTES", 256)
+    monkeypatch.setattr(service, "LITELLM_LOG_BACKUP_COUNT", 2)
+    child_log = tmp_path / "local" / "agenttalk-ovh" / "gateway" / "litellm.log"
 
     rc = run_service(
         root,
@@ -273,6 +324,7 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
         key_path=key,
         front_token_path=front_token,
         internal_token_path=internal_token,
+        child_log_path=child_log,
         popen=fake_popen,
     )
 
@@ -286,7 +338,61 @@ def test_runner_uses_env_only_secrets_and_pinned_single_worker_argv(
     env = captured["env"]
     assert env["OVH_KEY"] == "provider-secret"
     assert env["LITELLM_MASTER_KEY"].startswith("atgw-")
+    assert captured["stdout"] is subprocess.PIPE
+    assert captured["stderr"] is subprocess.STDOUT
+    logs = sorted(child_log.parent.glob("litellm.log*"))
+    assert child_log in logs
+    assert child_log.with_suffix(".log.1") in logs
+    assert len(logs) <= 3
+    assert all(path.stat().st_size <= 256 for path in logs)
+    logged = "".join(path.read_text(encoding="utf-8") for path in logs)
+    assert "provider-secret" not in logged
+    assert env["LITELLM_MASTER_KEY"] not in logged
+    assert "[REDACTED]" in logged
     assert not runtime_marker_path(root).exists()
+
+
+def test_litellm_readiness_allows_cold_start_beyond_thirty_seconds(
+    monkeypatch,
+) -> None:
+    now = [0.0]
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    class Front:
+        calls = 0
+
+        def internal_liveliness(self) -> bool:
+            self.calls += 1
+            return self.calls == 3
+
+    front = Front()
+    monkeypatch.setattr(service.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(service.time, "sleep", lambda _seconds: now.__setitem__(0, now[0] + 31))
+
+    service._wait_liveliness(front, Process())
+
+    assert service.LITELLM_READINESS_TIMEOUT_SECONDS == 120.0
+    assert front.calls == 3
+    assert now[0] == 62.0
+
+
+def test_litellm_readiness_fails_immediately_when_process_exits() -> None:
+    class Process:
+        @staticmethod
+        def poll():
+            return 1
+
+    class Front:
+        @staticmethod
+        def internal_liveliness() -> bool:
+            raise AssertionError("liveliness probe ran after process exit")
+
+    with pytest.raises(GatewayConfigError, match="exited before readiness"):
+        service._wait_liveliness(Front(), Process())
 
 
 def test_operator_stop_uses_gateway_kill_switch_before_bounded_task_end(tmp_path) -> None:

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -10,7 +10,14 @@ from pathlib import Path
 import pytest
 
 from agenttalk import ovh_gateway_service as service
-from agenttalk.ovh_gateway import GatewayConfigError, MODEL_ALIAS, SpendLedger, price_policy_hash
+from agenttalk.ovh_gateway import (
+    GatewayConfigError,
+    LedgerBlocked,
+    MODEL_ALIAS,
+    SpendLedger,
+    child_cap_policy_hash,
+    price_policy_hash,
+)
 from agenttalk.ovh_gateway_service import (
     MAX_TASK_RESTARTS,
     TaskCommands,
@@ -480,24 +487,23 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     install_task(root, commands=commands)
     manifest = service.load_install_manifest(root)
     start = service._process_start_token(os.getpid())
-    service._durable_write_json(
-        runtime_marker_path(root),
-        {
-            "schema_version": 1,
-            "runner_pid": os.getpid(),
-            "runner_start": start,
-            "litellm_pid": os.getpid(),
-            "litellm_start": start,
-            "task_name": project_task_name(root),
-            "price_policy_hash": price_policy_hash(),
-            "config_sha256": manifest["litellm_config_sha256"],
-            "public_bind": "127.0.0.1:4000",
-            "internal_bind": "127.0.0.1:4001",
-            "front_token_sha256": hashlib.sha256(
-                front_token.read_text(encoding="utf-8").strip().encode("utf-8")
-            ).hexdigest(),
-        },
-    )
+    runtime = {
+        "schema_version": service.RUNTIME_SCHEMA_VERSION,
+        "runner_pid": os.getpid(),
+        "runner_start": start,
+        "litellm_pid": os.getpid(),
+        "litellm_start": start,
+        "task_name": project_task_name(root),
+        "price_policy_hash": price_policy_hash(),
+        "child_cap_policy_hash": child_cap_policy_hash(),
+        "config_sha256": manifest["litellm_config_sha256"],
+        "public_bind": "127.0.0.1:4000",
+        "internal_bind": "127.0.0.1:4001",
+        "front_token_sha256": hashlib.sha256(
+            front_token.read_text(encoding="utf-8").strip().encode("utf-8")
+        ).hexdigest(),
+    }
+    service._durable_write_json(runtime_marker_path(root), runtime)
     monkeypatch.setattr(
         service,
         "exclusive_bind_probe",
@@ -546,7 +552,8 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
     assert accepted["worker_spend_ready"] is True
     assert accepted["worker_spend_errors"] == []
 
-    front_token.write_text("replacement-token\n", encoding="utf-8")
+    replacement_token = service.generate_token()
+    front_token.write_text(replacement_token + "\n", encoding="utf-8")
     replaced = gateway_status(
         root,
         commands=commands,
@@ -555,7 +562,72 @@ def test_status_requires_attested_runtime_front_and_internal_liveliness(
         internal_token_path=internal_token,
     )
     assert replaced["ready"] is False
+    assert "child_cap_issuer_mismatch" in replaced["errors"]
     assert "runtime_marker_invalid" in replaced["errors"]
+
+    runtime["front_token_sha256"] = hashlib.sha256(
+        replacement_token.encode("utf-8")
+    ).hexdigest()
+    service._durable_write_json(runtime_marker_path(root), runtime)
+    clean_restart = gateway_status(
+        root,
+        commands=commands,
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    assert clean_restart["runtime_marker_present"] is True
+    assert clean_restart["ready"] is False
+    assert clean_restart["worker_spend_ready"] is False
+    assert "child_cap_issuer_mismatch" in clean_restart["errors"]
+    assert "child_cap_issuer_mismatch" in clean_restart["worker_spend_errors"]
+
+
+def test_runner_refuses_replaced_front_token_before_child_spawn(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    ledger = SpendLedger(
+        tmp_path / "spend" / "ledger.sqlite3",
+        tmp_path / "spend" / "install.json",
+    )
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    key = tmp_path / "secrets" / "provider.txt"
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    key.write_text("provider-secret\n", encoding="utf-8")
+    front_token.write_text(service.generate_token() + "\n", encoding="utf-8")
+    spawned = False
+
+    def fake_popen(*_args, **_kwargs):
+        nonlocal spawned
+        spawned = True
+        raise AssertionError("provider child must not spawn")
+
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+
+    with pytest.raises(LedgerBlocked, match="front token"):
+        run_service(
+            root,
+            ledger=ledger,
+            key_path=key,
+            front_token_path=front_token,
+            internal_token_path=internal_token,
+            popen=fake_popen,
+        )
+
+    assert spawned is False
 
 
 def test_start_waits_for_attested_readiness(tmp_path, monkeypatch) -> None:
@@ -590,6 +662,43 @@ def test_start_waits_for_attested_readiness(tmp_path, monkeypatch) -> None:
 
     assert result["ready"] is True
     assert commands.started == [project_task_name(root)]
+
+
+def test_start_refuses_child_cap_issuer_mismatch_before_task_start(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    ledger = SpendLedger(
+        tmp_path / "spend" / "ledger.sqlite3",
+        tmp_path / "spend" / "install.json",
+    )
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        opening_micro_eur=0,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        ledger=ledger,
+        front_token_path=tmp_path / "secrets" / "front.txt",
+        internal_token_path=tmp_path / "secrets" / "internal.txt",
+    )
+    commands = FakeCommands()
+    install_task(root, commands=commands)
+    monkeypatch.setattr(
+        service,
+        "gateway_status",
+        lambda *_args, **_kwargs: {
+            "ready": False,
+            "errors": ["child_cap_issuer_mismatch"],
+        },
+    )
+
+    with pytest.raises(LedgerBlocked, match="front token"):
+        start_task(root, commands=commands, ledger=ledger)
+
+    assert commands.started == []
 
 
 def test_start_is_idempotent_when_attested_service_is_already_ready(

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import subprocess  # nosec B404 - fixed local executable under an explicit test opt-in
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from agenttalk.ovh_gateway import (
+    MODEL_ALIAS,
+    SpendLedger,
+    render_litellm_config,
+    settlement_cost_micro_eur,
+)
+from agenttalk.ovh_gateway_front import FrontConfig, GatewayFront
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+class _FakeOpenAI:
+    def __init__(self, *, status: int = 200) -> None:
+        self.requests: list[dict] = []
+        self.status = status
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", "0"))
+                body = json.loads(self.rfile.read(length))
+                owner.requests.append({"path": self.path, "body": body})
+                if self.path != "/v1/chat/completions":
+                    self.send_error(404)
+                    return
+                if owner.status != 200:
+                    response = b"fake-provider-error fake-provider-secret"
+                    self.send_response(owner.status)
+                    self.send_header("Content-Type", "text/plain")
+                    self.send_header("Content-Length", str(len(response)))
+                    self.end_headers()
+                    self.wfile.write(response)
+                    return
+                if body.get("stream") is True:
+                    chunks = [
+                        {
+                            "id": "chatcmpl-fake",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": MODEL_ALIAS,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {"role": "assistant", "content": "ok"},
+                                "finish_reason": None,
+                            }],
+                        },
+                        {
+                            "id": "chatcmpl-fake",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": MODEL_ALIAS,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {},
+                                "finish_reason": "stop",
+                            }],
+                            "usage": {
+                                "prompt_tokens": 50,
+                                "completion_tokens": 10,
+                                "total_tokens": 60,
+                            },
+                        },
+                    ]
+                    response = b"".join(
+                        b"data: " + json.dumps(chunk).encode("utf-8") + b"\n\n"
+                        for chunk in chunks
+                    ) + b"data: [DONE]\n\n"
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(response)))
+                    self.end_headers()
+                    self.wfile.write(response)
+                    return
+                response = json.dumps({
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": MODEL_ALIAS,
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [{
+                                "id": "toolu_fake",
+                                "type": "function",
+                                "function": {
+                                    "name": "Read",
+                                    "arguments": json.dumps({"file_path": "README.md"}),
+                                },
+                            }],
+                        },
+                        "finish_reason": "tool_calls",
+                    }],
+                    "usage": {
+                        "prompt_tokens": 50,
+                        "completion_tokens": 10,
+                        "total_tokens": 60,
+                    },
+                }).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.port = int(self.server.server_address[1])
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _FakeOpenAI:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+def _wait_liveliness(port: int, process: subprocess.Popen, *, timeout: float = 30) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            pytest.fail(f"LiteLLM exited during startup with code {process.returncode}")
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+        try:
+            connection.request("GET", "/health/liveliness")
+            response = connection.getresponse()
+            response.read()
+            if response.status == 200:
+                return
+        except OSError:
+            pass
+        finally:
+            connection.close()
+        time.sleep(0.1)
+    pytest.fail("LiteLLM did not become live")
+
+
+@pytest.mark.parametrize("upstream_status", [200, 429, 500])
+def test_anthropic_messages_routes_once_to_chat_completions_with_representative_tools(
+    tmp_path: Path,
+    upstream_status: int,
+) -> None:
+    executable_value = os.environ.get("AGENTTALK_TEST_LITELLM_EXE")
+    if not executable_value:
+        pytest.skip("set AGENTTALK_TEST_LITELLM_EXE for the pinned local conformance test")
+    executable = Path(executable_value).resolve()
+    if not executable.is_file():
+        pytest.fail("AGENTTALK_TEST_LITELLM_EXE is not a file")
+
+    port = _free_port()
+    public_port = _free_port()
+    with _FakeOpenAI(status=upstream_status) as upstream:
+        config = tmp_path / "litellm.yaml"
+        config.write_text(
+            render_litellm_config(api_base=f"http://127.0.0.1:{upstream.port}/v1"),
+            encoding="utf-8",
+        )
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key.upper() in {"PATH", "SYSTEMROOT", "WINDIR", "TEMP", "TMP"}
+        }
+        env.update({
+            "PYTHONUTF8": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "OVH_KEY": "fake-upstream-key",
+            "LITELLM_MASTER_KEY": "sk-fake-internal",
+        })
+        process = subprocess.Popen(  # nosec B603 - argv is fixed and executable is opt-in
+            [
+                str(executable),
+                "--config",
+                str(config),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--num_workers",
+                "1",
+            ],
+            cwd=tmp_path,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
+        ledger.initialize(generation="a" * 32)
+        front = GatewayFront(
+            FrontConfig(
+                public_token="sk-fake-front",
+                internal_token="sk-fake-internal",
+                public_port=public_port,
+                internal_port=port,
+                request_timeout_seconds=10,
+            ),
+            ledger,
+        )
+        front_server = front.make_server()
+        front_thread = threading.Thread(target=front_server.serve_forever, daemon=True)
+        try:
+            _wait_liveliness(port, process)
+            front_thread.start()
+            tools = [
+                {
+                    "name": name,
+                    "description": f"Representative Claude Code {name} tool",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                        "additionalProperties": False,
+                    },
+                }
+                for name in ("Read", "Edit", "Grep")
+            ]
+            request = json.dumps({
+                "model": MODEL_ALIAS,
+                "max_tokens": 64,
+                "stream": True,
+                "store": True,
+                "messages": [{"role": "user", "content": "Read README.md"}],
+                "tools": tools,
+            }).encode("utf-8")
+            connection = http.client.HTTPConnection("127.0.0.1", public_port, timeout=15)
+            try:
+                connection.request(
+                    "POST",
+                    "/v1/messages",
+                    body=request,
+                    headers={
+                        "Authorization": "Bearer sk-fake-front",
+                        "Content-Type": "application/json",
+                        "Host": f"127.0.0.1:{public_port}",
+                    },
+                )
+                response = connection.getresponse()
+                response_body = response.read()
+            finally:
+                connection.close()
+        finally:
+            if front_thread.is_alive():
+                front_server.shutdown()
+            front_server.server_close()
+            front_thread.join(timeout=5)
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+    assert len(upstream.requests) == 1
+    translated = upstream.requests[0]
+    assert translated["path"] == "/v1/chat/completions"
+    assert translated["body"]["store"] is False
+    assert translated["body"]["model"] == MODEL_ALIAS
+    assert [tool["function"]["name"] for tool in translated["body"]["tools"]] == [
+        "Read",
+        "Edit",
+        "Grep",
+    ]
+    assert all(tool["type"] == "function" for tool in translated["body"]["tools"])
+    assert all("parameters" in tool["function"] for tool in translated["body"]["tools"])
+    assert "input" not in translated["body"]
+    assert "max_output_tokens" not in translated["body"]
+
+    ledger_status = ledger.status()
+    if upstream_status == 200:
+        assert response.status == 200, response_body.decode("utf-8", "replace")
+        assert b"message_stop" in response_body
+        assert ledger_status["current_committed_micro_eur"] == settlement_cost_micro_eur(
+            50,
+            10,
+        )
+        assert ledger_status["unresolved"] == []
+    else:
+        assert response.status == 502, response_body.decode("utf-8", "replace")
+        assert b"fake-provider-secret" not in response_body
+        assert ledger_status["current_committed_micro_eur"] == 0
+        assert len(ledger_status["unresolved"]) == 1
+        assert ledger_status["unresolved"][0]["state"] == "uncertain"

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -139,7 +139,7 @@ class _FakeOpenAI:
         self.thread.join(timeout=5)
 
 
-def _wait_liveliness(port: int, process: subprocess.Popen, *, timeout: float = 30) -> None:
+def _wait_liveliness(port: int, process: subprocess.Popen, *, timeout: float = 60) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
@@ -208,7 +208,11 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
             stderr=subprocess.DEVNULL,
         )
         ledger = SpendLedger(tmp_path / "ledger.sqlite3", tmp_path / "install.json")
-        ledger.initialize(generation="a" * 32)
+        ledger.initialize(
+            opening_micro_eur=0,
+            opening_evidence="fake LiteLLM fixture, observed 2026-07-16",
+            generation="a" * 32,
+        )
         front = GatewayFront(
             FrontConfig(
                 public_token="sk-fake-front",
@@ -262,16 +266,19 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
             finally:
                 connection.close()
         finally:
-            if front_thread.is_alive():
-                front_server.shutdown()
-            front_server.server_close()
-            front_thread.join(timeout=5)
-            process.terminate()
             try:
-                process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5)
+                if front_thread.is_alive():
+                    front_server.shutdown()
+                front_server.server_close()
+                if front_thread.ident is not None:
+                    front_thread.join(timeout=5)
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
 
     assert len(upstream.requests) == 1
     translated = upstream.requests[0]

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -21,6 +21,9 @@ from agenttalk.ovh_gateway import (
 from agenttalk.ovh_gateway_front import FrontConfig, GatewayFront
 
 
+TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind(("127.0.0.1", 0))
@@ -212,6 +215,13 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
             opening_micro_eur=0,
             opening_evidence="fake LiteLLM fixture, observed 2026-07-16",
             generation="a" * 32,
+            child_cap_issuer_token=TEST_CHILD_CAP_ISSUER,
+        )
+        credential = ledger.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="litellm-conformance-message",
+            request_id="q-litellm-conformance",
+            issuer_token=TEST_CHILD_CAP_ISSUER,
         )
         front = GatewayFront(
             FrontConfig(
@@ -256,7 +266,7 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
                     "/v1/messages",
                     body=request,
                     headers={
-                        "Authorization": "Bearer sk-fake-front",
+                        "Authorization": f"Bearer {credential.token}",
                         "Content-Type": "application/json",
                         "Host": f"127.0.0.1:{public_port}",
                     },

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agenttalk.wrapper import run
+from agenttalk.wrapper.loop import CLASS_AMBIGUOUS, CLASS_CONFIG_BLOCKED, CLASS_INFRA
+
+
+def test_non_profile_child_environment_is_unchanged(tmp_path, monkeypatch) -> None:
+    ambient = {
+        "PATH": "p",
+        "UNRELATED_SECRET": "still-historical",
+        "ANTHROPIC_API_KEY": "still-historical",
+        "AGENTTALK_LEAD_LOOP_LEASE": "removed-by-existing-contract",
+        "AGENTTALK_WRAPPER_GENERATION": "removed-by-existing-contract",
+        "AGENTTALK_INBOUND_REQUEST_ID": "removed-by-existing-contract",
+    }
+    monkeypatch.setattr(os, "environ", ambient.copy())
+    result = run._child_env(tmp_path)
+    assert result == {
+        "PATH": "p",
+        "UNRELATED_SECRET": "still-historical",
+        "ANTHROPIC_API_KEY": "still-historical",
+        "AGENTTALK_PY": str(run.Path(run.sys.executable).resolve()),
+        "AGENTTALK_ROOT": str(tmp_path.resolve()),
+    }
+
+
+def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {
+            "PATH": "safe-path",
+            "SystemRoot": "C:\\Windows",
+            "TEMP": "C:\\Temp",
+            "AGENTTALK_SELF": "qwen-dev-1",
+            "AGENTTALK_NO_CHILD_WINDOW": "1",
+            "AGENTTALK_LEAD_LOOP_LEASE": "must-not-pass",
+            "AGENTTALK_WRAPPER_GENERATION": "stale-must-not-pass",
+            "AGENTTALK_INBOUND_REQUEST_ID": "stale-must-not-pass",
+            "ANTHROPIC_API_KEY": "must-not-pass",
+            "ANTHROPIC_AUTH_TOKEN": "ambient-must-not-pass",
+            "OVH_KEY": "must-not-pass",
+            "UNRELATED_SECRET": "must-not-pass",
+        },
+    )
+    env = run._child_env(
+        tmp_path,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "front-token",
+        },
+        wrapper_generation="generation",
+        inbound_request_id="request",
+    )
+    assert env["PATH"] == "safe-path"
+    assert env["SystemRoot"] == "C:\\Windows"
+    assert env["AGENTTALK_SELF"] == "qwen-dev-1"
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4000"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "front-token"
+    assert env["ANTHROPIC_MODEL"] == "Qwen3.5-397B-A17B"
+    assert env["AGENTTALK_WRAPPER_GENERATION"] == "generation"
+    assert env["AGENTTALK_INBOUND_REQUEST_ID"] == "request"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "OVH_KEY" not in env
+    assert "UNRELATED_SECRET" not in env
+    assert "AGENTTALK_LEAD_LOOP_LEASE" not in env
+    assert "ambient-must-not-pass" not in env.values()
+    assert "stale-must-not-pass" not in env.values()
+
+
+def test_ovh_qwen_profile_rejects_unpinned_gateway_or_extra_env(tmp_path) -> None:
+    with pytest.raises(ValueError, match="pinned loopback"):
+        run._child_env(
+            tmp_path,
+            backend_profile="ovh-qwen",
+            profile_env={
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                "ANTHROPIC_AUTH_TOKEN": "token",
+            },
+        )
+    with pytest.raises(ValueError, match="unsupported keys"):
+        run._child_env(
+            tmp_path,
+            backend_profile="ovh-qwen",
+            profile_env={
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+                "ANTHROPIC_AUTH_TOKEN": "token",
+                "ANTHROPIC_API_KEY": "forbidden",
+            },
+        )
+    with pytest.raises(ValueError, match="pinned model alias"):
+        run._child_env(
+            tmp_path,
+            backend_profile="ovh-qwen",
+            profile_env={
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+                "ANTHROPIC_AUTH_TOKEN": "token",
+                "ANTHROPIC_MODEL": "other-model",
+            },
+        )
+
+
+@pytest.mark.parametrize("code", ["ATGW_POLICY_BLOCKED", "ATGW_LEDGER_BLOCKED"])
+def test_ovh_policy_and_ledger_blocks_are_terminal_non_poison(code) -> None:
+    classification, summary = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": f'API Error: 503 {{"type":"{code}"}}'},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_CONFIG_BLOCKED
+    assert "hold" in summary
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "API Error: Connection refused (127.0.0.1:4000)",
+        "API Error: status code: 429",
+        'API Error: 502 {"type":"ATGW_INFRA_UNAVAILABLE"}',
+        "API Error: http 503",
+    ],
+)
+def test_ovh_gateway_outages_are_infra_never_poison(fixture) -> None:
+    classification, _ = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": fixture},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_INFRA
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "API Error: status code: 422",
+        'API Error: 400 {"type":"ATGW_CONFIG_ERROR"}',
+    ],
+)
+def test_ovh_route_failures_are_terminal_configuration_errors(fixture) -> None:
+    classification, _ = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": fixture},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_CONFIG_BLOCKED
+
+
+def test_unknown_qwen_failure_keeps_existing_ambiguous_fallback() -> None:
+    classification, _ = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": "unexpected model-specific output"},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_AMBIGUOUS

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -76,6 +76,7 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert "front-token" not in env.values()
     assert env["ANTHROPIC_MODEL"] == "Qwen3.5-397B-A17B"
     assert env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "2048"
+    assert env["MAX_THINKING_TOKENS"] == "0"
     assert env["CLAUDE_CONFIG_DIR"] == str(
         (tmp_path / ".agenttalk" / "gateway" / "claude-profile").resolve()
     )

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
+from agenttalk import ovh_gateway
+from agenttalk.store import Store
 from agenttalk.wrapper import run
+from agenttalk.wrapper import session
 from agenttalk.wrapper.loop import CLASS_AMBIGUOUS, CLASS_CONFIG_BLOCKED, CLASS_INFRA
 
 
@@ -64,7 +69,8 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert env["SystemRoot"] == "C:\\Windows"
     assert env["AGENTTALK_SELF"] == "qwen-dev-1"
     assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4000"
-    assert env["ANTHROPIC_AUTH_TOKEN"] == "front-token"
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "front-token" not in env.values()
     assert env["ANTHROPIC_MODEL"] == "Qwen3.5-397B-A17B"
     assert env["CLAUDE_CONFIG_DIR"] == str(
         (tmp_path / ".agenttalk" / "gateway" / "claude-profile").resolve()
@@ -80,6 +86,138 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert "AGENTTALK_LEAD_LOOP_LEASE" not in env
     assert "ambient-must-not-pass" not in env.values()
     assert "stale-must-not-pass" not in env.values()
+
+
+def test_ovh_qwen_turn_capability_replaces_master_front_token(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(os, "environ", {"PATH": "safe-path"})
+
+    env = run._child_env(
+        tmp_path,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "master-front-token",
+        },
+        gateway_capability="atgw-child-" + "a" * 43,
+    )
+
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "atgw-child-" + "a" * 43
+    assert "master-front-token" not in env.values()
+
+
+def test_real_qwen_spawner_mints_capability_for_immutable_message(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+    opened: list[dict[str, str]] = []
+    child_environments: list[dict[str, str]] = []
+
+    class FakeLedger:
+        def open_child_turn(self, **scope):
+            opened.append(scope)
+            return SimpleNamespace(token="atgw-child-" + "c" * 43)
+
+    class FakeProcStream:
+        returncode = 0
+
+        def __init__(self, *_args, child_env, **_kwargs):
+            child_environments.append(child_env)
+
+        def __iter__(self):
+            yield json.dumps(
+                {"type": "stream_event", "event": {"type": "message_start"}}
+            )
+            yield json.dumps(
+                {"type": "stream_event", "event": {"type": "message_stop"}}
+            )
+
+    monkeypatch.setattr(ovh_gateway, "SpendLedger", FakeLedger)
+    monkeypatch.setattr(run, "_ProcStream", FakeProcStream)
+    state = session.SessionState(cli="claude", claude_session_id="session-1")
+    drive = run.make_drive(
+        store,
+        "qwen-dev-1",
+        "claude",
+        state,
+        ["claude"],
+        render=False,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "master-front-token",
+        },
+    )
+
+    outcome = drive(
+        {
+            "id": "immutable-message-id",
+            "from": "lead",
+            "kind": "question",
+            "body": "do work",
+            "meta": {"request_id": "q-parent"},
+        }
+    )
+
+    assert outcome.ok is True
+    assert opened == [
+        {
+            "agent": "qwen-dev-1",
+            "message_id": "immutable-message-id",
+            "request_id": "q-parent",
+            "issuer_token": "master-front-token",
+        }
+    ]
+    assert child_environments[0]["ANTHROPIC_AUTH_TOKEN"] == (
+        "atgw-child-" + "c" * 43
+    )
+    assert "master-front-token" not in child_environments[0].values()
+
+
+def test_qwen_spawner_never_launches_when_capability_issue_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+
+    class BlockedLedger:
+        def open_child_turn(self, **_scope):
+            raise ovh_gateway.ChildTurnCapBlocked("cap schema unavailable")
+
+    def must_not_spawn(*_args, **_kwargs):
+        raise AssertionError("paid child spawned before durable cap issuance")
+
+    monkeypatch.setattr(ovh_gateway, "SpendLedger", BlockedLedger)
+    monkeypatch.setattr(run, "_ProcStream", must_not_spawn)
+    drive = run.make_drive(
+        store,
+        "qwen-dev-1",
+        "claude",
+        session.SessionState(cli="claude", claude_session_id="session-1"),
+        ["claude"],
+        render=False,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "master-front-token",
+        },
+    )
+
+    outcome = drive(
+        {
+            "id": "immutable-message-id",
+            "from": "lead",
+            "kind": "question",
+            "body": "do work",
+            "meta": {"request_id": "q-parent"},
+        }
+    )
+
+    assert outcome.ok is False
+    assert outcome.failure_class == CLASS_CONFIG_BLOCKED
+    assert "capability unavailable" in outcome.summary
 
 
 def test_ovh_qwen_profile_rejects_unpinned_gateway_or_extra_env(tmp_path) -> None:
@@ -146,6 +284,20 @@ def test_ovh_policy_and_ledger_blocks_are_terminal_non_poison(code) -> None:
     )
     assert classification == CLASS_CONFIG_BLOCKED
     assert "hold" in summary
+
+
+def test_ovh_child_turn_cap_is_terminal_config_blocked() -> None:
+    classification, summary = run._classify_drive_failure(
+        {
+            "terminal": True,
+            "terminal_text": (
+                'API Error: 403 {"type":"ATGW_CHILD_TURN_CAP_EXCEEDED"}'
+            ),
+        },
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_CONFIG_BLOCKED
+    assert "budget exhausted" in summary
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -43,6 +43,9 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
             "AGENTTALK_INBOUND_REQUEST_ID": "stale-must-not-pass",
             "ANTHROPIC_API_KEY": "must-not-pass",
             "ANTHROPIC_AUTH_TOKEN": "ambient-must-not-pass",
+            "CLAUDE_CONFIG_DIR": "C:\\Users\\operator\\.claude",
+            "HOME": "C:\\Users\\operator",
+            "USERPROFILE": "C:\\Users\\operator",
             "OVH_KEY": "must-not-pass",
             "UNRELATED_SECRET": "must-not-pass",
         },
@@ -63,11 +66,17 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4000"
     assert env["ANTHROPIC_AUTH_TOKEN"] == "front-token"
     assert env["ANTHROPIC_MODEL"] == "Qwen3.5-397B-A17B"
+    assert env["CLAUDE_CONFIG_DIR"] == str(
+        (tmp_path / ".agenttalk" / "gateway" / "claude-profile").resolve()
+    )
     assert env["AGENTTALK_WRAPPER_GENERATION"] == "generation"
     assert env["AGENTTALK_INBOUND_REQUEST_ID"] == "request"
     assert "ANTHROPIC_API_KEY" not in env
     assert "OVH_KEY" not in env
     assert "UNRELATED_SECRET" not in env
+    assert "HOME" not in env
+    assert "USERPROFILE" not in env
+    assert "C:\\Users\\operator\\.claude" not in env.values()
     assert "AGENTTALK_LEAD_LOOP_LEASE" not in env
     assert "ambient-must-not-pass" not in env.values()
     assert "stale-must-not-pass" not in env.values()
@@ -101,6 +110,30 @@ def test_ovh_qwen_profile_rejects_unpinned_gateway_or_extra_env(tmp_path) -> Non
                 "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
                 "ANTHROPIC_AUTH_TOKEN": "token",
                 "ANTHROPIC_MODEL": "other-model",
+            },
+        )
+
+
+def test_ovh_qwen_profile_refuses_a_path_resolving_outside_workspace(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    original_resolve = run.Path.resolve
+    outside = tmp_path.parent / "operator-claude-profile"
+
+    def resolve_with_profile_escape(path, *args, **kwargs):
+        if path.name == "claude-profile":
+            return outside
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(run.Path, "resolve", resolve_with_profile_escape)
+    with pytest.raises(ValueError, match="must resolve inside"):
+        run._child_env(
+            tmp_path,
+            backend_profile="ovh-qwen",
+            profile_env={
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+                "ANTHROPIC_AUTH_TOKEN": "token",
             },
         )
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -2008,6 +2008,44 @@ def test_supervise_bootstrap_check_accepts_constrained_ovh_qwen_profile(
     assert profile["status"] == "ok"
 
 
+def test_supervise_bootstrap_check_rejects_uncapped_qwen_lead_loop(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _team(tmp_path, "Polaris,qwen-dev-1")
+    s.set_role("Polaris", "lead")
+    s.set_operator_facing("Polaris")
+    s.set_trust_class("qwen-dev-1", "external-worker")
+    for name in ("Polaris", "qwen-dev-1"):
+        s.write_heartbeat(name)
+    qwen = _wrapped_supervisor_agent("qwen-dev-1", "claude")
+    qwen.pop("env")
+    qwen["launch"]["windows_args"].insert(
+        qwen["launch"]["windows_args"].index("--"), "--lead-loop"
+    )
+    qwen.update({
+        "backend_profile": "ovh-qwen",
+        "model": "Qwen3.5-397B-A17B",
+        "trust_class": "external-worker",
+    })
+    _write_supervisor_config(s, {"qwen-dev-1": qwen})
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    rc = _run(["supervise", "--bootstrap-check"], tmp_path)
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    profile = next(
+        check
+        for check in payload["checks"]
+        if check["id"] == "supervisor_ovh_qwen_profile"
+    )
+    assert profile["status"] == "error"
+    assert "lead-loop is unsupported" in profile["detail"]
+
+
 def test_supervise_bootstrap_check_rejects_ambient_provider_key_for_qwen(
     tmp_path: Path,
     capsys: pytest.CaptureFixture,

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1975,6 +1975,81 @@ def test_supervise_bootstrap_check_accepts_wrapped_claude_and_codex(
     assert ("Ramanujan", "claude") in by_agent_cli
 
 
+def test_supervise_bootstrap_check_accepts_constrained_ovh_qwen_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _team(tmp_path, "Polaris,qwen-dev-1")
+    s.set_role("Polaris", "lead")
+    s.set_operator_facing("Polaris")
+    s.set_trust_class("qwen-dev-1", "external-worker")
+    for name in ("Polaris", "qwen-dev-1"):
+        s.write_heartbeat(name)
+    qwen = _wrapped_supervisor_agent("qwen-dev-1", "claude")
+    qwen.pop("env")
+    qwen.update({
+        "backend_profile": "ovh-qwen",
+        "model": "Qwen3.5-397B-A17B",
+        "trust_class": "external-worker",
+    })
+    _write_supervisor_config(s, {"qwen-dev-1": qwen})
+    monkeypatch.delenv("OVH_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    rc = _run(["supervise", "--bootstrap-check"], tmp_path)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    profile = next(
+        check for check in payload["checks"]
+        if check["id"] == "supervisor_ovh_qwen_profile"
+    )
+    assert profile["status"] == "ok"
+
+
+def test_supervise_bootstrap_check_rejects_ambient_provider_key_for_qwen(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _team(tmp_path, "Polaris,qwen-dev-1")
+    s.set_role("Polaris", "lead")
+    s.set_operator_facing("Polaris")
+    s.set_trust_class("qwen-dev-1", "external-worker")
+    for name in ("Polaris", "qwen-dev-1"):
+        s.write_heartbeat(name)
+    qwen = _wrapped_supervisor_agent("qwen-dev-1", "claude")
+    qwen.pop("env")
+    qwen.update({
+        "backend_profile": "ovh-qwen",
+        "model": "Qwen3.5-397B-A17B",
+        "trust_class": "external-worker",
+    })
+    _write_supervisor_config(s, {"qwen-dev-1": qwen})
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-reach-qwen")
+
+    rc = _run(["supervise", "--bootstrap-check"], tmp_path)
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    profile = next(
+        check for check in payload["checks"]
+        if check["id"] == "supervisor_ovh_qwen_profile"
+    )
+    assert profile["status"] == "error"
+    assert "ambient provider keys" in profile["detail"]
+
+
+def test_supervisor_template_checks_qwen_secrets_before_agent_env() -> None:
+    ps = sup.PS_TEMPLATE
+    profile_check = ps.index("backend_profile -eq 'ovh-qwen'")
+    agent_env = ps.index("if ($a.env)")
+    assert profile_check < agent_env
+    assert "OVH_KEY" in ps[profile_check:agent_env]
+    assert "ANTHROPIC_API_KEY" in ps[profile_check:agent_env]
+
+
 def test_supervise_bootstrap_check_warns_on_roster_only_placeholders(
     tmp_path: Path, capsys: pytest.CaptureFixture,
 ) -> None:

--- a/tests/test_wrapper_claude.py
+++ b/tests/test_wrapper_claude.py
@@ -95,6 +95,18 @@ def test_claude_adapter_error_and_ratelimit() -> None:
     assert claude_adapter.map_event("not a dict") == []
 
 
+def test_claude_adapter_preserves_result_errors_array() -> None:
+    err = claude_adapter.map_event({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": True,
+        "errors": ["No conversation found with session ID: stale-session"],
+    })
+
+    assert err[0].type == ET.ADAPTER_ERROR
+    assert err[0].text == "No conversation found with session ID: stale-session"
+
+
 # --------------------------------------------------------- is_progress channel rule
 
 def test_text_delta_does_not_stamp_thinking_delta_does() -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -2314,6 +2314,54 @@ def test_make_drive_claude_resume_gives_up_after_two_then_fresh_session(tmp_path
     assert state.fresh_session_success_reason == "fresh_session_success"
 
 
+def test_make_drive_claude_missing_conversation_rotates_to_fresh_session(tmp_path) -> None:
+    calls = []
+
+    def spawn(argv, stdin):
+        calls.append(list(argv))
+        if "--resume" in argv:
+            return [json.dumps({
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "errors": ["No conversation found with session ID: stale-session"],
+            })]
+        return _claude_ok_lines()
+
+    state = session.SessionState(
+        cli="claude",
+        claude_session_id="stale-session",
+        turns=8,
+        resume_available=True,
+    )
+    drive = run.make_drive(
+        _store(tmp_path),
+        "beta",
+        "claude",
+        state,
+        ["claude"],
+        spawn=spawn,
+        clock=lambda: 0.0,
+        render=False,
+    )
+
+    first = drive(_claude_rec())
+    assert first.ok is False
+    assert state.resume_failure_count == 1
+    assert state.claude_session_id == "stale-session"
+
+    second = drive(_claude_rec())
+    assert second.ok is False and "resume_unavailable" in second.summary
+    assert state.claude_session_id != "stale-session"
+
+    third = drive(_claude_rec())
+    assert third.ok is True
+    assert "--resume" in calls[0]
+    assert "--resume" in calls[1]
+    assert "--session-id" in calls[2]
+    assert "--resume" not in calls[2]
+
+
 def test_make_drive_claude_prompt_too_long_on_resume_is_not_message_poison(tmp_path) -> None:
     # Resume-scoped session pressure never classifies the message as poison on the
     # first failed resume; it must go through the B4 resume ledger.


### PR DESCRIPTION
Folds the OVH Qwen gateway line (codex/qwen-capped-live-proof @ b38bb99) onto master — #38. The gateway lived ONLY on that codex branch (which the live process runs from via the editable venv); master had zero gateway files.

## Shape
- **Mostly additive**: +9051 lines, ~6000 new gateway source + ~4600 lines of new tests. Only **2 files conflicted**, both `both-added` (kept both): cli.py (`_positive_int_arg` #56 + `_micro_eur_arg` gateway) and tests/test_doctor.py (#41 deadman test + gateway doctor test).
- `wrapper/run.py` **auto-merged** preserving BOTH #51 resume self-heal AND the gateway child-cap minting (verified).
- No conflict markers; all modules import; **184/186 gateway+doctor tests pass locally**.

## Known: 2 local failures are environmental, not a regression
`test_forced_stop_removes_only_stale_marker...` and `test_operator_stop_uses_gateway_kill_switch...` probe the fixed **4000/4001** ports without monkeypatching `_both_sockets_free`; they fail only because the **live gateway occupies those ports on the dev machine**. Clean CI (no gateway) passes them. Pre-existing codex-test hermeticity weakness → fast-follow (monkeypatch the probe / ephemeral ports).

## Endpoint UNCHANGED here
`DEFAULT_API_BASE` stays the old pinned value. The qwen-3-5-397b endpoint switch + a ledger-preserving `reconfigure` land as a focused **follow-up** (operator-chosen sequencing: fold first).

## Risk to watch
The gateway suite adds runtime; the Windows wheel dev-gate leg is already near its 1800s cap (**#54**). If this PR reds on a Windows `check_timeout`, #54 (raise cap / split suite) is the prerequisite, not a fold defect.

**Do not auto-merge — needs review (large fold).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)