### PR TITLE
test(#59): de-flake the 4 timing/lock/socket races taxing Windows CI

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -575,7 +575,10 @@ def test_config_lock_recovery_never_path_replaces_stale_generation(
         real_replace(source, destination)
 
     monkeypatch.setattr(store_mod.os, "replace", forbid_path_overwrite)
-    with s._config_lock(timeout=0.2, poll=0.005):
+    # timeout is incidental to this test (it asserts recovery never overwrites the
+    # lock pathname, not any deadline); 0.2s is below loaded-Windows-FS lock
+    # latency and flaked in CI. Generous bounded value, same assertion.
+    with s._config_lock(timeout=5.0, poll=0.005):
         pass
 
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -147,36 +147,57 @@ def test_scoped_wait_does_not_redeliver_globally_consumed(store: Store, store_ro
 
 # ------------------- perf fix #1: scoped-wait scan bound (floor vs baseline)
 
-def test_scoped_wait_composing_extends_mid_wait(tmp_path: Path) -> None:
-    """Baseline behavior under the perf fix: a composing that arrives DURING
-    a scoped wait (id > baseline) still extends the deadline. The wait would
-    have timed out at its 0.5s base deadline; the +10s extension lets the
-    real reply (sent at ~0.8s) arrive and return 0."""
+def test_scoped_wait_composing_extends_mid_wait(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A composing that arrives DURING a scoped wait (id > baseline) extends the
+    deadline: the wait would have timed out at its 0.5s base deadline, but the
+    +10s extension lets the reply arrive and return 0.
+
+    DETERMINISTIC via an injected clock/sleep (was a real-clock thread race that
+    flaked under CI jitter): sleep #1 drops the composing and advances time past
+    the original deadline; sleep #2 drops the reply; then the wait returns 0."""
     root = _init_team(tmp_path, "lead,exec")
     _run(["send", "--from", "lead", "--to", "exec", "--kind", "question",
           "--meta", "request_id=q-fire", "-m", "fire", "--quiet"], root)
     assert _run(["drain", "--for", "exec", "--quiet"], root) == 0  # cursor=baseline
-    result: list[int] = []
+    now = 1_000.0
+    sleep_calls = 0
+    sent_reply = False
 
-    def _waiter() -> None:
-        result.append(cli.main([
-            "--root", str(root), "wait", "--for", "exec", "--to-request", "q-fire",
-            "--timeout", "0.5", "--grace", "0", "--interval", "0.05",
-            "--composing-extend", "10", "--heartbeat-interval", "0", "--quiet",
-        ]))
+    def fake_sleep(_duration: float) -> None:
+        nonlocal now, sleep_calls, sent_reply
+        sleep_calls += 1
+        if sleep_calls == 1:
+            # composing arrives mid-wait (id > baseline); advance PAST the 0.5s
+            # base deadline so only the +10s extension can keep the wait alive.
+            _run(["send", "--from", "lead", "--to", "exec", "--kind", "composing",
+                  "-m", "drafting", "--quiet"], root)
+            now += 0.6
+            return
+        if sleep_calls == 2:
+            _run(["send", "--from", "lead", "--to", "exec", "--kind", "review-result",
+                  "--meta", "request_id=q-fire", *_approval_meta_args(),
+                  "-m", "lgtm", "--quiet"], root)
+            sent_reply = True
+            return
+        raise AssertionError("wait loop kept sleeping after the deterministic reply")
 
-    t = threading.Thread(target=_waiter)
-    t.start()
-    _time.sleep(0.2)  # waiter arms; baseline captured
-    _run(["send", "--from", "lead", "--to", "exec", "--kind", "composing",
-          "-m", "drafting", "--quiet"], root)
-    _time.sleep(0.6)  # past the 0.5s base deadline — only the extension keeps it alive
-    _run(["send", "--from", "lead", "--to", "exec", "--kind", "review-result",
-          "--meta", "request_id=q-fire", *_approval_meta_args(),
-          "-m", "lgtm", "--quiet"], root)
-    t.join(timeout=15)
-    assert not t.is_alive(), "waiter never returned"
-    assert result == [0], "mid-wait composing failed to extend the deadline"
+    class FakeTime:
+        def time(self) -> float:
+            return now
+
+        def sleep(self, duration: float) -> None:
+            fake_sleep(duration)
+
+    monkeypatch.setattr(cli, "time", FakeTime())
+    rc = cli.main([
+        "--root", str(root), "wait", "--for", "exec", "--to-request", "q-fire",
+        "--timeout", "0.5", "--grace", "0", "--interval", "0.05",
+        "--composing-extend", "10", "--heartbeat-interval", "0", "--quiet",
+    ])
+    assert rc == 0, "mid-wait composing failed to extend the deadline"
+    assert sent_reply
 
 
 def test_scoped_wait_composing_extends_when_cursor_exceeds_baseline(
@@ -246,40 +267,53 @@ def test_scoped_wait_composing_extends_when_cursor_exceeds_baseline(
 
 
 def test_scoped_wait_rescind_wakes_when_cursor_exceeds_baseline(
-    tmp_path: Path, capsys
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     """Perf-fix edge: a rescind on the waited thread whose id falls in
     (baseline, floor] must still wake the scoped wait (exit 3) even after a
     concurrent consumer advanced the global cursor above it. Scanning only
-    from floor would never surface the rescind; min(floor, baseline) does."""
+    from floor would never surface the rescind; min(floor, baseline) does.
+
+    DETERMINISTIC via an injected clock/sleep (was a real-clock thread race):
+    sleep #1 lands the rescind AND advances the global cursor above it, then the
+    wait's next poll must surface the rescind and return 3."""
     root = _init_team(tmp_path, "lead,exec")
     _run(["send", "--from", "lead", "--to", "exec", "--kind", "question",
           "--meta", "request_id=q-fire", "-m", "fire", "--quiet"], root)
     assert _run(["drain", "--for", "exec", "--quiet"], root) == 0
     s = Store(root)
-    result: list[int] = []
+    now = 1_000.0
+    sleep_calls = 0
 
-    def _waiter() -> None:
-        result.append(cli.main([
-            "--root", str(root), "wait", "--for", "exec", "--to-request", "q-fire",
-            "--timeout", "2", "--grace", "0", "--interval", "0.05",
-            "--heartbeat-interval", "0",
-        ]))
+    def fake_sleep(_duration: float) -> None:
+        nonlocal now, sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            # rescind lands (id in (baseline, floor])...
+            assert _run(["rescind", "--from", "lead", "--to-request", "q-fire",
+                         "-m", "HOLD", "--quiet"], root) == 0
+            # ...then an unrelated message pulls the global cursor ABOVE it.
+            r1 = s.send(sender="lead", recipient="exec", kind="note", body="other")
+            s.advance_cursor("exec", r1.id)
+            assert s.cursor("exec") == r1.id  # floor now exceeds the rescind id
+            now += 1.0
+            return
+        raise AssertionError("wait loop kept sleeping after the deterministic rescind")
 
-    t = threading.Thread(target=_waiter)
-    t.start()
-    _time.sleep(0.3)  # waiter arms; baseline = the q-fire id
-    # rescind lands first (id in (baseline, floor])...
-    assert _run(["rescind", "--from", "lead", "--to-request", "q-fire",
-                 "-m", "HOLD", "--quiet"], root) == 0
-    # ...then a later unrelated message a concurrent consumer drains, pulling
-    # the global cursor ABOVE the rescind id.
-    r1 = s.send(sender="lead", recipient="exec", kind="note", body="other")
-    s.advance_cursor("exec", r1.id)
-    assert s.cursor("exec") == r1.id  # floor now exceeds the rescind id
-    t.join(timeout=15)
-    assert not t.is_alive(), "waiter failed to wake on the rescind"
-    assert result == [3], "rescind in (baseline, floor] was skipped by the scan bound"
+    class FakeTime:
+        def time(self) -> float:
+            return now
+
+        def sleep(self, duration: float) -> None:
+            fake_sleep(duration)
+
+    monkeypatch.setattr(cli, "time", FakeTime())
+    rc = cli.main([
+        "--root", str(root), "wait", "--for", "exec", "--to-request", "q-fire",
+        "--timeout", "2", "--grace", "0", "--interval", "0.05",
+        "--heartbeat-interval", "0",
+    ])
+    assert rc == 3, "rescind in (baseline, floor] was skipped by the scan bound"
     assert "RESCINDED" in capsys.readouterr().out
 
 

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -5,6 +5,7 @@ import io
 import json
 import socket
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
@@ -153,6 +154,21 @@ class RunningFront:
 
     def __enter__(self) -> RunningFront:
         self.thread.start()
+        # Readiness barrier: serve_forever() starts accepting asynchronously, and
+        # on a loaded runner (esp. Windows) a request can otherwise race a
+        # not-yet-accepting / just-recycled socket -> ConnectionAbortedError. Block
+        # until the listener actually accepts a connection before returning.
+        deadline = time.monotonic() + 5.0
+        while True:
+            try:
+                with socket.create_connection(
+                    ("127.0.0.1", self.config.public_port), timeout=0.5
+                ):
+                    break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("front did not become ready within 5s") from None
+                time.sleep(0.02)
         return self
 
     def __exit__(self, *_args: object) -> None:
@@ -182,13 +198,24 @@ class RunningFront:
             "Content-Type": "application/json",
         }
         request_headers.update(headers or {})
-        conn = http.client.HTTPConnection("127.0.0.1", self.config.public_port, timeout=5)
-        try:
-            conn.request(method, path, body=encoded, headers=request_headers)
-            response = conn.getresponse()
-            return response.status, response.read()
-        finally:
-            conn.close()
+        # Retry ONLY connection-level aborts (transient localhost socket races on
+        # loaded Windows runners) - never an HTTP response, so no status assertion
+        # is ever masked.
+        last_exc: OSError | None = None
+        for _ in range(5):
+            conn = http.client.HTTPConnection(
+                "127.0.0.1", self.config.public_port, timeout=5)
+            try:
+                conn.request(method, path, body=encoded, headers=request_headers)
+                response = conn.getresponse()
+                return response.status, response.read()
+            except (ConnectionAbortedError, ConnectionResetError,
+                    ConnectionRefusedError) as exc:
+                last_exc = exc
+                time.sleep(0.05)
+            finally:
+                conn.close()
+        raise last_exc if last_exc is not None else RuntimeError("request failed")
 
     def raw_request(self, request: bytes) -> tuple[int, bytes]:
         with socket.create_connection(


### PR DESCRIPTION
## Problem
Windows CI flaked reruns on nearly every PR this cycle (#56/#58/#59/#60/#62/#63/#64) across **three** distinct test classes. #54 raised the suite timeout cap but did nothing for these per-test races. Common root: real wall-clock timers / file locks / sockets with sub-second tolerances that get crossed under a loaded runner's scheduling jitter.

## Fixes (deterministic where possible; margins only where not — no assertion weakened, no production change)

**Coordination timing (2 tests)** — `test_scoped_wait_composing_extends_mid_wait`, `test_scoped_wait_rescind_wakes_when_cursor_exceeds_baseline`: ported off real threads + real `sleep()` onto the **deterministic injected-clock/sleep** pattern the sibling `test_scoped_wait_composing_extends_when_cursor_exceeds_baseline` already uses — `monkeypatch cli.time` with a `FakeTime`, and a `fake_sleep` that drops the composing/rescind + reply per poll. Zero wall-clock dependency remains.

**Config-lock (1 test)** — `test_config_lock_recovery_never_path_replaces_stale_generation`: the `_config_lock(timeout=0.2)` is **incidental** (the test asserts recovery never overwrites the lock pathname, not any deadline); 0.2s is below loaded-Windows-FS lock latency. Raised to a generous bounded 5.0s.

**Socket restart (1 test + the shared helper)** — `RunningFront` (used by many gateway-front tests): `__enter__` returned before `serve_forever` was accepting, so a request could race a not-yet-ready / just-recycled socket → `ConnectionAbortedError`. Added a **readiness barrier** (poll-connect until the listener accepts) and a **connection-level retry** in `request()` that retries *only* `ConnectionAborted/Reset/Refused` — never an HTTP response, so no status assertion is masked.

## Validation
Full `test_coordination.py` + full `test_ovh_gateway_front.py` (all `RunningFront` users) + the concurrency test: **97 passed**; ruff clean.

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
