### PR TITLE
fix(#56): scope APPDATA in the wrapped ovh-qwen child env

### DIFF
--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -540,7 +540,7 @@ def _child_env(
         # resolvable home WITHOUT leaking the operator's real home to the paid external
         # worker. LOCALAPPDATA is what agenttalk's own path resolution reads today;
         # APPDATA (Roaming) is included so Windows-native child tooling that consults
-        # %APPDATA% (git, npm, credential helpers, Python user site) also stays scoped
+        # %APPDATA% (npm, credential helpers, Python user site) also stays scoped
         # to the clone instead of falling back to the operator profile. If HMAC signing
         # is later enforced, wire the child's key via AGENTTALK_HMAC_KEY_FILE rather than
         # widening this to the operator's LOCALAPPDATA.

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -532,18 +532,23 @@ def _child_env(
         # is disposable with the watched-trial clone and contains no operator
         # credentials or history.
         env["CLAUDE_CONFIG_DIR"] = _ovh_qwen_claude_config_dir(workspace)
-        # The allowlist above drops LOCALAPPDATA/USERPROFILE/HOME, so a bus command the
-        # child shells out to (e.g. `agenttalk reply`) cannot resolve Path.home() and
-        # crashes in signing.default_keys_dir() BEFORE it can even decide signing is off
-        # ("RuntimeError: Could not determine home directory"). Point home + appdata at
-        # the disposable workspace clone: gives the child a resolvable home WITHOUT
-        # leaking the operator's real home to the paid external worker. If HMAC signing
+        # The allowlist above drops HOME/USERPROFILE/LOCALAPPDATA/APPDATA, so a bus
+        # command the child shells out to (e.g. `agenttalk reply`) cannot resolve
+        # Path.home() and crashes in signing.default_keys_dir() BEFORE it can even
+        # decide signing is off ("RuntimeError: Could not determine home directory").
+        # Point the full home set at the disposable workspace clone: gives the child a
+        # resolvable home WITHOUT leaking the operator's real home to the paid external
+        # worker. LOCALAPPDATA is what agenttalk's own path resolution reads today;
+        # APPDATA (Roaming) is included so Windows-native child tooling that consults
+        # %APPDATA% (git, npm, credential helpers, Python user site) also stays scoped
+        # to the clone instead of falling back to the operator profile. If HMAC signing
         # is later enforced, wire the child's key via AGENTTALK_HMAC_KEY_FILE rather than
         # widening this to the operator's LOCALAPPDATA.
         _scoped_home = str(workspace)
         env["HOME"] = _scoped_home
         env["USERPROFILE"] = _scoped_home
         env["LOCALAPPDATA"] = str(workspace / "AppData" / "Local")
+        env["APPDATA"] = str(workspace / "AppData" / "Roaming")
     elif backend_profile is not None:
         raise ValueError(f"unsupported backend_profile {backend_profile!r}")
     else:

--- a/tests/test_ovh_wrapper_profile.py
+++ b/tests/test_ovh_wrapper_profile.py
@@ -103,6 +103,60 @@ def test_ovh_qwen_child_environment_starts_from_allowlist(tmp_path, monkeypatch)
     assert "stale-must-not-pass" not in env.values()
 
 
+@pytest.mark.parametrize(
+    "operator_home_env",
+    [
+        pytest.param(
+            {"HOME": "/home/operator", "XDG_CONFIG_HOME": "/home/operator/.config"},
+            id="posix-style-input",
+        ),
+        pytest.param(
+            {
+                "HOME": "C:\\Users\\operator",
+                "USERPROFILE": "C:\\Users\\operator",
+                "LOCALAPPDATA": "C:\\Users\\operator\\AppData\\Local",
+                "APPDATA": "C:\\Users\\operator\\AppData\\Roaming",
+            },
+            id="windows-style-input",
+        ),
+    ],
+)
+def test_ovh_qwen_child_env_scopes_all_home_vars_on_both_platforms(
+    tmp_path, monkeypatch, operator_home_env
+) -> None:
+    # #56: the allowlist strips the child's home vars, so `agenttalk` run INSIDE the
+    # model's own turn cannot resolve its config/state home and crashes. The scoped
+    # env must supply the full home set (HOME + Windows USERPROFILE/LOCALAPPDATA/APPDATA)
+    # pointed at the disposable workspace clone, for both POSIX-style and Windows-style
+    # operator environments, and must never echo the operator's real home to the paid
+    # external worker. (_child_env sets these unconditionally, so no os.name branch to
+    # patch here; monkeypatching os.name on a Windows host also breaks pytest's Path
+    # repr on failure.)
+    ambient = {"PATH": "safe-path", "AGENTTALK_SELF": "qwen-dev-1"}
+    ambient.update(operator_home_env)
+    monkeypatch.setattr(os, "environ", ambient)
+
+    env = run._child_env(
+        tmp_path,
+        backend_profile="ovh-qwen",
+        profile_env={
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000",
+            "ANTHROPIC_AUTH_TOKEN": "front-token",
+        },
+    )
+
+    workspace = str(tmp_path.resolve())
+    # Every home var the child (and the tools it shells out to) may consult is present
+    # and scoped to the workspace clone.
+    assert env["HOME"] == workspace
+    assert env["USERPROFILE"] == workspace
+    assert env["LOCALAPPDATA"] == str((tmp_path / "AppData" / "Local").resolve())
+    assert env["APPDATA"] == str((tmp_path / "AppData" / "Roaming").resolve())
+    # The operator's real home never leaks into the paid worker's environment.
+    for leaked in operator_home_env.values():
+        assert leaked not in env.values()
+
+
 def test_ovh_qwen_child_env_lets_signing_resolve_home_without_crash(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## #56 — complete the home-var set for the wrapped ovh-qwen child

The ovh-qwen child env allowlist strips home vars; master already re-injects HOME/USERPROFILE/LOCALAPPDATA scoped to the disposable workspace clone. This adds the one remaining standard Windows home var — **APPDATA** → `<workspace>/AppData/Roaming` — so Windows-native child tooling (npm, credential helpers, Python user-site) stays scoped to the clone instead of falling back to the operator profile. No ambient inheritance widened; token/credential stripping unchanged.

+ parametrized test proving all four home vars are workspace-scoped and operator values don't survive (POSIX- and Windows-style input).

## Review
`codex-agenttalk-reviewer-1` (gpt-5.6-sol/ultra): **APPROVE-WITH-NIT** at `6104d46`, no blocking findings; 22 tests pass. The one doc nit (Git listed among APPDATA consumers — it uses HOME/USERPROFILE) is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
