### PR TITLE
fix(#58): config-blocked park writes a visible health state (no more frozen 'idle')

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -10066,6 +10066,7 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             manage_waiting=not lead_loop,  # the lead-loop LEASE owns the .waiting mirror
             cadence=cadence_hook,  # WP3 proactive sweep (lead-loop only)
             on_health_idle=health_writer.idle,
+            on_health_parked=health_writer.parked,  # #58: config-blocked park is visible, not a frozen 'idle'
             capacity_refresh=capacity_refresh,
             wrapper_generation=wrapper_generation,
             commit_gate=commit_gate,

--- a/src/agenttalk/wrapper/health.py
+++ b/src/agenttalk/wrapper/health.py
@@ -6,6 +6,7 @@ import time
 from typing import Any
 
 from agenttalk import health as health_model
+from agenttalk.correlation import resolve_request_id
 
 from .events import Event, EventType
 from .loop import CLASS_AMBIGUOUS, CLASS_CONFIG_BLOCKED, CLASS_INFRA, CLASS_POISON
@@ -111,6 +112,23 @@ class WrapperHealthWriter:
             request_id=self._request_id,
             msg_id=self._msg_id,
             force=True,
+        )
+
+    def parked(self, record: dict[str, Any] | None, reason_code: str = "config_blocked") -> None:
+        """The loop is HOLDING a config-blocked head without driving it (deterministic local
+        exec/config denial - e.g. a held gateway, an exec-denied bus write). Surface it as a
+        distinct advisory state carrying the parked head's ids, so ``status``/``doctor`` show
+        the worker as blocked-on-a-message instead of a frozen last state (the health-freeze
+        that hid the wedge, #58). Not forced: the first park is a state change (written at once)
+        and repeats throttle, so a long park is one visible transition, not a write storm."""
+        record = record if isinstance(record, dict) else {}
+        request_id = resolve_request_id(record)
+        msg_id = record.get("id")
+        self._write(
+            health_model.STATE_ERRORED_AMBIGUOUS,
+            reason_code=reason_code,
+            request_id=request_id if isinstance(request_id, str) else None,
+            msg_id=msg_id if isinstance(msg_id, str) else None,
         )
 
     def event(self, event: Event) -> None:

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -216,9 +216,6 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
              cadence: Callable[[], CadenceResult] | None = None,
              on_health_idle: Callable[[], None] | None = None,
              on_health_parked: Callable[[dict, str], None] | None = None,
-             config_blocked_reprobe_seconds: float = 120.0,
-             config_blocked_reprobe_backoff: float = 2.0,
-             config_blocked_reprobe_max_seconds: float = 1800.0,
              capacity_refresh: Callable[[], None] | None = None,
              capacity_interval_seconds: float = 60.0,
              wrapper_generation: str | None = None,
@@ -297,9 +294,6 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
             on_dead_letter=on_dead_letter, on_escalate=on_escalate, stamp=stamp,
             pre_commit=pre_commit, cadence=cadence, on_health_idle=on_health_idle,
             on_health_parked=on_health_parked,
-            config_blocked_reprobe_seconds=config_blocked_reprobe_seconds,
-            config_blocked_reprobe_backoff=config_blocked_reprobe_backoff,
-            config_blocked_reprobe_max_seconds=config_blocked_reprobe_max_seconds,
             capacity_refresh=capacity_refresh,
             capacity_interval_seconds=capacity_interval_seconds,
             commit_gate=commit_gate,
@@ -325,9 +319,6 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     cadence: Callable[[], CadenceResult] | None,
                     on_health_idle: Callable[[], None] | None,
                     on_health_parked: Callable[[dict, str], None] | None,
-                    config_blocked_reprobe_seconds: float,
-                    config_blocked_reprobe_backoff: float,
-                    config_blocked_reprobe_max_seconds: float,
                     capacity_refresh: Callable[[], None] | None,
                     capacity_interval_seconds: float,
                     commit_gate,
@@ -476,48 +467,13 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         store.mark_attempt_escalated(agent, record.get("id"), routed=routed)
 
     config_blocked_ids: set[str] = set()
-    # Per-head config-blocked RE-PROBE state (this run only; a relaunch starts empty ->
-    # re-probes the head on first sight, so a fix applied while the worker was down is
-    # picked up immediately). ``_probe_at`` = clock() of the last DRIVE probe; ``_interval``
-    # = the current (backing-off) wait before the next probe. Absent = never probed this run.
-    config_blocked_probe_at: dict[str, float] = {}
-    config_blocked_probe_interval: dict[str, float] = {}
-
-    def _config_blocked_reprobe_due(head_id: object) -> bool:
-        """True if a latched config-blocked head is due for a re-probe drive (the block may
-        have cleared). Never probes when reprobe is disabled (interval <= 0). First sight this
-        run (no recorded probe) is always due, so a relaunch re-drives the head at once."""
-        if config_blocked_reprobe_seconds <= 0:
-            return False
-        last = config_blocked_probe_at.get(head_id)
-        if last is None:
-            return True
-        interval = config_blocked_probe_interval.get(head_id, config_blocked_reprobe_seconds)
-        return (clock() - last) >= interval
-
-    def _config_blocked_mark_parked(head_id: object) -> None:
-        """Record that a drive probe just re-confirmed the block: restart the wait clock and
-        widen the next interval (bounded) so a PERSISTENT block backs off instead of re-driving
-        (and, for a paid worker, re-spending) every interval forever."""
-        prev = config_blocked_probe_interval.get(head_id)
-        nxt = (config_blocked_reprobe_seconds if prev is None
-               else min(config_blocked_reprobe_max_seconds,
-                        prev * max(1.0, config_blocked_reprobe_backoff)))
-        config_blocked_probe_interval[head_id] = nxt
-        config_blocked_probe_at[head_id] = clock()
-
-    def _config_blocked_clear(head_id: object) -> None:
-        config_blocked_probe_at.pop(head_id, None)
-        config_blocked_probe_interval.pop(head_id, None)
-        config_blocked_ids.discard(head_id) if isinstance(head_id, str) else None
 
     def _park_config_blocked(record: dict, *, reason_code: str = "config_blocked") -> None:
         """Hold a deterministic local config denial (e.g. a held gateway, an exec-denied bus
-        write) at the head WITHOUT consuming it. Emits a distinct advisory HEALTH state so
-        status/doctor show the worker as blocked-on-a-message rather than a frozen 'idle' - the
-        health-freeze that hid this wedge (#58). The heartbeat still stamps (a blocked worker is
-        not dead), so the supervisor does NOT restart it; recovery is the bounded re-probe, not a
-        relaunch (a relaunch re-parked on the stale latch, the original wedge)."""
+        write) at the head WITHOUT consuming it. Emits a distinct advisory HEALTH state (via
+        ``on_health_parked``) so status/doctor show the worker as blocked-on-a-message rather
+        than a frozen 'idle' - the health-freeze that hid this wedge (#58). The heartbeat still
+        stamps (a blocked worker is not dead), so the supervisor does NOT restart it."""
         nonlocal last_hb, fail_sleep
         if on_health_parked is not None:
             try:
@@ -918,17 +874,10 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         store.reconcile_crash_in_progress(agent, head_id, at=now_iso())
         rec = store.attempt_record(agent, head_id) or {}
         if rec.get("last_failure_class") == CLASS_CONFIG_BLOCKED:
-            # A head latched config-blocked by a PRIOR poll/run. Do NOT trust that latch
-            # forever: when a re-probe is due, fall through to re-drive (the block may have
-            # cleared - operator un-held the gateway, fixed the config). If not due, park
-            # quietly (visible health + fresh heartbeat) until the next probe window.
-            if not _config_blocked_reprobe_due(head_id):
-                if isinstance(head_id, str):
-                    config_blocked_ids.add(head_id)
-                _park_config_blocked(record)
-                continue
-            # else: re-probe -> fall through to the drive path below (the `!= CONFIG_BLOCKED`
-            # cap guards keep it from being disposed while still latched config-blocked).
+            if isinstance(head_id, str):
+                config_blocked_ids.add(head_id)
+            _park_config_blocked(record)
+            continue
         # AUTO-DISPOSE WITHOUT DRIVE if a cap is already reached on entry (covers the
         # relaunch/crash-accumulation path - test #3).
         if rec.get("last_failure_class") != CLASS_CONFIG_BLOCKED:
@@ -1049,7 +998,6 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 continue
             store.clear_attempt(agent, head_id)
             store.gc_attempts_below(agent, store.cursor(agent))
-            _config_blocked_clear(head_id)              # a re-probe that succeeded: recovered
             last_hb = clock()                           # drive already stamped on success
             _maybe_refresh_capacity(last_hb)
             fail_sleep = idle_interval                  # reset failure backoff
@@ -1064,7 +1012,6 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         if outcome.failure_class == CLASS_CONFIG_BLOCKED:
             if isinstance(head_id, str):
                 config_blocked_ids.add(head_id)
-            _config_blocked_mark_parked(head_id)   # a drive re-confirmed it: back off the probe
             _park_config_blocked(record)
             continue
         if (k_poison > 0 and outcome.failure_class == CLASS_POISON

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -476,9 +476,10 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         stamps (a blocked worker is not dead), so the supervisor does NOT restart it."""
         nonlocal last_hb, fail_sleep
         if on_health_parked is not None:
+            # advisory health must never break loop progress
             try:
                 on_health_parked(record, reason_code)
-            except Exception:  # noqa: BLE001, S110 - advisory health must never break loop progress
+            except Exception:  # noqa: BLE001, S110  # nosec
                 pass
         _escalate_once(record, CLASS_CONFIG_BLOCKED, retry_unrouted=False)
         stamp()                          # keeps wrapper heartbeat and lead-loop lease fresh

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -215,6 +215,10 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
              manage_waiting: bool = True,
              cadence: Callable[[], CadenceResult] | None = None,
              on_health_idle: Callable[[], None] | None = None,
+             on_health_parked: Callable[[dict, str], None] | None = None,
+             config_blocked_reprobe_seconds: float = 120.0,
+             config_blocked_reprobe_backoff: float = 2.0,
+             config_blocked_reprobe_max_seconds: float = 1800.0,
              capacity_refresh: Callable[[], None] | None = None,
              capacity_interval_seconds: float = 60.0,
              wrapper_generation: str | None = None,
@@ -292,6 +296,10 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
             noninfra_sub_ceiling=noninfra_sub_ceiling,
             on_dead_letter=on_dead_letter, on_escalate=on_escalate, stamp=stamp,
             pre_commit=pre_commit, cadence=cadence, on_health_idle=on_health_idle,
+            on_health_parked=on_health_parked,
+            config_blocked_reprobe_seconds=config_blocked_reprobe_seconds,
+            config_blocked_reprobe_backoff=config_blocked_reprobe_backoff,
+            config_blocked_reprobe_max_seconds=config_blocked_reprobe_max_seconds,
             capacity_refresh=capacity_refresh,
             capacity_interval_seconds=capacity_interval_seconds,
             commit_gate=commit_gate,
@@ -316,6 +324,10 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     pre_commit: Callable[[], None] | None,
                     cadence: Callable[[], CadenceResult] | None,
                     on_health_idle: Callable[[], None] | None,
+                    on_health_parked: Callable[[dict, str], None] | None,
+                    config_blocked_reprobe_seconds: float,
+                    config_blocked_reprobe_backoff: float,
+                    config_blocked_reprobe_max_seconds: float,
                     capacity_refresh: Callable[[], None] | None,
                     capacity_interval_seconds: float,
                     commit_gate,
@@ -464,10 +476,54 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         store.mark_attempt_escalated(agent, record.get("id"), routed=routed)
 
     config_blocked_ids: set[str] = set()
+    # Per-head config-blocked RE-PROBE state (this run only; a relaunch starts empty ->
+    # re-probes the head on first sight, so a fix applied while the worker was down is
+    # picked up immediately). ``_probe_at`` = clock() of the last DRIVE probe; ``_interval``
+    # = the current (backing-off) wait before the next probe. Absent = never probed this run.
+    config_blocked_probe_at: dict[str, float] = {}
+    config_blocked_probe_interval: dict[str, float] = {}
 
-    def _park_config_blocked(record: dict) -> None:
-        """Keep a deterministic local config denial visible without consuming the head."""
+    def _config_blocked_reprobe_due(head_id: object) -> bool:
+        """True if a latched config-blocked head is due for a re-probe drive (the block may
+        have cleared). Never probes when reprobe is disabled (interval <= 0). First sight this
+        run (no recorded probe) is always due, so a relaunch re-drives the head at once."""
+        if config_blocked_reprobe_seconds <= 0:
+            return False
+        last = config_blocked_probe_at.get(head_id)
+        if last is None:
+            return True
+        interval = config_blocked_probe_interval.get(head_id, config_blocked_reprobe_seconds)
+        return (clock() - last) >= interval
+
+    def _config_blocked_mark_parked(head_id: object) -> None:
+        """Record that a drive probe just re-confirmed the block: restart the wait clock and
+        widen the next interval (bounded) so a PERSISTENT block backs off instead of re-driving
+        (and, for a paid worker, re-spending) every interval forever."""
+        prev = config_blocked_probe_interval.get(head_id)
+        nxt = (config_blocked_reprobe_seconds if prev is None
+               else min(config_blocked_reprobe_max_seconds,
+                        prev * max(1.0, config_blocked_reprobe_backoff)))
+        config_blocked_probe_interval[head_id] = nxt
+        config_blocked_probe_at[head_id] = clock()
+
+    def _config_blocked_clear(head_id: object) -> None:
+        config_blocked_probe_at.pop(head_id, None)
+        config_blocked_probe_interval.pop(head_id, None)
+        config_blocked_ids.discard(head_id) if isinstance(head_id, str) else None
+
+    def _park_config_blocked(record: dict, *, reason_code: str = "config_blocked") -> None:
+        """Hold a deterministic local config denial (e.g. a held gateway, an exec-denied bus
+        write) at the head WITHOUT consuming it. Emits a distinct advisory HEALTH state so
+        status/doctor show the worker as blocked-on-a-message rather than a frozen 'idle' - the
+        health-freeze that hid this wedge (#58). The heartbeat still stamps (a blocked worker is
+        not dead), so the supervisor does NOT restart it; recovery is the bounded re-probe, not a
+        relaunch (a relaunch re-parked on the stale latch, the original wedge)."""
         nonlocal last_hb, fail_sleep
+        if on_health_parked is not None:
+            try:
+                on_health_parked(record, reason_code)
+            except Exception:  # noqa: BLE001, S110 - advisory health must never break loop progress
+                pass
         _escalate_once(record, CLASS_CONFIG_BLOCKED, retry_unrouted=False)
         stamp()                          # keeps wrapper heartbeat and lead-loop lease fresh
         last_hb = clock()
@@ -862,10 +918,17 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         store.reconcile_crash_in_progress(agent, head_id, at=now_iso())
         rec = store.attempt_record(agent, head_id) or {}
         if rec.get("last_failure_class") == CLASS_CONFIG_BLOCKED:
-            if isinstance(head_id, str):
-                config_blocked_ids.add(head_id)
-            _park_config_blocked(record)
-            continue
+            # A head latched config-blocked by a PRIOR poll/run. Do NOT trust that latch
+            # forever: when a re-probe is due, fall through to re-drive (the block may have
+            # cleared - operator un-held the gateway, fixed the config). If not due, park
+            # quietly (visible health + fresh heartbeat) until the next probe window.
+            if not _config_blocked_reprobe_due(head_id):
+                if isinstance(head_id, str):
+                    config_blocked_ids.add(head_id)
+                _park_config_blocked(record)
+                continue
+            # else: re-probe -> fall through to the drive path below (the `!= CONFIG_BLOCKED`
+            # cap guards keep it from being disposed while still latched config-blocked).
         # AUTO-DISPOSE WITHOUT DRIVE if a cap is already reached on entry (covers the
         # relaunch/crash-accumulation path - test #3).
         if rec.get("last_failure_class") != CLASS_CONFIG_BLOCKED:
@@ -986,6 +1049,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 continue
             store.clear_attempt(agent, head_id)
             store.gc_attempts_below(agent, store.cursor(agent))
+            _config_blocked_clear(head_id)              # a re-probe that succeeded: recovered
             last_hb = clock()                           # drive already stamped on success
             _maybe_refresh_capacity(last_hb)
             fail_sleep = idle_interval                  # reset failure backoff
@@ -1000,6 +1064,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         if outcome.failure_class == CLASS_CONFIG_BLOCKED:
             if isinstance(head_id, str):
                 config_blocked_ids.add(head_id)
+            _config_blocked_mark_parked(head_id)   # a drive re-confirmed it: back off the probe
             _park_config_blocked(record)
             continue
         if (k_poison > 0 and outcome.failure_class == CLASS_POISON

--- a/tests/test_wrapper_health.py
+++ b/tests/test_wrapper_health.py
@@ -352,6 +352,29 @@ def test_health_failure_and_degraded_mappings(tmp_path: Path) -> None:
     assert _health_state(s) == hm.STATE_DEGRADED_OUTPUT
 
 
+def test_health_writer_parked_surfaces_blocked_state_with_resolved_request_id(
+    tmp_path: Path,
+) -> None:
+    # #58: a config-blocked PARK must write a distinct, visible state (not leave a frozen
+    # 'idle'), carrying the parked head's ids. request_id is resolved from meta (the real bus
+    # shape, #17) - not read bare top-level where it is absent.
+    from agenttalk.wrapper.health import WrapperHealthWriter
+
+    s = _store(tmp_path)
+    w = WrapperHealthWriter(s, "beta", "claude", mode="wrapper-loop")
+    w.idle()                                        # start from idle_waiting
+    assert w.state == hm.STATE_IDLE_WAITING
+    w.parked({"id": "20990101-000000-000000-HEAL", "meta": {"request_id": "q-held-7"}})
+
+    assert w.state == hm.STATE_ERRORED_AMBIGUOUS    # no longer masquerading as idle
+    view = s.read_health("beta", ttl_seconds=999999)
+    assert view["state"] == hm.STATE_ERRORED_AMBIGUOUS
+    assert view["reason_code"] == "config_blocked"
+    raw = s.read_health_raw("beta")
+    assert raw["request_id"] == "q-held-7"          # resolved from meta, not a frozen None
+    assert raw["msg_id"] == "20990101-000000-000000-HEAL"
+
+
 def test_health_json_never_contains_message_or_output_content(tmp_path: Path) -> None:
     s = _store(tmp_path)
     secret = "SECRET_HEALTH_LEAK_74f78b"  # gitleaks:allow

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -412,6 +412,89 @@ def test_loop_idle_stamps_heartbeat(tmp_path) -> None:
     assert s.read_heartbeat("beta") is not None   # idle kept the heartbeat fresh
 
 
+# ------------------------------------------- #58: config-blocked park visibility + re-probe
+
+def _config_blocked_drive():
+    return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_CONFIG_BLOCKED,
+                             summary="ovh-qwen gateway is held (ledger_not_ready)")
+
+
+def test_config_blocked_head_parks_with_visible_health_not_frozen_idle(tmp_path) -> None:
+    # #58 part A: a config-blocked head is HELD (never consumed), but the park must surface a
+    # distinct health signal on EVERY park cycle (not a frozen 'idle') so status/doctor show
+    # the block. The heartbeat still stamps; the cursor never advances.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _config_blocked_drive()
+
+    parked: list[tuple] = []
+    idled = {"n": 0}
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=4, k_poison=0, k_escalate=0,
+        on_health_idle=lambda: idled.__setitem__("n", idled["n"] + 1),
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    # driven exactly ONCE (poll 1); later polls auto-park on the latched class without driving
+    # (constant clock -> re-probe never due).
+    assert drives["n"] == 1
+    assert len(parked) >= 2                              # visible on every park, not silent-once
+    assert all(pid == m.id and reason == "config_blocked" for pid, reason in parked)
+    assert idled["n"] == 1                               # only the one-time startup idle; parks never re-idle
+    assert s.read_heartbeat("beta") is not None          # heartbeat stays fresh (not dead)
+    assert s.cursor("beta") == ""                        # head still parked, never committed
+
+
+def test_config_blocked_head_reprobes_and_recovers_when_block_clears(tmp_path) -> None:
+    # #58 part B: the loop must not trust the latched config-blocked class forever. After the
+    # re-probe interval it re-drives; when the block has cleared the head is handled + committed.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    t = {"now": 0.0}
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        if drives["n"] == 1:
+            return _config_blocked_drive()               # blocked on first attempt
+        return True                                      # block cleared -> success
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: t["now"],
+        sleep=lambda d: t.__setitem__("now", t["now"] + max(d, 0.1)),
+        max_turns=1, max_polls=50, k_poison=0, k_escalate=0,
+        config_blocked_reprobe_seconds=1.0,
+    )
+    assert turns == 1
+    assert drives["n"] == 2                              # parked, then re-probed successfully
+    assert s.cursor("beta") == m.id                      # recovered -> committed, no manual reset
+
+
+def test_config_blocked_reprobe_can_be_disabled_and_parks_without_redriving(tmp_path) -> None:
+    # The re-probe is a knob: reprobe_seconds<=0 preserves the pure park-until-fixed behavior
+    # (no re-drive, so no re-spend), even across large time jumps.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+    t = {"now": 0.0}
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _config_blocked_drive()
+
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: t["now"],
+        sleep=lambda d: t.__setitem__("now", t["now"] + 100.0),   # huge jumps between polls
+        max_polls=6, k_poison=0, k_escalate=0,
+        config_blocked_reprobe_seconds=0.0,                       # disabled
+    )
+    assert drives["n"] == 1                              # never re-driven despite the time jumps
+
+
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -449,52 +449,6 @@ def test_config_blocked_head_parks_with_visible_health_not_frozen_idle(tmp_path)
     assert s.cursor("beta") == ""                        # head still parked, never committed
 
 
-def test_config_blocked_head_reprobes_and_recovers_when_block_clears(tmp_path) -> None:
-    # #58 part B: the loop must not trust the latched config-blocked class forever. After the
-    # re-probe interval it re-drives; when the block has cleared the head is handled + committed.
-    s = _store(tmp_path)
-    m = s.send(sender="alpha", recipient="beta", body="task")
-    t = {"now": 0.0}
-    drives = {"n": 0}
-
-    def drive(rec):
-        drives["n"] += 1
-        if drives["n"] == 1:
-            return _config_blocked_drive()               # blocked on first attempt
-        return True                                      # block cleared -> success
-
-    turns = loop.run_loop(
-        s, "beta", drive, clock=lambda: t["now"],
-        sleep=lambda d: t.__setitem__("now", t["now"] + max(d, 0.1)),
-        max_turns=1, max_polls=50, k_poison=0, k_escalate=0,
-        config_blocked_reprobe_seconds=1.0,
-    )
-    assert turns == 1
-    assert drives["n"] == 2                              # parked, then re-probed successfully
-    assert s.cursor("beta") == m.id                      # recovered -> committed, no manual reset
-
-
-def test_config_blocked_reprobe_can_be_disabled_and_parks_without_redriving(tmp_path) -> None:
-    # The re-probe is a knob: reprobe_seconds<=0 preserves the pure park-until-fixed behavior
-    # (no re-drive, so no re-spend), even across large time jumps.
-    s = _store(tmp_path)
-    s.send(sender="alpha", recipient="beta", body="task")
-    t = {"now": 0.0}
-    drives = {"n": 0}
-
-    def drive(rec):
-        drives["n"] += 1
-        return _config_blocked_drive()
-
-    loop.run_loop(
-        s, "beta", drive, clock=lambda: t["now"],
-        sleep=lambda d: t.__setitem__("now", t["now"] + 100.0),   # huge jumps between polls
-        max_polls=6, k_poison=0, k_escalate=0,
-        config_blocked_reprobe_seconds=0.0,                       # disabled
-    )
-    assert drives["n"] == 1                              # never re-driven despite the time jumps
-
-
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:


### PR DESCRIPTION
## #58 (Part A — observability) — the wrapped-worker wedge is now VISIBLE

A wrapped worker whose inbox head latched `last_failure_class == config_blocked` (a held gateway, or a prior exec-denied bus write) parked the head every poll while stamping the heartbeat and **never updating health.json** — so `status`/`doctor` showed a frozen prior state (usually "idle"). The block, and the starved mail behind it, were invisible. This cost hours of blind firefighting in the Qwen trial.

**Fix (this PR):** new `on_health_parked` hook; `_park_config_blocked` now emits a distinct advisory state (`errored_ambiguous` / `reason=config_blocked`) carrying the parked head's ids on every park cycle, so the block is legible instead of masquerading as idle. `request_id` resolved from `meta` via `correlation.resolve_request_id` (real bus shape — also advances #17's health.py read site). No dispose/drive-contract change, no model spend.

**Scope note:** an earlier cut also added a bounded re-probe for *auto-recovery* (Part B). A cross-model (Fable-5) adversarial review found a **confirmed blocker** in it — re-probes inflated `attempts_started`/`ambiguous_failures`, so after a long hold a crash-reconcile or a transient flake could `_dispose` the very config-blocked head it was meant to preserve — so Part B was reverted (commit 25df308) and deferred to a follow-up to be done right (dedicated non-disposing config_blocked counter + config-blocked-dominant carve-out + latch-preserve on crash + CLI knob wiring + total re-probe bound). This PR is the safe, contract-preserving observability half, which is the task-title fix ("health-freeze hides it").

**Verification.** Fixture Store + injected clock, no model spend. 1 loop test (visible-not-frozen park; never commits) + 1 health-writer test (parked state + meta-resolved request_id). `test_wrapper_loop` + `test_wrapper_health` = 125 green, ruff clean.

Partial #58 (observability). Re-probe recovery tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
