### PR TITLE
test(#59): de-flake the config-lock acquisition budgets that red-block every merge

### DIFF
--- a/tests/test_attention_cli.py
+++ b/tests/test_attention_cli.py
@@ -10,6 +10,9 @@ from agenttalk import cli
 from agenttalk.store import Store
 
 
+_DISPOSITION_RACE_LOCK_TIMEOUT = 60.0
+
+
 def _team(tmp_path: Path) -> Store:
     s = Store(tmp_path)
     s.init(["beta", "claude"])
@@ -293,7 +296,9 @@ def test_resolved_dead_letter_absent_from_attention_queue(tmp_path: Path) -> Non
     assert not [i for i in q2["items"] if i["item_id"] == dl_item]
 
 
-def test_disposition_race_under_lock_preserves_all_lines(tmp_path: Path) -> None:
+def test_disposition_race_under_lock_preserves_all_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # concurrent disposition appends serialize under store._config_lock() - no torn lines,
     # no lost writes, and the fail-safe reader finds every event.
     import threading
@@ -301,20 +306,35 @@ def test_disposition_race_under_lock_preserves_all_lines(tmp_path: Path) -> None
     from agenttalk import attention as A
     s = _team(tmp_path)
     n = 24
+    start = threading.Barrier(n)
+    errors: list[Exception] = []
+    real_config_lock = s._config_lock
+
+    def _config_lock_with_test_budget(
+        *, timeout: float = _DISPOSITION_RACE_LOCK_TIMEOUT, poll: float = 0.05,
+    ):
+        return real_config_lock(timeout=timeout, poll=poll)
+
+    monkeypatch.setattr(s, "_config_lock", _config_lock_with_test_budget)
 
     def _append(i: int) -> None:
-        A.append_disposition(s, {
-            "schema_version": A.SCHEMA_VERSION, "event_id": f"att-race{i:04d}",
-            "item_id": f"needs_operator:rid-{i}", "source": A.SOURCE_NEEDS_OPERATOR,
-            "action": A.ACTION_DEFER, "actor": "claude", "reason": "race",
-            "at": "2026-07-02T00:00:00Z", "until": "2099-01-01T00:00:00Z",
-            "source_snapshot": {"source_hash": f"h{i}", "refs": []}})
+        try:
+            start.wait(timeout=_DISPOSITION_RACE_LOCK_TIMEOUT)
+            A.append_disposition(s, {
+                "schema_version": A.SCHEMA_VERSION, "event_id": f"att-race{i:04d}",
+                "item_id": f"needs_operator:rid-{i}", "source": A.SOURCE_NEEDS_OPERATOR,
+                "action": A.ACTION_DEFER, "actor": "claude", "reason": "race",
+                "at": "2026-07-02T00:00:00Z", "until": "2099-01-01T00:00:00Z",
+                "source_snapshot": {"source_hash": f"h{i}", "refs": []}})
+        except Exception as exc:
+            errors.append(exc)
 
     threads = [threading.Thread(target=_append, args=(i,)) for i in range(n)]
     for t in threads:
         t.start()
     for t in threads:
         t.join()
+    assert errors == []
     valid, problems = A.read_dispositions(s)
     assert problems == []                                  # no torn lines
     assert {e["event_id"] for e in valid} == {f"att-race{i:04d}" for i in range(n)}

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -25,6 +25,9 @@ from agenttalk import store as store_mod
 from agenttalk.store import Store
 
 
+_SUCCESSFUL_CONFIG_LOCK_TIMEOUT = 5.0
+
+
 def test_concurrent_threads_send_no_loss(tmp_path: Path) -> None:
     """N threads each sending in a tight loop: every send lands on its own
     file and is delivered exactly once (exercises the within-process lock)."""
@@ -92,7 +95,7 @@ def test_config_lock_times_out_while_another_holder_is_active(tmp_path: Path) ->
 
     def hold() -> None:
         try:
-            with s._config_lock(timeout=1.0, poll=0.01):
+            with s._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.01):
                 entered.set()
                 if not release.wait(5.0):
                     raise TimeoutError("test did not release lock holder")
@@ -101,7 +104,7 @@ def test_config_lock_times_out_while_another_holder_is_active(tmp_path: Path) ->
 
     holder = threading.Thread(target=hold)
     holder.start()
-    assert entered.wait(2.0)
+    assert entered.wait(_SUCCESSFUL_CONFIG_LOCK_TIMEOUT)
     try:
         with pytest.raises(TimeoutError, match="config lock"):
             with s._config_lock(timeout=0.05, poll=0.005):
@@ -164,7 +167,7 @@ except FileExistsError:
 os.close(fd)
 lock.unlink()
 """
-    with store._config_lock(timeout=0.2, poll=0.005):
+    with store._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         blocked = subprocess.run(
             [sys.executable, "-c", legacy_probe, str(lock_path)],
             check=False,
@@ -241,7 +244,7 @@ def test_current_config_lock_publishes_complete_marker_without_replace(
         real_link(source, destination, follow_symlinks=follow_symlinks)
 
     monkeypatch.setattr(store_mod.os, "link", observed_link)
-    with store._config_lock(timeout=0.2, poll=0.005):
+    with store._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         record = json.loads(lock_path.read_text(encoding="utf-8"))
         assert record["protocol"] == "o_excl_v2"
         assert record["pid"] == os.getpid()
@@ -283,7 +286,7 @@ os._exit(91)
     assert os.path.samefile(lock_path, prepared)
     assert os.lstat(lock_path).st_nlink == 2
 
-    with store._config_lock(timeout=0.5, poll=0.005):
+    with store._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         pass
 
     assert not lock_path.exists()
@@ -303,7 +306,7 @@ def test_config_lock_safely_migrates_persistent_os_lock_marker(
     }).encode("utf-8")
     lock_path.write_bytes(legacy_record.ljust(store_mod._LOCK_METADATA_BYTES, b" "))
 
-    with store._config_lock(timeout=0.2, poll=0.005):
+    with store._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         pass
 
     assert not lock_path.exists()
@@ -377,7 +380,7 @@ os.close(fd)
         release_path.write_text("release", encoding="utf-8")
         assert holder.wait(timeout=5.0) == 0
 
-    with store._config_lock(timeout=0.2, poll=0.005):
+    with store._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         pass
     assert not lock_path.exists()
 
@@ -537,7 +540,7 @@ def test_config_lock_recovers_ownerless_or_zero_byte_marker(
     stale_mtime = time.time() - store_mod._LOCK_OWNERLESS_STALE_SECONDS - 1.0
     os.utime(lockf, (stale_mtime, stale_mtime))
 
-    with s._config_lock(timeout=0.5, poll=0.005):
+    with s._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         pass
 
     assert not lockf.exists()
@@ -575,10 +578,8 @@ def test_config_lock_recovery_never_path_replaces_stale_generation(
         real_replace(source, destination)
 
     monkeypatch.setattr(store_mod.os, "replace", forbid_path_overwrite)
-    # timeout is incidental to this test (it asserts recovery never overwrites the
-    # lock pathname, not any deadline); 0.2s is below loaded-Windows-FS lock
-    # latency and flaked in CI. Generous bounded value, same assertion.
-    with s._config_lock(timeout=5.0, poll=0.005):
+    # The timeout is incidental to this test: it asserts path identity, not latency.
+    with s._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT, poll=0.005):
         pass
 
 
@@ -621,7 +622,7 @@ def test_config_lock_release_failure_is_surfaced(
 
     monkeypatch.setattr(store_mod, "_release_file_lock", fail_release)
     with pytest.raises(OSError, match="release.*config lock"):
-        with s._config_lock(timeout=0.2):
+        with s._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT):
             pass
     assert not (s.dir / "config.lock").exists()
 
@@ -833,5 +834,5 @@ def test_concurrent_add_agent_no_lost_update(tmp_path: Path) -> None:
     assert "c" in agents and "d" in agents  # neither add lost
     # Compatible O_EXCL ownership clears the marker on release.
     assert not (s.dir / "config.lock").exists()
-    with s._config_lock(timeout=0.2):
+    with s._config_lock(timeout=_SUCCESSFUL_CONFIG_LOCK_TIMEOUT):
         pass


### PR DESCRIPTION
The Windows dev-gate legs keep going red on config-lock ACQUISITION TIMEOUTS under runner load, not on real defects — including on PR #82, whose diff is only a version bump + CHANGELOG. Tests-only change (2 files, no production file).

**Diagnosis (test budget vs product budget — the distinction that decides the fix):**
- `test_disposition_race_under_lock_preserves_all_lines` was unintentionally inheriting the PRODUCT `_config_lock()` default (10s) in a synthetic 24-writer/fsync property test. It now supplies a bounded test-only 60s acquisition budget, starts all 24 writers through a barrier, and captures worker exceptions explicitly. **The product default is unchanged.**
- `test_config_lock_safely_migrates_persistent_os_lock_marker` (0.2s) and `test_config_lock_recovers_ownerless_or_zero_byte_marker` (0.5s) used explicit sub-second TEST budgets; those and the same-class incidental successful acquisitions now share a named `_SUCCESSFUL_CONFIG_LOCK_TIMEOUT = 5.0`.

**Nothing proven was weakened.** Assertions and concurrency are identical. Sub-second budgets on the NEGATIVE tests are deliberately left alone (active-holder timeout, live zero-byte creator, truncated live owner, active persistent marker, fresh ownerless marker, symlink/hardlink/reparse/non-regular rejection) — there the budget IS the property being proven.

**Broken-product proof (the anti-tautology check):** disposition persistence was temporarily made a no-op and persistent/ownerless/dead-marker recovery disabled → the unchanged tests produced 4 expected failures (disposition saw 0 of 24 required events; persistent migration and both ownerless params timed out). Both mutations reverted; no production file is in the commit.

**Artificial-load proof:** 4 bounded CPU-pressure workers while repeating the 4 focused cases 5x → 20/20 passed.

Verified independently by the lead from the worktree CWD on the committed SHA: 54 passed, 2 skipped; ruff + bandit clean; `git status` empty.

**Open product question (deliberately NOT changed here):** whether the 10s product `_config_lock()` default should be raised for real production workloads is a separate policy call.