### PR TITLE
docs(release): complete the v0.79.0 release ritual (install pins, bounded guarantee, assurance ledger)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (checkpoint save) and `SessionStart`/`compact` (checkpoint resume), reporting per-hook
   `installed` / `already` / `skipped (reason)` so a partial or malformed install can never be
   presented as blanket success. A managed entry whose `type` is missing or wrong is repaired
-  rather than reported as already-installed. The installed commands carry a fail-soft fallback so
-  an `agenttalk` predating the `checkpoint` subcommand can never exit non-zero and block a
-  compaction, and `--codex` / `.codex/hooks.json` remains heartbeat-only. (#71)
+  rather than reported as already-installed. The installed commands carry a fail-soft fallback to
+  the silent heartbeat hook, so an `agenttalk` that predates the `checkpoint` subcommand but is
+  otherwise recent enough exits 0 instead of blocking a compaction. **Bounded legacy-PATH
+  residual:** the neutral fallback needs roughly v0.31.1 and the `--fallback-for` form needs
+  v0.69.6, so an OLDER executable selected first on `PATH` can still return exit 2 and block a
+  compact — upgrade or correct `PATH` before installing these hooks (documented at
+  `docs/USER-MANUAL.md`). `--codex` / `.codex/hooks.json` remains heartbeat-only. (#71)
 - **"Red-by-default until evidence exists" DoD forcing-gate.** `close` now supports pluggable
   Definition-of-Done dimensions that HOLD until independent, revision-bound evidence exists — the
   assurance dimension (inc-1) and the knowledge dimension (inc-2). (#60)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ a prerequisite.
 
 ```powershell
 # one-time install (canonical, tag-pinned)
-python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.78.0"
+python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.0"
 agenttalk install-skills          # installs bus skills + the dev-discipline devkit
 
 # in your project root, once per project
@@ -205,7 +205,7 @@ assigns the part per WP and the sk-loop skills follow.
 **End users (canonical, tag-pinned):**
 
 ```powershell
-python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.78.0"
+python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.0"
 ```
 
 Pin to a specific tag so you control upgrades. Replace the tag with

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -183,6 +183,45 @@ passed the lead gate but a clean CI runner did not), fixed test-only in the foll
 `748ca74`. Reviewed-SHA = the exact code reviewed + lead-gated (fast-forward
 merged); Tag = the release commit (adds version/CHANGELOG only).
 
+### v0.79.0 - checkpoint-before-compact + DoD forcing-gate + OVH gateway fold (63-commit backlog) (2026-07-25)
+**GOOD / ROBUST** - release base `v0.78.1` - ship SHA `bf40925` - tag `v0.79.0`
+- **Scope:** the accumulated 63-commit master backlog, rolled into one release so it could be
+  installed and exercised. Headline: checkpoint-before-compact (`agenttalk checkpoint
+  save|resume|show` + the `PreCompact`/`SessionStart` hook installer), the red-by-default DoD
+  forcing-gate (assurance + knowledge dimensions), the OVH-Qwen gateway fold onto master,
+  detection-grade owed-action enforcement, the hermetic `dev-gate`, store durability
+  (publication-order self-heal + validation snapshot), and the Windows-CI de-flakes.
+- **Risk record:** base SHA `v0.78.1`; candidate refs `9a1d367` (#84 de-flake) → `64e1669`
+  (#83 B1 hook installer) → ship `bf40925` (version + CHANGELOG only). Semantic dimensions
+  matched: operator-facing workflow + config-write behaviour (the installer mutates a user's
+  `.claude/settings.json`), packaging/install pins, and docs. Proposed tier: standard release
+  ritual with per-PR adversarial review; ratifier `claude-agenttalk-lead` (operator holds standing
+  release authorization). Final drift result: NONE at ship SHA — 15/15 dev-gate legs + CodeQL green
+  on the post-bump commit (the mandatory re-gate), after one rerun of a `windows/3.12` leg whose
+  two failures were artifact-classified as pre-existing wall-clock flakes in tests untouched by the
+  release diff (`test_wait_post_timeout_grace_returns_late_message`, `test_wait_duplicate_composing_counted_only_once`).
+- **Review panel + lenses:** `codex-agenttalk-reviewer-1` (adversarial correctness/security, the
+  bulk of the rounds), `claude-agenttalk-reviewer-3` (cross-family independent lens, incl. verifying
+  the PreCompact contract against the Claude Code binary itself and running a base-vs-head
+  classifier differential), and the GitHub Codex connector as a third independent signal — which
+  caught findings BOTH bus reviewers missed on three separate PRs, including the release-ritual
+  gaps fixed in `fix/release-0790-ritual` (stale canonical install pins, an overclaimed
+  compatibility guarantee, and this missing ledger entry).
+- **Docs-testing trigger:** TRIGGERED (installer writes to a user's config; new user-facing command;
+  install pins changed). Evidence: the B1 review required and verified a new `docs/USER-MANUAL.md`
+  reference section for checkpoint-before-compact plus corrections at six installer-reference sites;
+  `test_dev_gate_docs` + `test_skill_lint` green in the gate. Windows/PowerShell examples remain
+  *referenced-not-executed* per policy.
+- **Accepted residuals (documented, not hidden):** (a) a partial identity-bound settings file could
+  resolve different fallback identities for save vs resume, making `resume` inject empty context —
+  NOT reachable on a first install (needs pre-existing checkpoint entries), fixed in PR #86 for
+  v0.79.1; (b) the bounded legacy-PATH residual where an `agenttalk` older than ~v0.31.1/v0.69.6
+  first on `PATH` can still exit 2 from the fallback leg; (c) the v0.78.0/v0.78.1 ledger entries are
+  themselves missing and want a backfill.
+- **NOT in this release (parked for the operator):** #72 supervisor CLI-child health (PR #81) and
+  #73 wrapper landed-work reconciliation (PR #85) — both behavioural changes to supervisor/wrapper
+  lifecycle, held for an attended merge.
+
 ### v0.77.0 - Loud coordination-stall warnings (advisory, false-positive-disciplined) (2026-07-15)
 **GOOD / ROBUST / SECURE** - reviewed-SHA `39bc1e9` - tag `v0.77.0`
 - **Origin:** during this session `codex` idle-waited ~10 minutes on a design-critique reply from a

--- a/docs/USER-MANUAL.md
+++ b/docs/USER-MANUAL.md
@@ -59,7 +59,7 @@ decisions are what make a GO credible.
 Install once per machine. Pin the version in repeatable setups.
 
 ```powershell
-python -m pip install git+https://github.com/zoolok17/agenttalk.git@v0.78.0
+python -m pip install git+https://github.com/zoolok17/agenttalk.git@v0.79.0
 agenttalk --version
 agenttalk --help
 agenttalk install-skills


### PR DESCRIPTION
Closes the three GitHub-connector findings on the v0.79.0 release PR (#82) — which I merged in the same command that printed them, so the merge ran before I read the bodies. My own pre-merge rule, broken by batching. Docs only; no source change. **The v0.79.0 tag will point at this commit**, so the tagged tree own install instructions are correct.

- **P1 — stale canonical install pins.** `README.md:98`, `README.md:208` and `docs/USER-MANUAL.md:62` still pinned `v0.78.0`, so anyone following the documented install path would install the PREVIOUS release — without the checkpoint commands v0.79.0 advertises. The previous minor release advanced these pins as part of its bump; this restores that step. (Verified the other `v0.78.x` mentions in `docs/LEAD-GUIDE.md` and `docs/ISSUES.md` are historical prose — "since v0.78.0 the supervisor requires PowerShell Core 7+" — and correctly left alone.)
- **P2 — the CHANGELOG overclaimed the rollout guard.** It said an `agenttalk` predating the `checkpoint` subcommand "can never exit non-zero and block a compaction". The guarantee is bounded: the neutral fallback needs roughly v0.31.1 and the `--fallback-for` form needs v0.69.6, so an OLDER executable first on `PATH` can still exit 2 and block a compact. Now stated explicitly, matching `docs/USER-MANUAL.md` and the source comment. (The overclaim is the defect — same discipline applied to every review this session, including my own release notes.)
- **P2 — missing assurance-ledger entry.** `docs/ASSURANCE.md` requires one entry per release recording base SHA, candidate refs, semantic dimensions, tier, ratifier + verdict, panel members + lenses, ship SHA and drift result. A 63-commit release had none. Added, including the docs-testing trigger + evidence, the three accepted residuals, and the two changes deliberately parked for an attended operator merge (#81, #85). It also notes that the v0.78.0/v0.78.1 entries are themselves missing and want a backfill.

Evidence: `tests/test_dev_gate_docs.py` + `tests/test_skill_lint.py` — 23 passed; all four edited docs verified strict UTF-8, no BOM, no NUL.