### PR TITLE
fix(#67): widen only the Windows dev-gate leg's job timeout (90→120)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,17 +20,27 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}/src
       PYTHONDONTWRITEBYTECODE: '1'
-    timeout-minutes: 90
+    # Per-OS ceiling: the two pytest runs (source + wheel) are each capped at
+    # 2700s in dev-gate.json, so a single leg's pytest budget alone is 90 min.
+    # The Windows runner's slow filesystem + costly process/venv creation push
+    # its wall time up to that ceiling, leaving no headroom for setup and the
+    # other per-leg checks — the leg is then killed by duration, not by a test
+    # failure. Windows gets a wider ceiling; the fast Linux/macOS legs keep a
+    # tight cap so a genuine hang there still fails quickly.
+    timeout-minutes: ${{ matrix.os.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         os:
           - id: linux
             runner: ubuntu-latest
+            timeout_minutes: 90
           - id: windows
             runner: windows-latest
+            timeout_minutes: 120
           - id: macos
             runner: macos-latest
+            timeout_minutes: 90
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
## #67 — windows/3.11 dev-gate leg times out under runner load

Root cause (Codex reviewer-1 confirmed): each leg runs pytest **twice** (source + wheel), each capped at 2700s in `dev-gate.json` → 2×2700 = 5400s = **exactly** the old 90-min job cap, leaving zero headroom for export/build/venv/install/contracts. Under Windows runner contention (slow NTFS+Defender I/O, process-heavy gate) the leg gets killed by the job timeout before finishing — not a test failure.

## Change
`.github/workflows/tests.yml`: per-OS `timeout-minutes` via `matrix.os.timeout_minutes` — **Windows 120**, Linux/macOS unchanged at 90. Surgical; fast legs still fail fast on a real hang.

## Guardrails (verified in review)
- 3-OS × Python 3.10–3.13 floor (`dev_gate.py` REQUIRED_CI_PYTHONS + `manifest_floor_weakened`) **untouched**; coverage/quality floors untouched.
- Every pytest subprocess still capped at 45 min on every OS (only job-level headroom added on Windows).
- No new zizmor/template-injection finding (numeric, repo-authored matrix field).

## Review
`codex-agenttalk-reviewer-1` (gpt-5.6-sol/ultra): **APPROVE-WITH-NITS** at `11eff09`, no blocking findings; 87 dev-gate tests pass. Optional nits (stale test comment + a per-OS-timeout drift-guard assertion) tracked as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
