### PR TITLE
fix(#62): transient gateway hold retries-through so a held worker self-heals

### DIFF
--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -59,7 +59,19 @@ _BENIGN_PIPE_TEARDOWN_ERRNOS = {errno.EINVAL, errno.EPIPE}
 
 
 class _GatewayChildCapUnavailable(RuntimeError):
-    """The wrapper could not durably issue a scoped paid-child credential."""
+    """The wrapper could not durably issue a scoped paid-child credential.
+
+    ``transient`` marks an operator-resolvable gateway HOLD (a durable accounting
+    hold, an unresolved prior attempt, or a clock rollback needing reconciliation -
+    i.e. any ``LedgerHold``) as opposed to a durable local/config denial. A transient
+    hold is classified INFRA (retry-through, never dead-lettered) so a worker blocked
+    only because the gateway is held self-heals when the hold clears, instead of
+    sticky-parking as config_blocked forever (#62). A NON-transient cause (missing
+    message id, ChildTurnCapExceeded, a local exec denial) stays config_blocked."""
+
+    def __init__(self, message: str, *, transient: bool = False) -> None:
+        super().__init__(message)
+        self.transient = transient
 
 # Legacy infra-like text markers. These are low-confidence hints only; they deliberately
 # no longer classify known_global_infra without a structured CLI status/rate-limit fact.
@@ -1594,12 +1606,26 @@ def _classify_drive_failure(
         CLASS_POISON,
     )
 
+    # A TRANSIENT, operator-resolvable gateway hold surfaced at mint time (#62): classify
+    # INFRA (retry-through, never dead-lettered) so the worker self-heals when the hold
+    # clears. Deterministic explicit signal - checked before any text heuristics.
+    if sig.get("gateway_transient_hold"):
+        return CLASS_INFRA, "OVH gateway is temporarily held; retrying until it clears"
+
     if backend_profile == "ovh-qwen":
         text = _ovh_qwen_failure_text(sig)
+        # A per-message child-turn cap (calls/cost/wall-time) is PERMANENT for that message
+        # - a capped/expired turn can never re-mint - so it must stay config_blocked (park),
+        # NOT retry (an INFRA classification would spin forever, never dead-lettering).
         if "atgw_child_turn_cap_exceeded" in text:
             return CLASS_CONFIG_BLOCKED, "OVH child turn budget exhausted"
-        if "atgw_policy_blocked" in text or "atgw_ledger_blocked" in text:
-            return CLASS_CONFIG_BLOCKED, "OVH trial policy or accounting hold"
+        # A ledger HOLD (503 ATGW_LEDGER_BLOCKED = held/unresolved) is TRANSIENT and clears
+        # on operator action -> retry-through (INFRA) so a mid-turn hold self-heals (#62).
+        # A policy block (trial cutoff / model mismatch) is terminal -> stays config_blocked.
+        if "atgw_ledger_blocked" in text:
+            return CLASS_INFRA, "OVH gateway transport is temporarily held"
+        if "atgw_policy_blocked" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH trial policy hold"
         if "atgw_config_error" in text or "status code: 422" in text or "http 422" in text:
             return CLASS_CONFIG_BLOCKED, "OVH gateway route or configuration error"
         infra_markers = (
@@ -1883,7 +1909,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             # Same for a disabled/invalid work_heartbeat config.
             gateway_capability = None
             if backend_profile == "ovh-qwen":
-                from agenttalk.ovh_gateway import GatewayError, SpendLedger
+                from agenttalk.ovh_gateway import GatewayError, LedgerHold, SpendLedger
 
                 if not active_message_id:
                     raise _GatewayChildCapUnavailable(
@@ -1898,6 +1924,18 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             (profile_env or {}).get("ANTHROPIC_AUTH_TOKEN") or ""
                         ),
                     ).token
+                except LedgerHold as exc:
+                    # A held/unresolved/clock-rollback gateway: TRANSIENT + operator-
+                    # resolvable. Mark it so the turn classifies INFRA (retry-through) and
+                    # the worker self-heals when the hold clears, instead of parking as
+                    # config_blocked forever (#62). ChildTurnCapExceeded is deliberately a
+                    # LedgerBlocked (not LedgerHold), so a permanently-capped message never
+                    # takes this path and never spins.
+                    raise _GatewayChildCapUnavailable(
+                        "durable child turn capability unavailable: "
+                        f"{type(exc).__name__}",
+                        transient=True,
+                    ) from exc
                 except (GatewayError, OSError, ValueError) as exc:
                     raise _GatewayChildCapUnavailable(
                         "durable child turn capability unavailable: "
@@ -2046,9 +2084,18 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         except _GatewayChildCapUnavailable as e:
             _capture_child_output("stderr", f"{type(e).__name__}: {e}")
             _finalize_child_output()
-            sig["config_blocked"] = True
-            sig["config_blocked_text"] = str(e)
-            sig["error"] = str(e)
+            if e.transient:
+                # Transient, operator-resolvable gateway hold: classify INFRA (retry-
+                # through, never dead-lettered) so the worker resumes when the hold
+                # clears rather than sticky-parking as config_blocked (#62). No child
+                # spawned, no spend - the retry is cheap.
+                sig["gateway_transient_hold"] = True
+                sig["retryable"] = True
+                sig["error"] = str(e)
+            else:
+                sig["config_blocked"] = True
+                sig["config_blocked_text"] = str(e)
+                sig["error"] = str(e)
             return sig
         except OSError as e:
             _capture_child_output("stderr", f"{type(e).__name__}: {e}")

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -327,14 +327,50 @@ def test_ovh_qwen_profile_refuses_a_path_resolving_outside_workspace(
         )
 
 
-@pytest.mark.parametrize("code", ["ATGW_POLICY_BLOCKED", "ATGW_LEDGER_BLOCKED"])
-def test_ovh_policy_and_ledger_blocks_are_terminal_non_poison(code) -> None:
+def test_ovh_policy_block_is_terminal_config_blocked() -> None:
+    # A trial-cutoff / model-mismatch policy block is TERMINAL (won't clear by retry).
     classification, summary = run._classify_drive_failure(
-        {"terminal": True, "terminal_text": f'API Error: 503 {{"type":"{code}"}}'},
+        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_POLICY_BLOCKED"}'},
         backend_profile="ovh-qwen",
     )
     assert classification == CLASS_CONFIG_BLOCKED
     assert "hold" in summary
+
+
+def test_ovh_ledger_block_is_transient_infra_retry_through() -> None:
+    # #62: a 503 ATGW_LEDGER_BLOCKED is a held/unresolved gateway - TRANSIENT and operator-
+    # resolvable. It must classify INFRA (retry-through, never dead-lettered) so a hold
+    # applied mid-turn self-heals when it clears, NOT config_blocked (which sticky-parks).
+    # (This deliberately reverses the prior "ledger block is terminal" assumption - the bug.)
+    classification, summary = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_LEDGER_BLOCKED"}'},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_INFRA
+    assert "held" in summary
+
+
+def test_gateway_transient_hold_signal_classifies_infra() -> None:
+    # #62: a mint-time LedgerHold (gateway held / unresolved / clock-rollback) is surfaced by
+    # the spawner as an explicit gateway_transient_hold signal -> INFRA (retry-through), so a
+    # worker blocked only because the gateway is held resumes when the hold clears.
+    classification, summary = run._classify_drive_failure(
+        {"gateway_transient_hold": True, "error": "durable child turn capability unavailable: LedgerHold"},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_INFRA
+    assert "held" in summary
+    # deterministic regardless of backend
+    other, _ = run._classify_drive_failure(
+        {"gateway_transient_hold": True}, backend_profile=None,
+    )
+    assert other == CLASS_INFRA
+
+
+def test_gateway_cap_unavailable_carries_transient_flag() -> None:
+    # The exception distinguishes a transient hold from a durable local denial.
+    assert run._GatewayChildCapUnavailable("x", transient=True).transient is True
+    assert run._GatewayChildCapUnavailable("x").transient is False
 
 
 def test_ovh_child_turn_cap_is_terminal_config_blocked() -> None:


### PR DESCRIPTION
## #62 — a held gateway now self-heals instead of sticky-parking

The last piece of the Qwen-reliability arc (after #58 made the wedge visible, #63 stopped the doomed held-mint).

**The gap:** after #63, a held gateway cleanly *refuses* to mint a child turn (`LedgerHold`) — but the wrapper classified that refusal as `config_blocked`, which **sticky-parks the inbox head and never re-drives, even after the operator clears the hold.** So a worker blocked only because the gateway was temporarily held stayed parked until a manual reset. This was Fable's finding on #70 (I'd wrongly claimed #63 auto-recovered).

**Fix:** a held / unresolved / clock-rollback gateway state is **transient and operator-resolvable**, so classify it **INFRA** (retry-through under backoff, never dead-lettered) — the worker resumes automatically the instant the hold clears. Two coordinated paths, both required (fixing only one still sticky-parks via the other):

1. **Mint-time:** `_GatewayChildCapUnavailable` carries a `transient` flag, set iff the underlying error is a `LedgerHold` (type-based — `ChildTurnCapExceeded` is a `LedgerBlocked`, **not** a `LedgerHold`, so a permanently-capped message never takes this path). The spawner emits an explicit `gateway_transient_hold` signal → `_classify_drive_failure` → `CLASS_INFRA`. No child spawned, no spend — the retry is cheap and pre-model.
2. **Mid-turn:** a 503 `ATGW_LEDGER_BLOCKED` now classifies INFRA instead of config_blocked. This deliberately reverses the prior "ledger block is terminal" test assumption — **that assumption *was* the sticky-park bug.**

**The trap I did NOT trip:** a per-message child-turn cap (calls/cost/**wall-time**, `ATGW_CHILD_TURN_CAP_EXCEEDED`) stays `config_blocked` — a capped/expired turn can never re-mint the same `message_id`, so retrying it would spin forever and never dead-letter. Policy block (trial cutoff / model mismatch) also stays terminal.

**Verification.** 293 gateway+wrapper tests green, ruff + bandit clean. New/updated tests: `gateway_transient_hold` → INFRA (backend-agnostic); `ATGW_LEDGER_BLOCKED` → INFRA (updated the test that encoded the old terminal assumption); cap + policy still config_blocked; exception carries the flag.

**Review focus (cross-model welcome):** the `isinstance(exc, LedgerHold)` discriminator (does it correctly exclude every permanent-cap case?); whether reclassifying `ATGW_LEDGER_BLOCKED` as retryable can spin on a *non-self-clearing* LedgerBlocked (e.g. DB-open contention vs corruption); and the INFRA retry/escalate/never-DL semantics for an overnight hold.

**Deliberately deferred (documented):** the general `config_blocked` re-probe (a genuine local exec-denial later fixed) — a genuine local denial needs a human fix, so escalate+park is appropriate. This PR closes the high-value case: the hold.

Closes #62 (hold self-heal). Residuals (reap stuck-open turns; mid-turn-hold wall-clock; multi-agent `_unresolved` false-park) remain tracked notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
