### PR TITLE
feat(#17): read-side request_id/broadcast_id/correlation resolvers (incr 1)

### DIFF
--- a/src/agenttalk/correlation.py
+++ b/src/agenttalk/correlation.py
@@ -1,0 +1,31 @@
+"""Resolve a message's correlation ids from any valid location (#17).
+
+On real bus messages the tracked id lives in ``meta["request_id"]`` and the
+top-level ``request_id`` key is absent; ``recv_api.to_record`` normalizes it to
+top-level; ``correlation_id`` is a third derived form. Reading only one location
+is the #60/#61 bug class. These helpers resolve from all valid locations so a
+reader is correct regardless of record shape.
+
+Only ``request_id`` / ``broadcast_id`` / ``correlation_id`` are consulted — the
+deliberately-distinct keys ``origin_request_id`` / ``parent_request`` /
+``forwarded_request_id`` are never folded in.
+"""
+
+from __future__ import annotations
+
+
+def resolve_request_id(record: dict) -> str | None:
+    """request_id from top-level, then ``meta``, then ``correlation_id``."""
+    return (record.get("request_id")
+            or (record.get("meta") or {}).get("request_id")
+            or record.get("correlation_id"))
+
+
+def resolve_broadcast_id(record: dict) -> str | None:
+    """broadcast_id from top-level, then ``meta``."""
+    return record.get("broadcast_id") or (record.get("meta") or {}).get("broadcast_id")
+
+
+def resolve_correlation_id(record: dict) -> str | None:
+    """The correlation token: request_id if present, else broadcast_id."""
+    return resolve_request_id(record) or resolve_broadcast_id(record)

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,73 @@
+"""Tests for the #17 correlation resolvers.
+
+Drafted by the wrapped Qwen worker (qwen-dev-1) over the agenttalk bus; adapted
+to the package import path and reviewed/landed by the lead. Covers all three
+record shapes (real on-disk message with request_id in meta, normalized recv
+record with it top-level, correlation_id-only) plus the broadcast alias and the
+guard that distinct *_request_id keys are never folded in.
+"""
+
+from agenttalk.correlation import (
+    resolve_broadcast_id,
+    resolve_correlation_id,
+    resolve_request_id,
+)
+
+
+class TestResolveRequestId:
+    def test_real_on_disk_message_shape(self):
+        # Real on-disk message: meta.request_id only, no top-level request_id.
+        record = {"id": "msg-123", "meta": {"request_id": "q-1"}}
+        assert resolve_request_id(record) == "q-1"
+
+    def test_normalized_recv_record(self):
+        # Normalized recv record: both top-level and meta have request_id.
+        record = {"request_id": "q-2", "meta": {"request_id": "q-2"}}
+        assert resolve_request_id(record) == "q-2"
+
+    def test_correlation_id_only(self):
+        assert resolve_request_id({"correlation_id": "q-3"}) == "q-3"
+
+    def test_empty_record(self):
+        assert resolve_request_id({}) is None
+
+    def test_empty_meta(self):
+        assert resolve_request_id({"meta": {}}) is None
+
+    def test_broadcast_message(self):
+        # Broadcast: request_id == broadcast_id, both in meta.
+        record = {"meta": {"request_id": "b-9", "broadcast_id": "b-9"}}
+        assert resolve_request_id(record) == "b-9"
+        assert resolve_broadcast_id(record) == "b-9"
+
+    def test_guard_does_not_read_origin_or_forwarded(self):
+        # Must NOT resolve origin_request_id / forwarded_request_id.
+        record = {"meta": {"origin_request_id": "esc-x", "forwarded_request_id": "f-y"}}
+        assert resolve_request_id(record) is None
+
+
+class TestResolveBroadcastId:
+    def test_top_level_broadcast_id(self):
+        assert resolve_broadcast_id({"broadcast_id": "b-1"}) == "b-1"
+
+    def test_meta_broadcast_id(self):
+        assert resolve_broadcast_id({"meta": {"broadcast_id": "b-2"}}) == "b-2"
+
+    def test_top_level_preferred_over_meta(self):
+        record = {"broadcast_id": "b-top", "meta": {"broadcast_id": "b-meta"}}
+        assert resolve_broadcast_id(record) == "b-top"
+
+    def test_no_broadcast_id(self):
+        assert resolve_broadcast_id({}) is None
+
+
+class TestResolveCorrelationId:
+    def test_request_id_takes_precedence(self):
+        record = {"request_id": "q-1", "broadcast_id": "b-1"}
+        assert resolve_correlation_id(record) == "q-1"
+
+    def test_broadcast_id_when_no_request_id(self):
+        assert resolve_correlation_id({"broadcast_id": "b-1"}) == "b-1"
+
+    def test_no_correlation_id(self):
+        assert resolve_correlation_id({}) is None


### PR DESCRIPTION
## What
Increment 1 of #17 — a small, additive, **zero-behavior-change** module `agenttalk/correlation.py` with `resolve_request_id` / `resolve_broadcast_id` / `resolve_correlation_id`, plus 14 unit tests.

On real bus messages the correlation id lives in `meta.request_id` (top-level absent); `recv_api.to_record` normalizes it top-level; `correlation_id` is a third form. Reading only one location is the #60/#61 bug class. These helpers read all valid locations and never fold the deliberately-distinct `origin_`/`parent_`/`forwarded_` keys.

## Why now / scope
See `docs/request-id-normalization-audit.md`. The audit's decisive finding: do **not** normalize by changing the signed `Message.to_dict()` shape (breaks HMAC on existing files) — normalize as a **read-side contract**. This PR adds the resolver + tests only. **Increment 2** (separate PR) wires the 4 latent bare top-level reads: `wrapper/loop.py:383`, `wrapper/health.py:104`, `store.py:3768-3769`, `store.py:3936-3937`.

## Tests
14 tests, all three record shapes incl. a **real on-disk message shape** (the exact mismatch that let #60 through — see the test-real-record-shape lesson), the broadcast `request_id==broadcast_id` alias, and the distinct-key guard. ruff clean.

## Note
Implementation **drafted by the wrapped Qwen worker (qwen-dev-1)** over the agenttalk bus — the first real dogfooded worker contribution — then adapted to the package import path and reviewed/landed by the lead.

Part of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
