### PR TITLE
fix: give wrapped agents the exact `agenttalk reply` invocation (#11/#38)

### DIFF
--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -134,6 +134,26 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
             json.dumps(owed, ensure_ascii=False, indent=2, sort_keys=True),
             "```",
         ]
+    else:
+        # Ordinary replies go via `agenttalk reply`. Give the EXACT invocation so the
+        # model does not guess flags: the confusable near-synonyms (--to / --to-id /
+        # --request-id / --body) and inline multi-line -m bodies caused repeated failed
+        # reply attempts that burned the whole turn without a reply landing.
+        rid = record.get("request_id")
+        anchor = f"--to-request {rid}" if rid else "--to-request <request_id from the header above>"
+        out += [
+            "== HOW TO REPLY TO THIS MESSAGE (exact form) ==",
+            "Answer on THIS thread with ONE command. Short, single-line answer:",
+            f"  & \"$env:AGENTTALK_PY\" -m agenttalk reply {anchor} -m 'your answer here'",
+            "Code, or ANY multi-line answer: FIRST write it to a file with your Write tool, then "
+            "send that file (inline multi-line text in -m is corrupted by shell quoting):",
+            f"  & \"$env:AGENTTALK_PY\" -m agenttalk reply {anchor} --file <path-you-just-wrote>",
+            "For review-result / proposal-response add --kind <status> and typed --meta key=value "
+            "(repeatable). To decline an unrelated broadcast add --na instead of a body.",
+            "The ONLY valid flags are: --from, --to-request (or --to-id <message-id>), --kind, "
+            "-m/--message, --file, --meta, --na. There is NO --to, --request-id, or --body; "
+            "inventing a flag errors and wastes the turn. Send the reply ONCE; do not retry variants.",
+        ]
     out += ["== HOW TO HANDLE ==", rules]
     return "\n".join(out)
 

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -42,6 +42,32 @@ def test_prompt_assembly_includes_message_and_rules() -> None:
     assert "REJOIN CONTEXT" in p2 and "roster: a,b" in p2 and "custom rules" in p2
 
 
+def test_prompt_gives_exact_reply_invocation_for_ordinary_thread() -> None:
+    # A wrapped model fumbled `agenttalk reply` flags (--to / --request-id / --body)
+    # and inline multi-line -m bodies, burning a turn without a reply. The prompt must
+    # hand it the EXACT invocation, pre-filled with this message's request_id.
+    rec = {"from": "lead", "to": "qwen-dev-1", "kind": "question", "subject": "clamp",
+           "body": "write clamp", "correlation_id": "qwen-auto-clamp-3",
+           "request_id": "qwen-auto-clamp-3", "broadcast_id": None}
+    p = prompt.assemble_turn_prompt(rec)
+    assert "HOW TO REPLY TO THIS MESSAGE" in p
+    assert "--to-request qwen-auto-clamp-3" in p          # concrete anchor, not a placeholder
+    assert "--file <path-you-just-wrote>" in p            # steer code/multi-line to a file
+    assert "There is NO --to, --request-id, or --body" in p
+    assert "Send the reply ONCE; do not retry variants." in p
+
+
+def test_owed_action_question_uses_file_transport_not_reply_template() -> None:
+    # Commit-gated (owed_action) questions keep the fixed-argv file transport; they must
+    # NOT also get the reply template (one unambiguous instruction, no double guidance).
+    rec = {"from": "lead", "to": "qwen-dev-1", "kind": "question", "subject": "gated",
+           "body": "answer", "correlation_id": "rq-9", "request_id": "rq-9",
+           "broadcast_id": None, "owed_action": {"draft_path": "x", "operation": {}}}
+    p = prompt.assemble_turn_prompt(rec)
+    assert "OWED ACTION TRANSPORT" in p
+    assert "HOW TO REPLY TO THIS MESSAGE" not in p
+
+
 def test_prompt_assembly_includes_injected_lessons_without_sync() -> None:
     rec = {"from": "alpha", "to": "beta", "kind": "message", "subject": "docs",
            "body": "please update docs", "correlation_id": "rq-1",


### PR DESCRIPTION
## Diagnosis (from qwen-dev-1's live session transcript)
The wrapped Qwen worker *computed* answers correctly but **never posted a bus reply**. Its claude session log showed **8 Bash attempts** at `agenttalk reply` with invented/confused flags — `--to`, `--to-id <agent>`, `--request-id`, `--body` — plus inline **multi-line `-m`** code bodies that shell quoting corrupts. It never landed a valid reply and burned the whole per-child call budget → the wrapper's `computed but did not emit the owed reply`. The prompt told it to reply "on the correct thread" but never gave the **exact flags**, so the model guessed.

Not permission (mode is `bypassPermissions`), not the endpoint/model — a **prompt/ergonomics** gap. Model-agnostic: it blocks *any* wrapped worker (3.5, 3.6, …) from replying.

## Fix
Add a concrete, per-message **"HOW TO REPLY TO THIS MESSAGE (exact form)"** block in `assemble_turn_prompt`, pre-filled with the message's `request_id`:
- short answer → `reply --to-request <rid> -m '...'`
- code / any multi-line → **write a file first**, then `reply --to-request <rid> --file <path>`
- enumerates the ONLY valid flags; states "There is NO --to, --request-id, or --body"; "Send the reply ONCE; do not retry variants."

Shown only for non-`owed_action` threads — commit-gated questions keep their existing fixed-argv file transport (no double guidance).

## Tests
`test_prompt_gives_exact_reply_invocation_for_ordinary_thread` (concrete anchor + `--file` + no-invented-flags) and `test_owed_action_question_uses_file_transport_not_reply_template`. 13 prompt tests + ruff green.

Unblocks the clean autonomous reply we couldn't get in the live test; validated by re-running the wrapped worker after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)