### PR TITLE
fix(#38/#11): resolve reply request_id from meta + --to-id fallback

### DIFF
--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -103,13 +103,22 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
     out: list[str] = []
     if rejoin:
         out += ["== REJOIN CONTEXT ==", rejoin, ""]
+    # request_id is conventionally carried in meta.request_id on real bus messages;
+    # the top-level record["request_id"] is usually null. Resolve from every place a
+    # tracked correlation id can live so the header and the reply anchor below echo a
+    # value the worker can actually use. (Was: top-level only -> null header -> the
+    # worker had no anchor to copy and guessed flags, burning the turn.)
+    _meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
+    resolved_request_id = (record.get("request_id")
+                           or _meta.get("request_id")
+                           or record.get("correlation_id"))
     out.append("== INBOUND AGENTTALK MESSAGE ==")
     out.append(f"from: {record.get('from')}  to: {record.get('to')}  "
                f"kind: {record.get('kind')}")
     if record.get("subject"):
         out.append(f"subject: {record['subject']}")
     out.append(f"correlation_id: {record.get('correlation_id')} "
-               f"(request_id={record.get('request_id')} "
+               f"(request_id={resolved_request_id} "
                f"broadcast_id={record.get('broadcast_id')})")
     out += ["", record.get("body") or "", ""]
     # The FULL structured record, incl meta + scoped state. Classification data
@@ -139,8 +148,16 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
         # model does not guess flags: the confusable near-synonyms (--to / --to-id /
         # --request-id / --body) and inline multi-line -m bodies caused repeated failed
         # reply attempts that burned the whole turn without a reply landing.
-        rid = record.get("request_id")
-        anchor = f"--to-request {rid}" if rid else "--to-request <request_id from the header above>"
+        # Prefer the resolved request_id (thread anchor); if the message carries no
+        # correlation id at all, anchor to THIS message's own id via --to-id, which is
+        # always present. Never emit a placeholder the worker has to fill in itself.
+        _msg_id = record.get("id")
+        if resolved_request_id:
+            anchor = f"--to-request {resolved_request_id}"
+        elif _msg_id:
+            anchor = f"--to-id {_msg_id}"
+        else:
+            anchor = "--to-request <request_id from the header above>"
         out += [
             "== HOW TO REPLY TO THIS MESSAGE (exact form) ==",
             "Answer on THIS thread with ONE command. Short, single-line answer:",

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -57,6 +57,34 @@ def test_prompt_gives_exact_reply_invocation_for_ordinary_thread() -> None:
     assert "Send the reply ONCE; do not retry variants." in p
 
 
+def test_prompt_reply_anchor_resolves_request_id_from_meta() -> None:
+    # REAL bus messages carry the tracked id in meta.request_id with a NULL top-level
+    # request_id (the on-disk shape produced by `send --meta request_id=...`). The
+    # earlier fix read top-level only, so the header showed request_id=None and the
+    # anchor became an unfillable placeholder -> the worker had nothing to copy and
+    # fumbled the reply. Resolve from meta so the anchor is concrete.
+    rec = {"id": "20260721-165700-178595-iVUi", "from": "lead", "to": "qwen-dev-1",
+           "kind": "question", "subject": "clamp", "body": "write clamp",
+           "correlation_id": None, "request_id": None, "broadcast_id": None,
+           "meta": {"request_id": "qwen-auto-clamp-3"}}
+    p = prompt.assemble_turn_prompt(rec)
+    assert "--to-request qwen-auto-clamp-3" in p            # concrete anchor from meta
+    assert "request_id=qwen-auto-clamp-3" in p              # header echoes the resolved id
+    assert "<request_id from the header above>" not in p    # never a placeholder here
+
+
+def test_prompt_reply_anchor_falls_back_to_message_id_when_no_request_id() -> None:
+    # A bare `send` (no request_id anywhere) still needs a usable anchor. `reply`
+    # supports --to-id <message-id>, and the inbound id is always present, so anchor to
+    # it rather than emit a placeholder the worker must fill in itself.
+    rec = {"id": "20260721-190942-058910-q6rN", "from": "lead", "to": "qwen-dev-1",
+           "kind": "question", "subject": "adhoc", "body": "do a thing",
+           "correlation_id": None, "request_id": None, "broadcast_id": None, "meta": {}}
+    p = prompt.assemble_turn_prompt(rec)
+    assert "--to-id 20260721-190942-058910-q6rN" in p       # anchor to the message id
+    assert "--to-request <request_id" not in p              # no unfillable placeholder
+
+
 def test_owed_action_question_uses_file_transport_not_reply_template() -> None:
     # Commit-gated (owed_action) questions keep the fixed-argv file transport; they must
     # NOT also get the reply template (one unambiguous instruction, no double guidance).


### PR DESCRIPTION
## Problem (corrected)
#60 pre-fills the exact `agenttalk reply` invocation with the thread's request_id, but reads it from **top-level `record["request_id"]`** only. On real bus messages that field is **null** — the tracked id lives in **`meta.request_id`**. So the pre-filled anchor collapses to `--to-request <request_id from the header above>` (an unfillable placeholder) and the header shows `request_id=None`.

**Important nuance (verified in a live wrapped-worker run):** this did NOT hard-break replies. The prompt also dumps the full STRUCTURED RECORD as JSON, which DOES contain `meta.request_id`, so a capable model recovers the id from there and replies successfully. The value of this PR is making the anchor **correct without depending on the model mining the JSON block** — which matters for weaker models (the point of running Qwen workers).

## Fix (`prompt.assemble_turn_prompt`)
- Resolve request_id from `record["request_id"]` **OR** `meta.request_id` **OR** `correlation_id`; render the resolved value in the header.
- Anchor: `--to-request <resolved>` when present; else `--to-id <message-id>` (always present; `reply` supports it). Never emit a placeholder.

## Tests
Use the **real** record shapes #60's tests missed (they set a top-level request_id, a shape real messages never have):
- `meta.request_id` only (top-level null) → concrete `--to-request` anchor + header echoes it.
- no request_id anywhere → `--to-id <message-id>` fallback, no placeholder.

## Related
- Systemic root: request_id stored in `meta` but read top-level in several places → task #17 (normalize request_id at write time).
- NOT the reply-path blocker found in the same run: the `ovh-qwen` wrapper env allowlist strips `LOCALAPPDATA`/`USERPROFILE`, crashing `agenttalk reply` in signing.py until the model manually exports them (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
