### PR TITLE
test(#74 inst-9): synchronize the bus-tail mid-run arrival race (unblocks PR #66)

### DIFF
--- a/tests/test_reply_tail.py
+++ b/tests/test_reply_tail.py
@@ -244,25 +244,64 @@ def test_tail_timeout_exits_0(
 def test_tail_picks_up_messages_that_arrive_during_run(
     store_root: Path,
     capsys: pytest.CaptureFixture,
-    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """End-to-end: launch tail in a thread, send a message, verify
-    tail printed it before timing out."""
+    """Tail observes a message published after its first live poll."""
     import threading
+
     s = Store(store_root)
+    body = "injected during tail"
+    tail_ready = threading.Event()
+    message_observed = threading.Event()
+    stop_tail = threading.Event()
+    scan_count = 0
+    original_scan = Store._scan_messages
 
-    def send_after_delay():
-        import time as _time
-        _time.sleep(0.3)
-        s.send(sender="alpha", recipient="beta", body="injected during tail")
+    def scan_messages(store: Store, *, since_id: str | None = None):
+        nonlocal scan_count
+        valid, invalid = original_scan(store, since_id=since_id)
+        if store.root == s.root:
+            scan_count += 1
+            if scan_count == 2:
+                # Default tail performs one baseline scan, then enters its live loop.
+                tail_ready.set()
+            if any(message.body == body for message in valid):
+                message_observed.set()
+        return valid, invalid
 
-    t = threading.Thread(target=send_after_delay, daemon=True)
+    def sleep_until_stopped(interval: float) -> None:
+        if stop_tail.wait(interval):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(Store, "_scan_messages", scan_messages)
+    monkeypatch.setattr(cli.time, "sleep", sleep_until_stopped)
+
+    result: list[int] = []
+    errors: list[BaseException] = []
+
+    def run_tail() -> None:
+        try:
+            result.append(
+                _run(["tail", "--timeout", "30", "--interval", "0.1"], store_root)
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=run_tail, daemon=True)
     t.start()
-    rc = _run(["tail", "--timeout", "1.5", "--interval", "0.1"], store_root)
-    t.join(timeout=2)
-    assert rc == 0
+    try:
+        assert tail_ready.wait(timeout=5), "tail never reached its first live poll"
+        s.send(sender="alpha", recipient="beta", body=body)
+        assert message_observed.wait(timeout=5), "tail never observed the new message"
+    finally:
+        stop_tail.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert errors == []
+    assert result == [0]
     out = capsys.readouterr().out
-    assert "injected during tail" in out
+    assert body in out
 
 
 # ----------------------------------------------------------- Store.last_received_for


### PR DESCRIPTION
Test-only. De-flakes `test_tail_picks_up_messages_that_arrive_during_run`, which is **instance 9 of the #74 wall-clock-assumption family** and is currently red-blocking PR #66.

## Why this one is the family's cleanest specimen

PR #66 is a **one-line dev-dependency bump** — `zizmor >= 1.20` -> `>= 1.28.0` in a requirements file — and this test failed on its windows/3.13 leg. There is no reachable path from a linter's version constraint to a bus tail race, so the diff provably did not cause it.

The literal failure, read from that leg's `dev-gate-evidence.json` (run 30176589793):

```
assert "injected during tail" in out
E   AssertionError: assert 'injected during tail' in ''
```

Note `in ''` — tail produced *nothing*, not partial output.

## The actual mechanism, which is not "the timeout was too short"

The old test used `sleep(0.3)` as a guess that tail had finished its initial **seen-set scan**. Under scheduler pressure the sender wins that race and publishes first — so tail classifies the new message as **pre-existing baseline** and correctly declines to stream it. The test was not measuring what it claimed to measure.

That distinction matters for the rest of the #74 sweep: raising the timeout would never have fixed this, because the bug is an *ordering* fault, not a *duration* fault.

## The fix

Establishes both orderings that `sleep()` was guessing at:

1. Instruments the real `Store._scan_messages` boundary and signals readiness only once tail has completed its baseline scan **and** its first live poll.
2. Publishes only after that signal, then waits until a later real scan contains the message before a stop event interrupts tail so the assertion can run.

The CLI timeout is 30s purely as a failsafe; healthy runs finish in ~2s and no sleep or deadline decides correctness. Deliberately the opposite of raising a bound — per #84, longer waits spent under contention convert a fast red into a leg that blows its cap and (per #88) uploads no evidence at all.

## Evidence

- **Broken-product proof.** With a temporary `return 0` after tail's first live poll, the repaired test fails at its real observation condition (`tail never observed the new message`). Mutation removed and the product blob verified byte-identical to baseline (`29ef17db...`, `matches_baseline=True`). The test keeps its teeth.
- **CPU-pressure proof.** 4 busy-loop workers across 20 independent pytest processes: **20/20 pass**, 1.81s–2.19s.
- Full file: 19/19 pass. `ruff check` clean.
- **Neighbour sweep.** No sibling in the file retains this shape, with the reason stated: the other tail tests use a CLI timeout only to terminate a single-threaded observation, so no background action must win a race against a deadline. Seven siblings enumerated by line.

## Honesty notes

- The original test **passed locally** on `7338d4e`; no local reproduction of the CI flake is claimed. The CI failure above is the specimen.
- **Bounded residual:** the harness observes tail's private canonical scan boundary because tail exposes no public readiness signal. A future tail-polling refactor may require updating this harness even when public behaviour stays correct.

Built by `codex-agenttalk-developer-4`. Branch verified clean and product-free before push: 1 file, +53/-14, no `src/` changes.
