### PR TITLE
fix(#71): resolve ONE checkpoint fallback identity for both hook events

### DIFF
--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -6526,6 +6526,15 @@ def _fallback_activity_hook_agent(settings: dict) -> str | None:
     return None
 
 
+def _fallback_checkpoint_hook_agent(settings: dict) -> str | None:
+    for event, _action, _matcher in _CHECKPOINT_HOOK_SPECS:
+        for command in _iter_hook_commands(settings, event):
+            parsed = _parse_checkpoint_hook_command(command)
+            if parsed is not None and parsed[1] == "fallback":
+                return parsed[2]
+    return None
+
+
 def _has_fallback_activity_hook(settings: dict) -> bool:
     return _fallback_activity_hook_agent(settings) is not None
 
@@ -6662,8 +6671,6 @@ def _merge_checkpoint_event_hook(
     action: str,
     matcher: str,
     target_agent: str | None = None,
-    fallback_agent: str | None = None,
-    preserve_existing_fallback: bool = False,
 ) -> str:
     """Canonicalize one managed checkpoint hook without touching unrelated hooks."""
     groups, skipped = _hook_event_groups(settings, event)
@@ -6671,7 +6678,6 @@ def _merge_checkpoint_event_hook(
         return skipped or f"skipped (malformed hooks.{event})"
 
     owned: list[tuple[dict, dict]] = []
-    existing_fallback: str | None = None
     for group in groups:
         if not isinstance(group, dict):
             continue
@@ -6685,19 +6691,8 @@ def _merge_checkpoint_event_hook(
             if parsed is None:
                 continue
             owned.append((group, item))
-            if (
-                preserve_existing_fallback
-                and existing_fallback is None
-                and parsed[1] == "fallback"
-            ):
-                existing_fallback = parsed[2]
 
-    agent = target_agent
-    if agent is None and preserve_existing_fallback:
-        agent = existing_fallback
-    if agent is None:
-        agent = fallback_agent
-    target_command = checkpoint_hook_command(action, agent)
+    target_command = checkpoint_hook_command(action, target_agent)
 
     if (
         len(owned) == 1
@@ -6754,8 +6749,6 @@ def _merge_checkpoint_hooks(
     settings: dict,
     *,
     target_agent: str | None = None,
-    fallback_agent: str | None = None,
-    preserve_existing_fallback: bool = False,
 ) -> dict[str, str]:
     statuses: dict[str, str] = {}
     for event, action, matcher in _CHECKPOINT_HOOK_SPECS:
@@ -6765,8 +6758,6 @@ def _merge_checkpoint_hooks(
             action=action,
             matcher=matcher,
             target_agent=target_agent,
-            fallback_agent=fallback_agent,
-            preserve_existing_fallback=preserve_existing_fallback,
         )
     return statuses
 
@@ -6842,6 +6833,13 @@ def install_activity_hook(store: Store, *, claude: bool = True,
                 "skipped (malformed settings root)",
             )
         else:
+            # Resolve once from the original file so a partial install cannot
+            # bind save and resume differently after the heartbeat merge.
+            checkpoint_agent = (
+                _fallback_checkpoint_hook_agent(settings)
+                or _fallback_activity_hook_agent(settings)
+                or interactive_for
+            )
             statuses = {"PostToolUse": _merge_post_tool_use_hook(
                 settings,
                 target_command=target_command,
@@ -6849,9 +6847,7 @@ def install_activity_hook(store: Store, *, claude: bool = True,
             )}
             statuses.update(_merge_checkpoint_hooks(
                 settings,
-                target_agent=interactive_for,
-                fallback_agent=_fallback_activity_hook_agent(settings),
-                preserve_existing_fallback=interactive_for is None,
+                target_agent=checkpoint_agent,
             ))
             if "installed" in statuses.values():
                 p.parent.mkdir(parents=True, exist_ok=True)

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -6526,11 +6526,19 @@ def _fallback_activity_hook_agent(settings: dict) -> str | None:
     return None
 
 
-def _fallback_checkpoint_hook_agent(settings: dict) -> str | None:
+def _fallback_checkpoint_hook_agent(
+    settings: dict,
+    active_agents: Iterable[str],
+) -> str | None:
+    roster = set(active_agents)
     for event, _action, _matcher in _CHECKPOINT_HOOK_SPECS:
         for command in _iter_hook_commands(settings, event):
             parsed = _parse_checkpoint_hook_command(command)
-            if parsed is not None and parsed[1] == "fallback":
+            if (
+                parsed is not None
+                and parsed[1] == "fallback"
+                and parsed[2] in roster
+            ):
                 return parsed[2]
     return None
 
@@ -6833,13 +6841,19 @@ def install_activity_hook(store: Store, *, claude: bool = True,
                 "skipped (malformed settings root)",
             )
         else:
-            # Resolve once from the original file so a partial install cannot
-            # bind save and resume differently after the heartbeat merge.
-            checkpoint_agent = (
-                _fallback_checkpoint_hook_agent(settings)
-                or _fallback_activity_hook_agent(settings)
-                or interactive_for
-            )
+            # An explicit liaison binding is authoritative. Neutral installs
+            # resolve once from the original file and retain only active
+            # checkpoint identities before falling back to the heartbeat.
+            if interactive_for is not None:
+                checkpoint_agent = interactive_for
+            else:
+                checkpoint_agent = (
+                    _fallback_checkpoint_hook_agent(
+                        settings,
+                        store.active_agents(),
+                    )
+                    or _fallback_activity_hook_agent(settings)
+                )
             statuses = {"PostToolUse": _merge_post_tool_use_hook(
                 settings,
                 target_command=target_command,

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -2507,6 +2507,13 @@ def _post_tool_commands(path: Path) -> list[str]:
     return _hook_commands(path, "PostToolUse")
 
 
+def _managed_hook_group(matcher: str, command: str) -> list[dict]:
+    return [{
+        "matcher": matcher,
+        "hooks": [{"type": "command", "command": command}],
+    }]
+
+
 def _recognized_heartbeat_commands(commands: list[str]) -> list[str]:
     return [
         command
@@ -3141,6 +3148,55 @@ def test_install_activity_hook_interactive_rebinds_wrong_fallback_without_dup(
     assert _post_tool_commands(settings) == ["agenttalk heartbeat --hook --fallback-for lead"]
 
 
+@pytest.mark.parametrize(
+    ("existing_agent", "expected_status"),
+    [
+        ("worker", "installed"),
+        ("lead", "already"),
+    ],
+    ids=["stale-fallback-rebound", "matching-fallback-unchanged"],
+)
+def test_install_activity_hook_explicit_identity_controls_all_managed_hooks(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    existing_agent: str,
+    expected_status: str,
+) -> None:
+    store = _team(tmp_path)
+    store.set_operator_facing("lead")
+    settings = store.root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps({"hooks": {
+        "PostToolUse": _managed_hook_group(
+            "*", sup.fallback_activity_hook_command(existing_agent),
+        ),
+        "PreCompact": _managed_hook_group(
+            "*", sup.checkpoint_hook_command("save", existing_agent),
+        ),
+        "SessionStart": _managed_hook_group(
+            "compact", sup.checkpoint_hook_command("resume", existing_agent),
+        ),
+    }}), encoding="utf-8")
+
+    assert _run(
+        ["supervise", "--install-activity-hook", "--interactive-for", "lead"],
+        tmp_path,
+    ) == 0
+
+    output = capsys.readouterr().out
+    for event in ("PostToolUse", "PreCompact", "SessionStart"):
+        assert f"{expected_status}: {settings} [{event}]" in output
+    assert _post_tool_commands(settings) == [
+        sup.fallback_activity_hook_command("lead"),
+    ]
+    assert _hook_commands(settings, "PreCompact") == [
+        sup.checkpoint_hook_command("save", "lead"),
+    ]
+    assert _hook_commands(settings, "SessionStart") == [
+        sup.checkpoint_hook_command("resume", "lead"),
+    ]
+
+
 def test_install_activity_hook_neutral_does_not_downgrade_existing_fallback(
     tmp_path: Path,
     capsys: pytest.CaptureFixture,
@@ -3267,6 +3323,74 @@ def test_install_activity_hook_uses_one_checkpoint_fallback_for_partial_config(
     envelope = json.loads(capsys.readouterr().out)
     context = envelope["hookSpecificOutput"]["additionalContext"]
     assert context.startswith("Checkpoint reload for lead:")
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_agent", "expected_agent", "precompact_status"),
+    [
+        ("retired", "worker", "installed"),
+        ("lead", "lead", "already"),
+    ],
+    ids=["retired-fallback-ignored", "active-fallback-preserved"],
+)
+def test_install_activity_hook_neutral_uses_only_rostered_checkpoint_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    checkpoint_agent: str,
+    expected_agent: str,
+    precompact_status: str,
+) -> None:
+    store = _team(tmp_path, "lead,worker,retired")
+    store.retire_agent("retired", reason="renamed")
+    settings = store.root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps({"hooks": {
+        "PostToolUse": _managed_hook_group(
+            "*", sup.fallback_activity_hook_command("worker"),
+        ),
+        "PreCompact": _managed_hook_group(
+            "*", sup.checkpoint_hook_command("save", checkpoint_agent),
+        ),
+    }}), encoding="utf-8")
+
+    assert _run(["supervise", "--install-activity-hook"], tmp_path) == 0
+
+    output = capsys.readouterr().out
+    expected_statuses = {
+        "PostToolUse": "already",
+        "PreCompact": precompact_status,
+        "SessionStart": "installed",
+    }
+    for event, status in expected_statuses.items():
+        assert f"{status}: {settings} [{event}]" in output
+    assert _post_tool_commands(settings) == [
+        sup.fallback_activity_hook_command("worker"),
+    ]
+    save_command = sup.checkpoint_hook_command("save", expected_agent)
+    resume_command = sup.checkpoint_hook_command("resume", expected_agent)
+    assert _hook_commands(settings, "PreCompact") == [save_command]
+    assert _hook_commands(settings, "SessionStart") == [resume_command]
+
+    monkeypatch.delenv("AGENTTALK_SELF", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.TextIOWrapper(io.BytesIO(b"{}"), encoding="utf-8"),
+    )
+    save_argv = shlex.split(save_command.split(" || ", 1)[0])[1:]
+    assert _run(save_argv, tmp_path) == 0
+    assert capsys.readouterr() == ("", "")
+    saved = checkpoint.read_checkpoint(store, expected_agent)
+    assert saved is not None
+    assert saved["agent"] == expected_agent
+    assert checkpoint.read_checkpoint(store, "retired") is None
+
+    resume_argv = shlex.split(resume_command.split(" || ", 1)[0])[1:]
+    assert _run(resume_argv, tmp_path) == 0
+    envelope = json.loads(capsys.readouterr().out)
+    context = envelope["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith(f"Checkpoint reload for {expected_agent}:")
 
 
 def test_install_activity_hook_neutral_dedupes_mixed_fallback_and_neutral(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -7,6 +7,7 @@ fixtures. The generated PS/bash scripts are thin executors (documented-manual).
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import shlex
@@ -19,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from agenttalk import cli, ephemeral as eph, health as hm, supervisor as sup
+from agenttalk import checkpoint, cli, ephemeral as eph, health as hm, supervisor as sup
 from agenttalk.store import Store
 
 
@@ -3169,6 +3170,103 @@ def test_install_activity_hook_neutral_does_not_downgrade_existing_fallback(
 
     assert _run(["supervise", "--install-activity-hook"], tmp_path) == 0
     assert "already:" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_statuses"),
+    [
+        (
+            "only-precompact-bound",
+            {"PostToolUse": "already", "PreCompact": "already", "SessionStart": "installed"},
+        ),
+        (
+            "only-sessionstart-bound",
+            {"PostToolUse": "already", "PreCompact": "installed", "SessionStart": "already"},
+        ),
+        (
+            "both-neutral",
+            {"PostToolUse": "already", "PreCompact": "installed", "SessionStart": "installed"},
+        ),
+    ],
+)
+def test_install_activity_hook_uses_one_checkpoint_fallback_for_partial_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    shape: str,
+    expected_statuses: dict[str, str],
+) -> None:
+    store = _team(tmp_path)
+    settings = store.root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+
+    def group(matcher: str, command: str) -> list[dict]:
+        return [{
+            "matcher": matcher,
+            "hooks": [{"type": "command", "command": command}],
+        }]
+
+    if shape == "only-precompact-bound":
+        hooks = {
+            "PostToolUse": group(
+                "*", sup.fallback_activity_hook_command("worker"),
+            ),
+            "PreCompact": group(
+                "*", sup.checkpoint_hook_command("save", "lead"),
+            ),
+        }
+    elif shape == "only-sessionstart-bound":
+        hooks = {
+            "PostToolUse": group(
+                "*", sup.fallback_activity_hook_command("worker"),
+            ),
+            "SessionStart": group(
+                "compact", sup.checkpoint_hook_command("resume", "lead"),
+            ),
+        }
+    else:
+        hooks = {
+            "PostToolUse": group(
+                "*", sup.fallback_activity_hook_command("lead"),
+            ),
+            "PreCompact": group(
+                "*", sup.checkpoint_hook_command("save"),
+            ),
+            "SessionStart": group(
+                "compact", sup.checkpoint_hook_command("resume"),
+            ),
+        }
+    settings.write_text(json.dumps({"hooks": hooks}), encoding="utf-8")
+
+    assert _run(["supervise", "--install-activity-hook"], tmp_path) == 0
+
+    output = capsys.readouterr().out
+    for event, status in expected_statuses.items():
+        assert f"{status}: {settings} [{event}]" in output
+    save_command = sup.checkpoint_hook_command("save", "lead")
+    resume_command = sup.checkpoint_hook_command("resume", "lead")
+    assert _hook_commands(settings, "PreCompact") == [save_command]
+    assert _hook_commands(settings, "SessionStart") == [resume_command]
+
+    monkeypatch.delenv("AGENTTALK_SELF", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.TextIOWrapper(io.BytesIO(b"{}"), encoding="utf-8"),
+    )
+    save_argv = shlex.split(save_command.split(" || ", 1)[0])[1:]
+    assert _run(save_argv, tmp_path) == 0
+    assert capsys.readouterr() == ("", "")
+    saved = checkpoint.read_checkpoint(store, "lead")
+    assert saved is not None
+    assert saved["agent"] == "lead"
+    assert checkpoint.read_checkpoint(store, "worker") is None
+
+    resume_argv = shlex.split(resume_command.split(" || ", 1)[0])[1:]
+    assert _run(resume_argv, tmp_path) == 0
+    envelope = json.loads(capsys.readouterr().out)
+    context = envelope["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith("Checkpoint reload for lead:")
 
 
 def test_install_activity_hook_neutral_dedupes_mixed_fallback_and_neutral(


### PR DESCRIPTION
First v0.79.1 item — the connector P2 consciously accepted (with recorded reasoning) to unblock the v0.79.0 tag on PR #83.

**The defect:** when the installer upgraded a *partial* identity-bound configuration (only `PreCompact` bound, or only `SessionStart`), each event discovered its fallback **independently**. So `save` kept the bound identity while `resume` was installed neutral. In the liaison window — the one window with no `AGENTTALK_SELF` — `save` wrote that agent checkpoint while `resume` could not resolve an identity and emitted **empty context**, even though the installer reported both hooks as authoritative. Third instance of the silent-false-assurance class already fixed twice on #83 (the F2 partial-install reporting, and the malformed-`type` repair).

**The fix:** resolve ONE checkpoint fallback from the original settings *before* mutating any hook, with precedence: existing fallback-bound **checkpoint** entry → fallback-bound **heartbeat** entry → explicit `--interactive-for`. That single result is applied to both `PreCompact`/save and `SessionStart`/resume; per-event discovery is removed. Installer reporting stays per-event and still reflects what was actually written.

**Failing-first evidence** against `64e1669`: `2 failed, 1 passed` — both partial-bound shapes reproduced the defect, and the diagnosis was sharper than the report: the missing event was inheriting the **heartbeat** identity instead of the existing **checkpoint** identity, which is why precedence order is load-bearing. After the fix: `3 passed`.

**Regressions** (parameterized): only-`PreCompact`-bound, only-`SessionStart`-bound, and both-neutral. Each asserts one identity across both generated commands, exact per-event installer reporting, and — with `AGENTTALK_SELF` absent — that `save` writes the selected agent checkpoint and `resume` emits **non-empty** SessionStart context for that same agent.

Lead verified the committed SHA independently: clean tree, 52 hook/fallback tests green from the worktree CWD.

Not reachable on a first install (it needs pre-existing checkpoint entries in a partial state), which is why v0.79.0 shipped without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)