### PR TITLE
fix(#56/#11): scope wrapped ovh-qwen child home so agenttalk reply resolves

### DIFF
--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -520,6 +520,18 @@ def _child_env(
         # is disposable with the watched-trial clone and contains no operator
         # credentials or history.
         env["CLAUDE_CONFIG_DIR"] = _ovh_qwen_claude_config_dir(workspace)
+        # The allowlist above drops LOCALAPPDATA/USERPROFILE/HOME, so a bus command the
+        # child shells out to (e.g. `agenttalk reply`) cannot resolve Path.home() and
+        # crashes in signing.default_keys_dir() BEFORE it can even decide signing is off
+        # ("RuntimeError: Could not determine home directory"). Point home + appdata at
+        # the disposable workspace clone: gives the child a resolvable home WITHOUT
+        # leaking the operator's real home to the paid external worker. If HMAC signing
+        # is later enforced, wire the child's key via AGENTTALK_HMAC_KEY_FILE rather than
+        # widening this to the operator's LOCALAPPDATA.
+        _scoped_home = str(workspace)
+        env["HOME"] = _scoped_home
+        env["USERPROFILE"] = _scoped_home
+        env["LOCALAPPDATA"] = str(workspace / "AppData" / "Local")
     elif backend_profile is not None:
         raise ValueError(f"unsupported backend_profile {backend_profile!r}")
     else:

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -85,12 +85,48 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert "ANTHROPIC_API_KEY" not in env
     assert "OVH_KEY" not in env
     assert "UNRELATED_SECRET" not in env
-    assert "HOME" not in env
-    assert "USERPROFILE" not in env
+    # Home is scoped to the disposable workspace clone (NOT the operator's real home):
+    # the child needs a resolvable Path.home()/LOCALAPPDATA so `agenttalk reply` does
+    # not crash in signing.default_keys_dir(), but must never see the operator's home.
+    assert env["HOME"] == str(tmp_path.resolve())
+    assert env["USERPROFILE"] == str(tmp_path.resolve())
+    assert env["LOCALAPPDATA"] == str((tmp_path / "AppData" / "Local").resolve())
+    assert "C:\\Users\\operator" not in env.values()
     assert "C:\\Users\\operator\\.claude" not in env.values()
     assert "AGENTTALK_LEAD_LOOP_LEASE" not in env
     assert "ambient-must-not-pass" not in env.values()
     assert "stale-must-not-pass" not in env.values()
+
+
+def test_ovh_qwen_child_env_lets_signing_resolve_home_without_crash(
+    tmp_path, monkeypatch
+) -> None:
+    # REGRESSION: with the allowlist stripping LOCALAPPDATA/USERPROFILE/HOME, a child
+    # shelling out to `agenttalk reply` crashed with "Could not determine home
+    # directory" inside signing.default_keys_dir() (Path.home()) before it could even
+    # decide signing was off. Applying the scoped child env must let key-path resolution
+    # return a path UNDER the workspace and never raise.
+    from agenttalk import signing
+
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {"PATH": "safe-path", "SystemRoot": "C:\\Windows", "AGENTTALK_SELF": "qwen-dev-1"},
+    )
+    env = run._child_env(
+        tmp_path,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "front-token",
+        },
+    )
+    # Simulate the child process seeing exactly this environment.
+    monkeypatch.setattr(os, "environ", dict(env))
+    key_path = signing.resolve_key_path("deadbeef")   # must NOT raise
+    workspace = str(tmp_path.resolve())
+    assert str(key_path).startswith(workspace)         # resolved under the scoped home
+    assert not key_path.exists()                       # signing stays unenforced (no key)
 
 
 def test_ovh_qwen_turn_capability_replaces_master_front_token(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem (found in a live wrapped-worker run)
The `ovh-qwen` child env allowlist (`wrapper/run.py`) intentionally drops `LOCALAPPDATA`/`USERPROFILE`/`HOME`. But when the wrapped worker shells out to a bus command like `agenttalk reply`, that Python subprocess cannot resolve `Path.home()` and crashes inside `signing.default_keys_dir()`:

```
RuntimeError: Could not determine home directory.
```

— and this happens *before* it can even determine that signing is unenforced. In the observed run a capable model recovered by manually running `export HOME=… && export LOCALAPPDATA=…` (4 wasted turns + paid gateway calls). A weaker Qwen model would likely never post its reply at all — so this, not the request_id anchor (#61), was the real reply-path blocker.

## Fix
`wrapper/run.py` ovh-qwen profile: point `HOME`/`USERPROFILE`/`LOCALAPPDATA` at the **disposable workspace clone** — the same philosophy as the existing scoped `CLAUDE_CONFIG_DIR`. The child gets a resolvable home **without seeing the operator's real home**.

Chosen (Option B) over widening the allowlist to pass the operator's real `LOCALAPPDATA` (Option A), which would leak operator paths to the paid external worker. Signing stays unenforced (no key under the scoped dir); if HMAC signing is later enabled, wire the child key via `AGENTTALK_HMAC_KEY_FILE` rather than widening this.

## Tests (`test_ovh_wrapper_profile.py`)
- Allowlist test updated: `HOME`/`USERPROFILE`/`LOCALAPPDATA` are the scoped workspace, and the operator home (`C:\Users\operator`) never appears in env values.
- New regression: with the child env applied, `signing.resolve_key_path(...)` resolves **under the workspace** and does **not raise** — the exact crash that broke replies.

## Related
- The actual blocker behind the 2026-07-21 wrapped-Qwen reply failure (task #56).
- Same family as #33 (what env a sandboxed external worker inherits).
- Independent of #61 (reply request_id anchor) — different file, both off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
