### PR TITLE
feat(#38): pin qwen-3-5 endpoint + ledger-preserving `gateway reconfigure`

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -8300,6 +8300,8 @@ def cmd_gateway(args: argparse.Namespace) -> int:
             result = service.start_task(store.root)
         elif action == "stop":
             result = service.stop_task(store.root, timeout_seconds=args.timeout)
+        elif action == "reconfigure":
+            result = service.reconfigure_endpoint(store.root)
         elif action == "run":
             return service.run_service(store.root)
         elif action == "reconcile":
@@ -13580,6 +13582,14 @@ def build_parser() -> argparse.ArgumentParser:
     gw_stop.set_defaults(func=cmd_gateway)
     gw_status = gwsub.add_parser("status", help="Show an allowlisted non-secret status.")
     gw_status.set_defaults(func=cmd_gateway)
+    gw_reconfigure = gwsub.add_parser(
+        "reconfigure",
+        help=(
+            "Re-render config to the pinned endpoint + rebind the manifest "
+            "(ledger/token-preserving; the gateway must be stopped first)."
+        ),
+    )
+    gw_reconfigure.set_defaults(func=cmd_gateway)
     gw_reconcile = gwsub.add_parser(
         "reconcile",
         help="Explicitly resolve one uncertain provider attempt.",

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -47,7 +47,15 @@ from .redaction import redact_diagnostic_text
 
 TASK_SCHEMA_VERSION = 1
 RUNTIME_SCHEMA_VERSION = 2
-DEFAULT_API_BASE = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
+# PINNED upstream (#38). The gateway will only ever call this exact base — it is
+# a code constant, never a caller/runtime argument (a runtime-injectable base
+# would be an SSRF/exfiltration lever). To change it: edit this line (reviewed
+# via PR) then run `agenttalk gateway reconfigure` (re-renders the config +
+# rebinds the manifest, ledger-preserving). LiteLLM's openai provider POSTs
+# {api_base}/chat/completions, so this terminates at the level above that.
+# If the operator-gated live test 404s on the route, the fallback base is the
+# bare "https://qwen-3-5-397b.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat".
+DEFAULT_API_BASE = "https://qwen-3-5-397b.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1"
 STOP_TIMEOUT_SECONDS = 30.0
 LITELLM_READINESS_TIMEOUT_SECONDS = 120.0
 LITELLM_LOG_MAX_BYTES = 1024 * 1024
@@ -462,6 +470,80 @@ def initialize_install(
         "litellm_executable": str(executable),
         "front_token_path": str(front_path),
         "internal_token_path": str(internal_path),
+    }
+
+
+def reconfigure_endpoint(root: str | os.PathLike[str]) -> dict:
+    """Re-render the LiteLLM config to the PINNED ``DEFAULT_API_BASE`` and rebind
+    the install manifest's config hash — WITHOUT touching the spend ledger, the
+    tokens, or the registered task.
+
+    This is how a code-reviewed endpoint change (a new ``DEFAULT_API_BASE``) is
+    applied to an EXISTING install. ``initialize_install`` refuses to replace
+    existing state, and the manifest binds the config's sha256, so a bare edit of
+    the generated config would fail closed (``install_manifest_invalid``). The
+    pinned-base property is preserved: the endpoint comes only from the code
+    constant, never a caller argument.
+
+    Refuses while the gateway is running (both loopback sockets must be free) so
+    the freshly rendered on-disk config can never disagree with a proxy that
+    loaded the previous config into memory. The caller must ``stop`` first; the
+    new endpoint takes effect on the next ``start``.
+    """
+    root = canonical_project_root(root)
+    config_path = litellm_config_path(root)
+    manifest_path = install_manifest_path(root)
+    missing = [p.name for p in (config_path, manifest_path) if not p.exists()]
+    if missing:
+        raise GatewayConfigError(
+            "gateway reconfigure requires an existing install; missing: "
+            + ", ".join(missing)
+        )
+    if not _both_sockets_free():
+        raise GatewayConfigError(
+            "refusing to reconfigure while the gateway is running; stop it first"
+        )
+    # Read the existing manifest RAW — do NOT validate its config hash here (we
+    # are about to change the config). Every other field is preserved verbatim.
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GatewayConfigError("gateway install manifest is unreadable") from exc
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+        raise GatewayConfigError("gateway install manifest schema mismatch")
+    for key, expected in (
+        ("public_bind", f"{PUBLIC_HOST}:{PUBLIC_PORT}"),
+        ("internal_bind", f"{INTERNAL_HOST}:{INTERNAL_PORT}"),
+    ):
+        if manifest.get(key) != expected:
+            raise GatewayConfigError(f"gateway install manifest {key} mismatch")
+    if manifest.get("price_policy_hash") != price_policy_hash():
+        raise GatewayConfigError("gateway install manifest price policy mismatch")
+    executable = Path(str(manifest.get("litellm_executable") or "")).resolve()
+    if not executable.is_file():
+        raise GatewayConfigError(
+            "gateway install manifest references a missing artifact"
+        )
+    if Path(str(manifest.get("litellm_config") or "")).resolve() != config_path.resolve():
+        raise GatewayConfigError("gateway install manifest config path mismatch")
+    previous_hash = manifest.get("litellm_config_sha256")
+    # Re-render from the PINNED constant only (never a caller argument).
+    _durable_write_bytes(
+        config_path,
+        render_litellm_config(api_base=DEFAULT_API_BASE).encode("utf-8"),
+    )
+    config_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+    manifest["litellm_config_sha256"] = config_hash
+    _durable_write_json(manifest_path, manifest)
+    # Confirm the rewritten manifest validates against the freshly rendered config.
+    load_install_manifest(root)
+    return {
+        "reconfigured": True,
+        "api_base": DEFAULT_API_BASE,
+        "config_path": str(config_path),
+        "config_sha256": config_hash,
+        "previous_config_sha256": previous_hash,
+        "changed": previous_hash != config_hash,
     }
 
 

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 import os
 import socket
 import subprocess
@@ -763,3 +764,89 @@ def test_stop_refuses_unknown_listener_when_task_is_absent(tmp_path, monkeypatch
 
     with pytest.raises(GatewayConfigError, match="task is absent"):
         stop_task(tmp_path, commands=FakeCommands(), timeout_seconds=0)
+
+
+def _install_for_reconfigure(tmp_path, ledger):
+    root = tmp_path / "project"
+    executable = tmp_path / "litellm.exe"
+    executable.write_bytes(b"fake")
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    initialize_install(
+        root,
+        litellm_executable=executable,
+        opening_micro_eur=580_000,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    return root, front_token, internal_token
+
+
+def test_reconfigure_rebinds_config_and_manifest_and_preserves_ledger_and_tokens(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    install_json = tmp_path / "spend" / "install.json"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", install_json)
+    root, front_token, internal_token = _install_for_reconfigure(tmp_path, ledger)
+
+    # Simulate a pre-change install whose generated config points at a stale base.
+    cfg = litellm_config_path(root)
+    stale = service.render_litellm_config(api_base="https://stale.example/v1").encode("utf-8")
+    cfg.write_bytes(stale)
+    manifest_path = service.install_manifest_path(root)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["litellm_config_sha256"] = hashlib.sha256(stale).hexdigest()
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    ledger_before = install_json.read_bytes()
+    front_before = front_token.read_bytes()
+    internal_before = internal_token.read_bytes()
+
+    result = service.reconfigure_endpoint(root)
+
+    assert result["reconfigured"] is True
+    assert result["changed"] is True
+    assert result["api_base"] == service.DEFAULT_API_BASE
+    expected_cfg = service.render_litellm_config(
+        api_base=service.DEFAULT_API_BASE
+    ).encode("utf-8")
+    assert cfg.read_bytes() == expected_cfg
+    assert result["config_sha256"] == hashlib.sha256(expected_cfg).hexdigest()
+    reloaded = service.load_install_manifest(root)
+    assert reloaded["litellm_config_sha256"] == result["config_sha256"]
+    # Ledger marker + both tokens are byte-for-byte untouched.
+    assert install_json.read_bytes() == ledger_before
+    assert front_token.read_bytes() == front_before
+    assert internal_token.read_bytes() == internal_before
+
+
+def test_reconfigure_refuses_while_gateway_running(tmp_path, monkeypatch) -> None:
+    ledger = SpendLedger(
+        tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json"
+    )
+    root, _, _ = _install_for_reconfigure(tmp_path, ledger)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: False)
+    with pytest.raises(GatewayConfigError, match="while the gateway is running"):
+        service.reconfigure_endpoint(root)
+
+
+def test_reconfigure_requires_existing_install(tmp_path) -> None:
+    with pytest.raises(GatewayConfigError, match="requires an existing install"):
+        service.reconfigure_endpoint(tmp_path / "project")
+
+
+def test_reconfigure_is_idempotent_on_a_fresh_install(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    ledger = SpendLedger(
+        tmp_path / "spend" / "ledger.sqlite3", tmp_path / "spend" / "install.json"
+    )
+    root, _, _ = _install_for_reconfigure(tmp_path, ledger)
+    # A fresh install already renders the pinned base, so reconfigure is a no-op.
+    first = service.reconfigure_endpoint(root)
+    assert first["changed"] is False
+    second = service.reconfigure_endpoint(root)
+    assert second["changed"] is False
+    assert second["config_sha256"] == first["config_sha256"]


### PR DESCRIPTION
Follow-up to the #57 gateway fold. Small, focused diff (3 files, +180): switches the pinned upstream to your Qwen 3.5 endpoint and adds the missing seam to apply an endpoint change to an existing install without wiping state.

## Changes
- **`DEFAULT_API_BASE` → `https://qwen-3-5-397b.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1`** (operator-provided; bare `/api/openai_compat` documented in-file as the fallback if the live test 404s). Still a **pinned code constant** — never runtime-injectable (preserves the anti-SSRF property CodeQL/the reviewer checked).
- **New `agenttalk gateway reconfigure`**: re-renders the LiteLLM config from the pinned base and rebinds **only** the install manifest's config sha256 — never touches the spend ledger, tokens, or the registered task. Refuses while the gateway is running (both loopback sockets must be free) so on-disk config can't disagree with a proxy that loaded the old one. Re-validates the manifest before returning.

## Why it's needed
`init` refuses to replace existing state and the manifest binds the config hash, so a bare edit of the generated config fails closed (`install_manifest_invalid`). This is the sanctioned, ledger-preserving path — the €2.77 spend history / €25 cap accounting survive.

## Tests (hermetic — monkeypatch `_both_sockets_free`, no real-port dependency)
rebind + ledger/token preservation; refuse-while-running; require-existing-install; idempotent-on-fresh-install. 4 pass; ruff clean; 64 gateway + 34 cli/service tests green locally.

## Operator-gated live sequence after merge
`stop → reconfigure → start → clear-hold → one capped call → re-hold`. That capped call is the first real Qwen response (and confirms the `/v1` suffix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)