### PR TITLE
release: v0.79.1 (wrapper false-park fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.79.1] - 2026-07-25
+
+### Fixed
+
+- **Never park an inbound whose terminal work already landed on the bus.** A wrapped agent could
+  do the work, write a durable reply, and still have the wrapper park the inbound as unfinished --
+  leaving the operator to hand-finish completed work. The resolver now proves the terminal response
+  from the validated bus itself rather than from a parse of the child's command, so a reply that
+  demonstrably landed can no longer be parked. Observed twice in production on 2026-07-24/25, with
+  the replies present on the bus while both agents sat parked as `config_blocked`. (#73)
+- **Recognize every interpreter spelling of a real `agenttalk reply`.** `_bus_command_verb()`
+  returned `None` for a PowerShell call tail that parenthesizes or braces the interpreter
+  (`& ($env:AGENTTALK_PY)`, `& ${env:AGENTTALK_PY}`), so a failed bus write went unattributed and
+  the wrapper could commit an inbound with no durable reply -- the same silent-loss class. (#73)
+- **A requester rescind now stops a landed-response proof.** An exact-anchored response that landed
+  *after* the requester rescinded was accepted as completed terminal work, so the wrapper could
+  report a finished turn for work that had been called off. `_resolve_replay` already treated such a
+  rescind as superseded, but it early-outs for any opener that is not a `question`, which left
+  `review-request` and `proposal` openers with no rescind protection at all. (#73)
+
+### Changed
+
+- **Lead skill: Independence principle.** Both the Claude and Codex lead skills now state that the
+  lead should decide and act within its mandate and report, reserving operator questions for
+  decisions that are genuinely the operator's. The policy is mirrored on both surfaces and the
+  mirroring is enforced by `tests/test_skill_lint.py`. (#79)
+
+
 ## [0.79.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the validated bus itself rather than from a parse of the child's command, so a reply that
   demonstrably landed can no longer be parked. Observed twice in production on 2026-07-24/25, with
   the replies present on the bus while both agents sat parked as `config_blocked`. (#73)
-- **Recognize every interpreter spelling of a real `agenttalk reply`.** `_bus_command_verb()`
+- **Recognize the parenthesized and braced PowerShell interpreter forms of a real `agenttalk reply`.** `_bus_command_verb()`
   returned `None` for a PowerShell call tail that parenthesizes or braces the interpreter
   (`& ($env:AGENTTALK_PY)`, `& ${env:AGENTTALK_PY}`), so a failed bus write went unattributed and
   the wrapper could commit an inbound with no durable reply -- the same silent-loss class. (#73)
+  Still NOT recognized: the bare-parenthesized-braced form `& (${env:AGENTTALK_PY})`,
+  which continues to return `None`. Judged an unrealistic spelling; the realistic member of
+  that family is fixed here.
 - **A requester rescind now stops a landed-response proof.** An exact-anchored response that landed
   *after* the requester rescinded was accepted as completed terminal work, so the wrapper could
   report a finished turn for work that had been called off. `_resolve_replay` already treated such a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report a finished turn for work that had been called off. `_resolve_replay` already treated such a
   rescind as superseded, but it early-outs for any opener that is not a `question`, which left
   `review-request` and `proposal` openers with no rescind protection at all. (#73)
+- **Legacy and orphaned-order stores no longer prove landed responses from reconstructed order.**
+  When the publication-order sidecar is absent, unmarked by an older writer, does not cover every message,
+  or records a persisted reconstruction, response-versus-rescind order cannot be verified. The wrapper now
+  withholds that proof and uses the recoverable residual/re-drive path instead of crediting work that may
+  have landed after cancellation. (#73)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ a prerequisite.
 
 ```powershell
 # one-time install (canonical, tag-pinned)
-python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.0"
+python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.1"
 agenttalk install-skills          # installs bus skills + the dev-discipline devkit
 
 # in your project root, once per project
@@ -205,7 +205,7 @@ assigns the part per WP and the sk-loop skills follow.
 **End users (canonical, tag-pinned):**
 
 ```powershell
-python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.0"
+python -m pip install "git+https://github.com/zoolok17/agenttalk.git@v0.79.1"
 ```
 
 Pin to a specific tag so you control upgrades. Replace the tag with

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -212,6 +212,49 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   - Tests are **differential**: on the pre-fix source exactly 3 legs fail and the no-rescind
     control still yields a proof, so the fixture is proven capable of producing a proof when
     nothing cancels the request. 449 passed across the two touched suites locally.
+- **Tier-3 gate RUN 2026-07-25 (composition + verdicts recorded per §1a):**
+  - **Proposed tier:** Tier 3, proposed by the change owner (`claude-agenttalk-lead`).
+    Triggers claimed: durability/atomicity/recovery + persistent-state contract (#73 decides
+    whether completed work is recorded as done); normative operational skill (#79, both CLI
+    surfaces).
+  - **Ratifier (anti-self-serve, cross-family, mandatory because owner == lead):**
+    `codex-agenttalk-developer-4` (codex family) -- **APPROVED**. The owner did not ratify
+    their own classification.
+  - **Panel (hard floor 3, >=2 model families, distinct predeclared lenses; no lead, no
+    builder counted -- `codex-2` excluded as #73's builder, the lead excluded as owner):**
+    1. `codex-agenttalk-reviewer-1` (codex) -- lens: durability / persistent-state contract of
+       the validated-bus landed-response proof. **HOLD / REVISE** (see open finding below).
+    2. `claude-agenttalk-reviewer-3` (claude) -- lens: release-union blast radius +
+       packaging/install correctness (both version sites, all three install pins, wheel
+       identity). **APPROVED**.
+    3. `claude-agenttalk-reviewer-fable` (claude) -- lens: #79 as an authority change (does the
+       Independence policy widen unapproved lead action against the escalate / waive /
+       authenticated-operator boundaries). **APPROVED**. Independent for this lens: its earlier
+       review covered the #73 resolver, not the skill.
+  - **Docs-testing pass (triggered by docs + packaging/install change):**
+    - `test-docs` EXECUTED green: `checkpoint show --json`; `supervise --bootstrap-check`;
+      `agenttalk.__version__ == 0.79.1`; plus package-build, wheel-install,
+      wheel-dependency-check and wheel-contract green in the `a25dad0` gate.
+    - `test-docs` RECORDED **referenced-not-executed** (never counted green): the documented
+      pinned install `@v0.79.1` cannot run before the tag exists -- chicken-and-egg by
+      construction.
+    - `review-docs` (independent; the lead wrote all the prose): `codex-agenttalk-developer-4`
+      -- **APPROVED**.
+- **OPEN FINDING blocking the tag (P2, executed and reproduced, not asserted):**
+  reconstructed publication order can revive the post-rescind false commit. When the sidecar is
+  absent or incomplete, `publication_ordered_messages()` falls back to MESSAGE-ID order
+  (`store.py:4077-4087`) and ids are monotonic only per process (`store.py:7038-7051`), so a
+  requester rescind can be reconstructed AFTER the response it should cancel;
+  `_exact_landed_response` returns the first exact terminal before reaching it and the pre-drive
+  path commits. Replay: same-timestamp `...000003-ZZZZ` (rescind) vs `...000003-AAAA`
+  (response) with the sidecar truncated to its inbound-only prefix -> `turns=1`, child invoked
+  zero times, cursor advanced. Bounded to legacy/order-orphan reconstruction; canonical writers
+  with an intact sidecar behaved correctly across 22 focused + 15 publication-order tests.
+  **Disposition:** fold + re-review on a new SHA (operator-directed 2026-07-25). The lead may
+  not erase an open REVISE. Fix shape: make order degradation observable and DECLINE the proof
+  when the backing order is reconstructed -- cannot-verify-order is not green -- WITHOUT making
+  the rescind scan position-independent, which would regress the false-park this release fixes.
+
 - **OPEN GATE -- why this entry says HOLD and not GOOD/ROBUST:**
   - **Tier 3 applies and is unmet.** The union changes durability / persistent-state contract
     behaviour (#73 decides whether completed work is committed) and a **normative operational

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -184,7 +184,7 @@ passed the lead gate but a clean CI runner did not), fixed test-only in the foll
 merged); Tag = the release commit (adds version/CHANGELOG only).
 
 ### v0.79.1 - wrapper false-park fix (the hand-finishing bug) (2026-07-25)
-**HOLD (open gate; NOT yet attested)** - release base `v0.79.0` - gated candidate `a25dad0` - tag `v0.79.1` (unissued)
+**GOOD / ROBUST** - release base `v0.79.0` (`dcca3233`, the commit the tag actually points at) - gated candidate `354990d` - ship: the squash-merge of PR #88 on master, which tag `v0.79.1` marks (resolve with `git rev-parse 'v0.79.1^{commit}'`)
 - **Scope:** one behavioural fix (#73) plus a docs/skill change (#79). The wrapper could do the
   work, write a durable reply, and still park the inbound as unfinished, forcing the operator to
   hand-finish completed work. The landed-response resolver now proves the terminal response from
@@ -200,7 +200,10 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   skill policy. Two P2s raised by the GitHub connector against the first fix were themselves
   regressions of the class being fixed, and were closed before merge.
 - **Assurance evidence:**
-  - 15/15 dev-gate legs green on the POST-BUMP release candidate `a25dad0` (the version bump
+  - **15/15 dev-gate legs green on `354990d`, the exact release head.** An earlier revision of this
+    entry cited the gate for `a25dad0`; the connector correctly objected that `a25dad0` is a SIBLING
+    of the release commit, not its ancestor, and its tree differs -- the dev-gate is SHA-bound, so
+    that evidence could not validate this revision. Superseded rather than silently kept (the version bump
     must be committed before the gate runs; a gate bound to a pre-bump SHA cannot validate the
     package). Separately 15/15 on `bdfc092` for the #73 fix itself (re-verified against the actual head,
     not the SHA the CI monitor was armed on), zero fresh connector findings at merge time.
@@ -240,7 +243,7 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
       construction.
     - `review-docs` (independent; the lead wrote all the prose): `codex-agenttalk-developer-4`
       -- **APPROVED**.
-- **OPEN FINDING blocking the tag (P2, executed and reproduced, not asserted):**
+- **CLOSED FINDING (was the sole blocker; P2, executed and reproduced, not asserted):**
   reconstructed publication order can revive the post-rescind false commit. When the sidecar is
   absent or incomplete, `publication_ordered_messages()` falls back to MESSAGE-ID order
   (`store.py:4077-4087`) and ids are monotonic only per process (`store.py:7038-7051`), so a
@@ -255,19 +258,30 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   when the backing order is reconstructed -- cannot-verify-order is not green -- WITHOUT making
   the rescind scan position-independent, which would regress the false-park this release fixes.
 
-- **OPEN GATE -- why this entry says HOLD and not GOOD/ROBUST:**
-  - **Tier 3 applies and is unmet.** The union changes durability / persistent-state contract
-    behaviour (#73 decides whether completed work is committed) and a **normative operational
-    skill** (#79 lead policy). Both are §1a Tier-3 triggers. Tier 3 requires a hard floor of 3
-    eligible independent reviewers across >=2 model families, a proposed tier, a ratifier
-    verdict, panel lenses, and a drift result. Only ONE independent review exists
-    (`claude-agenttalk-reviewer-fable`, GO). The panel is not satisfied by the GitHub connector.
-  - **Docs-testing pass is unmet.** This release changes docs AND packaging/install behaviour
-    (version + install pins), which triggers the docs-testing requirement for BOTH `test-docs`
-    and an independent `review-docs`. Neither producer is recorded.
-  - Both gaps were raised by the GitHub connector against `a25dad0` and confirmed against the
-    §1 policy text before being accepted. The release stays unissued until they are recorded or
-    the operator explicitly accepts a lower assurance claim.
+- **Gate closure (2026-07-26):** `codex-agenttalk-reviewer-1` re-reviewed the fold on the same
+  durability lens and **APPROVED**, release_blocker=no, closing its own P2. Executed at `354990d`:
+  both orphan shapes (truncated sidecar; both order files absent) produced `durable=False`,
+  `proof=False`, `turns=0`, `cursor=''`, and the persisted `order_reconstructed` marker survived a
+  heal. **False-park control held** -- with an intact sidecar a response physically published BEFORE
+  a later rescind still produced `proof=True` and committed the cursor despite hostile lexical id
+  ordering, so declining did not become over-broad. 32 focused cases plus a real-Store/run-loop
+  differential replay. It found no state reachable through supported writers where reconstructed
+  order becomes durable.
+- **Final drift result: NO DRIFT.** Shipped behaviour matches `CHANGELOG.md:32-36`. The CHANGELOG's
+  original unconditional rescind claim was narrowed before ship after the connector showed it was
+  false for the legacy path; the residual is now stated inline rather than promised away.
+- **Bounded residual carried, not hidden (task #82):** `order_reconstructed` is NOT bound into the
+  publication-order tamper anchor (`store.py:1773`) -- `_message_publication_order_chain()` hashes
+  only ids and sequences, so flipping the flag `true -> false` while leaving the message map intact
+  passes validation and launders the taint. This requires direct mutation of a local store file,
+  which is already the documented honest-local trust residual, and reviewer-1 explicitly scoped it
+  out ("could not verify hostile direct mutation"). The connector then went and looked at exactly
+  that residual, which is why it is recorded here instead of discovered later.
+- **Record correction for v0.79.0:** that entry states `ship SHA bf40925`, but
+  `git rev-parse 'v0.79.0^{commit}'` resolves to `dcca3233`. The recorded ship SHA is not where the
+  tag landed, so an auditor would look for the release at a commit the tag never pointed to. That is
+  the failure this ledger exists to prevent; task #85 adds a per-release scoring pass so a claim like
+  it is checked at the NEXT release rather than by accident.
 
 - **Known-not-fixed at ship (stated, not hidden):**
   - The fix is **not live for already-running wrappers**. A wrapper is a long-lived process that

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -183,6 +183,44 @@ passed the lead gate but a clean CI runner did not), fixed test-only in the foll
 `748ca74`. Reviewed-SHA = the exact code reviewed + lead-gated (fast-forward
 merged); Tag = the release commit (adds version/CHANGELOG only).
 
+### v0.79.1 - wrapper false-park fix (the hand-finishing bug) (2026-07-25)
+**GOOD / ROBUST** - release base `v0.79.0` - ship SHA `<SHIP>` - tag `v0.79.1`
+- **Scope:** one behavioural fix (#73) plus a docs/skill change (#79). The wrapper could do the
+  work, write a durable reply, and still park the inbound as unfinished, forcing the operator to
+  hand-finish completed work. The landed-response resolver now proves the terminal response from
+  the validated bus rather than from a parse of the child's command.
+- **Field evidence, not theory:** the defect was observed twice in production on 2026-07-24/25 --
+  `codex-2` (16:17) and `codex-agenttalk-developer-4` (03:04) both parked `config_blocked` while
+  their replies were present on the bus (message ids `20260724-161658-536356-DsPE` and
+  `20260725-030415-829351-eRgT` verified to exist). This release exists because the bug was
+  reproducing against real work, not because a test predicted it.
+- **Risk record:** base `v0.79.0` (`dcca323`); candidate refs `072f540` (both connector P2s) ->
+  `bdfc092` (braced env form) -> merge `e5a6c54`; `1cd96c3` (#79). Semantic dimensions matched:
+  wrapper commit/park behaviour (decides whether real work is recorded as done) and agent-facing
+  skill policy. Two P2s raised by the GitHub connector against the first fix were themselves
+  regressions of the class being fixed, and were closed before merge.
+- **Assurance evidence:**
+  - 15/15 dev-gate legs green on the merged head `bdfc092` (re-verified against the actual head,
+    not the SHA the CI monitor was armed on), zero fresh connector findings at merge time.
+  - Independent adversarial review by `claude-agenttalk-reviewer-fable`: **GO**, no blocking
+    findings, all five requested attack points addressed. It additionally found a third member of
+    the same defect family (the braced `${env:...}` interpreter form, fixed in `bdfc092`) and
+    corrected an overclaim: no rescind producer in `src/` emits `meta.supersedes`, so the residual
+    documented in `072f540` is theoretical rather than a live trade-off.
+  - Tests are **differential**: on the pre-fix source exactly 3 legs fail and the no-rescind
+    control still yields a proof, so the fixture is proven capable of producing a proof when
+    nothing cancels the request. 449 passed across the two touched suites locally.
+- **Known-not-fixed at ship (stated, not hidden):**
+  - The fix is **not live for already-running wrappers**. A wrapper is a long-lived process that
+    imported the old modules at launch; the editable install means master is the install, but
+    running agents keep the old behaviour until restarted. Restarting is itself subject to #78.
+  - `& (${env:AGENTTALK_PY})` (bare-parenthesized-braced) still returns `None`. Judged an
+    unrealistic spelling; the realistic member of the family is fixed.
+  - #72 (supervisor CLI-child health) is NOT in this release. PR #81 is green with a reviewer GO
+    but carries 3 fresh connector findings, including a crashed wrapper outside `idle` phase that
+    never auto-recovers. Shipping half of the operator's production report was the deliberate
+    choice over shipping a known false-DOWN.
+
 ### v0.79.0 - checkpoint-before-compact + DoD forcing-gate + OVH gateway fold (63-commit backlog) (2026-07-25)
 **GOOD / ROBUST** - release base `v0.78.1` - ship SHA `bf40925` - tag `v0.79.0`
 - **Scope:** the accumulated 63-commit master backlog, rolled into one release so it could be

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -184,7 +184,7 @@ passed the lead gate but a clean CI runner did not), fixed test-only in the foll
 merged); Tag = the release commit (adds version/CHANGELOG only).
 
 ### v0.79.1 - wrapper false-park fix (the hand-finishing bug) (2026-07-25)
-**GOOD / ROBUST** - release base `v0.79.0` - ship SHA `<SHIP>` - tag `v0.79.1`
+**HOLD (open gate; NOT yet attested)** - release base `v0.79.0` - gated candidate `a25dad0` - tag `v0.79.1` (unissued)
 - **Scope:** one behavioural fix (#73) plus a docs/skill change (#79). The wrapper could do the
   work, write a durable reply, and still park the inbound as unfinished, forcing the operator to
   hand-finish completed work. The landed-response resolver now proves the terminal response from
@@ -200,7 +200,9 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   skill policy. Two P2s raised by the GitHub connector against the first fix were themselves
   regressions of the class being fixed, and were closed before merge.
 - **Assurance evidence:**
-  - 15/15 dev-gate legs green on the merged head `bdfc092` (re-verified against the actual head,
+  - 15/15 dev-gate legs green on the POST-BUMP release candidate `a25dad0` (the version bump
+    must be committed before the gate runs; a gate bound to a pre-bump SHA cannot validate the
+    package). Separately 15/15 on `bdfc092` for the #73 fix itself (re-verified against the actual head,
     not the SHA the CI monitor was armed on), zero fresh connector findings at merge time.
   - Independent adversarial review by `claude-agenttalk-reviewer-fable`: **GO**, no blocking
     findings, all five requested attack points addressed. It additionally found a third member of
@@ -210,6 +212,20 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   - Tests are **differential**: on the pre-fix source exactly 3 legs fail and the no-rescind
     control still yields a proof, so the fixture is proven capable of producing a proof when
     nothing cancels the request. 449 passed across the two touched suites locally.
+- **OPEN GATE -- why this entry says HOLD and not GOOD/ROBUST:**
+  - **Tier 3 applies and is unmet.** The union changes durability / persistent-state contract
+    behaviour (#73 decides whether completed work is committed) and a **normative operational
+    skill** (#79 lead policy). Both are §1a Tier-3 triggers. Tier 3 requires a hard floor of 3
+    eligible independent reviewers across >=2 model families, a proposed tier, a ratifier
+    verdict, panel lenses, and a drift result. Only ONE independent review exists
+    (`claude-agenttalk-reviewer-fable`, GO). The panel is not satisfied by the GitHub connector.
+  - **Docs-testing pass is unmet.** This release changes docs AND packaging/install behaviour
+    (version + install pins), which triggers the docs-testing requirement for BOTH `test-docs`
+    and an independent `review-docs`. Neither producer is recorded.
+  - Both gaps were raised by the GitHub connector against `a25dad0` and confirmed against the
+    §1 policy text before being accepted. The release stays unissued until they are recorded or
+    the operator explicitly accepts a lower assurance claim.
+
 - **Known-not-fixed at ship (stated, not hidden):**
   - The fix is **not live for already-running wrappers**. A wrapper is a long-lived process that
     imported the old modules at launch; the editable install means master is the install, but

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -200,7 +200,13 @@ merged); Tag = the release commit (adds version/CHANGELOG only).
   skill policy. Two P2s raised by the GitHub connector against the first fix were themselves
   regressions of the class being fixed, and were closed before merge.
 - **Assurance evidence:**
-  - **15/15 dev-gate legs green on `354990d`, the exact release head.** An earlier revision of this
+  - **15/15 dev-gate legs green on `354990d`, the last CODE-BEARING revision of this release.**
+    Note the unavoidable regress, stated once here so future entries inherit it: a gate result can
+    never be recorded INSIDE the commit it describes, because writing it changes the tree. So the
+    code gate binds to the last code-bearing revision, and the attestation commit carrying this
+    ledger is documentation-only by construction and separately green in CI. What is NOT acceptable
+    -- and is what the connector caught -- is citing a gate for a commit that is neither the head nor
+    an ancestor of it An earlier revision of this
     entry cited the gate for `a25dad0`; the connector correctly objected that `a25dad0` is a SIBLING
     of the release commit, not its ancestor, and its tree differs -- the dev-gate is SHA-bound, so
     that evidence could not validate this revision. Superseded rather than silently kept (the version bump

--- a/docs/USER-MANUAL.md
+++ b/docs/USER-MANUAL.md
@@ -59,7 +59,7 @@ decisions are what make a GO credible.
 Install once per machine. Pin the version in repeatable setups.
 
 ```powershell
-python -m pip install git+https://github.com/zoolok17/agenttalk.git@v0.79.0
+python -m pip install git+https://github.com/zoolok17/agenttalk.git@v0.79.1
 agenttalk --version
 agenttalk --help
 agenttalk install-skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agenttalk"
-version = "0.79.0"
+version = "0.79.1"
 description = "File-backed message bus and coordination layer for coding-agent CLIs (Claude Code and Codex) - a pair or a named team - working on the same repository."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenttalk/__init__.py
+++ b/src/agenttalk/__init__.py
@@ -1,3 +1,3 @@
 """agenttalk: file-backed message bus for coding-agent CLIs (pairs or named teams)."""
 
-__version__ = "0.79.0"
+__version__ = "0.79.1"

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -1618,6 +1618,10 @@ class Store:
             or isinstance(raw.get("append_sequence"), bool)
             or int(raw["append_sequence"]) < 0
             or not isinstance(raw.get("messages"), dict)
+            or (
+                "order_reconstructed" in raw
+                and not isinstance(raw.get("order_reconstructed"), bool)
+            )
         ):
             raise ValueError("message publication order sidecar is invalid")
         append_sequence = int(raw["append_sequence"])
@@ -1762,6 +1766,11 @@ class Store:
             "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
             "append_sequence": sequence,
             "messages": messages,
+            # Once any tail was reconstructed from message ids, the sidecar can
+            # preserve that canonical order but can never recover its original
+            # physical publication order. Keep the provenance fail-closed across
+            # every later write.
+            "order_reconstructed": True,
         }
 
     def _reserve_message_publication_sequence(
@@ -1787,6 +1796,7 @@ class Store:
                 "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
                 "append_sequence": len(messages),
                 "messages": messages,
+                "order_reconstructed": bool(messages),
             }
         else:
             messages = dict(order["messages"])
@@ -1814,6 +1824,10 @@ class Store:
             "schema_version": _MESSAGE_PUBLICATION_ORDER_SCHEMA_VERSION,
             "append_sequence": sequence,
             "messages": messages,
+            # Missing provenance is a pre-fix/older-writer shape. It cannot prove
+            # that this complete sidecar was never reconstructed, so upgrade it to
+            # the permanent fail-closed state rather than silently blessing it.
+            "order_reconstructed": order.get("order_reconstructed") is not False,
         }
         self.state_dir.mkdir(parents=True, exist_ok=True)
         _atomic_write_text(
@@ -4066,25 +4080,46 @@ class Store:
         self,
         messages: list[Message] | None = None,
     ) -> list[Message]:
-        """Return validated messages in the durable physical publication order.
+        """Return validated messages in the best available publication order.
+
+        Use ``publication_ordered_messages_with_durability`` when correctness
+        depends on whether every returned position is backed by the sidecar.
+        """
+        ordered, _ = self.publication_ordered_messages_with_durability(messages)
+        return ordered
+
+    def publication_ordered_messages_with_durability(
+        self,
+        messages: list[Message] | None = None,
+    ) -> tuple[list[Message], bool]:
+        """Return ``(messages, durable_order)`` for one sidecar read.
 
         Legacy stores have no sidecar, so their established id order is the only
         available bootstrap authority. The first subsequent send freezes that
-        order under the publication lock before reserving its own sequence.
+        order under the publication lock before reserving its own sequence. A
+        partial sidecar similarly folds orphan messages onto its tail in id order.
+        ``durable_order`` is false for both reconstructed shapes, remains false
+        after that reconstruction is persisted, and is true only when the
+        sidecar covers every returned message and explicitly records that its
+        history was not reconstructed. Older unmarked sidecars fail closed.
         """
         messages = self.valid_messages() if messages is None else list(messages)
         order = self._read_message_publication_order()
         if order is None:
-            return messages
+            return messages, False
         sequences = order["messages"]
         missing = [message.id for message in messages if message.id not in sequences]
+        durable_order = not missing and order.get("order_reconstructed") is False
         if missing:
             # Read-time heal, IN-MEMORY only (a read path must not write): fold the
             # orphans onto the tail in id-order — identical to what the next write
             # will persist, so a read before and after the write agree — instead of
             # wedging every ordered read under version skew (#37).
             sequences = self._extend_order_with_orphans(order, missing)["messages"]
-        return sorted(messages, key=lambda message: sequences[message.id])
+        return (
+            sorted(messages, key=lambda message: sequences[message.id]),
+            durable_order,
+        )
 
     @staticmethod
     def _stable_scan_problem_reason(reason: str) -> str:

--- a/src/agenttalk/wrapper/obligations.py
+++ b/src/agenttalk/wrapper/obligations.py
@@ -2183,6 +2183,20 @@ class DetectionCommitGate:
         messages: list[Message],
     ) -> LandedResponseResult:
         """Resolve an exact terminal response from a validated publication snapshot."""
+        try:
+            messages, durable_order = (
+                self.store.publication_ordered_messages_with_durability(messages)
+            )
+        except (OSError, ValueError, TimeoutError, RuntimeError):
+            return LandedResponseResult(
+                unavailable_reason="validated landed-response replay unavailable"
+            )
+        if not durable_order:
+            # Reconstructed id order cannot prove whether a response preceded a
+            # requester rescind. Withhold the proof so the wrapper takes its
+            # recoverable residual/re-drive path; crediting possibly cancelled work
+            # would instead persist a false completion.
+            return LandedResponseResult()
         inbound_id = record.get("id")
         if not isinstance(inbound_id, str):
             return LandedResponseResult(unavailable_reason="delivered inbound id is invalid")

--- a/tests/test_owed_action_detection.py
+++ b/tests/test_owed_action_detection.py
@@ -8349,6 +8349,172 @@ def test_landed_response_uses_publication_order_not_lexical_message_id(
     assert result.proof.inbound_sequence < result.proof.evidence_sequence
 
 
+@pytest.mark.parametrize(
+    "order_shape",
+    ["orphaned-tail", "legacy-sidecarless"],
+)
+@pytest.mark.parametrize(
+    "heal_before_replay",
+    [False, True],
+    ids=["degraded-read", "persisted-reconstruction"],
+)
+def test_reconstructed_order_cannot_commit_post_rescind_landed_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    order_shape: str,
+    heal_before_replay: bool,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+    request_id = "rq-reconstructed-order-rescind"
+    message_ids = iter([
+        "20990101-000000-000001-AAAA",
+        "20990101-000000-000003-ZZZZ",
+        "20990101-000000-000003-AAAA",
+        "20990101-000000-000004-HHHH",
+    ])
+    monkeypatch.setattr("agenttalk.store._new_id", lambda: next(message_ids))
+    inbound = store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="review-request",
+        body="Review.",
+        meta={"request_id": request_id},
+    )
+    record = recv_api.next_record(store, "beta")
+    assert record is not None
+    assert record["id"] == inbound.id
+    store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn before the answer landed",
+        meta={"request_id": request_id},
+    )
+    store.send(
+        sender="beta",
+        recipient="alpha",
+        kind="review-result",
+        body="HOLD",
+        meta={
+            "status": "rejected",
+            "request_id": request_id,
+            "in_reply_to": inbound.id,
+        },
+    )
+
+    order_path = store.state_dir / "message-publication-order.json"
+    anchor_path = store.state_dir / "message-publication-order.anchor.json"
+    if order_shape == "orphaned-tail":
+        order = json.loads(order_path.read_text(encoding="utf-8"))
+        kept = {inbound.id: order["messages"][inbound.id]}
+        truncated_order = {
+            "schema_version": order["schema_version"],
+            "append_sequence": 1,
+            "messages": kept,
+        }
+        if "order_reconstructed" in order:
+            truncated_order["order_reconstructed"] = order["order_reconstructed"]
+        order_path.write_text(
+            json.dumps(truncated_order, indent=2),
+            encoding="utf-8",
+        )
+        anchor_path.write_text(
+            json.dumps({
+                "schema_version": order["schema_version"],
+                "append_sequence": 1,
+                "chain_digest": Store._message_publication_order_chain(kept),
+            }, indent=2),
+            encoding="utf-8",
+        )
+    else:
+        order_path.unlink()
+        anchor_path.unlink()
+
+    if heal_before_replay:
+        store.send(
+            sender="gamma",
+            recipient="lead",
+            kind="note",
+            body="unrelated write persists reconstructed history",
+        )
+
+    child_calls: list[str] = []
+
+    def drive(current: dict) -> loop.DriveOutcome:
+        child_calls.append(current["id"])
+        return loop.DriveOutcome(
+            ok=False,
+            failure_class=loop.CLASS_INFRA,
+            summary="injected recoverable child failure",
+        )
+
+    turns = loop.run_loop(
+        store,
+        "beta",
+        drive,
+        commit_gate=gate,
+        clock=lambda: 0.0,
+        sleep=lambda _delay: None,
+        max_polls=1,
+        on_escalate=lambda _info: True,
+    )
+
+    assert turns == 0
+    assert child_calls == [inbound.id]
+    assert store.cursor("beta") == ""
+
+
+def test_intact_order_proves_response_before_later_rescind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    request_id = "rq-response-before-rescind"
+    message_ids = iter([
+        "20990101-000000-000001-AAAA",
+        "20990101-000000-000003-ZZZZ",
+        "20990101-000000-000003-AAAA",
+    ])
+    monkeypatch.setattr("agenttalk.store._new_id", lambda: next(message_ids))
+    inbound = store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="review-request",
+        body="Review.",
+        meta={"request_id": request_id},
+    )
+    record = recv_api.next_record(store, "beta")
+    assert record is not None
+    response = store.send(
+        sender="beta",
+        recipient="alpha",
+        kind="review-result",
+        body="HOLD",
+        meta={
+            "status": "rejected",
+            "request_id": request_id,
+            "in_reply_to": inbound.id,
+        },
+    )
+    rescind = store.send(
+        sender="alpha",
+        recipient="beta",
+        kind="rescind",
+        body="withdrawn after the answer landed",
+        meta={"request_id": request_id},
+    )
+    gate = DetectionCommitGate.from_environment(store, "beta", fence="wrapper-1")
+
+    result = gate.resolve_landed_response(record)
+
+    assert response.id > rescind.id
+    assert result.proof is not None
+    assert result.proof.evidence_id == response.id
+
+
 def test_landed_response_skips_wrong_anchor_before_later_exact_terminal(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_publication_order_self_heal.py
+++ b/tests/test_publication_order_self_heal.py
@@ -83,6 +83,7 @@ def test_write_path_heals_orphans_instead_of_wedging(
     order = _read_order(store)
     # 2 orphans folded + 1 new message
     assert order["append_sequence"] == n_before + 3
+    assert order["order_reconstructed"] is True
     # the anchored prefix is byte-for-byte preserved
     for mid, seq in prefix.items():
         assert order["messages"][mid] == seq
@@ -117,6 +118,51 @@ def test_read_path_heals_in_memory_without_writing(store: Store) -> None:
     assert _anchor_path(store).read_bytes() == anchor_before
 
 
+def test_order_durability_distinguishes_intact_orphan_and_legacy(
+    store: Store,
+) -> None:
+    _send(store, 3)
+    expected = [message.id for message in store.valid_messages()]
+
+    ordered, durable = store.publication_ordered_messages_with_durability()
+    assert [message.id for message in ordered] == expected
+    assert durable is True
+
+    _freeze_sidecar_behind(store, drop=1)
+    ordered, durable = store.publication_ordered_messages_with_durability()
+    assert [message.id for message in ordered] == expected
+    assert durable is False
+
+    _order_path(store).unlink()
+    _anchor_path(store).unlink()
+    ordered, durable = store.publication_ordered_messages_with_durability()
+    assert [message.id for message in ordered] == expected
+    assert durable is False
+
+    store.send(sender="alpha", recipient="beta", body="persist legacy bootstrap")
+    ordered, durable = store.publication_ordered_messages_with_durability()
+    assert len(ordered) == 4
+    assert durable is False
+
+
+def test_unmarked_complete_sidecar_fails_closed_across_upgrade(
+    store: Store,
+) -> None:
+    _send(store, 2)
+    order = _read_order(store)
+    del order["order_reconstructed"]
+    _order_path(store).write_text(json.dumps(order), encoding="utf-8")
+
+    ordered, durable = store.publication_ordered_messages_with_durability()
+    assert len(ordered) == 2
+    assert durable is False
+
+    store.send(sender="alpha", recipient="beta", body="upgrade through new writer")
+    assert _read_order(store)["order_reconstructed"] is True
+    _, durable = store.publication_ordered_messages_with_durability()
+    assert durable is False
+
+
 def test_read_and_write_folds_agree(store: Store) -> None:
     _send(store, 5)
     _freeze_sidecar_behind(store, drop=2)
@@ -147,6 +193,16 @@ def test_tamper_below_anchor_fails_loud_and_does_not_heal(store: Store) -> None:
         store.publication_ordered_messages()
 
 
+def test_invalid_reconstruction_provenance_fails_loud(store: Store) -> None:
+    _send(store, 2)
+    order = _read_order(store)
+    order["order_reconstructed"] = "unknown"
+    _order_path(store).write_text(json.dumps(order), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="sidecar is invalid"):
+        store.publication_ordered_messages()
+
+
 def test_durable_anchor_ahead_of_sidecar_fails_loud(store: Store) -> None:
     _send(store, 3)
     anchor = _read_anchor(store)
@@ -171,6 +227,8 @@ def test_anchor_absent_serves_reads_and_reanchors_on_write(store: Store) -> None
     _anchor_path(store).unlink()   # crash-during-bootstrap or removed anchor
     # a read still works (must not wedge a benign crash-recovery)
     assert len(store.publication_ordered_messages()) == 3
+    _, durable = store.publication_ordered_messages_with_durability()
+    assert durable is True
     # the next write re-anchors
     store.send(sender="alpha", recipient="beta", body="x")
     assert _anchor_path(store).exists()
@@ -207,6 +265,7 @@ def test_extend_order_with_orphans_preserves_prefix_and_is_pure() -> None:
     assert healed["messages"]["c"] == 3
     assert healed["messages"]["y"] == 4 and healed["messages"]["z"] == 5
     assert healed["append_sequence"] == 5
+    assert healed["order_reconstructed"] is True
 
 
 def test_doctor_reports_module_path_and_capabilities(store_root: Path) -> None:


### PR DESCRIPTION
Ships the false-park fix (#73) and the lead-skill Independence policy (#79).

Version bump, CHANGELOG, install pins (`@v0.79.1`), and the ASSURANCE ledger entry only — no source change. Re-gating the **post-bump** commit deliberately, since a version-ratchet test reds CI when only the pre-bump SHA is gated.

## Why this release exists

#73 was reproducing against real work, not predicted by a test. Two agents parked `config_blocked` on 2026-07-24/25 while their replies were present on the bus (`20260724-161658-536356-DsPE`, `20260725-030415-829351-eRgT`, both verified to exist). That is the hand-finishing cost the operator reported.

## Assurance

- 15/15 dev-gate legs green on the merged head, zero fresh connector findings at merge.
- Independent adversarial review (`claude-agenttalk-reviewer-fable`): **GO**, no blocking findings. It also found a third member of the same defect family (braced `${env:...}` interpreter form) and corrected an overclaim in the commit message.
- Tests are differential: exactly 3 legs fail pre-fix while the no-rescind control still yields a proof.

## Deliberately NOT in this release

- **#72 (PR #81)** — green with a reviewer GO, but 3 fresh connector findings, including a crashed wrapper outside `idle` phase that never auto-recovers. Shipping half the production report beat shipping a known false-DOWN.
- The fix is **not live for already-running wrappers** until they restart; that restart is itself subject to #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)