### PR TITLE
fix(#54): raise shared pytest gate cap 1800->2700s for the wheel leg

### DIFF
--- a/dev-gate.json
+++ b/dev-gate.json
@@ -70,7 +70,7 @@
         "-q"
       ],
       "test_requirement": "pytest>=8.0",
-      "timeout_seconds": 1800
+      "timeout_seconds": 2700
     },
     "ruff": {
       "kind": "ruff",

--- a/tests/test_dev_gate.py
+++ b/tests/test_dev_gate.py
@@ -463,6 +463,16 @@ def test_manifest_requires_every_subprocess_timeout(check_id: str) -> None:
         dev_gate.validate_manifest(manifest)
 
 
+def test_committed_pytest_timeout_has_wheel_leg_headroom() -> None:
+    # Regression guard (#54): the single `pytest` timeout is shared by both the
+    # fast source legs (~9min) and the slow wheel legs (isolated venv + install +
+    # full suite, ~30min on loaded Windows runners). At 1800s the wheel leg hit the
+    # cap at ~92-99% and forced multi-cycle CI rerun loops. Keep generous headroom
+    # so it cannot silently regress; the CI job allows timeout-minutes: 90.
+    manifest = _manifest()
+    assert manifest["checks"]["pytest"]["timeout_seconds"] >= 2400
+
+
 def test_logical_plan_digest_is_runtime_path_independent_and_semantic() -> None:
     manifest = dev_gate.validate_manifest(_manifest())
     original = dev_gate.logical_plan_digest(manifest, "release")


### PR DESCRIPTION
## Problem
The dev-gate manifest uses a **single `pytest` timeout** for both leg modes:
- **source** pytest (`pytest-source-*`) — ~9 min
- **wheel** pytest (`pytest-wheel-*`) — isolated venv + wheel install + full suite, **~30 min on loaded Windows runners**

At `1800s` the wheel leg repeatedly hit the cap at ~92–99% complete (`agenttalk dev-gate: timed out after 1800s`), forcing multi-cycle CI rerun loops. It bit #56, #58, #59, #60, and #62 (3× on #62 alone — the immediate motivation).

## Fix
Raise the shared cap `1800 → 2700s` (45 min) in `dev-gate.json`.
- Source legs unaffected (finish ~9 min — huge headroom either way).
- CI job is `timeout-minutes: 90`, which comfortably fits a source + wheel pytest pass plus build/install/static checks.
- No code or schema change; the manifest `logical_plan_sha256` recomputes self-consistently (verified locally).

## Regression guard
New test asserts the committed `pytest` timeout stays `>= 2400s`, so it can't silently regress below what the wheel leg needs under load.

## Validation
- `validate_manifest` + `logical_plan_digest` recompute cleanly with the new value (local smoke).
- `tests/test_dev_gate.py`: 84 passed (incl. the new guard); ruff clean.
- This PR's own CI runs against the new cap, so the wheel leg should no longer self-flake on the timeout.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
