### PR TITLE
fix(#62): transient gateway hold = re-driving park (self-heals, never dead-lettered)

### DIFF
--- a/src/agenttalk/wrapper/health.py
+++ b/src/agenttalk/wrapper/health.py
@@ -9,7 +9,13 @@ from agenttalk import health as health_model
 from agenttalk.correlation import resolve_request_id
 
 from .events import Event, EventType
-from .loop import CLASS_AMBIGUOUS, CLASS_CONFIG_BLOCKED, CLASS_INFRA, CLASS_POISON
+from .loop import (
+    CLASS_AMBIGUOUS,
+    CLASS_CONFIG_BLOCKED,
+    CLASS_GATEWAY_HELD,
+    CLASS_INFRA,
+    CLASS_POISON,
+)
 
 
 class WrapperHealthWriter:
@@ -184,6 +190,12 @@ def classify_failure(sig: dict[str, Any], failure_class: str | None) -> tuple[st
         return health_model.STATE_STUCK_SUSPECTED, "turn_watchdog_fired"
     if failure_class == CLASS_CONFIG_BLOCKED:
         return health_model.STATE_ERRORED_AMBIGUOUS, _setup_failure_reason(sig) or "config_blocked"
+    if failure_class == CLASS_GATEWAY_HELD:
+        # Transient, operator-resolvable gateway hold (#62): honestly an outage-like, retryable
+        # wait - NOT an error and NOT idle. Distinct reason_code so status/doctor show a worker
+        # blocked-on-a-held-gateway (that will self-heal on clear), not a frozen or dead one.
+        # Checked before the sig["error"] branch below, which the hold also sets.
+        return health_model.STATE_RATE_LIMITED_OR_OUTAGE, "gateway_held"
     if sig.get("error"):
         return health_model.STATE_RATE_LIMITED_OR_OUTAGE, "spawn_exec_error"
     rc = sig.get("rc")

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -34,6 +34,14 @@ CLASS_INFRA = "known_global_infra"
 CLASS_AMBIGUOUS = "ambiguous_or_unknown"
 CLASS_CONFIG_BLOCKED = "config_blocked"
 CLASS_INFRA_RETRY_EXHAUSTED = "infra_retry_exhausted"
+# A TRANSIENT, operator-resolvable gateway HOLD surfaced at mint time (a held/unresolved
+# OVH ledger, a clock rollback awaiting reconcile - any LedgerHold): no child spawned, no
+# spend. Distinct from CONFIG_BLOCKED (a DURABLE local denial that sticky-parks and never
+# re-drives) and from INFRA (which dead-letters at the infra-exhaustion backstop and withholds
+# the heartbeat). A held head is parked WITHOUT persisting an attempt (no counter climbs -> no
+# ceiling trips -> NEVER dead-lettered) yet re-drives every poll, so the worker self-heals the
+# instant the operator clears the hold. See _hold_park + the failed-turn branch below (#62).
+CLASS_GATEWAY_HELD = "gateway_held"
 
 
 @dataclass(frozen=True)
@@ -483,6 +491,33 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 pass
         _escalate_once(record, CLASS_CONFIG_BLOCKED, retry_unrouted=False)
         stamp()                          # keeps wrapper heartbeat and lead-loop lease fresh
+        last_hb = clock()
+        sleep(fail_sleep)
+        fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+
+    def _hold_park(record: dict) -> None:
+        """Blocked-but-alive RE-DRIVING park for a TRANSIENT gateway HOLD (CLASS_GATEWAY_HELD,
+        #62): the mint refused because the gateway is held/unresolved - NO child spawned, NO
+        spend. CLEAR the write-ahead attempt (drive() already stamped it via record_attempt_start)
+        so NO failure counter climbs and attempts_started never reaches a ceiling -> the held head
+        is NEVER dead-lettered (operator ruling: park a held message indefinitely). The head is
+        left UNCOMMITTED, so the next poll re-drives it and it self-heals the instant the hold
+        clears. Distinct from _park_config_blocked, which persists last_failure_class=config_blocked
+        and thereby sticky-latches at the entry re-park (never re-driving). The heartbeat is
+        re-stamped (drive() cleared it on the failed turn) so a held worker reads as blocked, not
+        dead -> the supervisor does NOT restart it (no restart-storm under a long hold). Health is
+        surfaced by drive()'s health_writer.failure (STATE_RATE_LIMITED_OR_OUTAGE + 'gateway_held'),
+        so this park does not also write health (avoiding a state flip-flop).
+
+        TRADE-OFF (bounded, fail-safe): clearing the attempt also forgets any PRIOR genuine
+        failures on this head, so a message that is BOTH intermittently-held AND poison has its
+        poison run reset each hold. This only slows convergence for that pathological input and
+        errs toward retrying (never toward a wrongful dead-letter). It is unavoidable: preserving
+        history via record_attempt_result would let the write-ahead attempts_started climb into the
+        K_escalate dispose, dead-lettering the held head - exactly what park-indefinitely forbids."""
+        nonlocal last_hb, fail_sleep
+        store.clear_attempt(agent, record.get("id"))
+        stamp()                          # blocked != dead: keep heartbeat + lead-loop lease fresh
         last_hb = clock()
         sleep(fail_sleep)
         fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
@@ -1006,7 +1041,17 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             if max_turns is not None and turns >= max_turns:
                 return turns
             continue
-        # FAILED turn: record the classified failure (clears in_progress), then decide.
+        # FAILED turn.
+        if outcome.failure_class == CLASS_GATEWAY_HELD:
+            # TRANSIENT, operator-resolvable gateway hold at mint time (#62): do NOT persist an
+            # attempt result. A "blocked-but-alive re-driving park" - clears the write-ahead
+            # attempt (no counter climbs -> never dead-lettered), keeps the heartbeat fresh, and
+            # leaves the head UNCOMMITTED so it re-drives next poll and self-heals when the hold
+            # clears. Must precede record_attempt_result so gateway_held is never written to the
+            # ledger (and so it can never reach a dispose ceiling). See _hold_park.
+            _hold_park(record)
+            continue
+        # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,
                                     summary=outcome.summary, at=now_iso())
         rec = store.attempt_record(agent, head_id) or {}

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -475,6 +475,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         store.mark_attempt_escalated(agent, record.get("id"), routed=routed)
 
     config_blocked_ids: set[str] = set()
+    gateway_held_escalated: set[str] = set()
 
     def _park_config_blocked(record: dict, *, reason_code: str = "config_blocked") -> None:
         """Hold a deterministic local config denial (e.g. a held gateway, an exec-denied bus
@@ -509,14 +510,31 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         surfaced by drive()'s health_writer.failure (STATE_RATE_LIMITED_OR_OUTAGE + 'gateway_held'),
         so this park does not also write health (avoiding a state flip-flop).
 
+        Escalate ONCE per head on first entering the held state: an operator-placed hold is
+        expected (park indefinitely, ruling), but a LedgerHold can also be AUTONOMOUS (an
+        unresolved provider attempt, a clock anomaly) that the operator never heard about - a
+        silent indefinite fleet stall. The one-shot routed notice restores the signal master
+        emitted via config_blocked, without a per-poll storm. The dedup lives in the loop
+        (gateway_held_escalated), NOT the attempt record, which clear_attempt wipes every poll.
+
         TRADE-OFF (bounded, fail-safe): clearing the attempt also forgets any PRIOR genuine
         failures on this head, so a message that is BOTH intermittently-held AND poison has its
-        poison run reset each hold. This only slows convergence for that pathological input and
-        errs toward retrying (never toward a wrongful dead-letter). It is unavoidable: preserving
-        history via record_attempt_result would let the write-ahead attempts_started climb into the
-        K_escalate dispose, dead-lettering the held head - exactly what park-indefinitely forbids."""
+        poison run reset each hold. On ovh-qwen this is bounded by the ledger's per-message caps
+        (300s wall / 8 calls / EUR 0.50) -> ChildTurnCapExceeded -> config_blocked park, so it
+        cannot retry a poison message forever. It errs toward retrying (never toward a wrongful
+        dead-letter). It is unavoidable: preserving history via record_attempt_result would let the
+        write-ahead attempts_started climb into the K_escalate dispose, dead-lettering the held
+        head - exactly what park-indefinitely forbids."""
         nonlocal last_hb, fail_sleep
-        store.clear_attempt(agent, record.get("id"))
+        head_id = record.get("id")
+        if isinstance(head_id, str) and head_id not in gateway_held_escalated:
+            gateway_held_escalated.add(head_id)
+            try:                              # a notification must never crash the loop
+                if on_escalate is not None:
+                    on_escalate(_info(record, {}, CLASS_GATEWAY_HELD))
+            except Exception:  # noqa: BLE001, S110  # nosec
+                pass
+        store.clear_attempt(agent, head_id)
         stamp()                          # blocked != dead: keep heartbeat + lead-loop lease fresh
         last_hb = clock()
         sleep(fail_sleep)

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -59,7 +59,19 @@ _BENIGN_PIPE_TEARDOWN_ERRNOS = {errno.EINVAL, errno.EPIPE}
 
 
 class _GatewayChildCapUnavailable(RuntimeError):
-    """The wrapper could not durably issue a scoped paid-child credential."""
+    """The wrapper could not durably issue a scoped paid-child credential.
+
+    ``transient`` marks an operator-resolvable gateway HOLD (a durable accounting hold, an
+    unresolved prior attempt, or a clock rollback awaiting reconcile - i.e. any ``LedgerHold``).
+    A transient cause classifies CLASS_GATEWAY_HELD: the head is parked WITHOUT persisting an
+    attempt and re-drives every poll, so a worker blocked only because the gateway is held
+    self-heals when the hold clears, instead of sticky-parking as config_blocked forever (#62).
+    A NON-transient cause (missing message id, a local exec/config denial, ChildTurnCapExceeded
+    - which is a LedgerBlocked, deliberately NOT a LedgerHold) stays config_blocked."""
+
+    def __init__(self, message: str, *, transient: bool = False) -> None:
+        super().__init__(message)
+        self.transient = transient
 
 # Legacy infra-like text markers. These are low-confidence hints only; they deliberately
 # no longer classify known_global_infra without a structured CLI status/rate-limit fact.
@@ -1590,16 +1602,31 @@ def _classify_drive_failure(
     from .loop import (
         CLASS_AMBIGUOUS,
         CLASS_CONFIG_BLOCKED,
+        CLASS_GATEWAY_HELD,
         CLASS_INFRA,
         CLASS_POISON,
     )
 
+    # A TRANSIENT, operator-resolvable gateway HOLD surfaced at mint time (#62): classify
+    # CLASS_GATEWAY_HELD (parked, re-driving, NEVER dead-lettered) so the worker self-heals
+    # when the hold clears. Deterministic explicit signal - checked before any text heuristics.
+    if sig.get("gateway_transient_hold"):
+        return CLASS_GATEWAY_HELD, "OVH gateway is temporarily held; retrying until it clears"
+
     if backend_profile == "ovh-qwen":
         text = _ovh_qwen_failure_text(sig)
+        # A per-message child-turn cap (calls/cost/wall-time) is PERMANENT for that message - a
+        # capped/expired turn can never re-mint - so it stays config_blocked (park), never retry.
         if "atgw_child_turn_cap_exceeded" in text:
             return CLASS_CONFIG_BLOCKED, "OVH child turn budget exhausted"
-        if "atgw_policy_blocked" in text or "atgw_ledger_blocked" in text:
-            return CLASS_CONFIG_BLOCKED, "OVH trial policy or accounting hold"
+        # A ledger HOLD (503 ATGW_LEDGER_BLOCKED = held/unresolved) is TRANSIENT and clears on
+        # operator action -> CLASS_GATEWAY_HELD (re-drive, never dead-letter), matching the
+        # mint-time hold above. A policy block (trial cutoff / model mismatch) is terminal ->
+        # stays config_blocked.
+        if "atgw_ledger_blocked" in text:
+            return CLASS_GATEWAY_HELD, "OVH gateway transport is temporarily held"
+        if "atgw_policy_blocked" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH trial policy hold"
         if "atgw_config_error" in text or "status code: 422" in text or "http 422" in text:
             return CLASS_CONFIG_BLOCKED, "OVH gateway route or configuration error"
         infra_markers = (
@@ -1883,7 +1910,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             # Same for a disabled/invalid work_heartbeat config.
             gateway_capability = None
             if backend_profile == "ovh-qwen":
-                from agenttalk.ovh_gateway import GatewayError, SpendLedger
+                from agenttalk.ovh_gateway import GatewayError, LedgerHold, SpendLedger
 
                 if not active_message_id:
                     raise _GatewayChildCapUnavailable(
@@ -1898,6 +1925,19 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             (profile_env or {}).get("ANTHROPIC_AUTH_TOKEN") or ""
                         ),
                     ).token
+                except LedgerHold as exc:
+                    # A held/unresolved/clock-rollback gateway: TRANSIENT + operator-resolvable.
+                    # Mark it so the turn classifies CLASS_GATEWAY_HELD (parked, re-driving, never
+                    # dead-lettered) and the worker self-heals when the hold clears, instead of
+                    # sticky-parking as config_blocked forever (#62). ChildTurnCapExceeded is
+                    # deliberately a LedgerBlocked (NOT a LedgerHold), so a permanently-capped
+                    # message never takes this path and stays config_blocked. Ordered before the
+                    # GatewayError catch below because LedgerHold IS a GatewayError subclass.
+                    raise _GatewayChildCapUnavailable(
+                        "durable child turn capability unavailable: "
+                        f"{type(exc).__name__}",
+                        transient=True,
+                    ) from exc
                 except (GatewayError, OSError, ValueError) as exc:
                     raise _GatewayChildCapUnavailable(
                         "durable child turn capability unavailable: "
@@ -2046,9 +2086,18 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         except _GatewayChildCapUnavailable as e:
             _capture_child_output("stderr", f"{type(e).__name__}: {e}")
             _finalize_child_output()
-            sig["config_blocked"] = True
-            sig["config_blocked_text"] = str(e)
-            sig["error"] = str(e)
+            if e.transient:
+                # Transient, operator-resolvable gateway hold: NO child spawned, NO spend.
+                # Mark it so _classify_drive_failure returns CLASS_GATEWAY_HELD -> the loop parks
+                # WITHOUT persisting an attempt and re-drives next poll, self-healing when the hold
+                # clears (#62). NOT config_blocked (which would sticky-park forever) and NOT INFRA
+                # (which dead-letters at the infra-exhaustion backstop and withholds the heartbeat).
+                sig["gateway_transient_hold"] = True
+                sig["error"] = str(e)
+            else:
+                sig["config_blocked"] = True
+                sig["config_blocked_text"] = str(e)
+                sig["error"] = str(e)
             return sig
         except OSError as e:
             _capture_child_output("stderr", f"{type(e).__name__}: {e}")

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1615,18 +1615,18 @@ def _classify_drive_failure(
 
     if backend_profile == "ovh-qwen":
         text = _ovh_qwen_failure_text(sig)
-        # A per-message child-turn cap (calls/cost/wall-time) is PERMANENT for that message - a
-        # capped/expired turn can never re-mint - so it stays config_blocked (park), never retry.
         if "atgw_child_turn_cap_exceeded" in text:
             return CLASS_CONFIG_BLOCKED, "OVH child turn budget exhausted"
-        # A ledger HOLD (503 ATGW_LEDGER_BLOCKED = held/unresolved) is TRANSIENT and clears on
-        # operator action -> CLASS_GATEWAY_HELD (re-drive, never dead-letter), matching the
-        # mint-time hold above. A policy block (trial cutoff / model mismatch) is terminal ->
-        # stays config_blocked.
-        if "atgw_ledger_blocked" in text:
-            return CLASS_GATEWAY_HELD, "OVH gateway transport is temporarily held"
-        if "atgw_policy_blocked" in text:
-            return CLASS_CONFIG_BLOCKED, "OVH trial policy hold"
+        # A ledger/policy block surfaced as terminal TEXT (a 503 seen by an ALREADY-MINTED child
+        # turn mid-stream) stays config_blocked, unchanged from master. CLASS_GATEWAY_HELD is
+        # scoped to the MINT-TIME hold only (the gateway_transient_hold signal above), where no
+        # turn was minted so re-driving genuinely self-heals. A mid-turn hold cannot: the minted
+        # turn's 300s wall-clock keeps burning during the hold, so after the operator clears it a
+        # re-mint hits ChildTurnCapExceeded -> config_blocked anyway. Making the mid-turn text
+        # self-heal needs a turn-reaper for held-expired rows (the #63 residual / #62 follow-up),
+        # NOT a classification change here (Fable review of b173f36, MAJOR-1).
+        if "atgw_policy_blocked" in text or "atgw_ledger_blocked" in text:
+            return CLASS_CONFIG_BLOCKED, "OVH trial policy or accounting hold"
         if "atgw_config_error" in text or "status code: 422" in text or "http 422" in text:
             return CLASS_CONFIG_BLOCKED, "OVH gateway route or configuration error"
         infra_markers = (

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -10,7 +10,12 @@ from agenttalk import ovh_gateway
 from agenttalk.store import Store
 from agenttalk.wrapper import run
 from agenttalk.wrapper import session
-from agenttalk.wrapper.loop import CLASS_AMBIGUOUS, CLASS_CONFIG_BLOCKED, CLASS_INFRA
+from agenttalk.wrapper.loop import (
+    CLASS_AMBIGUOUS,
+    CLASS_CONFIG_BLOCKED,
+    CLASS_GATEWAY_HELD,
+    CLASS_INFRA,
+)
 
 
 def test_non_profile_child_environment_is_unchanged(tmp_path, monkeypatch) -> None:
@@ -327,14 +332,87 @@ def test_ovh_qwen_profile_refuses_a_path_resolving_outside_workspace(
         )
 
 
-@pytest.mark.parametrize("code", ["ATGW_POLICY_BLOCKED", "ATGW_LEDGER_BLOCKED"])
-def test_ovh_policy_and_ledger_blocks_are_terminal_non_poison(code) -> None:
+def test_ovh_policy_block_is_terminal_config_blocked() -> None:
+    # A policy block (trial cutoff / model mismatch) is TERMINAL for the message: it must park
+    # (config_blocked), never retry - the operator has to change policy for it to ever succeed.
     classification, summary = run._classify_drive_failure(
-        {"terminal": True, "terminal_text": f'API Error: 503 {{"type":"{code}"}}'},
+        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_POLICY_BLOCKED"}'},
         backend_profile="ovh-qwen",
     )
     assert classification == CLASS_CONFIG_BLOCKED
-    assert "hold" in summary
+    assert "policy" in summary
+
+
+def test_ovh_ledger_block_is_transient_gateway_held() -> None:
+    # A ledger block (503 ATGW_LEDGER_BLOCKED = held/unresolved accounting) is TRANSIENT and
+    # clears on operator action -> CLASS_GATEWAY_HELD (parked, re-driving, never dead-lettered),
+    # so a mid-turn hold self-heals when cleared instead of sticky-parking as config_blocked (#62).
+    classification, summary = run._classify_drive_failure(
+        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_LEDGER_BLOCKED"}'},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_GATEWAY_HELD
+    assert "held" in summary
+
+
+def test_gateway_transient_hold_signal_classifies_gateway_held() -> None:
+    # The mint-time LedgerHold surfaces as an explicit sig flag, classified BEFORE any text
+    # heuristic and independent of backend profile.
+    classification, summary = run._classify_drive_failure(
+        {"gateway_transient_hold": True, "error": "durable child turn capability unavailable"},
+        backend_profile="ovh-qwen",
+    )
+    assert classification == CLASS_GATEWAY_HELD
+    assert "held" in summary
+
+
+def test_qwen_spawner_classifies_gateway_held_on_ledger_hold_without_spawning(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    # The REAL make_drive path: a mint-time LedgerHold must (a) never spawn a paid child and
+    # (b) classify CLASS_GATEWAY_HELD (transient), NOT config_blocked. This pins the except
+    # ORDERING at the mint site - LedgerHold is a GatewayError subclass, so it must be caught
+    # first; if the broad `except GatewayError` shadowed it, this would be config_blocked (#62).
+    store = Store(tmp_path)
+    store.init(["lead", "qwen-dev-1"])
+
+    class HeldLedger:
+        def open_child_turn(self, **_scope):
+            raise ovh_gateway.LedgerHold("gateway has a durable accounting hold")
+
+    def must_not_spawn(*_args, **_kwargs):
+        raise AssertionError("paid child spawned while the gateway was held")
+
+    monkeypatch.setattr(ovh_gateway, "SpendLedger", HeldLedger)
+    monkeypatch.setattr(run, "_ProcStream", must_not_spawn)
+    drive = run.make_drive(
+        store,
+        "qwen-dev-1",
+        "claude",
+        session.SessionState(cli="claude", claude_session_id="session-1"),
+        ["claude"],
+        render=False,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "master-front-token",
+        },
+    )
+
+    outcome = drive(
+        {
+            "id": "immutable-message-id",
+            "from": "lead",
+            "kind": "question",
+            "body": "do work",
+            "meta": {"request_id": "q-parent"},
+        }
+    )
+
+    assert outcome.ok is False
+    assert outcome.failure_class == CLASS_GATEWAY_HELD
+    assert "held" in outcome.summary
 
 
 def test_ovh_child_turn_cap_is_terminal_config_blocked() -> None:

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -332,27 +332,20 @@ def test_ovh_qwen_profile_refuses_a_path_resolving_outside_workspace(
         )
 
 
-def test_ovh_policy_block_is_terminal_config_blocked() -> None:
-    # A policy block (trial cutoff / model mismatch) is TERMINAL for the message: it must park
-    # (config_blocked), never retry - the operator has to change policy for it to ever succeed.
+@pytest.mark.parametrize("code", ["ATGW_POLICY_BLOCKED", "ATGW_LEDGER_BLOCKED"])
+def test_ovh_policy_and_ledger_blocks_as_terminal_text_stay_config_blocked(code) -> None:
+    # A ledger/policy block surfaced as terminal TEXT is a 503 seen by an ALREADY-MINTED child
+    # turn mid-stream: it stays config_blocked (unchanged from master). CLASS_GATEWAY_HELD is
+    # scoped to the MINT-TIME hold only (see the signal test below) - a mid-turn hold cannot
+    # self-heal because the minted turn's 300s wall-clock keeps burning during the hold, so a
+    # post-clear re-mint hits ChildTurnCapExceeded -> config_blocked anyway (Fable review of
+    # b173f36, MAJOR-1). Full mid-turn recovery is the turn-reaper follow-up, not a classification.
     classification, summary = run._classify_drive_failure(
-        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_POLICY_BLOCKED"}'},
+        {"terminal": True, "terminal_text": f'API Error: 503 {{"type":"{code}"}}'},
         backend_profile="ovh-qwen",
     )
     assert classification == CLASS_CONFIG_BLOCKED
-    assert "policy" in summary
-
-
-def test_ovh_ledger_block_is_transient_gateway_held() -> None:
-    # A ledger block (503 ATGW_LEDGER_BLOCKED = held/unresolved accounting) is TRANSIENT and
-    # clears on operator action -> CLASS_GATEWAY_HELD (parked, re-driving, never dead-lettered),
-    # so a mid-turn hold self-heals when cleared instead of sticky-parking as config_blocked (#62).
-    classification, summary = run._classify_drive_failure(
-        {"terminal": True, "terminal_text": 'API Error: 503 {"type":"ATGW_LEDGER_BLOCKED"}'},
-        backend_profile="ovh-qwen",
-    )
-    assert classification == CLASS_GATEWAY_HELD
-    assert "held" in summary
+    assert "hold" in summary
 
 
 def test_gateway_transient_hold_signal_classifies_gateway_held() -> None:

--- a/tests/test_wrapper_health.py
+++ b/tests/test_wrapper_health.py
@@ -352,6 +352,21 @@ def test_health_failure_and_degraded_mappings(tmp_path: Path) -> None:
     assert _health_state(s) == hm.STATE_DEGRADED_OUTPUT
 
 
+def test_classify_failure_maps_gateway_held_to_outage_before_the_error_branch() -> None:
+    # #62: a TRANSIENT gateway hold is honestly an outage-like, retryable wait - NOT idle, NOT
+    # dead, NOT a generic exec error. It also sets sig["error"], so the gateway_held branch must
+    # win over the sig["error"] -> "spawn_exec_error" mapping, keeping the reason_code honest so
+    # status/doctor show a worker blocked-on-a-held-gateway (that will self-heal on clear).
+    from agenttalk.wrapper.health import classify_failure
+    from agenttalk.wrapper.loop import CLASS_GATEWAY_HELD
+
+    state, reason = classify_failure(
+        {"error": "durable child turn capability unavailable"}, CLASS_GATEWAY_HELD
+    )
+    assert state == hm.STATE_RATE_LIMITED_OR_OUTAGE
+    assert reason == "gateway_held"
+
+
 def test_health_writer_parked_surfaces_blocked_state_with_resolved_request_id(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -449,6 +449,73 @@ def test_config_blocked_head_parks_with_visible_health_not_frozen_idle(tmp_path)
     assert s.cursor("beta") == ""                        # head still parked, never committed
 
 
+# ------------------------------------- #62: transient gateway hold = re-driving park (self-heal)
+
+def _gateway_held_drive():
+    return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_GATEWAY_HELD,
+                             summary="OVH gateway is temporarily held; retrying until it clears")
+
+
+def test_gateway_held_head_redrives_and_self_heals_when_the_hold_clears(tmp_path) -> None:
+    # #62: a TRANSIENT gateway hold parks the head WITHOUT persisting an attempt and RE-DRIVES
+    # every poll (unlike the config_blocked latch, which drives ONCE then re-parks without
+    # driving). When the operator clears the hold, the very next drive succeeds and commits -
+    # the worker self-heals with no restart, no dead-letter, no manual reset.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        if drives["n"] < 3:                    # held for the first two polls...
+            return _gateway_held_drive()
+        return loop.DriveOutcome(ok=True)      # ...then the hold clears -> the turn succeeds
+
+    parked: list = []
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=6, k_poison=2, k_escalate=2,   # realistic ceilings: prove they never trip
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 3                       # RE-DROVE each poll (not driven-once-then-latched)
+    assert turns == 1                             # self-healed: the head drove to success
+    assert parked == []                           # gateway_held surfaces via drive()'s health,
+    #                                               NOT the config_blocked on_health_parked path
+    assert s.dead_lettered_count("beta") == 0     # never dead-lettered while held
+    assert s.cursor("beta") == m.id               # committed after the hold cleared
+    assert s.read_heartbeat("beta") is not None   # heartbeat stayed fresh (no restart-storm)
+
+
+def test_gateway_held_never_disposes_and_keeps_attempt_ledger_flat_under_a_long_hold(
+    tmp_path,
+) -> None:
+    # #62 (operator ruling: park a held message INDEFINITELY): a hold that never clears must
+    # NEVER dead-letter the head, no matter how many polls elapse - even under tight poison /
+    # escalate ceilings. Because each held poll CLEARS the write-ahead attempt, no failure
+    # counter climbs, so no ceiling is ever reached. This is the whole point of gateway_held vs
+    # the naive CLASS_INFRA (which dead-letters at the infra-exhaustion backstop).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _gateway_held_drive()             # held forever
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=20, k_poison=1, k_escalate=1,  # ceilings that WOULD dispose an ordinary failure
+    )
+    assert turns == 0
+    assert drives["n"] == 20                      # re-drove EVERY poll (never latched, never gave up)
+    assert s.dead_lettered_count("beta") == 0     # NEVER dead-lettered (park-indefinitely)
+    assert s.cursor("beta") == ""                 # head never consumed
+    rec = s.attempt_record("beta", m.id)
+    # ledger stays flat: no attempt persisted between holds (cleared each poll), so at most the
+    # single in-flight write-ahead of the current poll is ever present.
+    assert rec in (None, {}) or int(rec.get("attempts_started") or 0) <= 1
+
+
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -516,6 +516,27 @@ def test_gateway_held_never_disposes_and_keeps_attempt_ledger_flat_under_a_long_
     assert rec in (None, {}) or int(rec.get("attempts_started") or 0) <= 1
 
 
+def test_gateway_held_escalates_exactly_once_across_a_long_hold(tmp_path) -> None:
+    # #62 (Fable review MAJOR-2): a LedgerHold can be AUTONOMOUS (an unresolved provider attempt,
+    # a clock anomaly) that the operator never placed - a silent indefinite stall. The hold-park
+    # must emit ONE routed escalation on first entering the held state (restoring the signal
+    # master gave via config_blocked), and then NOT storm it every poll - even though clear_attempt
+    # wipes the per-attempt escalation dedup each poll (the dedup lives in the loop instead).
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+
+    def drive(rec):
+        return _gateway_held_drive()             # held for the whole run
+
+    escalations: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=15, k_poison=0, k_escalate=0,
+        on_escalate=lambda info: escalations.append(info.get("msg_id")) or True,
+    )
+    assert len(escalations) == 1                  # one-shot, not once-per-poll
+
+
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:


### PR DESCRIPTION
Closes #62. Supersedes #71 (the naive CLASS_INFRA attempt).

## Problem
A wrapped Qwen worker whose child-turn mint refuses because the OVH gateway is HELD previously sticky-parked as `config_blocked` forever — it never re-drove, so it stayed wedged until a manual reset even after the operator cleared the hold. (The #58 follow-up.)

The naive fix (#71) reclassified the hold as `CLASS_INFRA`, which Fable review showed regressed the overnight workflow: it dead-letters at the 4h infra-exhaustion backstop and withholds the heartbeat → supervisor restart-storm.

## Design
A new failure class **`CLASS_GATEWAY_HELD`**, distinct from both `config_blocked` (durable local denial — latches, never re-drives) and `INFRA` (dead-letters + withholds heartbeat). A held **mint** now:
- parks **without persisting an attempt** — `_hold_park` clears the write-ahead attempt, so no failure counter climbs and **no dispose ceiling is ever reached → the held message is NEVER dead-lettered** (operator ruling: park a held message indefinitely);
- keeps the **heartbeat fresh** (blocked ≠ dead → no supervisor restart-storm);
- leaves the head **uncommitted** → it **re-drives every poll and self-heals the instant the hold clears**;
- emits **one routed escalation** on first entering the held state (autonomous holds — an unresolved provider attempt, a clock anomaly — must not silently stall the fleet).

**Scope:** `gateway_held` is the **mint-time** `LedgerHold` only (no turn minted → re-driving genuinely self-heals). A mid-turn 503 (`atgw_ledger_blocked` text on an already-minted turn) stays `config_blocked` — its 300s wall-clock burns during the hold, so it can't self-heal by classification; that needs a turn-reaper for held-expired rows (the #63 residual).

## Review
Independently reviewed by a cross-model (Fable-5) adversarial pass prompted to refute the design. Two majors found and fixed in the second commit (mid-turn over-claim → scoped to mint-time; missing escalation → one-shot routed notice). Surviving-verified claims: counter-flatness/no-DLQ, mint-time self-heal, heartbeat freshness, `except LedgerHold` ordering, no class-set leaks.

## Tests
- real `make_drive`→`LedgerHold` spawner path (pins the `except` ordering; no paid child spawned);
- classification (mint-time signal → held; terminal ledger/policy text → config_blocked);
- health mapping (held → `rate_limited_or_outage` + `gateway_held`, before the generic error branch);
- loop-level **re-drive-then-self-heal**, **never-disposes-under-a-long-hold** (tight poison/escalate ceilings), and **escalates-exactly-once**.

All touched suites green locally (305 passed); ruff + bandit clean.
