### PR TITLE
fix(#63): refuse to mint a child turn while the gateway is held

### DIFF
--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -1162,6 +1162,19 @@ class SpendLedger:
                     raise ChildTurnCapBlocked("child turn issuer credential is invalid")
                 self._validate_child_cap_clock(conn, current)
                 self._validate_clock(metadata, current)
+                # Refuse to MINT a turn while transport is held (durable accounting hold, or
+                # an unresolved prior attempt) - mirrors the reserve-side gate in
+                # _reserve_locked. Otherwise a turn opened under a hold starts its wall-time
+                # ceiling immediately and burns the whole budget while blocked, so it is
+                # already (near-)expired the instant the hold clears (#63: the held-gateway
+                # child turn that expired mid-work, surfacing as a misleading config_blocked).
+                # A held mint raises LedgerHold (a GatewayError) which the wrapper spawner
+                # treats as a transient park, and the next drive after the hold clears mints a
+                # fresh turn with a full wall-time window.
+                if metadata.get("service_hold"):
+                    raise LedgerHold("gateway has a durable accounting hold")
+                if self._unresolved(conn):
+                    raise LedgerHold("an unresolved provider attempt blocks new transport")
                 row = conn.execute(
                     "SELECT * FROM child_turns WHERE agent=? AND message_id=?",
                     (agent, message_id),

--- a/src/agenttalk/ovh_gateway.py
+++ b/src/agenttalk/ovh_gateway.py
@@ -1168,9 +1168,12 @@ class SpendLedger:
                 # ceiling immediately and burns the whole budget while blocked, so it is
                 # already (near-)expired the instant the hold clears (#63: the held-gateway
                 # child turn that expired mid-work, surfacing as a misleading config_blocked).
-                # A held mint raises LedgerHold (a GatewayError) which the wrapper spawner
-                # treats as a transient park, and the next drive after the hold clears mints a
-                # fresh turn with a full wall-time window.
+                # A held mint raises LedgerHold (a GatewayError) -> the wrapper spawner treats it
+                # as a blocked turn, so NO doomed turn is opened and no wall-time is wasted.
+                # (The LEDGER permits a fresh full-window mint once the hold clears. The wrapper
+                # currently maps this to config_blocked and parks the head WITHOUT re-driving, so
+                # recovery after the hold clears is not yet automatic - #62 makes a transient
+                # gateway hold retry-through (INFRA) so the parked head self-heals on clear.)
                 if metadata.get("service_hold"):
                     raise LedgerHold("gateway has a durable accounting hold")
                 if self._unresolved(conn):

--- a/tests/test_ovh_gateway.py
+++ b/tests/test_ovh_gateway.py
@@ -329,6 +329,54 @@ def test_child_turn_call_cap_is_durable_and_fail_closed(tmp_path) -> None:
     assert all(row["attempt_id"] != "f" * 32 for row in status["unresolved"])
 
 
+def test_child_turn_mint_is_refused_while_held_and_gets_a_full_window_after_clear(
+    tmp_path,
+) -> None:
+    # #63: a child turn opened UNDER a hold burns its 300s wall-time ceiling while the
+    # gateway cannot spend, so it is (near-)expired the instant the hold clears (the live
+    # incident: a held-gateway turn that expired mid-work and surfaced as a misleading
+    # config_blocked "budget exhausted"). Mint must refuse while held (no doomed turn),
+    # and mint fresh with a FULL window measured from now once the hold clears.
+    clock = Clock(datetime(2026, 7, 15, 12, tzinfo=timezone.utc))
+    ledger = make_ledger(tmp_path, clock)
+    ledger.place_hold(reason="operator hold between paid tests")
+
+    with pytest.raises(LedgerHold, match="durable accounting hold"):
+        ledger.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="20260715-120000-000000-held",
+            request_id="q-held",
+            issuer_token=TEST_CHILD_CAP_ISSUER,
+        )
+    assert ledger.status()["active_child_turns"] == []  # no doomed turn opened while held
+
+    ledger.clear_hold(reason="operator resumed paid work")
+    clock.value = datetime(2026, 7, 15, 12, 5, tzinfo=timezone.utc)  # 5 min elapsed under hold
+    credential = ledger.open_child_turn(
+        agent="qwen-dev-1",
+        message_id="20260715-120000-000000-held",
+        request_id="q-held",
+        issuer_token=TEST_CHILD_CAP_ISSUER,
+    )
+    # Full 300s window from 12:05 (the clear), NOT a stale window that started at 12:00.
+    assert credential.expires_at == "2026-07-15T12:10:00.000000Z"
+
+
+def test_child_turn_mint_is_refused_while_a_prior_attempt_is_unresolved(tmp_path) -> None:
+    # #63: an unresolved prior attempt is a transport hold too - minting under it would open
+    # a turn that only wastes wall-time until reserve fails. Refuse at mint, matching reserve.
+    ledger = make_ledger(tmp_path)
+    ledger.reserve("1" * 32)  # reserved-but-unsettled -> unresolved
+    with pytest.raises(LedgerHold, match="unresolved"):
+        ledger.open_child_turn(
+            agent="qwen-dev-1",
+            message_id="20260715-120000-000000-unresolved",
+            request_id="q-unresolved",
+            issuer_token=TEST_CHILD_CAP_ISSUER,
+        )
+    assert ledger.status()["active_child_turns"] == []
+
+
 def test_child_turn_mint_requires_non_inherited_controller_issuer(tmp_path) -> None:
     ledger = make_ledger(tmp_path)
     untrusted_child = SpendLedger(ledger.db_path, ledger.marker_path, now=ledger.now)


### PR DESCRIPTION
## #63 — held-gateway child turns burn their wall-time and fail-closed misleadingly

**Ground truth (from `ledger.sqlite3`, the live incident):** a `qwen-dev-1` child turn opened `13:46:44` while the gateway was HELD, wall-time expiry `13:51:44`. The hold cleared `13:51:37`; the turn made exactly **one** call (settled, €0.029 — a review generated fine) in the ~2s of TTL remaining, then the next call (the reply) hit `child turn wall-time ceiling exceeded` → 403, which the wrapped worker surfaced as a misleading `config_blocked: "OVH child turn budget exhausted"` and parked on.

**Root cause:** `open_child_turn` (mint) fetches `metadata` but never checks the hold — so a turn minted under a hold starts its 300s wall clock immediately and burns it all while blocked. `_reserve_locked` (the per-call path) *does* gate on `service_hold` + unresolved attempts; mint didn't.

**Fix:** `open_child_turn` mirrors that gate — refuse to mint while `service_hold` is set or an unresolved attempt blocks transport, raising `LedgerHold`. `LedgerHold` is a `GatewayError`, which the wrapper spawner (`run.py:1901`) already treats as a transient park — so **behavior under hold is unchanged** except that no doomed turn is opened, and the next drive after the hold clears mints a fresh turn with a full wall-time window.

**Verification.** `LedgerHold` at mint (no turn row created) + a full 300s window measured from the clear (not a stale open-during-hold timestamp); mint refused while a prior attempt is unresolved. Targeted `test_ovh_gateway` suite green, ruff clean.

**Review focus (cross-model welcome):** correctness of gating mint on `service_hold` + `_unresolved` (does refusing to mint break any legitimate under-hold flow? the only prod caller is `run.py:1893`, which maps `GatewayError` → park); and whether the wall-clock-from-mint semantics have other pathological interactions.

**Deliberately NOT in this PR (follow-ups, same #63):** (1) 13 turns stuck `state='open'`, never reaped to terminal — hygiene/accounting clutter; does NOT block new per-`(agent,message_id)` turns. (2) wall-time/cap expiry classified `config_blocked` rather than retryable-transient, so the wrapped loop sticky-parks instead of retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update (post cross-model review):** Fable-5 confirmed the ledger fix is correct, minimal, transactionally clean, and genuinely prevents the doomed mint (both new tests fail on master). It correctly flagged that the original "self-heals after the hold clears" claim was **false**: a mint-time `LedgerHold` routes through the wrapper as `config_blocked`, which sticky-parks the head without re-driving (the #58/#62 behavior). Comment + this description corrected. Recovery-after-clear is folded into **#62** (reclassify a transient gateway hold as retry-through `INFRA`). This PR remains the safe, strictly-better fix: no doomed turn, no wasted wall-time/spend, fails safe + visible. Residuals noted for #62: mid-turn holds still burn wall-time; global `_unresolved` at mint can false-park a 2nd agent (benign single-agent).
