### PR TITLE
feat(#60): DoD knowledge dimension (inc-2) + Codex-hardened fix-batch

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -15,6 +15,7 @@ import stat
 import subprocess  # nosec B404
 import sys
 import time
+import unicodedata
 import uuid
 import webbrowser
 from datetime import datetime, timedelta, timezone
@@ -2319,6 +2320,23 @@ def _build_dod_eval(store, record: dict):
     return bundle
 
 
+def _substantive_len(text: str) -> int:
+    """Count VISIBLE, substantive characters in ``text``: exclude whitespace and every Unicode
+    separator (category Z*) and other/control/format (category C*) character. Used for the
+    knowledge ``min_body_chars`` triviality floor so padding cannot buy past it anywhere in the
+    body - trailing/leading/interior whitespace, and invisible fillers like U+200B ZERO WIDTH
+    SPACE (Cf) or control characters, all contribute zero. (`str.strip()` alone removed only
+    edge whitespace and left both interior-space and zero-width padding open.)"""
+    n = 0
+    for ch in text:
+        if ch.isspace():
+            continue
+        if unicodedata.category(ch)[0] in ("Z", "C"):
+            continue
+        n += 1
+    return n
+
+
 def _resolve_dod_knowledge(store, spec: dict, record: dict) -> dict:
     """Resolve the CURATED knowledge notes BOUND to this close's revision (never reads a note by
     id - #44; the addressable identity is (domain,key), and a note is bound by a sha anchor /
@@ -2344,11 +2362,13 @@ def _resolve_dod_knowledge(store, spec: dict, record: dict) -> dict:
             if note.get("type") not in types:
                 continue
             if _knowledge_note_bound_to(note, revision):
-                # Measure the STRIPPED body: min_body_chars is a triviality floor, and a body of
-                # one real char + 39 trailing spaces has substantive length 1, not 40. Trim
-                # surrounding whitespace so padding cannot buy past the floor.
+                # min_body_chars is a SUBSTANTIVE-content floor, so measure only visible content:
+                # count characters that are not whitespace and not in a Unicode separator (Z*) or
+                # other/control/format (C*) category. This defeats padding ANYWHERE in the body,
+                # not just at the edges - trailing spaces, interior "x x x ..." runs, and invisible
+                # fillers like U+200B ZERO WIDTH SPACE (Cf) or control chars all count as zero.
                 bound.append({"type": note.get("type"),
-                              "body_len": len(str(note.get("body") or "").strip())})
+                              "body_len": _substantive_len(str(note.get("body") or ""))})
         except Exception:  # noqa: BLE001, S112  # nosec - skip a malformed note, never crash
             continue
     return {
@@ -2925,10 +2945,11 @@ def cmd_close(args: argparse.Namespace) -> int:
             # mutators (`gate set`/`gate waive`, `knowledge retract`, signoff writes) - those live
             # under the config lock, a separate mutex - and `commit` itself does a cross-file
             # read+write (`load_close` -> `_write_close`). So an evidence mutation landing in that
-            # window can leave a persisted GO whose evidence has since changed. This is a KNOWN,
-            # documented race (near-impossible under today's serial single-operator use); full
-            # closure needs one enforced lock spanning every evidence writer + this commit, and a
-            # stale-GO detector - both ride the #31 close-provenance envelope. Do NOT restore the
+            # window can leave a persisted GO whose evidence has since changed. This is a narrow
+            # KNOWN, documented race tracked by #66/#31 (no enforced serialization invariant
+            # excludes the evidence mutators today); full closure needs one enforced lock spanning
+            # every evidence writer + this commit, and a stale-GO detector - both ride the #31
+            # close-provenance envelope. Do NOT restore the
             # earlier "no ack/counter can invalidate a GO between check and write" claim; it was
             # false (proven by a real-CLI repro that persisted GO against a gate set red mid-publish).
             with close_mod.close_transaction(store, args.id) as transaction:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2321,23 +2321,29 @@ def _build_dod_eval(store, record: dict):
 
 
 # Blank-glyph fillers that render empty/space but fall in an otherwise-"visible" general category
-# (Lo/So), so the category + combining-mark filtering in _substantive_len misses them. Small,
-# named, and stable (these are the non-C/non-Z blanks Unicode defines).
+# (Lo/So), so the category + combining-mark filtering in _substantive_len misses them. This is a
+# MAINTAINED blocklist, NOT an exhaustive oracle: Unicode has no stdlib "renders blank" predicate,
+# and these blanks are deliberately categorized as letters/symbols (so category/isalnum can't
+# separate them from real content) and are not all Default_Ignorable. We defend the known classes;
+# an obscure blank not yet listed is an accepted, bounded residual (see _substantive_len).
 _BLANK_GLYPH_FILLERS = frozenset({
-    0x115F,   # HANGUL CHOSEONG FILLER (Lo)
-    0x1160,   # HANGUL JUNGSEONG FILLER (Lo)
-    0x3164,   # HANGUL FILLER (Lo)
-    0xFFA0,   # HALFWIDTH HANGUL FILLER (Lo)
-    0x2800,   # BRAILLE PATTERN BLANK (So)
+    0x115F,    # HANGUL CHOSEONG FILLER (Lo)
+    0x1160,    # HANGUL JUNGSEONG FILLER (Lo)
+    0x3164,    # HANGUL FILLER (Lo)
+    0xFFA0,    # HALFWIDTH HANGUL FILLER (Lo)
+    0x2800,    # BRAILLE PATTERN BLANK (So)
+    0x1D159,   # MUSICAL SYMBOL NULL NOTEHEAD (So) - no glyph in a supporting renderer
+    0x13441,   # EGYPTIAN HIEROGLYPH FULL BLANK (Lo) - rendered as whitespace (Unicode ch.11)
+    0x13442,   # EGYPTIAN HIEROGLYPH HALF BLANK (Lo) - rendered as whitespace
 })
 
 
 def _substantive_len(text: str) -> int:
     """Count VISIBLE, substantive characters in ``text`` for the knowledge ``min_body_chars``
     triviality floor, so padding cannot buy past it ANYWHERE in the body. A char contributes only
-    if it is not whitespace AND not any of the invisible/blank classes below. Together these cover
-    the entire Unicode Default_Ignorable_Code_Point set plus the blank-glyph fillers that fall in
-    otherwise-"visible" categories (general category alone is NOT a visibility predicate):
+    if it is not whitespace AND not any of the invisible/blank classes below. General category
+    alone is NOT a visibility predicate, and Python's stdlib exposes no "renders blank" oracle, so
+    this is a BEST-EFFORT metric over the classes we can detect, NOT a proof of visibility:
 
     - whitespace (`str.isspace()`) and separators (category Z*);
     - other/control/format/surrogate/private-use/unassigned (category C*) - this alone covers
@@ -2347,12 +2353,17 @@ def _substantive_len(text: str) -> int:
       COMBINING GRAPHEME JOINER (U+034F), all VARIATION SELECTORs (U+FE00-FE0F, U+E0100-E01EF),
       and the Mongolian free variation selectors. A base letter still counts; a standalone mark
       does not. (Spacing marks Mc, e.g. Indic vowel signs, DO carry width and are counted.);
-    - a small explicit set of blank-glyph fillers that render empty but sit in Lo/So: the Hangul
-      fillers and BRAILLE PATTERN BLANK.
+    - a MAINTAINED set of blank-glyph fillers that render empty but sit in Lo/So (`_BLANK_GLYPH_
+      FILLERS`): Hangul fillers, BRAILLE PATTERN BLANK, MUSICAL SYMBOL NULL NOTEHEAD, and the
+      EGYPTIAN HIEROGLYPH FULL/HALF BLANK.
 
-    `str.strip()` alone removed only edge whitespace; category Z*/C* alone missed the Mn variation
-    selectors and the Lo/So blank fillers. Exotic gaming of one's OWN quality gate is outside the
-    core threat model, but these known-invisible classes are defended so the floor is meaningful."""
+    BOUNDED RESIDUAL (honest, do not re-overclaim): the blank-filler set is NOT exhaustive - there
+    is no stdlib visibility oracle and Unicode keeps adding blanks, so an obscure blank codepoint
+    not yet listed could pass this floor. That is an ACCEPTED residual: this floor defends the
+    "did you write anything visible" contract against the known invisible/blank classes; gaming
+    one's OWN quality gate with an exotic unlisted blank is outside the core threat model. Add new
+    blanks to `_BLANK_GLYPH_FILLERS` as they are found. (`str.strip()` alone removed only edge
+    whitespace; Z*/C* alone missed the Mn variation selectors and the Lo/So blank fillers.)"""
     n = 0
     for ch in text:
         if ch.isspace():

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2344,8 +2344,11 @@ def _resolve_dod_knowledge(store, spec: dict, record: dict) -> dict:
             if note.get("type") not in types:
                 continue
             if _knowledge_note_bound_to(note, revision):
+                # Measure the STRIPPED body: min_body_chars is a triviality floor, and a body of
+                # one real char + 39 trailing spaces has substantive length 1, not 40. Trim
+                # surrounding whitespace so padding cannot buy past the floor.
                 bound.append({"type": note.get("type"),
-                              "body_len": len(str(note.get("body") or ""))})
+                              "body_len": len(str(note.get("body") or "").strip())})
         except Exception:  # noqa: BLE001, S112  # nosec - skip a malformed note, never crash
             continue
     return {
@@ -2914,9 +2917,20 @@ def cmd_close(args: argparse.Namespace) -> int:
         verdict = close_mod.VERDICT_GO if args.verdict == "go" else close_mod.VERDICT_HOLD
         barrier_epoch = None
         try:
-            # The lock spans reload, all impure evaluations, verdict derivation,
-            # persistence, and the optional barrier stamp. No cooperating ack or
-            # counter can invalidate a GO between check and write.
+            # The per-close lock spans reload, all impure evaluations, verdict derivation,
+            # persistence, and the optional barrier stamp - and evidence is resolved immediately
+            # before the write (nothing but in-memory record mutation sits between the resolve at
+            # `_build_dod_eval`/`compute_verdict` and `transaction.commit`), keeping the exposure
+            # minimal. It is NOT airtight (#66): the per-close lock does NOT exclude EVIDENCE
+            # mutators (`gate set`/`gate waive`, `knowledge retract`, signoff writes) - those live
+            # under the config lock, a separate mutex - and `commit` itself does a cross-file
+            # read+write (`load_close` -> `_write_close`). So an evidence mutation landing in that
+            # window can leave a persisted GO whose evidence has since changed. This is a KNOWN,
+            # documented race (near-impossible under today's serial single-operator use); full
+            # closure needs one enforced lock spanning every evidence writer + this commit, and a
+            # stale-GO detector - both ride the #31 close-provenance envelope. Do NOT restore the
+            # earlier "no ack/counter can invalidate a GO between check and write" claim; it was
+            # false (proven by a real-CLI repro that persisted GO against a gate set red mid-publish).
             with close_mod.close_transaction(store, args.id) as transaction:
                 record = transaction.record
                 if record.get("status") == close_mod.PUBLISHED:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2314,7 +2314,63 @@ def _build_dod_eval(store, record: dict):
               "required_dimensions": dims}
     if "assurance" in dims:
         bundle["assurance"] = _resolve_dod_assurance_gate(store, dims["assurance"], record)
+    if "knowledge" in dims:
+        bundle["knowledge"] = _resolve_dod_knowledge(store, dims["knowledge"], record)
     return bundle
+
+
+def _resolve_dod_knowledge(store, spec: dict, record: dict) -> dict:
+    """Resolve the CURATED knowledge notes BOUND to this close's revision (never reads a note by
+    id - #44; the addressable identity is (domain,key), and a note is bound by a sha anchor /
+    verified_against_sha equal to the close revision). All I/O here; :func:`close._evaluate_dod_
+    knowledge` only counts. Any malformed note/anchor is skipped, never raised."""
+    from agenttalk import knowledge as kn
+
+    revision = str(record.get("revision") or "")
+    types = set(spec.get("types") or [])
+    bound: list[dict] = []
+    try:
+        events, _problems = kn.read_events(store)
+        views = kn.resolve_views(events)
+    except Exception:  # noqa: BLE001 - a broken knowledge log must not crash `close check`
+        events, views = [], {}
+    for _key, slot in (views.items() if isinstance(views, dict) else []):
+        note = slot.get("curated") if isinstance(slot, dict) else None
+        if not isinstance(note, dict):
+            continue
+        try:
+            if not kn.is_curated(note) or kn.is_retracted(note):
+                continue
+            if note.get("type") not in types:
+                continue
+            if _knowledge_note_bound_to(note, revision):
+                bound.append({"type": note.get("type"),
+                              "body_len": len(str(note.get("body") or ""))})
+        except Exception:  # noqa: BLE001, S112  # nosec - skip a malformed note, never crash
+            continue
+    return {
+        "when": spec.get("when", "on_remediation"),
+        "min_notes": spec.get("min_notes", 1),
+        "min_body_chars": spec.get("min_body_chars", 0),
+        "types": sorted(types),
+        "has_remediation": bool(record.get("remediation_items")),
+        "bound_notes": bound,
+    }
+
+
+def _knowledge_note_bound_to(note: dict, revision: str) -> bool:
+    """A note is bound to ``revision`` iff its sha anchor (lessons nest it under ``lesson``) OR
+    its ``verified_against_sha`` equals the close revision (both are full 40-char SHAs)."""
+    if not revision:
+        return False
+    if note.get("verified_against_sha") == revision:
+        return True
+    if note.get("type") == "lesson":
+        anchor = (note.get("lesson") or {}).get("anchor")
+    else:
+        anchor = note.get("anchor")
+    return (isinstance(anchor, dict) and anchor.get("kind") == "sha"
+            and anchor.get("sha") == revision)
 
 
 def _resolve_dod_assurance_gate(store, spec: dict, record: dict) -> dict:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2320,18 +2320,49 @@ def _build_dod_eval(store, record: dict):
     return bundle
 
 
+# Blank-glyph fillers that render empty/space but fall in an otherwise-"visible" general category
+# (Lo/So), so the category + combining-mark filtering in _substantive_len misses them. Small,
+# named, and stable (these are the non-C/non-Z blanks Unicode defines).
+_BLANK_GLYPH_FILLERS = frozenset({
+    0x115F,   # HANGUL CHOSEONG FILLER (Lo)
+    0x1160,   # HANGUL JUNGSEONG FILLER (Lo)
+    0x3164,   # HANGUL FILLER (Lo)
+    0xFFA0,   # HALFWIDTH HANGUL FILLER (Lo)
+    0x2800,   # BRAILLE PATTERN BLANK (So)
+})
+
+
 def _substantive_len(text: str) -> int:
-    """Count VISIBLE, substantive characters in ``text``: exclude whitespace and every Unicode
-    separator (category Z*) and other/control/format (category C*) character. Used for the
-    knowledge ``min_body_chars`` triviality floor so padding cannot buy past it anywhere in the
-    body - trailing/leading/interior whitespace, and invisible fillers like U+200B ZERO WIDTH
-    SPACE (Cf) or control characters, all contribute zero. (`str.strip()` alone removed only
-    edge whitespace and left both interior-space and zero-width padding open.)"""
+    """Count VISIBLE, substantive characters in ``text`` for the knowledge ``min_body_chars``
+    triviality floor, so padding cannot buy past it ANYWHERE in the body. A char contributes only
+    if it is not whitespace AND not any of the invisible/blank classes below. Together these cover
+    the entire Unicode Default_Ignorable_Code_Point set plus the blank-glyph fillers that fall in
+    otherwise-"visible" categories (general category alone is NOT a visibility predicate):
+
+    - whitespace (`str.isspace()`) and separators (category Z*);
+    - other/control/format/surrogate/private-use/unassigned (category C*) - this alone covers
+      U+200B, U+FEFF, U+2060, the bidi marks/overrides, tag chars, soft hyphen, etc.;
+    - zero-width combining marks (categories Mn nonspacing / Me enclosing) - these have no advance
+      width of their own and only modify a base, so a run of them is invisible: covers the
+      COMBINING GRAPHEME JOINER (U+034F), all VARIATION SELECTORs (U+FE00-FE0F, U+E0100-E01EF),
+      and the Mongolian free variation selectors. A base letter still counts; a standalone mark
+      does not. (Spacing marks Mc, e.g. Indic vowel signs, DO carry width and are counted.);
+    - a small explicit set of blank-glyph fillers that render empty but sit in Lo/So: the Hangul
+      fillers and BRAILLE PATTERN BLANK.
+
+    `str.strip()` alone removed only edge whitespace; category Z*/C* alone missed the Mn variation
+    selectors and the Lo/So blank fillers. Exotic gaming of one's OWN quality gate is outside the
+    core threat model, but these known-invisible classes are defended so the floor is meaningful."""
     n = 0
     for ch in text:
         if ch.isspace():
             continue
-        if unicodedata.category(ch)[0] in ("Z", "C"):
+        cat = unicodedata.category(ch)
+        if cat[0] in ("Z", "C"):
+            continue
+        if cat in ("Mn", "Me"):
+            continue
+        if ord(ch) in _BLANK_GLYPH_FILLERS:
             continue
         n += 1
     return n

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -1015,9 +1015,10 @@ def _evaluate_dod_knowledge(record: dict, k: dict | None) -> list[tuple[str, str
     #66 KNOWN RACE (documented, tracked): the CLI resolves ``bound_notes`` (an I/O read of the
     knowledge log) and then persists the close verdict in a separate step; a ``knowledge retract``
     landing in that window can leave a persisted GO citing a now-retracted note. The publish path
-    re-resolves right before the write to make this RARE (not a guaranteed closure - the write is
-    not atomic with the evidence read across files); full closure + a stale-GO detector ride the
-    #31 close-provenance envelope. This evaluator is pure and correct for the inputs it is given."""
+    resolves evidence immediately before the write to keep the exposure narrow (not a guaranteed
+    closure - the write is not atomic with the evidence read across files); full closure + a
+    stale-GO detector ride the #31 close-provenance envelope. This is a narrow known race tracked
+    by #66/#31. This evaluator is pure and correct for the inputs it is given."""
     if not isinstance(k, dict):
         return [(HOLD_MISSING_KNOWLEDGE,
                  "knowledge evidence is required for this scope but was not resolved")]

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -88,6 +88,8 @@ HOLD_INVALID_DOD_POLICY = "invalid_dod_policy"
 HOLD_MISSING_ASSURANCE = "missing_assurance_evidence"
 HOLD_STALE_ASSURANCE = "stale_assurance_evidence"
 HOLD_UNATTESTED_ASSURANCE = "unattested_assurance_evidence"
+HOLD_MISSING_KNOWLEDGE = "missing_knowledge_evidence"
+HOLD_TRIVIAL_EVIDENCE = "trivial_knowledge_evidence"
 
 RELEASE_CLASS_SCOPES = {"release", "milestone", "feature", "hotfix"}
 
@@ -97,7 +99,8 @@ DOD_DIRNAME = "dod.json"
 # dimension the engine cannot enforce is a policy error (you must not be able to require what
 # cannot be checked - a silent soft-pass is exactly the failure this gate exists to prevent).
 # inc-1: assurance only. inc-2 adds knowledge; inc-3 adds coverage + a depth-signoff dimension.
-_DOD_SUPPORTED_DIMENSIONS = frozenset({"assurance"})
+_DOD_SUPPORTED_DIMENSIONS = frozenset({"assurance", "knowledge"})
+_KNOWLEDGE_NOTE_TYPES = frozenset({"decision", "gotcha", "lesson", "pointer", "seam"})
 _DOD_ALLOWED_TOP_KEYS = frozenset({"schema_version", "scopes"})
 _DOD_ASSURANCE_KEYS = frozenset({"gate", "max_age_days"})
 _DOD_SCHEMA_VERSION = 1
@@ -783,6 +786,8 @@ def validate_dod_policy(raw: object) -> dict:
                     f"(supported: {sorted(_DOD_SUPPORTED_DIMENSIONS)})")
             if dim == "assurance":
                 norm[dim] = _validate_dod_assurance_spec(spec, scope_name)
+            elif dim == "knowledge":
+                norm[dim] = _validate_dod_knowledge_spec(spec, scope_name)
         key = str(scope_name).lower()
         if key in scopes:
             # two scope names that collide after lowercasing are ambiguous -> fail closed.
@@ -809,6 +814,39 @@ def _validate_dod_assurance_spec(spec: object, scope_name: str) -> dict:
         raise CloseError(
             f"dod scope {scope_name!r} assurance.max_age_days must be a non-negative integer")
     return {"gate": gate, "max_age_days": max_age}
+
+
+def _validate_dod_knowledge_spec(spec: object, scope_name: str) -> dict:
+    """Normalize a scope's ``knowledge`` requirement. ``when``: on_remediation (default; required
+    only when the close carries a fix) | always. ``min_notes``: how many CURATED, non-trivial,
+    revision-bound notes clear it (default 1). ``types``: allowed note types (default the
+    lesson/gotcha/decision trio). ``min_body_chars``: triviality floor - knowledge.validate_body
+    only forbids empty, so a stub could otherwise clear the gate (default 40)."""
+    if not isinstance(spec, dict):
+        raise CloseError(f"dod scope {scope_name!r} knowledge must be an object")
+    when = spec.get("when", "on_remediation")
+    if when not in ("on_remediation", "always"):
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge.when must be 'on_remediation' or 'always'")
+    min_notes = spec.get("min_notes", 1)
+    if not isinstance(min_notes, int) or isinstance(min_notes, bool) or min_notes < 1:
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge.min_notes must be an integer >= 1")
+    types = spec.get("types", ["lesson", "gotcha", "decision"])
+    if not isinstance(types, list) or not types or not all(isinstance(t, str) for t in types):
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge.types must be a non-empty list of strings")
+    bad = [t for t in types if t not in _KNOWLEDGE_NOTE_TYPES]
+    if bad:
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge.types has unknown type(s) {bad} "
+            f"(known: {sorted(_KNOWLEDGE_NOTE_TYPES)})")
+    min_body_chars = spec.get("min_body_chars", 40)
+    if not isinstance(min_body_chars, int) or isinstance(min_body_chars, bool) or min_body_chars < 0:
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge.min_body_chars must be a non-negative integer")
+    return {"when": when, "min_notes": min_notes,
+            "types": sorted(set(types)), "min_body_chars": min_body_chars}
 
 
 def dod_policy_hash(policy: dict) -> str:
@@ -857,6 +895,8 @@ def evaluate_dod(record: dict, dod_eval: dict | None) -> list[tuple[str, str]]:
     out: list[tuple[str, str]] = []
     if "assurance" in required:
         out.extend(_evaluate_dod_assurance(record, dod_eval.get("assurance")))
+    if "knowledge" in required:
+        out.extend(_evaluate_dod_knowledge(record, dod_eval.get("knowledge")))
     return out
 
 
@@ -935,6 +975,40 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
             out.append((HOLD_STALE_ASSURANCE,
                         f"assurance gate {gate!r} freshness is required but its age is invalid"))
     return out
+
+
+def _evaluate_dod_knowledge(record: dict, k: dict | None) -> list[tuple[str, str]]:
+    """PURE: the knowledge dimension flips "write down what you learned" from opt-in to
+    red-by-default (Papendal shipped a multi-day build with ZERO notes). A close that produced a
+    fix HOLDs unless it cites >= min_notes CURATED, non-trivial knowledge notes of an allowed type
+    that are BOUND to the close. BINDING: a note is bound iff its ``sha`` anchor (or
+    ``verified_against_sha``) equals the close ``revision`` - the close record has no request_id,
+    so a sha match to the closed commit is the only clean, non-circular link (the CLI resolves the
+    curated/typed/bound set; this only COUNTS). ``when=on_remediation`` (default) requires it only
+    when the close carries remediation; ``when=always`` always requires it. Distinguishes 'nothing
+    captured' (HOLD_MISSING_KNOWLEDGE) from 'only stubs captured' (HOLD_TRIVIAL_EVIDENCE)."""
+    if not isinstance(k, dict):
+        return [(HOLD_MISSING_KNOWLEDGE,
+                 "knowledge evidence is required for this scope but was not resolved")]
+    when = k.get("when", "on_remediation")
+    required = when == "always" or (when == "on_remediation" and bool(k.get("has_remediation")))
+    if not required:
+        return []
+    min_notes = k.get("min_notes", 1)
+    min_body_chars = k.get("min_body_chars", 0)
+    types = k.get("types") or []
+    bound = k.get("bound_notes") or []
+    qualifying = [n for n in bound
+                  if isinstance(n, dict) and int(n.get("body_len") or 0) >= int(min_body_chars)]
+    if len(qualifying) >= int(min_notes):
+        return []
+    if bound and not qualifying:
+        return [(HOLD_TRIVIAL_EVIDENCE,
+                 f"the {len(bound)} knowledge note(s) bound to this close revision are all below "
+                 f"min_body_chars={min_body_chars} (stubs do not count as captured knowledge)")]
+    return [(HOLD_MISSING_KNOWLEDGE,
+             f"scope requires >= {min_notes} curated knowledge note(s) of {types} bound to the "
+             f"close revision (by sha anchor / verified_against_sha); found {len(qualifying)}")]
 
 
 def merge_candidate_refsets(*refsets: dict) -> dict:

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -101,6 +101,13 @@ DOD_DIRNAME = "dod.json"
 # inc-1: assurance only. inc-2 adds knowledge; inc-3 adds coverage + a depth-signoff dimension.
 _DOD_SUPPORTED_DIMENSIONS = frozenset({"assurance", "knowledge"})
 _KNOWLEDGE_NOTE_TYPES = frozenset({"decision", "gotcha", "lesson", "pointer", "seam"})
+# The DoD knowledge dimension only counts DELIBERATE, human-authored knowledge (a lesson, a
+# gotcha, a decision) as evidence that "what we learned was written down". seam/pointer are
+# structural index notes, NOT that kind of evidence - a policy must not be able to satisfy the
+# knowledge gate with them, so the CONFIGURABLE types are this trio, a strict subset of
+# _KNOWLEDGE_NOTE_TYPES (a policy may narrow to a subset of the trio, never widen past it).
+_DOD_KNOWLEDGE_ALLOWED_TYPES = frozenset({"decision", "gotcha", "lesson"})
+_DOD_KNOWLEDGE_KEYS = frozenset({"when", "min_notes", "types", "min_body_chars"})
 _DOD_ALLOWED_TOP_KEYS = frozenset({"schema_version", "scopes"})
 _DOD_ASSURANCE_KEYS = frozenset({"gate", "max_age_days"})
 _DOD_SCHEMA_VERSION = 1
@@ -818,12 +825,20 @@ def _validate_dod_assurance_spec(spec: object, scope_name: str) -> dict:
 
 def _validate_dod_knowledge_spec(spec: object, scope_name: str) -> dict:
     """Normalize a scope's ``knowledge`` requirement. ``when``: on_remediation (default; required
-    only when the close carries a fix) | always. ``min_notes``: how many CURATED, non-trivial,
-    revision-bound notes clear it (default 1). ``types``: allowed note types (default the
-    lesson/gotcha/decision trio). ``min_body_chars``: triviality floor - knowledge.validate_body
-    only forbids empty, so a stub could otherwise clear the gate (default 40)."""
+    only when the close carries an ACCEPTED COUNTER / remediation item - see the honesty note in
+    :func:`_evaluate_dod_knowledge`, NOT "any fix") | always. ``min_notes``: how many CURATED,
+    non-trivial, revision-bound notes clear it (default 1). ``types``: allowed note types, a
+    subset of the lesson/gotcha/decision trio (default the whole trio). ``min_body_chars``:
+    triviality floor - knowledge.validate_body only forbids empty, so a stub could otherwise
+    clear the gate (default 40). Rejects UNKNOWN keys fail-closed (a ``min_note`` typo must RAISE,
+    not silently apply the ``min_notes`` default and let one note through)."""
     if not isinstance(spec, dict):
         raise CloseError(f"dod scope {scope_name!r} knowledge must be an object")
+    unknown = set(spec) - set(_DOD_KNOWLEDGE_KEYS)
+    if unknown:
+        # e.g. a "min_note"/"min_body_char" typo must RAISE, not silently drop the requirement.
+        raise CloseError(
+            f"dod scope {scope_name!r} knowledge has unknown key(s): {sorted(unknown)}")
     when = spec.get("when", "on_remediation")
     if when not in ("on_remediation", "always"):
         raise CloseError(
@@ -836,11 +851,12 @@ def _validate_dod_knowledge_spec(spec: object, scope_name: str) -> dict:
     if not isinstance(types, list) or not types or not all(isinstance(t, str) for t in types):
         raise CloseError(
             f"dod scope {scope_name!r} knowledge.types must be a non-empty list of strings")
-    bad = [t for t in types if t not in _KNOWLEDGE_NOTE_TYPES]
+    bad = [t for t in types if t not in _DOD_KNOWLEDGE_ALLOWED_TYPES]
     if bad:
         raise CloseError(
-            f"dod scope {scope_name!r} knowledge.types has unknown type(s) {bad} "
-            f"(known: {sorted(_KNOWLEDGE_NOTE_TYPES)})")
+            f"dod scope {scope_name!r} knowledge.types has disallowed type(s) {bad} - the "
+            f"knowledge dimension only counts {sorted(_DOD_KNOWLEDGE_ALLOWED_TYPES)} "
+            f"(seam/pointer are structural index notes, not captured-learning evidence)")
     min_body_chars = spec.get("min_body_chars", 40)
     if not isinstance(min_body_chars, int) or isinstance(min_body_chars, bool) or min_body_chars < 0:
         raise CloseError(
@@ -979,14 +995,29 @@ def _evaluate_dod_assurance(record: dict, a: dict | None) -> list[tuple[str, str
 
 def _evaluate_dod_knowledge(record: dict, k: dict | None) -> list[tuple[str, str]]:
     """PURE: the knowledge dimension flips "write down what you learned" from opt-in to
-    red-by-default (Papendal shipped a multi-day build with ZERO notes). A close that produced a
-    fix HOLDs unless it cites >= min_notes CURATED, non-trivial knowledge notes of an allowed type
-    that are BOUND to the close. BINDING: a note is bound iff its ``sha`` anchor (or
-    ``verified_against_sha``) equals the close ``revision`` - the close record has no request_id,
-    so a sha match to the closed commit is the only clean, non-circular link (the CLI resolves the
-    curated/typed/bound set; this only COUNTS). ``when=on_remediation`` (default) requires it only
-    when the close carries remediation; ``when=always`` always requires it. Distinguishes 'nothing
-    captured' (HOLD_MISSING_KNOWLEDGE) from 'only stubs captured' (HOLD_TRIVIAL_EVIDENCE)."""
+    red-by-default (Papendal shipped a multi-day build with ZERO notes). HOLDs unless the close
+    cites >= min_notes CURATED, non-trivial knowledge notes of an allowed type that are BOUND to
+    the close. BINDING: a note is bound iff its ``sha`` anchor (or ``verified_against_sha``) equals
+    the close ``revision`` - the close record has no request_id, so a sha match to the closed
+    commit is the only clean, non-circular link (the CLI resolves the curated/typed/bound set;
+    this only COUNTS). Distinguishes 'nothing captured' (HOLD_MISSING_KNOWLEDGE) from 'only stubs
+    captured' (HOLD_TRIVIAL_EVIDENCE).
+
+    ``when`` HONESTY (do not overclaim): ``when=always`` ALWAYS requires notes. ``when=on_remediation``
+    (default) requires them only when ``has_remediation`` is set, and ``has_remediation`` is
+    precisely ``bool(record["remediation_items"])`` - i.e. the close carries an ACCEPTED COUNTER /
+    remediation item. It is NOT a general "a fix was produced" signal: a hotfix that lands without
+    an accepted counter has no remediation_items and so is NOT triggered. There is no authoritative
+    durable "fix produced" fact to bind to yet (that would be a separate task). So a scope that must
+    capture knowledge on EVERY close (not only counter-bearing ones) MUST use ``when=always``;
+    ``on_remediation`` is the narrower "when we formally accepted a counter" trigger. #64/#65-adjacent.
+
+    #66 KNOWN RACE (documented, tracked): the CLI resolves ``bound_notes`` (an I/O read of the
+    knowledge log) and then persists the close verdict in a separate step; a ``knowledge retract``
+    landing in that window can leave a persisted GO citing a now-retracted note. The publish path
+    re-resolves right before the write to make this RARE (not a guaranteed closure - the write is
+    not atomic with the evidence read across files); full closure + a stale-GO detector ride the
+    #31 close-provenance envelope. This evaluator is pure and correct for the inputs it is given."""
     if not isinstance(k, dict):
         return [(HOLD_MISSING_KNOWLEDGE,
                  "knowledge evidence is required for this scope but was not resolved")]

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1580,3 +1580,18 @@ def test_resolve_dod_knowledge_default_ignorable_body_does_not_clear(
     k = cli._resolve_dod_knowledge(s, spec, rec)
     assert k["bound_notes"] == [{"type": "gotcha", "body_len": 0}]
     assert close._evaluate_dod_knowledge(rec, k)[0][0] == close.HOLD_TRIVIAL_EVIDENCE
+
+
+@pytest.mark.parametrize("cp,label", [
+    ("\U0001D159", "musical-null-notehead"),   # So
+    ("\U00013441", "egyptian-full-blank"),      # Lo, rendered as whitespace (Unicode ch.11)
+    ("\U00013442", "egyptian-half-blank"),      # Lo
+])
+def test_substantive_len_maintained_blank_fillers_are_zero(cp, label) -> None:
+    # Blank glyphs in Lo/So that no category rule can catch (they are deliberately categorized as
+    # letters/symbols) — covered only by the maintained _BLANK_GLYPH_FILLERS blocklist. Added when
+    # Codex found them; the bounded residual (obscure unlisted blanks) is documented, not claimed
+    # closed.
+    assert ord(cp) in cli._BLANK_GLYPH_FILLERS         # it IS in the maintained set
+    assert cli._substantive_len(cp * 40) == 0          # 40 blanks -> 0 substantive
+    assert cli._substantive_len(cp * 39 + "z") == 1    # a single real char still counts

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -23,6 +23,7 @@ import threading
 import pytest
 
 from agenttalk import cli, close, gates
+from agenttalk import knowledge as kn
 from agenttalk.store import Store
 
 SHA = "a" * 40
@@ -966,7 +967,7 @@ def test_validate_dod_policy_allows_absent_max_age() -> None:
     {"schema_version": True, "scopes": {}},
     {"schema_version": 1, "scopes": "nope"},
     {"schema_version": 1, "scopes": {"release": "nope"}},
-    {"schema_version": 1, "scopes": {"release": {"knowledge": {"min_notes": 1}}}},  # unsupported
+    {"schema_version": 1, "scopes": {"release": {"coverage": {"floor_pct": 70}}}},  # unsupported
     {"schema_version": 1, "scopes": {"release": {"assurance": {}}}},                # missing gate
     {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": ""}}}},      # empty gate
     {"schema_version": 1, "scopes": {"release": {"assurance": {"gate": "g",
@@ -987,9 +988,9 @@ def test_load_dod_policy_malformed_fails_closed(tmp_path: Path) -> None:
     s = Store(tmp_path)
     s.init(["lead"])
     close.dod_policy_path(s).write_text('{"schema_version": 1, "scopes": {"release": '
-                                        '{"knowledge": {}}}}', encoding="utf-8")
+                                        '{"coverage": {}}}}', encoding="utf-8")
     policy, err = close.load_dod_policy(s)
-    assert policy is None and err and "knowledge" in err
+    assert policy is None and err and "coverage" in err
 
 
 # ------------------------------------------------------ derive_required_dod
@@ -1157,7 +1158,7 @@ def test_cli_dod_stale_when_gate_bound_to_other_revision(tmp_path: Path, capsys)
 def test_cli_dod_malformed_policy_fails_closed_without_crash(tmp_path: Path, capsys) -> None:
     root = _init(tmp_path)
     close.dod_policy_path(Store(root)).write_text(
-        '{"schema_version": 1, "scopes": {"release": {"knowledge": {}}}}', encoding="utf-8")
+        '{"schema_version": 1, "scopes": {"release": {"coverage": {}}}}', encoding="utf-8")
     assert _open(root) == 0
     assert _accept(root) == 0
     rc, codes = _check_holds(root, capsys)
@@ -1303,3 +1304,161 @@ def test_evaluate_dod_assurance_revisionless_waiver_does_not_clear() -> None:
     # (Codex re-review of 848841a, BLOCKER). Authenticated operator escape = task #65.
     a = _assurance_bundle(status="waived", waiver_active=True, revision=None)
     assert close.HOLD_MISSING_ASSURANCE in _dcodes(close.evaluate_dod(_satisfied(), _dod_eval(a)))
+
+
+# ============================================================ #60 inc-2: knowledge dimension
+
+def _knowledge_bundle(**over) -> dict:
+    """A satisfied resolved knowledge bundle (required on remediation, one bound non-trivial
+    note). Override any field to build the failing variants."""
+    b = {"when": "on_remediation", "min_notes": 1, "min_body_chars": 40,
+         "types": ["decision", "gotcha", "lesson"], "has_remediation": True,
+         "bound_notes": [{"type": "lesson", "body_len": 60}]}
+    b.update(over)
+    return b
+
+
+def _dod_eval_k(knowledge: dict | None) -> dict:
+    return {"policy_present": True, "policy_error": None,
+            "required_dimensions": {"knowledge": {}}, "knowledge": knowledge}
+
+
+# ---- validate the knowledge spec
+
+def test_validate_dod_knowledge_spec_defaults_roundtrip() -> None:
+    pol = close.validate_dod_policy(
+        {"schema_version": 1, "scopes": {"feature": {"knowledge": {}}}})
+    assert pol["scopes"]["feature"]["knowledge"] == {
+        "when": "on_remediation", "min_notes": 1,
+        "types": ["decision", "gotcha", "lesson"], "min_body_chars": 40}
+
+
+def test_validate_dod_knowledge_spec_explicit_roundtrip() -> None:
+    pol = close.validate_dod_policy({"schema_version": 1, "scopes": {"release": {
+        "knowledge": {"when": "always", "min_notes": 2, "types": ["gotcha"],
+                      "min_body_chars": 10}}}})
+    assert pol["scopes"]["release"]["knowledge"] == {
+        "when": "always", "min_notes": 2, "types": ["gotcha"], "min_body_chars": 10}
+
+
+@pytest.mark.parametrize("spec", [
+    {"when": "sometimes"},
+    {"min_notes": 0},
+    {"min_notes": True},
+    {"types": []},
+    {"types": ["bogus"]},
+    {"types": "gotcha"},
+    {"min_body_chars": -1},
+])
+def test_validate_dod_knowledge_spec_malformed_raises(spec) -> None:
+    with pytest.raises(close.CloseError):
+        close.validate_dod_policy(
+            {"schema_version": 1, "scopes": {"release": {"knowledge": spec}}})
+
+
+# ---- evaluate_dod knowledge (pure)
+
+def test_evaluate_dod_knowledge_not_required_when_no_remediation() -> None:
+    ev = _dod_eval_k(_knowledge_bundle(when="on_remediation", has_remediation=False,
+                                       bound_notes=[]))
+    assert close.evaluate_dod(_satisfied(), ev) == []
+
+
+def test_evaluate_dod_knowledge_always_with_no_notes_holds_missing() -> None:
+    # when=always requires knowledge even with no remediation on the close.
+    ev = _dod_eval_k(_knowledge_bundle(when="always", has_remediation=False, bound_notes=[]))
+    holds = close.evaluate_dod(_satisfied(), ev)
+    assert len(holds) == 1 and holds[0][0] == close.HOLD_MISSING_KNOWLEDGE
+
+
+def test_evaluate_dod_knowledge_remediation_no_notes_holds_missing() -> None:
+    ev = _dod_eval_k(_knowledge_bundle(bound_notes=[]))
+    assert close.evaluate_dod(_satisfied(), ev)[0][0] == close.HOLD_MISSING_KNOWLEDGE
+
+
+def test_evaluate_dod_knowledge_only_stubs_holds_trivial() -> None:
+    ev = _dod_eval_k(_knowledge_bundle(min_body_chars=40,
+                                       bound_notes=[{"type": "gotcha", "body_len": 12}]))
+    assert close.evaluate_dod(_satisfied(), ev)[0][0] == close.HOLD_TRIVIAL_EVIDENCE
+
+
+def test_evaluate_dod_knowledge_fewer_than_min_holds_missing() -> None:
+    ev = _dod_eval_k(_knowledge_bundle(min_notes=2,
+                                       bound_notes=[{"type": "lesson", "body_len": 60}]))
+    assert close.evaluate_dod(_satisfied(), ev)[0][0] == close.HOLD_MISSING_KNOWLEDGE
+
+
+def test_evaluate_dod_knowledge_satisfied_is_empty() -> None:
+    assert close.evaluate_dod(_satisfied(), _dod_eval_k(_knowledge_bundle())) == []
+
+
+def test_evaluate_dod_knowledge_missing_bundle_holds_missing() -> None:
+    ev = {"policy_present": True, "policy_error": None,
+          "required_dimensions": {"knowledge": {}}, "knowledge": None}
+    assert close.evaluate_dod(_satisfied(), ev)[0][0] == close.HOLD_MISSING_KNOWLEDGE
+
+
+# ---- compute_verdict integration (knowledge)
+
+def test_compute_verdict_unmet_knowledge_flips_go_to_hold() -> None:
+    result = close.compute_verdict(
+        _satisfied(), _gate_go(), None, None, _dod_eval_k(_knowledge_bundle(bound_notes=[])))
+    assert result["verdict"] == close.VERDICT_HOLD
+    assert _codes(result) == {close.HOLD_MISSING_KNOWLEDGE}   # reached the DoD fold, not MALFORMED
+
+
+def test_compute_verdict_satisfied_knowledge_stays_go() -> None:
+    result = close.compute_verdict(
+        _satisfied(), _gate_go(), None, None, _dod_eval_k(_knowledge_bundle()))
+    assert result["verdict"] == close.VERDICT_GO and result["holds"] == []
+
+
+# ---- resolver against REAL knowledge events (impure bridge, real note shape)
+
+def _add_note(store, *, key: str, ntype: str, body: str, anchor: dict | None,
+              vsha: str | None, curate: bool = True) -> None:
+    pub = kn.new_publish_event(
+        note_id="kn-" + key.replace(".", "-"), key=key, type=ntype, domain_id="cli",
+        body=body, anchor=anchor, verified_against_sha=vsha,
+        domain_registry_hash="rh1", domain_definition_hash="d" * 64,
+        author="dev", resolved_from="active_agent", at="t1")
+    kn.append_event(store, pub)
+    if curate:
+        kn.append_event(store, kn.new_curate_event(
+            base=pub, action="verify", curated_by="lead", resolved_from="lead",
+            at="t2", reason=None, domain_registry_hash="rh1"))
+
+
+def test_resolve_dod_knowledge_binds_curated_notes_by_sha_and_vsha(tmp_path: Path) -> None:
+    root = _init(tmp_path)
+    s = Store(root)
+    long_body = "a genuinely non-trivial lesson body well over forty characters long"
+    # bound by sha anchor (curated, allowed type) -> counts
+    _add_note(s, key="dod.bysha", ntype="gotcha", body=long_body,
+              anchor={"kind": "sha", "sha": SHA}, vsha=None)
+    # bound by verified_against_sha -> counts (path anchor, but vsha matches revision)
+    _add_note(s, key="dod.byvsha", ntype="decision", body=long_body,
+              anchor={"kind": "path", "path": "src/x.py"}, vsha=SHA)
+    # anchored to a DIFFERENT sha -> excluded
+    _add_note(s, key="dod.other", ntype="gotcha", body=long_body,
+              anchor={"kind": "sha", "sha": OTHER_SHA}, vsha=None)
+    # bound but UNCURATED -> excluded
+    _add_note(s, key="dod.uncur", ntype="gotcha", body=long_body,
+              anchor={"kind": "sha", "sha": SHA}, vsha=None, curate=False)
+    # bound + curated but WRONG type (seam not in the allowed set) -> excluded
+    _add_note(s, key="dod.wrongtype", ntype="seam", body=long_body,
+              anchor={"kind": "sha", "sha": SHA}, vsha=None)
+
+    spec = {"when": "on_remediation", "min_notes": 1, "min_body_chars": 40,
+            "types": ["decision", "gotcha", "lesson"]}
+    rec = close.empty_close(
+        "c", scope="release", revision=SHA, revision_kind="sha", gate_scope="release",
+        opened_by="lead", opened_at="t0", epoch_at_open=None, required_lenses=[],
+        revision_clean=True, dirty_artifact=None)
+    rec["remediation_items"] = {"r1": {"id": "r1", "blocker": False}}
+    k = cli._resolve_dod_knowledge(s, spec, rec)
+    assert k["has_remediation"] is True
+    kinds = sorted(n["type"] for n in k["bound_notes"])
+    assert kinds == ["decision", "gotcha"]   # only the two curated+bound+allowed-type notes
+    # and it clears the pure gate
+    assert close._evaluate_dod_knowledge(rec, k) == []

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1529,3 +1529,54 @@ def test_substantive_len_counts_only_visible_chars() -> None:
     assert cli._substantive_len("​​​") == 0    # zero-width spaces
     assert cli._substantive_len("  x\t\n") == 1
     assert cli._substantive_len("café ☃!") == 6               # accented + symbol count
+
+
+@pytest.mark.parametrize("body,label", [
+    ("͏" * 40, "combining-grapheme-joiner"),   # Mn, default-ignorable
+    ("️" * 40, "variation-selector-16"),        # Mn
+    ("\U000e0100" * 40, "variation-selector-17"),    # Mn (supplementary)
+    ("᠋" * 40, "mongolian-fvs-one"),            # Mn
+    ("ㅤ" * 40, "hangul-filler"),                # Lo, blank glyph
+    ("⠀" * 40, "braille-blank"),                # So, blank glyph
+    ("ᅟ" * 40, "hangul-choseong-filler"),       # Lo, blank glyph
+    ("﻿" * 40, "bom-zwnbsp"),                   # Cf (regression: still 0)
+])
+def test_substantive_len_default_ignorable_and_blank_glyphs_are_zero(body, label) -> None:
+    # Re-review round 3: general category is NOT a visibility predicate. Default-ignorable
+    # combining marks (Mn) and blank-glyph fillers (Lo/So) render empty but escaped the Z*/C*
+    # filter. A body of 40 of any of them must count as 0 substantive chars.
+    assert cli._substantive_len(body) == 0
+
+
+@pytest.mark.parametrize("body,expect", [
+    ("é" * 30, 30),        # base letter + combining acute: the 30 bases count, marks don't
+    ("abc️", 3),            # emoji variation selector after 3 letters -> 3
+    ("x" * 40 + "​" * 99, 40),   # padding after real content doesn't inflate OR deflate
+])
+def test_substantive_len_counts_visible_base_despite_marks(body, expect) -> None:
+    assert cli._substantive_len(body) == expect
+
+
+@pytest.mark.parametrize("body,label", [
+    ("͏" * 40, "combining-grapheme-joiner"),
+    ("️" * 40, "variation-selector-16"),
+    ("ㅤ" * 40, "hangul-filler"),
+    ("⠀" * 40, "braille-blank"),
+])
+def test_resolve_dod_knowledge_default_ignorable_body_does_not_clear(
+        tmp_path: Path, body, label) -> None:
+    # End-to-end (real publish/curate): an effectively-invisible note must NOT clear the floor.
+    root = _init(tmp_path)
+    s = Store(root)
+    _add_note(s, key=f"dod.di.{label}", ntype="gotcha", body=body,
+              anchor={"kind": "sha", "sha": SHA}, vsha=None)
+    spec = {"when": "on_remediation", "min_notes": 1, "min_body_chars": 40,
+            "types": ["decision", "gotcha", "lesson"]}
+    rec = close.empty_close(
+        "c", scope="release", revision=SHA, revision_kind="sha", gate_scope="release",
+        opened_by="lead", opened_at="t0", epoch_at_open=None, required_lenses=[],
+        revision_clean=True, dirty_artifact=None)
+    rec["remediation_items"] = {"r1": {"id": "r1", "blocker": False}}
+    k = cli._resolve_dod_knowledge(s, spec, rec)
+    assert k["bound_notes"] == [{"type": "gotcha", "body_len": 0}]
+    assert close._evaluate_dod_knowledge(rec, k)[0][0] == close.HOLD_TRIVIAL_EVIDENCE

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1496,12 +1496,20 @@ def test_resolve_dod_knowledge_binds_curated_notes_by_sha_and_vsha(tmp_path: Pat
     assert close._evaluate_dod_knowledge(rec, k) == []
 
 
-def test_resolve_dod_knowledge_whitespace_padded_body_does_not_clear(tmp_path: Path) -> None:
-    # BLOCKER 3: a body of one real char + 39 trailing spaces is 40 chars raw but substantively
-    # 1. The resolver must measure the STRIPPED length, so it must NOT buy past min_body_chars=40.
+@pytest.mark.parametrize("body,expect_len,label", [
+    ("x" + " " * 39, 1, "trailing-spaces"),                 # BLOCKER 3 (original)
+    ("x" + " " * 39 + "y", 2, "interior-spaces"),           # re-review: interior padding
+    ("​" * 40, 0, "zero-width-space-only"),            # re-review: invisible U+200B (Cf)
+    ("x " * 20, 20, "alternating-space"),                   # only the 20 visible x's count
+    ("\t\n" + "z" * 3 + " " * 30, 3, "mixed-ws-nbsp"),  # NBSP (Zs) + control -> 3
+])
+def test_resolve_dod_knowledge_padding_never_clears_floor(
+        tmp_path: Path, body, expect_len, label) -> None:
+    # min_body_chars is a SUBSTANTIVE-content floor: padding ANYWHERE - trailing/interior
+    # whitespace, invisible U+200B, NBSP, control chars - must not buy past it (Codex re-review).
     root = _init(tmp_path)
     s = Store(root)
-    _add_note(s, key="dod.padded", ntype="gotcha", body="x" + " " * 39,
+    _add_note(s, key=f"dod.pad.{label}", ntype="gotcha", body=body,
               anchor={"kind": "sha", "sha": SHA}, vsha=None)
     spec = {"when": "on_remediation", "min_notes": 1, "min_body_chars": 40,
             "types": ["decision", "gotcha", "lesson"]}
@@ -1511,6 +1519,13 @@ def test_resolve_dod_knowledge_whitespace_padded_body_does_not_clear(tmp_path: P
         revision_clean=True, dirty_artifact=None)
     rec["remediation_items"] = {"r1": {"id": "r1", "blocker": False}}
     k = cli._resolve_dod_knowledge(s, spec, rec)
-    assert k["bound_notes"] == [{"type": "gotcha", "body_len": 1}]   # stripped, not 40
-    # the padded stub is bound-but-not-qualifying -> HOLD_TRIVIAL_EVIDENCE, not a GO
+    assert k["bound_notes"] == [{"type": "gotcha", "body_len": expect_len}]
+    # bound-but-not-qualifying -> HOLD_TRIVIAL_EVIDENCE, never a GO
     assert close._evaluate_dod_knowledge(rec, k)[0][0] == close.HOLD_TRIVIAL_EVIDENCE
+
+
+def test_substantive_len_counts_only_visible_chars() -> None:
+    assert cli._substantive_len("hello world") == 10          # space excluded
+    assert cli._substantive_len("​​​") == 0    # zero-width spaces
+    assert cli._substantive_len("  x\t\n") == 1
+    assert cli._substantive_len("café ☃!") == 6               # accented + symbol count

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1356,6 +1356,38 @@ def test_validate_dod_knowledge_spec_malformed_raises(spec) -> None:
             {"schema_version": 1, "scopes": {"release": {"knowledge": spec}}})
 
 
+@pytest.mark.parametrize("spec", [
+    {"min_note": 2},            # BLOCKER 1: min_notes typo must RAISE, not silently default to 1
+    {"min_body_char": 10},      # min_body_chars typo
+    {"whens": "always"},        # when typo
+    {"type": ["gotcha"]},       # types typo
+    {"min_notes": 1, "extra": True},
+])
+def test_validate_dod_knowledge_spec_rejects_unknown_keys_failclosed(spec) -> None:
+    # A typo'd key must fail CLOSED (HOLD_INVALID_DOD_POLICY at the CLI), never be dropped so the
+    # intended (stricter) requirement silently reverts to a weaker default and a close GOes.
+    with pytest.raises(close.CloseError):
+        close.validate_dod_policy(
+            {"schema_version": 1, "scopes": {"release": {"knowledge": spec}}})
+
+
+@pytest.mark.parametrize("bad_type", ["seam", "pointer"])
+def test_validate_dod_knowledge_spec_rejects_structural_note_types(bad_type) -> None:
+    # MAJOR: seam/pointer are structural index notes, not captured-learning evidence. A policy
+    # must not be able to satisfy the knowledge dimension with them, so they are DISALLOWED as
+    # configurable types even though they are valid knowledge-note types generally.
+    with pytest.raises(close.CloseError):
+        close.validate_dod_policy({"schema_version": 1, "scopes": {"release": {
+            "knowledge": {"types": [bad_type]}}}})
+
+
+def test_validate_dod_knowledge_spec_allows_trio_subsets() -> None:
+    for subset in (["lesson"], ["gotcha", "decision"], ["decision", "gotcha", "lesson"]):
+        pol = close.validate_dod_policy({"schema_version": 1, "scopes": {"release": {
+            "knowledge": {"types": subset}}}})
+        assert pol["scopes"]["release"]["knowledge"]["types"] == sorted(set(subset))
+
+
 # ---- evaluate_dod knowledge (pure)
 
 def test_evaluate_dod_knowledge_not_required_when_no_remediation() -> None:
@@ -1462,3 +1494,23 @@ def test_resolve_dod_knowledge_binds_curated_notes_by_sha_and_vsha(tmp_path: Pat
     assert kinds == ["decision", "gotcha"]   # only the two curated+bound+allowed-type notes
     # and it clears the pure gate
     assert close._evaluate_dod_knowledge(rec, k) == []
+
+
+def test_resolve_dod_knowledge_whitespace_padded_body_does_not_clear(tmp_path: Path) -> None:
+    # BLOCKER 3: a body of one real char + 39 trailing spaces is 40 chars raw but substantively
+    # 1. The resolver must measure the STRIPPED length, so it must NOT buy past min_body_chars=40.
+    root = _init(tmp_path)
+    s = Store(root)
+    _add_note(s, key="dod.padded", ntype="gotcha", body="x" + " " * 39,
+              anchor={"kind": "sha", "sha": SHA}, vsha=None)
+    spec = {"when": "on_remediation", "min_notes": 1, "min_body_chars": 40,
+            "types": ["decision", "gotcha", "lesson"]}
+    rec = close.empty_close(
+        "c", scope="release", revision=SHA, revision_kind="sha", gate_scope="release",
+        opened_by="lead", opened_at="t0", epoch_at_open=None, required_lenses=[],
+        revision_clean=True, dirty_artifact=None)
+    rec["remediation_items"] = {"r1": {"id": "r1", "blocker": False}}
+    k = cli._resolve_dod_knowledge(s, spec, rec)
+    assert k["bound_notes"] == [{"type": "gotcha", "body_len": 1}]   # stripped, not 40
+    # the padded stub is bound-but-not-qualifying -> HOLD_TRIVIAL_EVIDENCE, not a GO
+    assert close._evaluate_dod_knowledge(rec, k)[0][0] == close.HOLD_TRIVIAL_EVIDENCE


### PR DESCRIPTION
## #60 inc-2 — DoD KNOWLEDGE dimension (close-level block)

Adds the knowledge dimension to the #60 Definition-of-Done forcing gate: a close whose scope requires `knowledge` and carries an accepted counter (or `when=always`) HOLDs unless it cites ≥`min_notes` curated, non-trivial, revision-bound notes of an allowed type (lesson/gotcha/decision). Forces the Papendal "zero notes captured" gap closed. Rebased clean onto master (`7be6928`); only the knowledge delta + the review fix-batch.

## Dogfood review — `codex-agenttalk-reviewer-1`, 5 adversarial rounds, APPROVED @ `93bea3d`
Six real fail-open classes the green suite never surfaced, all closed:
1. **BLOCKER** malformed knowledge spec fail-open → unknown-key allowlist (`min_note` typo now RAISES).
2. **MAJOR** `types` widened past lesson/gotcha/decision → restricted to the trio (seam/pointer rejected).
3. **BLOCKER** whitespace padding defeated `min_body_chars` → `_substantive_len`.
4. **BLOCKER** interior + zero-width (U+200B) padding → substantive-length metric.
5. **BLOCKER** default-ignorable combining marks (variation selectors, CGJ) + blank-glyph fillers (Hangul, Braille) → exclude Mn/Me + maintained `_BLANK_GLYPH_FILLERS`.
6. **BLOCKER** more blanks (Egyptian hieroglyph blanks, musical null notehead) + docstring overclaim → added + **honest bounded-residual doc** (no stdlib visibility oracle; enumeration provably non-exhaustive; obscure unlisted blank = accepted residual, out of the self-adversary threat model).

**BLOCKER 4 (`has_remediation`)** documented honestly (= "an accepted counter exists", not "a fix was produced"; must-always scopes use `when=always`).

## Known residual (tracked, NOT a blocker under the accepted contract)
- **#66/#31** DoD-resolution↔close-commit TOCTOU: evidence can change between resolve and the cross-file `_write_close`. Operator-ruled detection-first; real closure + a stale-GO detector ride the #31 close-provenance envelope. The false "no ack/counter can invalidate a GO" comment was corrected; the race is documented honestly at the publish site + evaluator.

165 `test_close.py` tests (incl. exotic-Unicode + real publish/curate regressions); 203 pass across the broader dod/knowledge/close suites; ruff + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
