### PR TITLE
feat(#60): DoD forcing-gate plane + assurance dimension (inc-1)

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2298,6 +2298,74 @@ def _build_signoff_eval(store, record: dict):
             "active_agents": active}
 
 
+def _build_dod_eval(store, record: dict):
+    """Resolve the #60 Definition-of-Done evidence (IMPURE) into the bundle
+    :func:`close.evaluate_dod` consumes (PURE). ``None`` when the close's scope has no DoD
+    requirements (byte-identical to pre-#60). Fails closed via ``policy_error`` on a malformed
+    ``dod.json``. Live-derived at check time - there is no frozen DoD route to forget to apply."""
+    from agenttalk import close as close_mod
+    policy, err = close_mod.load_dod_policy(store)
+    if err:
+        return {"policy_present": True, "policy_error": err, "required_dimensions": {}}
+    dims = close_mod.derive_required_dod(policy, record.get("scope"))["dimensions"]
+    if not dims:
+        return None
+    bundle = {"policy_present": policy is not None, "policy_error": None,
+              "required_dimensions": dims}
+    if "assurance" in dims:
+        bundle["assurance"] = _resolve_dod_assurance_gate(store, dims["assurance"])
+    return bundle
+
+
+def _resolve_dod_assurance_gate(store, spec: dict) -> dict:
+    """Read the named ``assurance:<scope>`` gate's OWN fields (never artifact.json - Q1 ruling)
+    so the DoD assurance dimension is a binding/freshness check over the CI-attested gate."""
+    from datetime import datetime, timezone
+
+    from agenttalk import gates as gate_mod
+    gate_name = spec["gate"]
+    state = gate_mod.load_gate_state(store.root)
+    g = (state.get("gates") or {}).get(gate_name)
+    if not isinstance(g, dict):
+        return {"gate": gate_name, "present": False}
+    now = datetime.now(timezone.utc)
+    waiver = g.get("waiver")
+    waiver_active = False
+    if isinstance(waiver, dict):
+        try:
+            waiver_active = gate_mod._waiver_active(waiver, now=now)
+        except (ValueError, TypeError):
+            waiver_active = False
+    return {
+        "gate": gate_name, "present": True,
+        "status": g.get("status"), "severity": g.get("severity"),
+        "evidence_source": g.get("evidence_source"), "revision": g.get("revision"),
+        "waiver_active": waiver_active,
+        "age_days": _iso_age_days(g.get("updated_at"), now),
+        "max_age_days": spec.get("max_age_days"),
+    }
+
+
+def _iso_age_days(updated_at: object, now) -> float | None:
+    """Age in days of an ISO-8601 ``updated_at`` vs ``now``; None if missing/unparseable. Never
+    raises (freshness is advisory - a bad timestamp must not crash `close check`)."""
+    if not isinstance(updated_at, str) or not updated_at.strip():
+        return None
+    try:
+        from datetime import timezone
+        parsed = datetime_fromisoformat_z(updated_at)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return max(0.0, (now - parsed).total_seconds() / 86400.0)
+    except (ValueError, TypeError):
+        return None
+
+
+def datetime_fromisoformat_z(value: str):
+    from datetime import datetime
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 def _signoff_risk_inventory(args, store, record: dict) -> list[dict]:
     """Build a risk inventory from CLI flags. Changed paths DEFAULT from the frozen
     revision's git diff (base..revision); manual --changed-path is an audited
@@ -2774,7 +2842,8 @@ def cmd_close(args: argparse.Namespace) -> int:
         rec = record if isinstance(record, dict) else {}
         signoff_eval = _build_signoff_eval(store, rec) if isinstance(record, dict) else None
         worktree_eval = _close_worktree_eval(store, rec) if isinstance(record, dict) else None
-        result = close_mod.compute_verdict(rec, gate_check, signoff_eval, worktree_eval)
+        dod_eval = _build_dod_eval(store, rec) if isinstance(record, dict) else None
+        result = close_mod.compute_verdict(rec, gate_check, signoff_eval, worktree_eval, dod_eval)
         if getattr(args, "json", False):
             print(json.dumps({**result, "gate_verdict": gate_check["verdict"],
                               "signoff_policy": (None if signoff_eval is None
@@ -2815,9 +2884,10 @@ def cmd_close(args: argparse.Namespace) -> int:
                         store.root, scope=record.get("gate_scope"))
                     signoff_eval = _build_signoff_eval(store, record)
                     worktree_eval = _close_worktree_eval(store, record)
+                    dod_eval = _build_dod_eval(store, record)
                     record["worktree_isolation"] = worktree_eval
                     result = close_mod.compute_verdict(
-                        record, gate_check, signoff_eval, worktree_eval)
+                        record, gate_check, signoff_eval, worktree_eval, dod_eval)
                     if args.verdict == "go" and result["verdict"] != close_mod.VERDICT_GO:
                         sys.stderr.write(
                             "agenttalk close publish: refusing GO - close check is HOLD:\n")

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2348,22 +2348,14 @@ def _resolve_dod_assurance_gate(store, spec: dict) -> dict:
 
 def _iso_age_days(updated_at: object, now) -> float | None:
     """Age in days of an ISO-8601 ``updated_at`` vs ``now``; None if missing/unparseable. Never
-    raises (freshness is advisory - a bad timestamp must not crash `close check`)."""
-    if not isinstance(updated_at, str) or not updated_at.strip():
+    raises (freshness is advisory - a bad timestamp must not crash `close check`). Reuses the
+    existing :func:`_parse_ts` timestamp parser."""
+    if not isinstance(updated_at, str):
         return None
-    try:
-        from datetime import timezone
-        parsed = datetime_fromisoformat_z(updated_at)
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return max(0.0, (now - parsed).total_seconds() / 86400.0)
-    except (ValueError, TypeError):
+    parsed = _parse_ts(updated_at)
+    if parsed is None:
         return None
-
-
-def datetime_fromisoformat_z(value: str):
-    from datetime import datetime
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return max(0.0, (now - parsed).total_seconds() / 86400.0)
 
 
 def _signoff_risk_inventory(args, store, record: dict) -> list[dict]:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2313,21 +2313,24 @@ def _build_dod_eval(store, record: dict):
     bundle = {"policy_present": policy is not None, "policy_error": None,
               "required_dimensions": dims}
     if "assurance" in dims:
-        bundle["assurance"] = _resolve_dod_assurance_gate(store, dims["assurance"])
+        bundle["assurance"] = _resolve_dod_assurance_gate(store, dims["assurance"], record)
     return bundle
 
 
-def _resolve_dod_assurance_gate(store, spec: dict) -> dict:
+def _resolve_dod_assurance_gate(store, spec: dict, record: dict) -> dict:
     """Read the named ``assurance:<scope>`` gate's OWN fields (never artifact.json - Q1 ruling)
-    so the DoD assurance dimension is a binding/freshness check over the CI-attested gate."""
+    so the DoD assurance dimension is a binding/freshness check over the CI-attested gate. Carries
+    the gate's own ``scope`` and the close's applicable scope so the evaluator can enforce that the
+    gate actually applies to this close (a feature-scoped gate must not satisfy a release close)."""
     from datetime import datetime, timezone
 
     from agenttalk import gates as gate_mod
     gate_name = spec["gate"]
     state = gate_mod.load_gate_state(store.root)
     g = (state.get("gates") or {}).get(gate_name)
+    close_scope = record.get("gate_scope")
     if not isinstance(g, dict):
-        return {"gate": gate_name, "present": False}
+        return {"gate": gate_name, "present": False, "close_gate_scope": close_scope}
     now = datetime.now(timezone.utc)
     waiver = g.get("waiver")
     waiver_active = False
@@ -2341,21 +2344,24 @@ def _resolve_dod_assurance_gate(store, spec: dict) -> dict:
         "status": g.get("status"), "severity": g.get("severity"),
         "evidence_source": g.get("evidence_source"), "revision": g.get("revision"),
         "waiver_active": waiver_active,
+        "gate_scope": g.get("scope"), "close_gate_scope": close_scope,
         "age_days": _iso_age_days(g.get("updated_at"), now),
         "max_age_days": spec.get("max_age_days"),
     }
 
 
 def _iso_age_days(updated_at: object, now) -> float | None:
-    """Age in days of an ISO-8601 ``updated_at`` vs ``now``; None if missing/unparseable. Never
-    raises (freshness is advisory - a bad timestamp must not crash `close check`). Reuses the
-    existing :func:`_parse_ts` timestamp parser."""
+    """SIGNED age in days of an ISO-8601 ``updated_at`` vs ``now`` (NEGATIVE = future-dated);
+    ``None`` if missing/unparseable. Never raises (a bad timestamp must not crash `close check`) -
+    but the DoD evaluator FAILS CLOSED on a ``None``/future age when freshness is required, so this
+    must NOT clamp a future timestamp to 0 (that would mask a future-dated attestation as fresh).
+    Reuses the existing :func:`_parse_ts` timestamp parser."""
     if not isinstance(updated_at, str):
         return None
     parsed = _parse_ts(updated_at)
     if parsed is None:
         return None
-    return max(0.0, (now - parsed).total_seconds() / 86400.0)
+    return (now - parsed).total_seconds() / 86400.0
 
 
 def _signoff_risk_inventory(args, store, record: dict) -> list[dict]:

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -872,7 +872,7 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
     yet cryptographically authenticated CI provenance - gates.py forbids greening a blocker from
     other sources, but the label itself is not signed, so an actor who can write gates.json can
     still assert it. Authenticated CI attestation is a separate substrate hardening (task #64,
-    sibling to the gate-waive authenticity work #13); until then this is the existing blocker-gate
+    sibling to the gate-waive authentication hardening); until then this is the existing blocker-gate
     mechanism (label-trust), NOT a cryptographic sole-certifier guarantee."""
     gate = (a or {}).get("gate") or "assurance"
     if not isinstance(a, dict) or not a.get("present"):
@@ -894,7 +894,7 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
     # honoring it would turn a single `gate waive` into a revision-independent bypass of the whole
     # forcing gate (Codex re-review of 848841a, BLOCKER). Only a green CI-attested, revision-bound
     # blocker gate clears assurance. The AUTHENTICATED operator escape (close dod-waive validating
-    # a typed operator-answer reference) is task #65 (depends on gate-waive authentication #13).
+    # a typed operator-answer reference) is task #65 (depends on authenticated gate-waive origin).
     if status != "green":
         detail = f"assurance gate {gate!r} is not green (status={status!r})"
         if status == "waived":

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -98,6 +98,15 @@ DOD_DIRNAME = "dod.json"
 # cannot be checked - a silent soft-pass is exactly the failure this gate exists to prevent).
 # inc-1: assurance only. inc-2 adds knowledge; inc-3 adds coverage + a depth-signoff dimension.
 _DOD_SUPPORTED_DIMENSIONS = frozenset({"assurance"})
+_DOD_ALLOWED_TOP_KEYS = frozenset({"schema_version", "scopes"})
+_DOD_ASSURANCE_KEYS = frozenset({"gate", "max_age_days"})
+_DOD_SCHEMA_VERSION = 1
+# Fail-closed bounds on the policy file itself: reject an oversized dod.json before decode, so a
+# pathological deeply-nested document cannot exhaust the parser (RecursionError) or memory.
+_DOD_MAX_BYTES = 64 * 1024
+# Bounded clock-skew allowance for freshness: an attestation timestamp up to this far in the
+# future is tolerated (clock jitter); beyond it is treated as an invalid future-dated attestation.
+_DOD_CLOCK_SKEW_DAYS = 300.0 / 86400.0
 
 _CLOSE_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\Z")
 _FULL_SHA_RE = re.compile(r"\A[0-9a-f]{40}\Z")
@@ -702,15 +711,19 @@ def load_dod_policy(store) -> tuple[dict | None, str | None]:
     if not path.exists():
         return None, None
     try:
+        size = path.stat().st_size
+        if size > _DOD_MAX_BYTES:
+            # bound the file BEFORE decode so a pathological document cannot exhaust the parser.
+            return None, f"dod.json exceeds max size ({size} > {_DOD_MAX_BYTES} bytes)"
         raw = json.loads(path.read_text(encoding="utf-8-sig"))
-    except (ValueError, OSError) as e:
-        return None, f"dod.json is unreadable/corrupt: {e}"
+    except (ValueError, OSError, RecursionError) as e:
+        # RecursionError: deeply-nested JSON. Must fail CLOSED, never propagate out of close check.
+        return None, f"dod.json is unreadable/corrupt: {type(e).__name__}: {e}"
     try:
         return validate_dod_policy(raw), None
     except CloseError as e:
         return None, str(e)
-    except (ValueError, TypeError, KeyError, AttributeError) as e:
-        # defense-in-depth: ANY malformed policy fails closed, never crashes `close check`.
+    except Exception as e:  # noqa: BLE001 - ANY malformed policy fails CLOSED, never crashes close check
         return None, f"malformed dod policy: {type(e).__name__}: {e}"
 
 
@@ -721,12 +734,26 @@ def validate_dod_policy(raw: object) -> dict:
     requirement that would silently soft-pass - that is the exact failure #60 prevents."""
     if not isinstance(raw, dict):
         raise CloseError("dod policy must be a JSON object")
+    unknown_top = set(raw) - set(_DOD_ALLOWED_TOP_KEYS)
+    if unknown_top:
+        # unknown keys fail CLOSED - a typo like "scope"/"scopez" must never be silently ignored.
+        raise CloseError(f"dod policy has unknown top-level key(s): {sorted(unknown_top)}")
     schema_version = raw.get("schema_version")
     if not isinstance(schema_version, int) or isinstance(schema_version, bool):
         raise CloseError("dod policy schema_version must be an integer")
-    scopes_raw = raw.get("scopes") or {}
-    if not isinstance(scopes_raw, dict):
-        raise CloseError("dod policy 'scopes' must be an object")
+    if schema_version != _DOD_SCHEMA_VERSION:
+        # reject unknown/future versions rather than best-effort interpreting them.
+        raise CloseError(
+            f"dod policy schema_version {schema_version} is unsupported "
+            f"(this build enforces {_DOD_SCHEMA_VERSION})")
+    # distinguish ABSENT (valid empty policy) from PRESENT-BUT-WRONG-TYPE (fail closed): `or {}`
+    # would collapse a present [] / "" / 0 to an empty policy and silently drop all requirements.
+    if "scopes" in raw:
+        scopes_raw = raw["scopes"]
+        if not isinstance(scopes_raw, dict):
+            raise CloseError("dod policy 'scopes' must be an object")
+    else:
+        scopes_raw = {}
     scopes: dict[str, dict] = {}
     for scope_name, dims in scopes_raw.items():
         if not isinstance(dims, dict):
@@ -739,13 +766,22 @@ def validate_dod_policy(raw: object) -> dict:
                     f"(supported: {sorted(_DOD_SUPPORTED_DIMENSIONS)})")
             if dim == "assurance":
                 norm[dim] = _validate_dod_assurance_spec(spec, scope_name)
-        scopes[str(scope_name).lower()] = norm
+        key = str(scope_name).lower()
+        if key in scopes:
+            # two scope names that collide after lowercasing are ambiguous -> fail closed.
+            raise CloseError(f"dod policy has case-insensitively colliding scope name {key!r}")
+        scopes[key] = norm
     return {"schema_version": schema_version, "scopes": scopes}
 
 
 def _validate_dod_assurance_spec(spec: object, scope_name: str) -> dict:
     if not isinstance(spec, dict):
         raise CloseError(f"dod scope {scope_name!r} assurance must be an object")
+    unknown = set(spec) - set(_DOD_ASSURANCE_KEYS)
+    if unknown:
+        # e.g. a "max_age_day" typo must RAISE, not silently drop the freshness requirement.
+        raise CloseError(
+            f"dod scope {scope_name!r} assurance has unknown key(s): {sorted(unknown)}")
     gate = spec.get("gate")
     if not isinstance(gate, str) or not gate.strip():
         raise CloseError(f"dod scope {scope_name!r} assurance.gate must be a non-empty string")
@@ -785,7 +821,10 @@ def evaluate_dod(record: dict, dod_eval: dict | None) -> list[tuple[str, str]]:
       "assurance": {                            # present iff "assurance" in required_dimensions
         "gate": str, "present": bool, "status": str|None, "severity": str|None,
         "evidence_source": str|None, "revision": str|None, "waiver_active": bool,
-        "age_days": float|None, "max_age_days": int|None,
+        "gate_scope": str|None,                 # the gate's OWN scope (None = global)
+        "close_gate_scope": str|None,           # the scope this close's gate check applies to
+        "age_days": float|None,                 # SIGNED age (negative = future); None if unparseable
+        "max_age_days": int|None,
       } | None,
     }
     ``None`` ⇒ [] (the scope has no DoD requirements)."""
@@ -806,35 +845,76 @@ def evaluate_dod(record: dict, dod_eval: dict | None) -> list[tuple[str, str]]:
 
 def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str]]:
     """PURE: the assurance dimension binds to the EXISTING ``assurance:<scope>`` gate's own
-    fields - it never reads artifact.json (Q1 ruling: CI stays the sole certifier, DoD is a
-    binding+freshness check). Cleared iff the gate is present, green from a CI attestation as a
-    blocker (or a live operator waiver), bound to THIS close's revision, and within max_age."""
+    fields - it never reads artifact.json. Cleared iff the gate is present, applies to this
+    close's scope, is green from a CI attestation as a blocker (or a revision-bound live operator
+    waiver), bound to THIS close's revision, and - when max_age_days is set - fresh.
+
+    RESIDUAL RISK (not closed by this dimension): the assurance guarantee is only as strong as
+    the blocker-gate substrate it reads. ``evidence_source == "automation_ci"`` is a LABEL, not
+    yet cryptographically authenticated CI provenance - gates.py forbids greening a blocker from
+    other sources, but the label itself is not signed, so an actor who can write gates.json can
+    still assert it. Authenticated CI attestation is a separate substrate hardening (sibling to
+    the gate-waive authenticity work, task #13); until then this is the existing blocker-gate
+    mechanism (label-trust), NOT a cryptographic sole-certifier guarantee."""
     gate = (a or {}).get("gate") or "assurance"
     if not isinstance(a, dict) or not a.get("present"):
         return [(HOLD_MISSING_ASSURANCE, f"required assurance gate {gate!r} is not present")]
+    # M2: the gate's OWN scope must apply to this close, mirroring gates.check_gates EXACTLY - a
+    # gate applies to a scoped check iff its scope is that scope or "global". A gate scoped to
+    # "feature" (or scope-less) therefore does NOT satisfy a "release" close. Only when the close
+    # itself imposes no scope (close_scope falsy) is any gate applicable (gates.py skips the filter).
+    gate_scope = a.get("gate_scope")
+    close_scope = a.get("close_gate_scope")
+    if close_scope and gate_scope not in (close_scope, "global"):
+        return [(HOLD_MISSING_ASSURANCE,
+                 f"assurance gate {gate!r} is recorded under scope {gate_scope!r}, not applicable "
+                 f"to this close's scope {close_scope!r} (needs that scope or 'global')")]
+    revision_bound = a.get("revision") == record.get("revision")
     status = a.get("status")
     if status == "waived" and a.get("waiver_active"):
-        # operator-waived not-applicable; gates.py enforces waiver validity + expiry.
+        # M1: an operator waiver clears ONLY when bound to THIS close's revision - otherwise a
+        # waiver granted for another revision would silently clear this (possibly newer) close.
+        if not revision_bound:
+            return [(HOLD_STALE_ASSURANCE,
+                     f"assurance gate {gate!r} waiver is not bound to the close revision "
+                     f"({a.get('revision')!r} != {record.get('revision')!r})")]
         return []
     if status != "green":
         return [(HOLD_MISSING_ASSURANCE,
                  f"assurance gate {gate!r} is not green (status={status!r})")]
     # A green blocker greens ONLY from automation_ci (gates.py enforces this at write time; we
-    # re-assert it so the DoD is honest even if a gate were hand-edited).
+    # re-assert it - see the RESIDUAL RISK note above on why this is label-trust, not a proof).
     if a.get("severity") != "blocker" or a.get("evidence_source") != "automation_ci":
         return [(HOLD_UNATTESTED_ASSURANCE,
                  f"assurance gate {gate!r} is green but not a CI-attested blocker "
                  f"(severity={a.get('severity')!r}, source={a.get('evidence_source')!r})")]
     out: list[tuple[str, str]] = []
-    if a.get("revision") != record.get("revision"):
+    if not revision_bound:
         out.append((HOLD_STALE_ASSURANCE,
                     f"assurance gate {gate!r} is attested for a different revision than the "
                     f"close ({a.get('revision')!r} != {record.get('revision')!r})"))
+    # B3: when freshness is REQUIRED (max_age_days set) it must FAIL CLOSED if it cannot be
+    # validated: a missing/unparseable timestamp (age is None) and a materially future-dated one
+    # are both HOLDs, not passes. The CLI provides a SIGNED age (negative = future, not clamped).
     max_age = a.get("max_age_days")
-    age = a.get("age_days")
-    if isinstance(max_age, int) and isinstance(age, (int, float)) and age > max_age:
-        out.append((HOLD_STALE_ASSURANCE,
-                    f"assurance gate {gate!r} attestation is older than max_age_days={max_age}"))
+    if isinstance(max_age, int) and not isinstance(max_age, bool):
+        age = a.get("age_days")
+        if age is None:
+            out.append((HOLD_STALE_ASSURANCE,
+                        f"assurance gate {gate!r} freshness is required (max_age_days={max_age}) "
+                        f"but its timestamp is missing or unparseable"))
+        elif isinstance(age, (int, float)) and not isinstance(age, bool):
+            if age < -_DOD_CLOCK_SKEW_DAYS:
+                out.append((HOLD_STALE_ASSURANCE,
+                            f"assurance gate {gate!r} is future-dated (age_days={age:.4f}); "
+                            f"refusing to treat a future attestation as fresh"))
+            elif age > max_age:
+                out.append((HOLD_STALE_ASSURANCE,
+                            f"assurance gate {gate!r} attestation is older than "
+                            f"max_age_days={max_age}"))
+        else:
+            out.append((HOLD_STALE_ASSURANCE,
+                        f"assurance gate {gate!r} freshness is required but its age is invalid"))
     return out
 
 

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -863,8 +863,9 @@ def evaluate_dod(record: dict, dod_eval: dict | None) -> list[tuple[str, str]]:
 def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str]]:
     """PURE: the assurance dimension binds to the EXISTING ``assurance:<scope>`` gate's own
     fields - it never reads artifact.json. Cleared iff the gate is present, applies to this
-    close's scope, is green from a CI attestation as a blocker (or a revision-bound live operator
-    waiver), bound to THIS close's revision, and - when max_age_days is set - fresh.
+    close's scope, is green from a CI attestation as a blocker, bound to THIS close's revision,
+    and - when max_age_days is set - fresh. A gate WAIVER does NOT clear this dimension (see the
+    waiver note below); the authenticated operator escape is task #65.
 
     RESIDUAL RISK (not closed by this dimension): the assurance guarantee is only as strong as
     the blocker-gate substrate it reads. ``evidence_source == "automation_ci"`` is a LABEL, not
@@ -888,22 +889,18 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
                  f"to this close's scope {close_scope!r} (needs that scope or 'global')")]
     revision_bound = a.get("revision") == record.get("revision")
     status = a.get("status")
-    if status == "waived" and a.get("waiver_active"):
-        # M1 (refined after re-review): a waiver with NO recorded revision is a deliberate operator
-        # BLANKET override for the scope - `gate waive` does not (yet) record a revision, and it is
-        # already bounded by operator authorship + expiry, so it clears (this is the design's
-        # escape valve; a read-side revision requirement would make every waiver un-authorable).
-        # A waiver whose gate carries a DIFFERENT revision (e.g. left over from a prior `gate set`
-        # at another commit) is the original cross-revision danger and still HOLDs.
-        gate_rev = a.get("revision")
-        if gate_rev is None or gate_rev == record.get("revision"):
-            return []
-        return [(HOLD_STALE_ASSURANCE,
-                 f"assurance gate {gate!r} waiver is bound to a different revision "
-                 f"({gate_rev!r} != {record.get('revision')!r})")]
+    # A gate WAIVER does NOT clear the DoD assurance dimension. `gate waive --operator <text>` is
+    # UNAUTHENTICATED caller free text (docs/ASSURANCE.md) with no authenticated operator, so
+    # honoring it would turn a single `gate waive` into a revision-independent bypass of the whole
+    # forcing gate (Codex re-review of 848841a, BLOCKER). Only a green CI-attested, revision-bound
+    # blocker gate clears assurance. The AUTHENTICATED operator escape (close dod-waive validating
+    # a typed operator-answer reference) is task #65 (depends on gate-waive authentication #13).
     if status != "green":
-        return [(HOLD_MISSING_ASSURANCE,
-                 f"assurance gate {gate!r} is not green (status={status!r})")]
+        detail = f"assurance gate {gate!r} is not green (status={status!r})"
+        if status == "waived":
+            detail = (f"assurance gate {gate!r} is waived, but an unauthenticated gate waiver does "
+                      f"not clear a DoD assurance requirement - needs a CI-attested green gate (#65)")
+        return [(HOLD_MISSING_ASSURANCE, detail)]
     # A green blocker greens ONLY from automation_ci (gates.py enforces this at write time; we
     # re-assert it - see the RESIDUAL RISK note above on why this is label-trust, not a proof).
     if a.get("severity") != "blocker" or a.get("evidence_source") != "automation_ci":

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -702,6 +702,20 @@ def dod_policy_path(store):
     return store.dir / DOD_DIRNAME
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict:
+    """``object_pairs_hook`` that fails CLOSED on a duplicated key at ANY object level. Python's
+    default decoder silently keeps the LAST value of a duplicated key, so a malformed policy like
+    ``{"scopes":{...},"scopes":{}}`` (erases all requirements) or a duplicated ``max_age_days``
+    (disables freshness) would decode to a valid-looking dict and produce a false GO *before*
+    validate_dod_policy ever runs. Rejecting duplicates at decode time closes that class."""
+    seen: dict[str, object] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate key {key!r} in dod.json (ambiguous policy; fail closed)")
+        seen[key] = value
+    return seen
+
+
 def load_dod_policy(store) -> tuple[dict | None, str | None]:
     """Load + validate ``.agenttalk/dod.json``. Returns (policy, error): a MISSING file is a
     valid EMPTY policy -> (None, None) meaning "no DoD, zero required dimensions" (close behaves
@@ -715,7 +729,10 @@ def load_dod_policy(store) -> tuple[dict | None, str | None]:
         if size > _DOD_MAX_BYTES:
             # bound the file BEFORE decode so a pathological document cannot exhaust the parser.
             return None, f"dod.json exceeds max size ({size} > {_DOD_MAX_BYTES} bytes)"
-        raw = json.loads(path.read_text(encoding="utf-8-sig"))
+        # object_pairs_hook rejects duplicate keys at every level (a duplicated key would otherwise
+        # silently keep its last value and erase a requirement / disable freshness -> false GO).
+        raw = json.loads(path.read_text(encoding="utf-8-sig"),
+                         object_pairs_hook=_reject_duplicate_keys)
     except (ValueError, OSError, RecursionError) as e:
         # RecursionError: deeply-nested JSON. Must fail CLOSED, never propagate out of close check.
         return None, f"dod.json is unreadable/corrupt: {type(e).__name__}: {e}"
@@ -853,8 +870,8 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
     the blocker-gate substrate it reads. ``evidence_source == "automation_ci"`` is a LABEL, not
     yet cryptographically authenticated CI provenance - gates.py forbids greening a blocker from
     other sources, but the label itself is not signed, so an actor who can write gates.json can
-    still assert it. Authenticated CI attestation is a separate substrate hardening (sibling to
-    the gate-waive authenticity work, task #13); until then this is the existing blocker-gate
+    still assert it. Authenticated CI attestation is a separate substrate hardening (task #64,
+    sibling to the gate-waive authenticity work #13); until then this is the existing blocker-gate
     mechanism (label-trust), NOT a cryptographic sole-certifier guarantee."""
     gate = (a or {}).get("gate") or "assurance"
     if not isinstance(a, dict) or not a.get("present"):
@@ -872,13 +889,18 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
     revision_bound = a.get("revision") == record.get("revision")
     status = a.get("status")
     if status == "waived" and a.get("waiver_active"):
-        # M1: an operator waiver clears ONLY when bound to THIS close's revision - otherwise a
-        # waiver granted for another revision would silently clear this (possibly newer) close.
-        if not revision_bound:
-            return [(HOLD_STALE_ASSURANCE,
-                     f"assurance gate {gate!r} waiver is not bound to the close revision "
-                     f"({a.get('revision')!r} != {record.get('revision')!r})")]
-        return []
+        # M1 (refined after re-review): a waiver with NO recorded revision is a deliberate operator
+        # BLANKET override for the scope - `gate waive` does not (yet) record a revision, and it is
+        # already bounded by operator authorship + expiry, so it clears (this is the design's
+        # escape valve; a read-side revision requirement would make every waiver un-authorable).
+        # A waiver whose gate carries a DIFFERENT revision (e.g. left over from a prior `gate set`
+        # at another commit) is the original cross-revision danger and still HOLDs.
+        gate_rev = a.get("revision")
+        if gate_rev is None or gate_rev == record.get("revision"):
+            return []
+        return [(HOLD_STALE_ASSURANCE,
+                 f"assurance gate {gate!r} waiver is bound to a different revision "
+                 f"({gate_rev!r} != {record.get('revision')!r})")]
     if status != "green":
         return [(HOLD_MISSING_ASSURANCE,
                  f"assurance gate {gate!r} is not green (status={status!r})")]

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -83,10 +83,21 @@ HOLD_INVALID_POLICY = "invalid_signoff_policy"
 HOLD_UNMAPPED_RISK = "unmapped_required_risk"
 HOLD_STALE_ROUTE = "stale_signoff_route"
 HOLD_WORKTREE_ISOLATION = "worktree_isolation_unverified"
+# DoD forcing-gate hold codes (#60) - the "red-by-default until typed evidence exists" dimensions.
+HOLD_INVALID_DOD_POLICY = "invalid_dod_policy"
+HOLD_MISSING_ASSURANCE = "missing_assurance_evidence"
+HOLD_STALE_ASSURANCE = "stale_assurance_evidence"
+HOLD_UNATTESTED_ASSURANCE = "unattested_assurance_evidence"
 
 RELEASE_CLASS_SCOPES = {"release", "milestone", "feature", "hotfix"}
 
 SIGNOFF_DIRNAME = "signoffs.json"
+DOD_DIRNAME = "dod.json"
+# Dimensions the DoD evaluator can actually enforce. This set GROWS per increment; declaring a
+# dimension the engine cannot enforce is a policy error (you must not be able to require what
+# cannot be checked - a silent soft-pass is exactly the failure this gate exists to prevent).
+# inc-1: assurance only. inc-2 adds knowledge; inc-3 adds coverage + a depth-signoff dimension.
+_DOD_SUPPORTED_DIMENSIONS = frozenset({"assurance"})
 
 _CLOSE_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\Z")
 _FULL_SHA_RE = re.compile(r"\A[0-9a-f]{40}\Z")
@@ -145,7 +156,8 @@ def empty_close(close_id: str, *, scope: str, revision: str, revision_kind: str,
 
 def compute_verdict(record: dict, gate_check: dict,
                     signoff_eval: dict | None = None,
-                    worktree_eval: dict | None = None) -> dict[str, Any]:
+                    worktree_eval: dict | None = None,
+                    dod_eval: dict | None = None) -> dict[str, Any]:
     """PURE: derive HOLD|GO + the stable hold codes from a close ``record`` and a
     ``gate_check`` result (:func:`gates.check_gates` output for the close's
     gate_scope). No I/O. GO requires, in order of the codes below: a well-formed
@@ -161,8 +173,14 @@ def compute_verdict(record: dict, gate_check: dict,
     already-resolved evaluation in; this function only COUNTS, so it stays pure and
     unit-testable. It is None for a P2-only close; a close that HAS
     ``required_signoffs`` but is handed no ``signoff_eval`` fails closed (the CLI
-    always supplies one for P3 closes). Returns
-    ``{"verdict", "holds": [{code, detail}], "ok"}``."""
+    always supplies one for P3 closes).
+
+    ``dod_eval`` is the same impure->pure bridge for the #60 Definition-of-Done
+    forcing gate: the CLI resolves the DoD policy + the required evidence (e.g. the
+    ``assurance:<scope>`` gate's fields) and passes the already-resolved bundle in;
+    :func:`evaluate_dod` only COUNTS. It is ``None`` when the close's scope has no
+    DoD requirements, in which case the fold is a no-op (byte-identical to today).
+    Returns ``{"verdict", "holds": [{code, detail}], "ok"}``."""
     holds: list[dict] = []
 
     def hold(code: str, detail: str) -> None:
@@ -248,6 +266,11 @@ def compute_verdict(record: dict, gate_check: dict,
 
     # P3: derived specialist sign-off counts (pure over the CLI-supplied eval).
     for code, detail in _evaluate_signoffs(record, signoff_eval):
+        hold(code, detail)
+    # DoD forcing gate (#60): red-by-default evidence dimensions, pure over the CLI-supplied
+    # ``dod_eval`` bundle (same impure->pure bridge as signoff_eval). Purely ADDITIVE - it can
+    # only ADD holds, never remove one, so it cannot loosen today's verdict. None ⇒ no DoD.
+    for code, detail in evaluate_dod(record, dod_eval):
         hold(code, detail)
     return _verdict(holds)
 
@@ -662,6 +685,157 @@ def load_signoff_policy(store) -> tuple[dict | None, str | None]:
         # defense-in-depth: ANY malformed policy must fail closed to
         # invalid_signoff_policy, never crash `close check` (fail-closed contract).
         return None, f"malformed signoff policy: {type(e).__name__}: {e}"
+
+
+# --------------------------------------------- #60 DoD forcing gate (red-by-default)
+
+def dod_policy_path(store):
+    return store.dir / DOD_DIRNAME
+
+
+def load_dod_policy(store) -> tuple[dict | None, str | None]:
+    """Load + validate ``.agenttalk/dod.json``. Returns (policy, error): a MISSING file is a
+    valid EMPTY policy -> (None, None) meaning "no DoD, zero required dimensions" (close behaves
+    byte-identically to before #60); a present-but-malformed/unparseable file fails CLOSED ->
+    (None, error), which the CLI surfaces as ``HOLD_INVALID_DOD_POLICY`` - never a crash."""
+    path = dod_policy_path(store)
+    if not path.exists():
+        return None, None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (ValueError, OSError) as e:
+        return None, f"dod.json is unreadable/corrupt: {e}"
+    try:
+        return validate_dod_policy(raw), None
+    except CloseError as e:
+        return None, str(e)
+    except (ValueError, TypeError, KeyError, AttributeError) as e:
+        # defense-in-depth: ANY malformed policy fails closed, never crashes `close check`.
+        return None, f"malformed dod policy: {type(e).__name__}: {e}"
+
+
+def validate_dod_policy(raw: object) -> dict:
+    """Validate + normalize ``.agenttalk/dod.json``. Raises CloseError (CLI ->
+    HOLD_INVALID_DOD_POLICY) on any malformed policy. A dimension the engine cannot enforce
+    (not in ``_DOD_SUPPORTED_DIMENSIONS``) is REJECTED: you must not be able to declare a
+    requirement that would silently soft-pass - that is the exact failure #60 prevents."""
+    if not isinstance(raw, dict):
+        raise CloseError("dod policy must be a JSON object")
+    schema_version = raw.get("schema_version")
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+        raise CloseError("dod policy schema_version must be an integer")
+    scopes_raw = raw.get("scopes") or {}
+    if not isinstance(scopes_raw, dict):
+        raise CloseError("dod policy 'scopes' must be an object")
+    scopes: dict[str, dict] = {}
+    for scope_name, dims in scopes_raw.items():
+        if not isinstance(dims, dict):
+            raise CloseError(f"dod scope {scope_name!r} must map to an object of dimensions")
+        norm: dict[str, dict] = {}
+        for dim, spec in dims.items():
+            if dim not in _DOD_SUPPORTED_DIMENSIONS:
+                raise CloseError(
+                    f"dod dimension {dim!r} is not supported in this version "
+                    f"(supported: {sorted(_DOD_SUPPORTED_DIMENSIONS)})")
+            if dim == "assurance":
+                norm[dim] = _validate_dod_assurance_spec(spec, scope_name)
+        scopes[str(scope_name).lower()] = norm
+    return {"schema_version": schema_version, "scopes": scopes}
+
+
+def _validate_dod_assurance_spec(spec: object, scope_name: str) -> dict:
+    if not isinstance(spec, dict):
+        raise CloseError(f"dod scope {scope_name!r} assurance must be an object")
+    gate = spec.get("gate")
+    if not isinstance(gate, str) or not gate.strip():
+        raise CloseError(f"dod scope {scope_name!r} assurance.gate must be a non-empty string")
+    max_age = spec.get("max_age_days")
+    if max_age is not None and (
+        not isinstance(max_age, int) or isinstance(max_age, bool) or max_age < 0
+    ):
+        raise CloseError(
+            f"dod scope {scope_name!r} assurance.max_age_days must be a non-negative integer")
+    return {"gate": gate, "max_age_days": max_age}
+
+
+def dod_policy_hash(policy: dict) -> str:
+    return _stable_hash(policy)
+
+
+def derive_required_dod(policy: dict | None, scope: str) -> dict:
+    """PURE: the DoD dimensions required for this close's ``scope``. ``{"dimensions": {}}`` when
+    there is no policy or the scope is unmapped (unmapped ⇒ zero requirements ⇒ safe default,
+    exactly like an absent policy). Live-derived at check time (no frozen apply/route), so the
+    gate can never be silently skipped by forgetting an apply step."""
+    if not policy:
+        return {"dimensions": {}}
+    scopes = policy.get("scopes") or {}
+    return {"dimensions": dict(scopes.get(str(scope or "").lower()) or {})}
+
+
+def evaluate_dod(record: dict, dod_eval: dict | None) -> list[tuple[str, str]]:
+    """PURE: given a close ``record`` and a CLI-resolved ``dod_eval`` bundle, return (code,
+    detail) DoD holds. All I/O (load the policy, read the assurance gate) happens in the CLI
+    and is passed in already resolved - this only COUNTS, mirroring :func:`_evaluate_signoffs`.
+
+    dod_eval = {
+      "policy_present": bool,
+      "policy_error": str | None,               # malformed dod.json -> HOLD_INVALID_DOD_POLICY
+      "required_dimensions": {dim: spec, ...},  # derived for THIS close's scope
+      "assurance": {                            # present iff "assurance" in required_dimensions
+        "gate": str, "present": bool, "status": str|None, "severity": str|None,
+        "evidence_source": str|None, "revision": str|None, "waiver_active": bool,
+        "age_days": float|None, "max_age_days": int|None,
+      } | None,
+    }
+    ``None`` ⇒ [] (the scope has no DoD requirements)."""
+    if dod_eval is None:
+        return []
+    if not isinstance(dod_eval, dict):
+        return [(HOLD_INVALID_DOD_POLICY, "dod evaluation bundle is malformed")]
+    if dod_eval.get("policy_error"):
+        return [(HOLD_INVALID_DOD_POLICY, str(dod_eval["policy_error"]))]
+    required = dod_eval.get("required_dimensions") or {}
+    if not required:
+        return []
+    out: list[tuple[str, str]] = []
+    if "assurance" in required:
+        out.extend(_evaluate_dod_assurance(record, dod_eval.get("assurance")))
+    return out
+
+
+def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str]]:
+    """PURE: the assurance dimension binds to the EXISTING ``assurance:<scope>`` gate's own
+    fields - it never reads artifact.json (Q1 ruling: CI stays the sole certifier, DoD is a
+    binding+freshness check). Cleared iff the gate is present, green from a CI attestation as a
+    blocker (or a live operator waiver), bound to THIS close's revision, and within max_age."""
+    gate = (a or {}).get("gate") or "assurance"
+    if not isinstance(a, dict) or not a.get("present"):
+        return [(HOLD_MISSING_ASSURANCE, f"required assurance gate {gate!r} is not present")]
+    status = a.get("status")
+    if status == "waived" and a.get("waiver_active"):
+        # operator-waived not-applicable; gates.py enforces waiver validity + expiry.
+        return []
+    if status != "green":
+        return [(HOLD_MISSING_ASSURANCE,
+                 f"assurance gate {gate!r} is not green (status={status!r})")]
+    # A green blocker greens ONLY from automation_ci (gates.py enforces this at write time; we
+    # re-assert it so the DoD is honest even if a gate were hand-edited).
+    if a.get("severity") != "blocker" or a.get("evidence_source") != "automation_ci":
+        return [(HOLD_UNATTESTED_ASSURANCE,
+                 f"assurance gate {gate!r} is green but not a CI-attested blocker "
+                 f"(severity={a.get('severity')!r}, source={a.get('evidence_source')!r})")]
+    out: list[tuple[str, str]] = []
+    if a.get("revision") != record.get("revision"):
+        out.append((HOLD_STALE_ASSURANCE,
+                    f"assurance gate {gate!r} is attested for a different revision than the "
+                    f"close ({a.get('revision')!r} != {record.get('revision')!r})"))
+    max_age = a.get("max_age_days")
+    age = a.get("age_days")
+    if isinstance(max_age, int) and isinstance(age, (int, float)) and age > max_age:
+        out.append((HOLD_STALE_ASSURANCE,
+                    f"assurance gate {gate!r} attestation is older than max_age_days={max_age}"))
+    return out
 
 
 def merge_candidate_refsets(*refsets: dict) -> dict:

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1240,3 +1240,49 @@ def test_cli_dod_gate_scoped_to_other_scope_does_not_satisfy(tmp_path: Path, cap
                    evidence=["run:x"], revision=SHA)
     rc, codes = _check_holds(root, capsys)
     assert rc == 3 and close.HOLD_MISSING_ASSURANCE in codes
+
+# ---------------------------- #60 inc-1 round-3 regressions (Codex re-review of f44e268)
+
+@pytest.mark.parametrize("body,label", [
+    ('{"schema_version":1,'
+     '"scopes":{"release":{"assurance":{"gate":"assurance:release","max_age_days":14}}},'
+     '"scopes":{}}', "dup top-level scopes erasing requirements"),
+    ('{"schema_version":1,'
+     '"scopes":{"release":{"assurance":{"gate":"g"}},"release":{"assurance":{"gate":"g2"}}}}',
+     "dup scope name"),
+    ('{"schema_version":1,"scopes":{"release":'
+     '{"assurance":{"gate":"g"},"assurance":{"gate":"g2"}}}}', "dup dimension key"),
+    ('{"schema_version":1,"scopes":{"release":{"assurance":'
+     '{"gate":"g","max_age_days":14,"max_age_days":null}}}}', "dup max_age_days disabling freshness"),
+])
+def test_load_dod_policy_rejects_duplicate_keys_fails_closed(tmp_path: Path, body, label) -> None:
+    # A duplicated JSON key silently keeps its LAST value in the stdlib decoder, which could erase
+    # a requirement or disable freshness -> false GO. The object_pairs_hook must fail CLOSED.
+    s = Store(tmp_path)
+    s.init(["lead"])
+    close.dod_policy_path(s).write_text(body, encoding="utf-8")
+    pol, err = close.load_dod_policy(s)
+    assert pol is None and err and "duplicate" in err.lower(), label
+
+
+def test_cli_dod_duplicate_scopes_does_not_false_go(tmp_path: Path, capsys) -> None:
+    # End-to-end: a policy that duplicates "scopes" (2nd one empty) must NOT resolve to zero
+    # requirements + GO; it must HOLD_INVALID_DOD_POLICY at `close check`.
+    root = _init(tmp_path)
+    close.dod_policy_path(Store(root)).write_text(
+        '{"schema_version":1,'
+        '"scopes":{"release":{"assurance":{"gate":"assurance:release","max_age_days":14}}},'
+        '"scopes":{}}', encoding="utf-8")
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_INVALID_DOD_POLICY in codes
+
+
+def test_evaluate_dod_assurance_revisionless_waiver_is_blanket_clear() -> None:
+    # A waiver with NO recorded revision is a deliberate operator BLANKET override (the design's
+    # escape valve; `gate waive` records no revision + is bounded by expiry/authorship). It clears
+    # even though the assurance gate is otherwise unmet, WITHOUT re-introducing the cross-revision
+    # danger (a waiver whose gate carries a DIFFERENT revision still HOLDs - see the M1 test).
+    a = _assurance_bundle(status="waived", waiver_active=True, revision=None)
+    assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -22,7 +22,7 @@ import threading
 
 import pytest
 
-from agenttalk import cli, close
+from agenttalk import cli, close, gates
 from agenttalk.store import Store
 
 SHA = "a" * 40
@@ -921,3 +921,222 @@ def test_cli_list_and_show(tmp_path: Path, capsys: pytest.CaptureFixture) -> Non
     assert _run(["close", "show", "--id", "rel"], root) == 0
     shown = json.loads(capsys.readouterr().out)
     assert shown["close_id"] == "rel"
+
+
+# ================================================ #60 DoD forcing gate (inc-1: assurance)
+
+def _assurance_bundle(**over) -> dict:
+    """A fully-satisfied resolved assurance-gate bundle (green, CI-attested blocker, bound to
+    SHA, fresh). Override any field to build the failing variants."""
+    b = {"gate": "assurance:release", "present": True, "status": "green",
+         "severity": "blocker", "evidence_source": "automation_ci",
+         "revision": SHA, "waiver_active": False, "age_days": 1.0, "max_age_days": 14}
+    b.update(over)
+    return b
+
+
+def _dod_eval(assurance: dict | None) -> dict:
+    return {"policy_present": True, "policy_error": None,
+            "required_dimensions": {"assurance": {"gate": "assurance:release",
+                                                   "max_age_days": 14}},
+            "assurance": assurance}
+
+
+# ------------------------------------------------------ validate_dod_policy
+
+def test_validate_dod_policy_valid_roundtrips_lowercased_and_normalized() -> None:
+    pol = close.validate_dod_policy({
+        "schema_version": 1,
+        "scopes": {"Release": {"assurance": {"gate": "assurance:release", "max_age_days": 14}}},
+    })
+    assert pol == {"schema_version": 1,
+                   "scopes": {"release": {"assurance": {"gate": "assurance:release",
+                                                        "max_age_days": 14}}}}
+
+
+def test_validate_dod_policy_allows_absent_max_age() -> None:
+    pol = close.validate_dod_policy(
+        {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": "a:r"}}}})
+    assert pol["scopes"]["release"]["assurance"]["max_age_days"] is None
+
+
+@pytest.mark.parametrize("raw", [
+    "not-a-dict",
+    {"schema_version": "1", "scopes": {}},
+    {"schema_version": True, "scopes": {}},
+    {"schema_version": 1, "scopes": "nope"},
+    {"schema_version": 1, "scopes": {"release": "nope"}},
+    {"schema_version": 1, "scopes": {"release": {"knowledge": {"min_notes": 1}}}},  # unsupported
+    {"schema_version": 1, "scopes": {"release": {"assurance": {}}}},                # missing gate
+    {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": ""}}}},      # empty gate
+    {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": "g",
+                                                               "max_age_days": -1}}}},
+])
+def test_validate_dod_policy_malformed_raises(raw) -> None:
+    with pytest.raises(close.CloseError):
+        close.validate_dod_policy(raw)
+
+
+def test_load_dod_policy_missing_is_empty(tmp_path: Path) -> None:
+    s = Store(tmp_path)
+    s.init(["lead"])
+    assert close.load_dod_policy(s) == (None, None)
+
+
+def test_load_dod_policy_malformed_fails_closed(tmp_path: Path) -> None:
+    s = Store(tmp_path)
+    s.init(["lead"])
+    close.dod_policy_path(s).write_text('{"schema_version": 1, "scopes": {"release": '
+                                        '{"knowledge": {}}}}', encoding="utf-8")
+    policy, err = close.load_dod_policy(s)
+    assert policy is None and err and "knowledge" in err
+
+
+# ------------------------------------------------------ derive_required_dod
+
+def test_derive_required_dod_no_policy_or_unmapped_scope_is_empty() -> None:
+    assert close.derive_required_dod(None, "release") == {"dimensions": {}}
+    pol = {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": "a:r"}}}}
+    assert close.derive_required_dod(pol, "feature") == {"dimensions": {}}
+
+
+def test_derive_required_dod_mapped_scope_returns_dims_case_insensitive() -> None:
+    pol = {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": "a:r"}}}}
+    assert close.derive_required_dod(pol, "RELEASE") == {
+        "dimensions": {"assurance": {"gate": "a:r"}}}
+
+
+# ------------------------------------------------------ evaluate_dod (pure)
+
+def test_evaluate_dod_none_or_no_required_is_empty() -> None:
+    assert close.evaluate_dod(_satisfied(), None) == []
+    assert close.evaluate_dod(_satisfied(), {"required_dimensions": {}}) == []
+
+
+def test_evaluate_dod_bundle_malformed_or_policy_error_holds_invalid() -> None:
+    assert close.evaluate_dod(_satisfied(), "nope")[0][0] == close.HOLD_INVALID_DOD_POLICY
+    err = close.evaluate_dod(_satisfied(), {"policy_error": "bad", "required_dimensions": {}})
+    assert err == [(close.HOLD_INVALID_DOD_POLICY, "bad")]
+
+
+def test_evaluate_dod_assurance_satisfied_is_empty() -> None:
+    assert close.evaluate_dod(_satisfied(), _dod_eval(_assurance_bundle())) == []
+
+
+def test_evaluate_dod_assurance_waived_active_is_empty() -> None:
+    a = _assurance_bundle(status="waived", waiver_active=True, evidence_source="operator_waiver",
+                          severity="blocker", revision=OTHER_SHA)  # binding not required for waiver
+    assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
+
+
+@pytest.mark.parametrize("over,code", [
+    ({"present": False}, close.HOLD_MISSING_ASSURANCE),
+    ({"status": "red"}, close.HOLD_MISSING_ASSURANCE),
+    ({"status": "skipped"}, close.HOLD_MISSING_ASSURANCE),
+    ({"status": "waived", "waiver_active": False}, close.HOLD_MISSING_ASSURANCE),
+    ({"severity": "warn"}, close.HOLD_UNATTESTED_ASSURANCE),
+    ({"evidence_source": "manual_review"}, close.HOLD_UNATTESTED_ASSURANCE),
+    ({"revision": OTHER_SHA}, close.HOLD_STALE_ASSURANCE),
+    ({"age_days": 30.0, "max_age_days": 14}, close.HOLD_STALE_ASSURANCE),
+])
+def test_evaluate_dod_assurance_failure_variants(over, code) -> None:
+    holds = close.evaluate_dod(_satisfied(), _dod_eval(_assurance_bundle(**over)))
+    assert code in {c for c, _ in holds}
+
+
+def test_evaluate_dod_assurance_missing_bundle_holds_missing() -> None:
+    ev = {"policy_present": True, "policy_error": None,
+          "required_dimensions": {"assurance": {}}, "assurance": None}
+    assert close.evaluate_dod(_satisfied(), ev)[0][0] == close.HOLD_MISSING_ASSURANCE
+
+
+# ------------------------------------------------------ compute_verdict integration
+
+def test_compute_verdict_dod_none_is_backward_identical() -> None:
+    base = close.compute_verdict(_satisfied(), _gate_go())
+    explicit = close.compute_verdict(_satisfied(), _gate_go(), None, None, None)
+    assert base == explicit and base["verdict"] == close.VERDICT_GO
+
+
+def test_compute_verdict_unmet_assurance_flips_go_to_hold_with_only_the_dod_hold() -> None:
+    # a close that is otherwise GO, plus a required-but-missing assurance dimension.
+    result = close.compute_verdict(
+        _satisfied(), _gate_go(), None, None, _dod_eval(_assurance_bundle(present=False)))
+    assert result["verdict"] == close.VERDICT_HOLD
+    assert _codes(result) == {close.HOLD_MISSING_ASSURANCE}   # reached the DoD fold, not MALFORMED
+
+
+def test_compute_verdict_satisfied_assurance_stays_go() -> None:
+    result = close.compute_verdict(
+        _satisfied(), _gate_go(), None, None, _dod_eval(_assurance_bundle()))
+    assert result["verdict"] == close.VERDICT_GO and result["holds"] == []
+
+
+def test_compute_verdict_dod_is_additive_only() -> None:
+    # a pre-existing gate hold PLUS an unmet DoD dimension -> both holds present (DoD only adds).
+    result = close.compute_verdict(
+        _satisfied(), _gate_hold(), None, None, _dod_eval(_assurance_bundle(present=False)))
+    codes = _codes(result)
+    assert close.HOLD_GATE in codes and close.HOLD_MISSING_ASSURANCE in codes
+
+
+# ------------------------------------------------------ CLI integration (impure bridge)
+
+def _write_dod(root: Path, gate: str = "assurance:release", max_age: int = 14) -> None:
+    close.dod_policy_path(Store(root)).write_text(json.dumps({
+        "schema_version": 1,
+        "scopes": {"release": {"assurance": {"gate": gate, "max_age_days": max_age}}},
+    }), encoding="utf-8")
+
+
+def _check_holds(root: Path, capsys) -> tuple[int, set[str]]:
+    capsys.readouterr()
+    rc = _run(["close", "check", "--id", "rel", "--json"], root)
+    out = json.loads(capsys.readouterr().out)
+    return rc, {h["code"] for h in out["holds"]}
+
+
+def test_cli_dod_absent_policy_is_byte_identical_go(tmp_path: Path, capsys) -> None:
+    root = _init(tmp_path)
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 0 and close.HOLD_MISSING_ASSURANCE not in codes
+
+
+def test_cli_dod_requires_assurance_gate_holds_until_ci_attested(tmp_path: Path, capsys) -> None:
+    root = _init(tmp_path)
+    _write_dod(root)
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    # no assurance:release gate yet -> the DoD forces a HOLD (the Papendal CVE-shipped-green gap).
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_MISSING_ASSURANCE in codes
+    # a green, CI-attested, revision-bound blocker gate clears the dimension -> GO.
+    gates.set_gate(root, name="assurance:release", status="green", severity="blocker",
+                   scope="release", actor="ci", evidence_source="automation_ci",
+                   evidence=["run:ci-123"], revision=SHA)
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 0 and close.HOLD_MISSING_ASSURANCE not in codes
+
+
+def test_cli_dod_stale_when_gate_bound_to_other_revision(tmp_path: Path, capsys) -> None:
+    root = _init(tmp_path)
+    _write_dod(root)
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    gates.set_gate(root, name="assurance:release", status="green", severity="blocker",
+                   scope="release", actor="ci", evidence_source="automation_ci",
+                   evidence=["run:ci-9"], revision=OTHER_SHA)  # bound to the WRONG revision
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_STALE_ASSURANCE in codes
+
+
+def test_cli_dod_malformed_policy_fails_closed_without_crash(tmp_path: Path, capsys) -> None:
+    root = _init(tmp_path)
+    close.dod_policy_path(Store(root)).write_text(
+        '{"schema_version": 1, "scopes": {"release": {"knowledge": {}}}}', encoding="utf-8")
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_INVALID_DOD_POLICY in codes

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1023,13 +1023,14 @@ def test_evaluate_dod_assurance_satisfied_is_empty() -> None:
     assert close.evaluate_dod(_satisfied(), _dod_eval(_assurance_bundle())) == []
 
 
-def test_evaluate_dod_assurance_waived_active_is_empty() -> None:
-    # An active operator waiver clears assurance ONLY when bound to the close revision (M1). The
-    # cross-revision bypass this test previously codified is now rejected (see the revision-bound
-    # regression test below).
+def test_evaluate_dod_assurance_active_waiver_does_not_clear() -> None:
+    # A gate WAIVER never clears the DoD assurance dimension - `gate waive --operator <text>` is
+    # unauthenticated caller free text, so honoring it would be a one-command bypass of the forcing
+    # gate (Codex re-review of 848841a). Even an active waiver bound to THIS revision HOLDs; only a
+    # green CI-attested gate clears. The authenticated operator escape is task #65.
     a = _assurance_bundle(status="waived", waiver_active=True, evidence_source="operator_waiver",
                           severity="blocker", revision=SHA)
-    assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
+    assert close.HOLD_MISSING_ASSURANCE in _dcodes(close.evaluate_dod(_satisfied(), _dod_eval(a)))
 
 
 @pytest.mark.parametrize("over,code", [
@@ -1123,6 +1124,24 @@ def test_cli_dod_requires_assurance_gate_holds_until_ci_attested(tmp_path: Path,
     assert rc == 0 and close.HOLD_MISSING_ASSURANCE not in codes
 
 
+def test_cli_dod_gate_waive_cannot_clear_assurance(tmp_path: Path, capsys) -> None:
+    # Codex re-review of 848841a (BLOCKER): `gate waive --operator <text>` is UNAUTHENTICATED
+    # caller free text (docs/ASSURANCE.md), so a single `gate waive` must NOT clear the DoD
+    # assurance dimension - otherwise it is a one-command, revision-independent bypass of the
+    # whole forcing gate. Prove the REAL CLI exploit path still HOLDs. Authenticated escape = #65.
+    root = _init(tmp_path)
+    _write_dod(root)
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    # waive the assurance gate with a CLAIMED operator - the command succeeds but confers no real
+    # operator authority, so the DoD must still HOLD_MISSING_ASSURANCE (not a false GO).
+    _run(["gate", "waive", "--from", "lead", "--name", "assurance:release", "--operator",
+          "claimed-boss", "--reason", "bypass", "--scope", "release", "--expires",
+          "2099-01-01"], root)
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_MISSING_ASSURANCE in codes
+
+
 def test_cli_dod_stale_when_gate_bound_to_other_revision(tmp_path: Path, capsys) -> None:
     root = _init(tmp_path)
     _write_dod(root)
@@ -1186,13 +1205,12 @@ def test_evaluate_dod_assurance_no_max_age_skips_freshness() -> None:
     assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
 
 
-def test_evaluate_dod_assurance_waiver_must_be_revision_bound() -> None:
-    # M1: a waiver on a DIFFERENT revision must NOT clear this close.
-    a = _assurance_bundle(status="waived", waiver_active=True, revision=OTHER_SHA)
-    assert close.HOLD_STALE_ASSURANCE in _dcodes(close.evaluate_dod(_satisfied(), _dod_eval(a)))
-    # a waiver bound to THIS revision clears.
-    a2 = _assurance_bundle(status="waived", waiver_active=True, revision=SHA)
-    assert close.evaluate_dod(_satisfied(), _dod_eval(a2)) == []
+def test_evaluate_dod_assurance_waiver_never_clears_any_revision() -> None:
+    # No gate waiver clears assurance, regardless of revision binding (unauthenticated - #65).
+    for rev in (OTHER_SHA, SHA, None):
+        a = _assurance_bundle(status="waived", waiver_active=True, revision=rev)
+        assert close.HOLD_MISSING_ASSURANCE in _dcodes(
+            close.evaluate_dod(_satisfied(), _dod_eval(a))), f"waiver rev={rev} must HOLD"
 
 
 def test_evaluate_dod_assurance_gate_scope_must_apply() -> None:
@@ -1279,10 +1297,9 @@ def test_cli_dod_duplicate_scopes_does_not_false_go(tmp_path: Path, capsys) -> N
     assert rc == 3 and close.HOLD_INVALID_DOD_POLICY in codes
 
 
-def test_evaluate_dod_assurance_revisionless_waiver_is_blanket_clear() -> None:
-    # A waiver with NO recorded revision is a deliberate operator BLANKET override (the design's
-    # escape valve; `gate waive` records no revision + is bounded by expiry/authorship). It clears
-    # even though the assurance gate is otherwise unmet, WITHOUT re-introducing the cross-revision
-    # danger (a waiver whose gate carries a DIFFERENT revision still HOLDs - see the M1 test).
+def test_evaluate_dod_assurance_revisionless_waiver_does_not_clear() -> None:
+    # A revision-less `gate waive` (its --operator is unauthenticated caller text) must NOT clear
+    # the DoD assurance dimension - otherwise a single command bypasses the forcing gate
+    # (Codex re-review of 848841a, BLOCKER). Authenticated operator escape = task #65.
     a = _assurance_bundle(status="waived", waiver_active=True, revision=None)
-    assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
+    assert close.HOLD_MISSING_ASSURANCE in _dcodes(close.evaluate_dod(_satisfied(), _dod_eval(a)))

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1024,8 +1024,11 @@ def test_evaluate_dod_assurance_satisfied_is_empty() -> None:
 
 
 def test_evaluate_dod_assurance_waived_active_is_empty() -> None:
+    # An active operator waiver clears assurance ONLY when bound to the close revision (M1). The
+    # cross-revision bypass this test previously codified is now rejected (see the revision-bound
+    # regression test below).
     a = _assurance_bundle(status="waived", waiver_active=True, evidence_source="operator_waiver",
-                          severity="blocker", revision=OTHER_SHA)  # binding not required for waiver
+                          severity="blocker", revision=SHA)
     assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
 
 
@@ -1140,3 +1143,100 @@ def test_cli_dod_malformed_policy_fails_closed_without_crash(tmp_path: Path, cap
     assert _accept(root) == 0
     rc, codes = _check_holds(root, capsys)
     assert rc == 3 and close.HOLD_INVALID_DOD_POLICY in codes
+
+
+# ---------------------------------- #60 inc-1 hardening regressions (Codex review of 46584e8)
+
+def _dcodes(holds) -> set[str]:
+    return {c for c, _ in holds}
+
+
+@pytest.mark.parametrize("raw", [
+    {"schema_version": 1, "scopes": []},                       # B2: present wrong-type != absent
+    {"schema_version": 1, "scopes": 0},                        # B2: falsy wrong-type
+    {"schema_version": 2, "scopes": {}},                       # B2: unsupported version
+    {"schema_version": 1, "scopes": {}, "extra": 1},           # B2: unknown top-level key
+    {"schema_version": 1, "scope": {"release": {}}},           # B2: misspelled 'scopes'
+    {"schema_version": 1,
+     "scopes": {"release": {"assurance": {"gate": "g", "max_age_day": 14}}}},  # B2: typo'd spec key
+    {"schema_version": 1,
+     "scopes": {"Release": {"assurance": {"gate": "g"}},
+                "release": {"assurance": {"gate": "g2"}}}},    # B2: case-insensitive collision
+])
+def test_validate_dod_policy_failclosed_regressions(raw) -> None:
+    with pytest.raises(close.CloseError):
+        close.validate_dod_policy(raw)
+
+
+@pytest.mark.parametrize("age_days,expect_hold", [
+    (None, True),    # B3: freshness required but timestamp missing/unparseable -> HOLD
+    (-1.0, True),    # B3: future-dated attestation is NOT fresh -> HOLD
+    (99.0, True),    # older than max_age_days=14 -> HOLD (control)
+    (1.0, False),    # genuinely fresh -> clears
+])
+def test_evaluate_dod_assurance_freshness_fails_closed(age_days, expect_hold) -> None:
+    a = _assurance_bundle(age_days=age_days, max_age_days=14)
+    holds = close.evaluate_dod(_satisfied(), _dod_eval(a))
+    assert (close.HOLD_STALE_ASSURANCE in _dcodes(holds)) is expect_hold
+
+
+def test_evaluate_dod_assurance_no_max_age_skips_freshness() -> None:
+    # freshness is OPTIONAL: with max_age_days unset, a None/old age must NOT hold on freshness.
+    a = _assurance_bundle(age_days=None, max_age_days=None)
+    assert close.evaluate_dod(_satisfied(), _dod_eval(a)) == []
+
+
+def test_evaluate_dod_assurance_waiver_must_be_revision_bound() -> None:
+    # M1: a waiver on a DIFFERENT revision must NOT clear this close.
+    a = _assurance_bundle(status="waived", waiver_active=True, revision=OTHER_SHA)
+    assert close.HOLD_STALE_ASSURANCE in _dcodes(close.evaluate_dod(_satisfied(), _dod_eval(a)))
+    # a waiver bound to THIS revision clears.
+    a2 = _assurance_bundle(status="waived", waiver_active=True, revision=SHA)
+    assert close.evaluate_dod(_satisfied(), _dod_eval(a2)) == []
+
+
+def test_evaluate_dod_assurance_gate_scope_must_apply() -> None:
+    # M2: a gate scoped to another scope (or scope-less) cannot satisfy a scoped close.
+    mismatch = _assurance_bundle(gate_scope="feature", close_gate_scope="release")
+    assert close.HOLD_MISSING_ASSURANCE in _dcodes(
+        close.evaluate_dod(_satisfied(), _dod_eval(mismatch)))
+    scopeless = _assurance_bundle(gate_scope=None, close_gate_scope="release")
+    assert close.HOLD_MISSING_ASSURANCE in _dcodes(
+        close.evaluate_dod(_satisfied(), _dod_eval(scopeless)))
+    # matching scope, and an explicit "global" gate, both clear (mirrors gates.check_gates).
+    assert close.evaluate_dod(_satisfied(), _dod_eval(
+        _assurance_bundle(gate_scope="release", close_gate_scope="release"))) == []
+    assert close.evaluate_dod(_satisfied(), _dod_eval(
+        _assurance_bundle(gate_scope="global", close_gate_scope="release"))) == []
+
+
+def test_load_dod_policy_oversized_fails_closed(tmp_path: Path) -> None:
+    s = Store(tmp_path)
+    s.init(["lead"])
+    close.dod_policy_path(s).write_text(
+        '{"schema_version":1,"scopes":{},"pad":"' + "a" * 70000 + '"}', encoding="utf-8")
+    pol, err = close.load_dod_policy(s)
+    assert pol is None and err and "size" in err.lower()
+
+
+def test_load_dod_policy_deeply_nested_fails_closed_without_crash(tmp_path: Path) -> None:
+    s = Store(tmp_path)
+    s.init(["lead"])
+    depth = 20000                                    # deep enough to blow json's recursion limit
+    close.dod_policy_path(s).write_text("[" * depth + "]" * depth, encoding="utf-8")
+    pol, err = close.load_dod_policy(s)              # must NOT raise (RecursionError caught)
+    assert pol is None and err
+
+
+def test_cli_dod_gate_scoped_to_other_scope_does_not_satisfy(tmp_path: Path, capsys) -> None:
+    # M2 end-to-end: a green CI-attested blocker whose OWN scope is "feature" does not satisfy a
+    # release close, even though it is named assurance:release and bound to the revision.
+    root = _init(tmp_path)
+    _write_dod(root)
+    assert _open(root) == 0
+    assert _accept(root) == 0
+    gates.set_gate(root, name="assurance:release", status="green", severity="blocker",
+                   scope="feature", actor="ci", evidence_source="automation_ci",
+                   evidence=["run:x"], revision=SHA)
+    rc, codes = _check_holds(root, capsys)
+    assert rc == 3 and close.HOLD_MISSING_ASSURANCE in codes


### PR DESCRIPTION
Part of #60 (increment 1 of the "red-by-default until evidence exists" forcing gate). Adds the DoD policy plane + the **assurance dimension**.

## What it does
A per-project `.agenttalk/dod.json` declares, per close scope, which evidence dimensions are required. A pure `evaluate_dod` folds into `close.compute_verdict` (new defaulted `dod_eval` kwarg — additive, so absent policy is byte-identical to today). Increment 1 ships the **assurance** dimension: a close whose scope requires assurance HOLDs unless a `severity=blocker`, `evidence_source=automation_ci`, revision-bound, (optionally) fresh `assurance:<scope>` gate is green. This closes the exact Papendal gap where a KEV-critical CVE shipped "green" because *no gate was required*.

Design notes: live-derivation (no frozen apply-route that could be forgotten); binds via the existing gate's own fields, never `artifact.json` (CI stays certifier per the Q1 ruling); malformed policy fails **closed** (`HOLD_INVALID_DOD_POLICY`).

## Dogfooded review — 8 defects caught by a real Codex team member over the bus
Reviewed by `codex-agenttalk-reviewer-1` (a live wrapped agent) across **4 adversarial passes**, each reproduced at the exact SHA. It found and I fixed:
- **B2** malformed policy fail-open (wrong-type scopes, unknown keys, bad schema version, key typos, scope collisions) → all fail closed.
- **B3** freshness fail-open (missing/unparseable/future timestamp) → fail closed with a bounded clock-skew.
- **M1/M2** cross-revision waiver + cross-scope gate → revision-binding + `gates.check_gates` scope applicability.
- **M3** deeply-nested JSON `RecursionError` → size bound + fail-closed decode.
- **dup-keys** duplicate JSON keys erasing requirements → `object_pairs_hook` rejects duplicates at every level.
- **waiver bypass** an unauthenticated `gate waive` could clear the DoD → the waiver-clear channel is removed entirely.

Final verdict: **APPROVED**, no blocking findings, full CLI exploit matrix re-run clean.

## Accepted, documented residuals (filed as follow-ups)
- **#64** — `evidence_source=automation_ci` is a label, not authenticated CI provenance (pre-existing gate-substrate limitation; operator-accepted).
- **#65** — no operator escape until an authenticated `close dod-waive` exists (a gate waiver deliberately cannot clear the DoD).

## Tests
114 in `tests/test_close.py` (incl. one-per-hold-code pure-evaluator cases, CLI integration, and CLI negatives replaying Codex's exact exploits). ruff + bandit clean.
