### PR TITLE
docs(lead-skill): how to publish a sandboxed worker's commit safely

### DIFF
--- a/src/agenttalk/skills/claude/agenttalk.lead.md
+++ b/src/agenttalk/skills/claude/agenttalk.lead.md
@@ -340,6 +340,57 @@ the agents you plan.
    summarize the outcome to the user with unresolved blockers called
    out explicitly.
 
+## Publishing a sandboxed worker's commit
+
+A sandboxed worker can commit in its own worktree but cannot push, so the
+lead publishes on its behalf. Three failures live in that one step, and the
+first two are silent.
+
+1. **Require a clean-SHA handoff.** The worker's reply must carry the final
+   full SHA and an empty `git status --porcelain` for its worktree. Pushing a
+   branch publishes the committed HEAD, never uncommitted edits — so a dirty
+   worktree publishes a tree nobody tested.
+   ```powershell
+   git -C <worktree> status --porcelain     # must be empty
+   git -C <worktree> log -1 --format=%H     # must equal the reported SHA
+   ```
+
+2. **Never let the current directory choose which commit is pushed.** This is
+   the trap:
+   ```powershell
+   # WRONG when run from the main checkout: HEAD is the MAIN branch,
+   # not the worker's commit. This publishes the base branch over the
+   # feature branch.
+   git push origin HEAD:<branch>
+   ```
+   Push the **explicit full SHA**, which cannot be ambiguous about which tree
+   it means and is self-documenting in shell history:
+   ```powershell
+   git push origin <full-sha>:refs/heads/<branch>
+   ```
+   `git -C <worktree> push origin HEAD:<branch>` also works. Prefer the
+   explicit SHA.
+
+   **`--force-with-lease` does not protect you here.** The lease asserts what
+   the *remote* looked like, which you may legitimately hold; it says nothing
+   about whether your *local* ref is the one you meant. A wrong-but-leased
+   force push is "safe" by the flag's definition and destructive in fact.
+
+3. **Verify the result, not the push output.** Pushing the base branch onto a
+   pull request's head makes the head equal the base, and hosts such as GitHub
+   read that as already-merged and **auto-close the PR**. The push output looks
+   like an ordinary fast-forward, so only an explicit check reveals it:
+   ```powershell
+   gh pr view <n> --json headRefOid,state,mergeable
+   ```
+   Recovery, if it happens: the objects are still local, so re-push the correct
+   explicit SHA and reopen the request. Confirm the head afterwards.
+
+The general rule behind all three: *which tree or object am I operating on* is
+a question to ANSWER explicitly, never to infer from ambient context. The same
+rule catches a stale checkout behind a running process, a test run from the
+wrong directory, and a static check scanning a tree the runtime never imports.
+
 ## Targeting
 
 - Use `agenttalk send --to <agent>` for one named recipient.

--- a/src/agenttalk/skills/claude/agenttalk.lead.md
+++ b/src/agenttalk/skills/claude/agenttalk.lead.md
@@ -378,13 +378,36 @@ first two are silent.
 
 3. **Verify the result, not the push output.** Pushing the base branch onto a
    pull request's head makes the head equal the base, and hosts such as GitHub
-   read that as already-merged and **auto-close the PR**. The push output looks
-   like an ordinary fast-forward, so only an explicit check reveals it:
+   then **auto-close the request** (often displaying it as *merged*). The push
+   output looks like an ordinary fast-forward, so only an explicit check
+   reveals it:
    ```powershell
    gh pr view <n> --json headRefOid,state,mergeable
    ```
-   Recovery, if it happens: the objects are still local, so re-push the correct
-   explicit SHA and reopen the request. Confirm the head afterwards.
+
+   **Recovery is conditional — read this before you need it.** The objects are
+   still local, so nothing is lost, but re-pushing the correct SHA and
+   reopening only works *directly* when that SHA is a **descendant of whatever
+   became the erroneous head**. GitHub refuses a reopen when the current head
+   is not a descendant of the head SHA recorded at close time. A worker's
+   branch frequently forks from an earlier base commit than the base has since
+   advanced to, so the refusal is the common case, not the rare one.
+
+   If the reopen is refused:
+   ```powershell
+   # 1. put back the SHA the host recorded as head at close time
+   git push origin <closed-time-head-sha>:refs/heads/<branch> --force
+   # 2. reopen while the head matches what was stored
+   gh pr reopen <n>
+   # 3. now push the correct commit (force-pushing an OPEN request is allowed)
+   git push origin <full-sha>:refs/heads/<branch> --force
+   gh pr view <n> --json headRefOid,state
+   ```
+   Capture `<closed-time-head-sha>` from `gh pr view <n> --json headRefOid`
+   before anything else changes it, or from the closed request's timeline.
+   Opening a fresh request is always a valid fallback. Note the recovery push
+   is a non-fast-forward and needs `--force`, since it overwrites the erroneous
+   state on the remote.
 
 The general rule behind all three: *which tree or object am I operating on* is
 a question to ANSWER explicitly, never to infer from ambient context. The same

--- a/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
+++ b/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
@@ -369,13 +369,36 @@ first two are silent.
 
 3. **Verify the result, not the push output.** Pushing the base branch onto a
    pull request's head makes the head equal the base, and hosts such as GitHub
-   read that as already-merged and **auto-close the PR**. The push output looks
-   like an ordinary fast-forward, so only an explicit check reveals it:
+   then **auto-close the request** (often displaying it as *merged*). The push
+   output looks like an ordinary fast-forward, so only an explicit check
+   reveals it:
    ```bash
    gh pr view <n> --json headRefOid,state,mergeable
    ```
-   Recovery, if it happens: the objects are still local, so re-push the correct
-   explicit SHA and reopen the request. Confirm the head afterwards.
+
+   **Recovery is conditional — read this before you need it.** The objects are
+   still local, so nothing is lost, but re-pushing the correct SHA and
+   reopening only works *directly* when that SHA is a **descendant of whatever
+   became the erroneous head**. GitHub refuses a reopen when the current head
+   is not a descendant of the head SHA recorded at close time. A worker's
+   branch frequently forks from an earlier base commit than the base has since
+   advanced to, so the refusal is the common case, not the rare one.
+
+   If the reopen is refused:
+   ```bash
+   # 1. put back the SHA the host recorded as head at close time
+   git push origin <closed-time-head-sha>:refs/heads/<branch> --force
+   # 2. reopen while the head matches what was stored
+   gh pr reopen <n>
+   # 3. now push the correct commit (force-pushing an OPEN request is allowed)
+   git push origin <full-sha>:refs/heads/<branch> --force
+   gh pr view <n> --json headRefOid,state
+   ```
+   Capture `<closed-time-head-sha>` from `gh pr view <n> --json headRefOid`
+   before anything else changes it, or from the closed request's timeline.
+   Opening a fresh request is always a valid fallback. Note the recovery push
+   is a non-fast-forward and needs `--force`, since it overwrites the erroneous
+   state on the remote.
 
 The general rule behind all three: *which tree or object am I operating on* is
 a question to ANSWER explicitly, never to infer from ambient context. The same

--- a/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
+++ b/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
@@ -331,6 +331,57 @@ the agents you plan.
    summarize the outcome to the user with unresolved blockers called
    out explicitly.
 
+## Publishing a sandboxed worker's commit
+
+A sandboxed worker can commit in its own worktree but cannot push, so the
+lead publishes on its behalf. Three failures live in that one step, and the
+first two are silent.
+
+1. **Require a clean-SHA handoff.** The worker's reply must carry the final
+   full SHA and an empty `git status --porcelain` for its worktree. Pushing a
+   branch publishes the committed HEAD, never uncommitted edits — so a dirty
+   worktree publishes a tree nobody tested.
+   ```bash
+   git -C <worktree> status --porcelain     # must be empty
+   git -C <worktree> log -1 --format=%H     # must equal the reported SHA
+   ```
+
+2. **Never let the current directory choose which commit is pushed.** This is
+   the trap:
+   ```bash
+   # WRONG when run from the main checkout: HEAD is the MAIN branch,
+   # not the worker's commit. This publishes the base branch over the
+   # feature branch.
+   git push origin HEAD:<branch>
+   ```
+   Push the **explicit full SHA**, which cannot be ambiguous about which tree
+   it means and is self-documenting in shell history:
+   ```bash
+   git push origin <full-sha>:refs/heads/<branch>
+   ```
+   `git -C <worktree> push origin HEAD:<branch>` also works. Prefer the
+   explicit SHA.
+
+   **`--force-with-lease` does not protect you here.** The lease asserts what
+   the *remote* looked like, which you may legitimately hold; it says nothing
+   about whether your *local* ref is the one you meant. A wrong-but-leased
+   force push is "safe" by the flag's definition and destructive in fact.
+
+3. **Verify the result, not the push output.** Pushing the base branch onto a
+   pull request's head makes the head equal the base, and hosts such as GitHub
+   read that as already-merged and **auto-close the PR**. The push output looks
+   like an ordinary fast-forward, so only an explicit check reveals it:
+   ```bash
+   gh pr view <n> --json headRefOid,state,mergeable
+   ```
+   Recovery, if it happens: the objects are still local, so re-push the correct
+   explicit SHA and reopen the request. Confirm the head afterwards.
+
+The general rule behind all three: *which tree or object am I operating on* is
+a question to ANSWER explicitly, never to infer from ambient context. The same
+rule catches a stale checkout behind a running process, a test run from the
+wrong directory, and a static check scanning a tree the runtime never imports.
+
 ## Targeting
 
 - Use `python -m agenttalk send --to <agent>` for one named recipient.

--- a/tests/test_skill_lint.py
+++ b/tests/test_skill_lint.py
@@ -77,6 +77,8 @@ SKILL_INVARIANTS = [
         "agenttalk broadcast",             # fan-out for group input
         "decide and act within",           # Independence policy (must be mirrored both sides)
         "do not stall on a call that is yours",  # Independence: report, don't over-ask
+        "does not protect you here",       # --force-with-lease is not a safeguard (mirror both sides)
+        "descendant of whatever",          # reopen is conditional; the fallback must not be dropped
     ]),
     ("agenttalk.consult.md", "agenttalk-consult", [
         "AGENTTALK_SELF",


### PR DESCRIPTION
Docs-only. Adds a **"Publishing a sandboxed worker's commit"** section to the lead skill, in both the Claude and Codex mirrors.

## Why

I made this mistake as lead on 2026-07-28, on this repo, and it was silent in two ways.

I did the hard part right — verified the worker's clean SHA, empty `git status --porcelain`, correct ancestry. Then, from the **main checkout**, I ran:

```
git push origin HEAD:<branch>   --force-with-lease
```

`HEAD` there is the main branch. That force-pushed **the base over the feature branch**.

Two consequences, and the second is the one nobody expects:

1. The branch pointer moved to the base commit, orphaning the worker's round. Recoverable — the objects were still local.
2. **GitHub auto-closed the pull request**, because a head equal to base reads as already-merged.

`--force-with-lease` did not protect me. The lease asserts what the *remote* looked like — which I did legitimately hold. It says nothing about whether my *local* ref is the one I meant. A wrong-but-leased force push is "safe" by the flag's definition and destructive in fact. That is the part I think is genuinely non-obvious, and the reason this is worth shipping rather than just remembering.

The push output looked like an ordinary fast-forward. Only an explicit `gh pr view --json headRefOid,state` revealed the closed PR.

## What the section says

- Require the clean-SHA handoff (empty porcelain + reported SHA matches) — pushing publishes the committed HEAD, never uncommitted edits.
- **Never let the current directory choose which commit is pushed.** Use the explicit full SHA — `git push origin <full-sha>:refs/heads/<branch>` — which cannot be ambiguous about which tree it means and is self-documenting in shell history. `git -C <worktree> push` also works.
- Why `--force-with-lease` is not a safeguard here.
- The auto-close consequence, and the recovery (re-push the explicit SHA, reopen, confirm the head).
- Verify the *result*, not the push output.

It closes on the general rule the three failures share, which is the same rule behind several other defects found this week:

> *Which tree or object am I operating on* is a question to ANSWER explicitly, never to infer from ambient context.

That one rule also catches a stale checkout behind a running process, a test run from the wrong directory, and a static check scanning a tree the runtime never imports.

## Scope and verification

- Both mirrors updated and kept in parity: `skills/claude/agenttalk.lead.md` (L343) and `skills/codex/agenttalk-lead/SKILL.md` (L334). Fences follow each file's existing convention (`powershell` / `bash`).
- Skill text is **project-agnostic** per the universal-skills rule — no repo names, agent names, or internals; only `<worktree>`, `<branch>`, `<full-sha>`, `<n>`.
- `tests/test_skill_lint.py` + `tests/test_install_skills.py`: **38 passed**.
- This branch was itself pushed using the explicit-SHA form the section prescribes.

Per `docs/ASSURANCE.md`, a docs change triggers docs-testing: `test-docs` plus an independent `review-docs`. Requesting that rather than self-certifying.
