### PR TITLE
docs(lead-skill): the clean-SHA check was a placebo under one git config

### DIFF
--- a/src/agenttalk/skills/claude/agenttalk.lead.md
+++ b/src/agenttalk/skills/claude/agenttalk.lead.md
@@ -365,9 +365,10 @@ first two are silent.
 2. **Never let the current directory choose which commit is pushed.** This is
    the trap:
    ```powershell
-   # WRONG when run from the main checkout: HEAD is the MAIN branch,
-   # not the worker's commit. This publishes the base branch over the
-   # feature branch.
+   # WRONG when run from the main checkout: HEAD is the MAIN branch, not the
+   # worker's commit. If Git accepts it — as a fast-forward, or with force or a
+   # lease — this publishes the base branch over the feature branch. A
+   # non-fast-forward rejection here is luck, not a safeguard.
    git push origin HEAD:<branch>
    ```
    Push the **explicit full SHA**, which cannot be ambiguous about which tree

--- a/src/agenttalk/skills/claude/agenttalk.lead.md
+++ b/src/agenttalk/skills/claude/agenttalk.lead.md
@@ -347,13 +347,20 @@ lead publishes on its behalf. Three failures live in that one step, and the
 first two are silent.
 
 1. **Require a clean-SHA handoff.** The worker's reply must carry the final
-   full SHA and an empty `git status --porcelain` for its worktree. Pushing a
-   branch publishes the committed HEAD, never uncommitted edits — so a dirty
-   worktree publishes a tree nobody tested.
+   full SHA and an empty status for its worktree. Pushing a branch publishes the
+   committed HEAD, never uncommitted edits — so a dirty worktree publishes a tree
+   nobody tested.
    ```powershell
-   git -C <worktree> status --porcelain     # must be empty
-   git -C <worktree> log -1 --format=%H     # must equal the reported SHA
+   git -C "<worktree>" status --porcelain --untracked-files=all   # must be empty
+   git -C "<worktree>" log -1 --format=%H                         # must equal the reported SHA
    ```
+   **Two details that make the difference between a check and a placebo.**
+   `--untracked-files=all` is required: a repository or user config setting
+   `status.showUntrackedFiles=no` makes a bare `--porcelain` print NOTHING even
+   when the worker has uncommitted new files, so the handoff passes and you
+   publish a commit missing files the worker's tests depended on. And quote the
+   path: `-C` takes exactly ONE argument, so an unquoted worktree under a path
+   containing spaces splits into two and git fails *before* validating anything.
 
 2. **Never let the current directory choose which commit is pushed.** This is
    the trap:
@@ -368,7 +375,7 @@ first two are silent.
    ```powershell
    git push origin <full-sha>:refs/heads/<branch>
    ```
-   `git -C <worktree> push origin HEAD:<branch>` also works. Prefer the
+   `git -C "<worktree>" push origin HEAD:<branch>` also works. Prefer the
    explicit SHA.
 
    **`--force-with-lease` does not protect you here.** The lease asserts what

--- a/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
+++ b/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
@@ -356,9 +356,10 @@ first two are silent.
 2. **Never let the current directory choose which commit is pushed.** This is
    the trap:
    ```bash
-   # WRONG when run from the main checkout: HEAD is the MAIN branch,
-   # not the worker's commit. This publishes the base branch over the
-   # feature branch.
+   # WRONG when run from the main checkout: HEAD is the MAIN branch, not the
+   # worker's commit. If Git accepts it — as a fast-forward, or with force or a
+   # lease — this publishes the base branch over the feature branch. A
+   # non-fast-forward rejection here is luck, not a safeguard.
    git push origin HEAD:<branch>
    ```
    Push the **explicit full SHA**, which cannot be ambiguous about which tree

--- a/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
+++ b/src/agenttalk/skills/codex/agenttalk-lead/SKILL.md
@@ -338,13 +338,20 @@ lead publishes on its behalf. Three failures live in that one step, and the
 first two are silent.
 
 1. **Require a clean-SHA handoff.** The worker's reply must carry the final
-   full SHA and an empty `git status --porcelain` for its worktree. Pushing a
-   branch publishes the committed HEAD, never uncommitted edits — so a dirty
-   worktree publishes a tree nobody tested.
+   full SHA and an empty status for its worktree. Pushing a branch publishes the
+   committed HEAD, never uncommitted edits — so a dirty worktree publishes a tree
+   nobody tested.
    ```bash
-   git -C <worktree> status --porcelain     # must be empty
-   git -C <worktree> log -1 --format=%H     # must equal the reported SHA
+   git -C "<worktree>" status --porcelain --untracked-files=all   # must be empty
+   git -C "<worktree>" log -1 --format=%H                         # must equal the reported SHA
    ```
+   **Two details that make the difference between a check and a placebo.**
+   `--untracked-files=all` is required: a repository or user config setting
+   `status.showUntrackedFiles=no` makes a bare `--porcelain` print NOTHING even
+   when the worker has uncommitted new files, so the handoff passes and you
+   publish a commit missing files the worker's tests depended on. And quote the
+   path: `-C` takes exactly ONE argument, so an unquoted worktree under a path
+   containing spaces splits into two and git fails *before* validating anything.
 
 2. **Never let the current directory choose which commit is pushed.** This is
    the trap:
@@ -359,7 +366,7 @@ first two are silent.
    ```bash
    git push origin <full-sha>:refs/heads/<branch>
    ```
-   `git -C <worktree> push origin HEAD:<branch>` also works. Prefer the
+   `git -C "<worktree>" push origin HEAD:<branch>` also works. Prefer the
    explicit SHA.
 
    **`--force-with-lease` does not protect you here.** The lease asserts what

--- a/tests/test_skill_lint.py
+++ b/tests/test_skill_lint.py
@@ -266,6 +266,42 @@ LEAD_SKILL_PATHS = (
 # followed by `-uno` is still broken.
 _UNTRACKED_OPT = re.compile(r"^(-u.*|--untracked-files(=.*)?)$")
 
+# The ONE spelling the recipe may use for the worker's worktree. `_run_extracted`
+# binds exactly this token and nothing else, so a taught command that names any other
+# target (`.`, `$PWD`, an empty string, a second `-C`) cannot be executed against the
+# fixture and silently pass.
+WORKTREE_PLACEHOLDER = "<worktree>"
+
+# A taught clean-SHA command is a single argv, not a shell program. `subprocess.run`
+# does not interpret any of these, so a pipeline or redirection written in the skill
+# would be handed to git as literal pathspecs: `... -- . | cat >/dev/null` returned
+# rc=0 with empty output while the worktree was dirty, because git saw `|`, `cat` and
+# `>/dev/null` as paths and `.` made the sentinel visible to the harness. Reject the
+# grammar instead of executing a command whose real behaviour differs from the test's.
+_SHELL_METACHARS = ("|", "&", ";", "<", ">", "`", "$(", "${", "\n", "\r")
+
+
+# A documented placeholder is `<word>` with no spaces; a redirection is `<`/`>` next to
+# a filename. Mask the former before scanning so the guard does not reject the very
+# recipe it exists to protect — the first version of this check flagged `<worktree>`
+# itself, which is a false-DOWN of exactly the kind these guards are meant to prevent.
+_PLACEHOLDER_TOKEN = re.compile(r"<[A-Za-z][A-Za-z0-9_.-]*>")
+
+
+def _shell_grammar_problems(cmd: str) -> list[str]:
+    """Reject anything that is a shell program rather than one plain argv."""
+    problems: list[str] = []
+    probe = _PLACEHOLDER_TOKEN.sub("PH", cmd)
+    for meta in _SHELL_METACHARS:
+        if meta in probe:
+            problems.append(
+                f"contains shell metacharacter {meta!r}; the recipe must be a single "
+                "argv because nothing interprets a shell here"
+            )
+    if cmd.rstrip().endswith("\\"):
+        problems.append("ends with a line continuation; the recipe must be one line")
+    return problems
+
 
 def _tokens(cmd: str, posix: bool) -> list[str] | None:
     """Tokenize, or None when the line cannot be tokenized (unbalanced quotes).
@@ -292,13 +328,22 @@ def _lead_bodies() -> list[tuple[str, str]]:
 
 
 def _strip_shell_comment(line: str) -> str:
-    """Drop a trailing shell comment. A `#` inside quotes is not a comment.
+    """Drop a trailing shell comment. A `#` inside quotes is not a comment, and
+    neither is a `#` ATTACHED to a word.
 
-    This exists because `--untracked-files=all` written in a COMMENT satisfied the
-    previous regex guard while the executed command lacked the flag entirely.
+    Two bypasses shaped this. First, `--untracked-files=all` written in a comment
+    satisfied a regex guard while the executed command lacked the flag. Then
+    `--untracked-files=all#broken` defeated the fix: breaking at every unquoted `#`
+    silently REPAIRED the broken token into the valid parent command before either
+    inspector saw it, so the guard validated a command the shell would never run
+    (`fatal: Invalid untracked files mode 'all#broken'`).
+
+    A shell opens a comment only where `#` STARTS a word — at the beginning of the
+    line or after whitespace. Anywhere else it is an ordinary character of the
+    current token, so it must be preserved and allowed to fail validation.
     """
     out, quote = [], None
-    for ch in line:
+    for i, ch in enumerate(line):
         if quote:
             out.append(ch)
             if ch == quote:
@@ -308,23 +353,45 @@ def _strip_shell_comment(line: str) -> str:
             quote = ch
             out.append(ch)
             continue
-        if ch == "#":
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
             break
         out.append(ch)
     return "".join(out).strip()
 
 
+# A prompt prefix is decoration, not part of the command. Without stripping it, a
+# VISIBLE `PS> git ... status ...` was skipped entirely (its first token was `PS>`),
+# so the recipe could be shown in a broken form while an inert copy hidden elsewhere
+# satisfied the "a status command exists" assertion.
+_PROMPT_PREFIX = re.compile(r"^\s*(?:PS[^>]*>|\$|>|#\s)\s*")
+
+# `<!-- ... -->` is not rendered, so a command inside it is not taught. Counting it
+# satisfied the global "there is a status command" check while every command a reader
+# can actually see was ignored or broken. Spans can cross lines, so blank the region
+# in place rather than dropping lines, to keep line numbers honest in failures.
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def _visible(text: str) -> str:
+    """The document as a reader sees it: HTML-comment spans blanked, lines preserved."""
+    return _HTML_COMMENT.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), text)
+
+
 def _fenced_git_commands(text: str) -> list[tuple[int, str]]:
-    """Every runnable ``git`` line inside a fenced block, comments stripped."""
+    """Every runnable ``git`` line inside a fenced block, comments stripped.
+
+    Operates on the VISIBLE document, so a decoy inside an HTML comment cannot stand in
+    for a command a reader is actually shown.
+    """
     cmds: list[tuple[int, str]] = []
     in_fence = False
-    for lineno, line in enumerate(text.splitlines(), start=1):
+    for lineno, line in enumerate(_visible(text).splitlines(), start=1):
         if line.strip().startswith(("```", "~~~")):
             in_fence = not in_fence
             continue
         if not in_fence:
             continue
-        stripped = _strip_shell_comment(line)
+        stripped = _strip_shell_comment(_PROMPT_PREFIX.sub("", line))
         first = stripped.split(" ", 1)[0] if stripped else ""
         if first in ("git", "git.exe"):
             cmds.append((lineno, stripped))
@@ -341,9 +408,9 @@ def _inline_git_commands(text: str) -> list[tuple[int, str]]:
     inline, and the quoting property has to hold for those too.
     """
     cmds: list[tuple[int, str]] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
+    for lineno, line in enumerate(_visible(text).splitlines(), start=1):
         for m in _INLINE_CODE.finditer(line):
-            snippet = _strip_shell_comment(m.group(1))
+            snippet = _strip_shell_comment(_PROMPT_PREFIX.sub("", m.group(1)))
             first = snippet.split(" ", 1)[0] if snippet else ""
             if first in ("git", "git.exe"):
                 cmds.append((lineno, snippet))
@@ -360,15 +427,31 @@ def _dash_c_problems(cmd: str) -> list[str]:
     if raw is None:
         return ["cannot be tokenized (unbalanced quotes)"]
     problems = []
+    seen = 0
     for i, tok in enumerate(raw):
         if tok != "-C":
             continue
+        seen += 1
         if i + 1 >= len(raw):
             problems.append("`-C` with no argument")
             continue
         arg = raw[i + 1]
         if not (len(arg) >= 2 and arg[0] == '"' and arg[-1] == '"'):
             problems.append(f"`-C {arg}` is not a whole quoted token")
+            continue
+        # Quoting alone is not enough. `git -C "."` is perfectly quoted and utterly
+        # wrong: run from a lead's own checkout it reports nothing about the worker's
+        # worktree, and the old harness hid that by rewriting the argument. The target
+        # must be the documented placeholder so the executed command and the taught
+        # command select the same repository.
+        if arg[1:-1] != WORKTREE_PLACEHOLDER:
+            problems.append(
+                f"`-C {arg}` targets {arg[1:-1]!r}, not {WORKTREE_PLACEHOLDER!r}; a "
+                "recipe that selects the current directory silently reports on the "
+                "wrong repository"
+            )
+    if seen > 1:
+        problems.append(f"{seen} `-C` options; git honours the last, so the target is ambiguous")
     return problems
 
 
@@ -393,11 +476,32 @@ def _untracked_problems(cmd: str) -> list[str]:
 
 
 def _run_extracted(cmd: str, repo: Path) -> subprocess.CompletedProcess:
-    """Execute an extracted command with its `-C` argument pointed at ``repo``."""
+    """Execute an extracted command, binding ONLY the documented placeholder to ``repo``.
+
+    The previous version replaced whatever followed `-C`, which meant it executed the
+    command only AFTER deleting the repository-selection behaviour it was supposed to
+    validate: `git -C "."` was silently rewritten to point at the fixture repo and
+    passed, while the real command run from a lead's own checkout returns rc=0 and
+    empty output and reports nothing about the worker's worktree. That is circular
+    validation — substituting the part under test.
+
+    So the binding is exact: the `-C` argument must be the placeholder, and the
+    placeholder is the only token substituted. Anything else raises rather than being
+    quietly repaired, because a caller that reaches here with an unbound target has
+    already lost the property this test exists to prove.
+    """
     toks = shlex.split(cmd, posix=True)
+    bound = 0
     for i, tok in enumerate(toks):
-        if tok == "-C" and i + 1 < len(toks):
-            toks[i + 1] = str(repo)
+        if tok == WORKTREE_PLACEHOLDER:
+            toks[i] = str(repo)
+            bound += 1
+    if bound != 1:
+        raise AssertionError(
+            f"refusing to execute {cmd!r}: expected exactly one {WORKTREE_PLACEHOLDER!r} "
+            f"to bind, found {bound}. The target must be the documented placeholder, "
+            "never a path this helper substitutes for it."
+        )
     return subprocess.run(toks, capture_output=True, text=True, timeout=60)
 
 
@@ -436,7 +540,7 @@ def test_lead_clean_sha_command_is_effective(tmp_path: Path) -> None:
             "the clean-SHA handoff step lost its command entirely"
         )
         for lineno, cmd in status_cmds:
-            problems = _untracked_problems(cmd) + _dash_c_problems(cmd)
+            problems = _untracked_problems(cmd) + _dash_c_problems(cmd) + _shell_grammar_problems(cmd)
             assert not problems, f"{label} lead skill line {lineno}: {problems} in {cmd!r}"
 
             res = _run_extracted(cmd, dirty)
@@ -497,6 +601,29 @@ CLEAN_SHA_BYPASSES = [
     # the original placebo
     ('git -C "<worktree>" status --porcelain',
      "bare porcelain"),
+    # --- bypasses that defeated the EXECUTING version (round 3), all four reported
+    # --- with reproductions by an independent reviewer while the suite stayed green.
+    # `#` attached to a token is not a comment; breaking at it REPAIRED the command.
+    # Real git: fatal: Invalid untracked files mode 'all#broken'
+    ('git -C "<worktree>" status --porcelain --untracked-files=all#broken',
+     "attached-# repaired by the comment stripper"),
+    # perfectly quoted and utterly wrong: reports on the lead's own checkout. The old
+    # harness rewrote the -C argument, so it validated after deleting the behaviour.
+    ('git -C "." status --porcelain --untracked-files=all',
+     "-C . targets the wrong repository"),
+    ('git -C "$PWD" status --porcelain --untracked-files=all',
+     "-C $PWD targets the wrong repository"),
+    ('git -C "" status --porcelain --untracked-files=all',
+     "-C empty targets the wrong repository"),
+    # git honours the last -C, so a correct target followed by another is ambiguous
+    ('git -C "<worktree>" -C "." status --porcelain --untracked-files=all',
+     "second -C overrides the target"),
+    # a shell program, not an argv: git receives |, cat and >/dev/null as pathspecs,
+    # while `.` makes the sentinel visible, so the harness saw a plausible result
+    ('git -C "<worktree>" status --porcelain --untracked-files=all -- . | cat >/dev/null',
+     "pipeline passed to git as pathspecs"),
+    ('git -C "<worktree>" status --porcelain --untracked-files=all > NUL',
+     "redirection discards the evidence"),
 ]
 
 
@@ -508,8 +635,52 @@ def test_clean_sha_guards_reject_known_bypasses(cmd: str, why: str) -> None:
     prove they reject a plausible rewording, which is exactly how the previous two
     attempts failed review.
     """
-    problems = _untracked_problems(cmd) + _dash_c_problems(cmd)
+    problems = _untracked_problems(cmd) + _dash_c_problems(cmd) + _shell_grammar_problems(cmd)
     assert problems, f"bypass NOT caught ({why}): {cmd!r}"
+
+
+def test_extraction_ignores_html_comments_and_sees_prompt_prefixed_commands() -> None:
+    """A decoy inside `<!-- -->` must NOT satisfy the guards, and a VISIBLE command
+    must not escape them by wearing a prompt prefix.
+
+    This is the fourth reported bypass, and it is a document-level one: a correct
+    command hidden in an HTML comment satisfied the global "a status command exists"
+    assertion, while the command a reader can actually see was skipped because its
+    first token was `PS>` rather than `git`. Both halves are needed - hiding the decoy
+    alone would just make the visible-but-ignored command the new hiding place.
+    """
+    doc = (
+        "# Recipe\n"
+        "<!--\n"
+        "```bash\n"
+        'git -C "<worktree>" status --porcelain --untracked-files=all\n'
+        "```\n"
+        "-->\n"
+        "```bash\n"
+        'PS> git -C "<worktree>" status --porcelain\n'
+        "```\n"
+    )
+    found = _fenced_git_commands(doc)
+
+    assert len(found) == 1, f"expected exactly the visible command, got {found}"
+    lineno, cmd = found[0]
+    assert lineno == 8, f"line number should point at the VISIBLE command, got {lineno}"
+    assert cmd == 'git -C "<worktree>" status --porcelain', cmd
+
+    # And having been seen, it must be judged - the prompt prefix bought it nothing.
+    assert _untracked_problems(cmd), (
+        "the visible command is a bare porcelain placebo and must be rejected once the "
+        "prompt prefix no longer hides it"
+    )
+
+    # Direction control: the commented-out text is genuinely well-formed, so its
+    # exclusion is what makes this test meaningful rather than an accident of syntax.
+    hidden = 'git -C "<worktree>" status --porcelain --untracked-files=all'
+    assert not (_untracked_problems(hidden) + _dash_c_problems(hidden)
+                + _shell_grammar_problems(hidden)), (
+        "the decoy must be a command that WOULD have passed; otherwise this test proves "
+        "nothing about HTML comments"
+    )
 
 
 def _fenced_bare_agenttalk_lines(text: str) -> list[tuple[int, str]]:

--- a/tests/test_skill_lint.py
+++ b/tests/test_skill_lint.py
@@ -79,6 +79,8 @@ SKILL_INVARIANTS = [
         "do not stall on a call that is yours",  # Independence: report, don't over-ask
         "does not protect you here",       # --force-with-lease is not a safeguard (mirror both sides)
         "descendant of whatever",          # reopen is conditional; the fallback must not be dropped
+        "status --porcelain --untracked-files=all",  # the operative clean-SHA command itself
+        "showUntrackedFiles=no",           # WHY the flag is required; the rationale must not be dropped
     ]),
     ("agenttalk.consult.md", "agenttalk-consult", [
         "AGENTTALK_SELF",
@@ -226,6 +228,67 @@ def test_sk_loop_has_no_stale_lane_names_or_default_force() -> None:
     for body, label in ((claude, "claude"), (codex, "codex")):
         present = [bad for bad in SK_LOOP_FORBIDDEN if _normalize(bad) in body]
         assert not present, f"{label} sk-loop still contains stale/forbidden: {present}"
+
+
+# ------------------------------- lead publish-a-worker-commit: semantic guards
+
+# The clean-SHA handoff check is only a check if it CAN fail. Two ways it silently
+# cannot, both of which shipped once (GH#91 -> GH#93):
+#   * a bare `status --porcelain` prints NOTHING under `status.showUntrackedFiles=no`,
+#     so a worktree full of uncommitted new files reads as clean; and
+#   * an unquoted `git -C <path>` splits on a worktree path containing spaces, so git
+#     fails BEFORE validating anything.
+# Prose probes in SKILL_INVARIANTS are cheap sentinels but they are not semantic
+# parity: a reworded section can keep every probe while deleting the operative
+# command, and reverting this fix to its immediate parent did exactly that with the
+# whole suite still green. These two guards assert the COMMAND SHAPE instead.
+
+_PORCELAIN_CALL = re.compile(r"status\s+--porcelain(?P<rest>[^\n]*)")
+_UNQUOTED_DASH_C = re.compile(r'git\s+-C\s+(?!")\S')
+
+LEAD_SKILL_PATHS = (
+    ("claude", ("claude", "agenttalk.lead.md")),
+    ("codex", ("codex", "agenttalk-lead", "SKILL.md")),
+)
+
+
+def _lead_bodies() -> list[tuple[str, str]]:
+    """RAW (un-normalized) lead skill bodies. These guards are line-oriented, so
+    they must NOT collapse newlines the way the prose probes do."""
+    out = []
+    for label, parts in LEAD_SKILL_PATHS:
+        path = SKILLS_ROOT
+        for part in parts:
+            path = path / part
+        out.append((label, path.read_text(encoding="utf-8")))
+    return out
+
+
+def test_lead_clean_sha_check_cannot_be_a_placebo() -> None:
+    """Every porcelain status check the lead skill teaches must carry
+    ``--untracked-files=all``, in BOTH mirrors."""
+    for label, raw in _lead_bodies():
+        calls = list(_PORCELAIN_CALL.finditer(raw))
+        assert calls, (
+            f"{label} lead skill no longer shows a porcelain status check at all - "
+            "the clean-SHA handoff step lost its command"
+        )
+        bare = [m.group(0) for m in calls if "--untracked-files=all" not in m.group("rest")]
+        assert not bare, (
+            f"{label} lead skill teaches a bare `status --porcelain`, which is "
+            f"silently empty under status.showUntrackedFiles=no: {bare}"
+        )
+
+
+def test_lead_worktree_paths_are_quoted() -> None:
+    """``git -C`` takes exactly ONE argument, so every occurrence in BOTH mirrors
+    must quote its path or the recipe dies on a worktree path with a space."""
+    for label, raw in _lead_bodies():
+        found = _UNQUOTED_DASH_C.search(raw)
+        assert found is None, (
+            f"{label} lead skill has an unquoted `git -C <path>` at offset "
+            f"{found.start()}: {raw[found.start():found.start() + 60]!r}"
+        )
 
 
 def _fenced_bare_agenttalk_lines(text: str) -> list[tuple[int, str]]:

--- a/tests/test_skill_lint.py
+++ b/tests/test_skill_lint.py
@@ -10,6 +10,9 @@ asserts both sides carry the same policy invariants.
 from __future__ import annotations
 
 import re
+import shlex
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -238,18 +241,42 @@ def test_sk_loop_has_no_stale_lane_names_or_default_force() -> None:
 #     so a worktree full of uncommitted new files reads as clean; and
 #   * an unquoted `git -C <path>` splits on a worktree path containing spaces, so git
 #     fails BEFORE validating anything.
-# Prose probes in SKILL_INVARIANTS are cheap sentinels but they are not semantic
-# parity: a reworded section can keep every probe while deleting the operative
-# command, and reverting this fix to its immediate parent did exactly that with the
-# whole suite still green. These two guards assert the COMMAND SHAPE instead.
-
-_PORCELAIN_CALL = re.compile(r"status\s+--porcelain(?P<rest>[^\n]*)")
-_UNQUOTED_DASH_C = re.compile(r'git\s+-C\s+(?!")\S')
+#
+# Two earlier attempts at guarding this were themselves defeated, which is why the
+# code below is shaped the way it is:
+#   1. Prose probes in SKILL_INVARIANTS: a reworded section keeps every probe while
+#      deleting the operative command.
+#   2. Regex over the whole body: `--untracked-files=all` written inside a trailing
+#      `#` comment satisfied it, and inserting the harmless global option
+#      `--no-pager` hid the unquoted `-C` from an adjacency pattern. Both bypasses
+#      kept the full suite green while the effective command was broken.
+#
+# So these guards do not pattern-match prose. They extract the RUNNABLE fenced
+# command, inspect its real tokens with comments stripped, and then EXECUTE the
+# extracted behavior against a temporary repository configured with the exact git
+# setting that made the original check a placebo.
 
 LEAD_SKILL_PATHS = (
     ("claude", ("claude", "agenttalk.lead.md")),
     ("codex", ("codex", "agenttalk-lead", "SKILL.md")),
 )
+
+# `-u` / `--untracked-files` in any spelling, including `-uno` and a bare `-u` whose
+# value is the next token. Git honours the LAST one it is given, so a correct flag
+# followed by `-uno` is still broken.
+_UNTRACKED_OPT = re.compile(r"^(-u.*|--untracked-files(=.*)?)$")
+
+
+def _tokens(cmd: str, posix: bool) -> list[str] | None:
+    """Tokenize, or None when the line cannot be tokenized (unbalanced quotes).
+
+    None is a REJECTION, never a skip: a command a shell cannot parse is not a
+    command the skill may teach.
+    """
+    try:
+        return shlex.split(cmd, posix=posix)
+    except ValueError:
+        return None
 
 
 def _lead_bodies() -> list[tuple[str, str]]:
@@ -264,31 +291,225 @@ def _lead_bodies() -> list[tuple[str, str]]:
     return out
 
 
-def test_lead_clean_sha_check_cannot_be_a_placebo() -> None:
-    """Every porcelain status check the lead skill teaches must carry
-    ``--untracked-files=all``, in BOTH mirrors."""
-    for label, raw in _lead_bodies():
-        calls = list(_PORCELAIN_CALL.finditer(raw))
-        assert calls, (
-            f"{label} lead skill no longer shows a porcelain status check at all - "
-            "the clean-SHA handoff step lost its command"
-        )
-        bare = [m.group(0) for m in calls if "--untracked-files=all" not in m.group("rest")]
-        assert not bare, (
-            f"{label} lead skill teaches a bare `status --porcelain`, which is "
-            f"silently empty under status.showUntrackedFiles=no: {bare}"
-        )
+def _strip_shell_comment(line: str) -> str:
+    """Drop a trailing shell comment. A `#` inside quotes is not a comment.
+
+    This exists because `--untracked-files=all` written in a COMMENT satisfied the
+    previous regex guard while the executed command lacked the flag entirely.
+    """
+    out, quote = [], None
+    for ch in line:
+        if quote:
+            out.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            out.append(ch)
+            continue
+        if ch == "#":
+            break
+        out.append(ch)
+    return "".join(out).strip()
 
 
-def test_lead_worktree_paths_are_quoted() -> None:
-    """``git -C`` takes exactly ONE argument, so every occurrence in BOTH mirrors
-    must quote its path or the recipe dies on a worktree path with a space."""
+def _fenced_git_commands(text: str) -> list[tuple[int, str]]:
+    """Every runnable ``git`` line inside a fenced block, comments stripped."""
+    cmds: list[tuple[int, str]] = []
+    in_fence = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.strip().startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            continue
+        stripped = _strip_shell_comment(line)
+        first = stripped.split(" ", 1)[0] if stripped else ""
+        if first in ("git", "git.exe"):
+            cmds.append((lineno, stripped))
+    return cmds
+
+
+_INLINE_CODE = re.compile(r"`([^`\n]+)`")
+
+
+def _inline_git_commands(text: str) -> list[tuple[int, str]]:
+    """Every ``git`` invocation written in inline backticks, comments stripped.
+
+    Fenced blocks are the runnable recipes, but the section also gives commands
+    inline, and the quoting property has to hold for those too.
+    """
+    cmds: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in _INLINE_CODE.finditer(line):
+            snippet = _strip_shell_comment(m.group(1))
+            first = snippet.split(" ", 1)[0] if snippet else ""
+            if first in ("git", "git.exe"):
+                cmds.append((lineno, snippet))
+    return cmds
+
+
+def _dash_c_problems(cmd: str) -> list[str]:
+    """Every ``-C`` argument in ``cmd`` that is not a single balanced-quoted token.
+
+    Finds `-C` wherever it appears, so intervening global options (`--no-pager`) or
+    a `git.exe` spelling cannot hide it.
+    """
+    raw = _tokens(_strip_shell_comment(cmd), posix=False)
+    if raw is None:
+        return ["cannot be tokenized (unbalanced quotes)"]
+    problems = []
+    for i, tok in enumerate(raw):
+        if tok != "-C":
+            continue
+        if i + 1 >= len(raw):
+            problems.append("`-C` with no argument")
+            continue
+        arg = raw[i + 1]
+        if not (len(arg) >= 2 and arg[0] == '"' and arg[-1] == '"'):
+            problems.append(f"`-C {arg}` is not a whole quoted token")
+    return problems
+
+
+def _untracked_problems(cmd: str) -> list[str]:
+    """Reject a `status` invocation whose EFFECTIVE untracked mode is not `all`."""
+    # Strip the comment HERE, not only in the extractor: these inspectors are the
+    # security boundary and must be safe wherever they are called. The bypass that
+    # motivated this wrote `--untracked-files=all` into a trailing comment.
+    toks = _tokens(_strip_shell_comment(cmd), posix=True)
+    if toks is None:
+        return ["cannot be tokenized (unbalanced quotes)"]
+    if "status" not in toks:
+        return []
+    opts = [t for t in toks if _UNTRACKED_OPT.match(t)]
+    if not opts:
+        return ["no --untracked-files=all (silently empty under status.showUntrackedFiles=no)"]
+    if len(opts) > 1:
+        return [f"multiple untracked-mode options {opts}; git honours the last one"]
+    if opts[0] != "--untracked-files=all":
+        return [f"untracked mode is {opts[0]!r}, not --untracked-files=all"]
+    return []
+
+
+def _run_extracted(cmd: str, repo: Path) -> subprocess.CompletedProcess:
+    """Execute an extracted command with its `-C` argument pointed at ``repo``."""
+    toks = shlex.split(cmd, posix=True)
+    for i, tok in enumerate(toks):
+        if tok == "-C" and i + 1 < len(toks):
+            toks[i + 1] = str(repo)
+    return subprocess.run(toks, capture_output=True, text=True, timeout=60)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], capture_output=True, check=True, timeout=60)
+
+
+def test_lead_clean_sha_command_is_effective(tmp_path: Path) -> None:
+    """The clean-SHA status command in BOTH mirrors must actually report an
+    untracked file under ``status.showUntrackedFiles=no`` — executed, not matched.
+
+    This is the property that matters: the previous two guards passed while the
+    effective command returned rc=0 and empty output in exactly this repository
+    configuration.
+    """
+    dirty = tmp_path / "dirty"
+    dirty.mkdir()
+    _git(dirty, "init")
+    _git(dirty, "config", "status.showUntrackedFiles", "no")
+    (dirty / "sentinel.txt").write_text("unpublished work\n", encoding="utf-8")
+
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    _git(clean, "init")
+    _git(clean, "config", "status.showUntrackedFiles", "no")
+
     for label, raw in _lead_bodies():
-        found = _UNQUOTED_DASH_C.search(raw)
-        assert found is None, (
-            f"{label} lead skill has an unquoted `git -C <path>` at offset "
-            f"{found.start()}: {raw[found.start():found.start() + 60]!r}"
+        # A line that will not tokenize is KEPT, not skipped, so it fails below
+        # rather than vanishing from the check.
+        status_cmds = [
+            (n, c) for n, c in _fenced_git_commands(raw)
+            if (_tokens(c, posix=True) is None or "status" in _tokens(c, posix=True))
+        ]
+        assert status_cmds, (
+            f"{label} lead skill has no runnable fenced `git ... status` command - "
+            "the clean-SHA handoff step lost its command entirely"
         )
+        for lineno, cmd in status_cmds:
+            problems = _untracked_problems(cmd) + _dash_c_problems(cmd)
+            assert not problems, f"{label} lead skill line {lineno}: {problems} in {cmd!r}"
+
+            res = _run_extracted(cmd, dirty)
+            assert res.returncode == 0, (
+                f"{label} line {lineno}: extracted command failed rc={res.returncode}: "
+                f"{res.stderr.strip()!r}"
+            )
+            assert "sentinel.txt" in res.stdout, (
+                f"{label} line {lineno}: EXECUTED command did not report an untracked "
+                f"file under status.showUntrackedFiles=no - it is a placebo. "
+                f"cmd={cmd!r} stdout={res.stdout!r}"
+            )
+
+            control = _run_extracted(cmd, clean)
+            assert control.stdout.strip() == "", (
+                f"{label} line {lineno}: command reports dirt in a clean repository, "
+                f"so an empty result would not mean anything: {control.stdout!r}"
+            )
+
+
+def test_lead_every_shown_git_c_is_quoted() -> None:
+    """``git -C`` takes exactly ONE argument, so EVERY git invocation the lead skill
+    shows - fenced or inline - must quote its path in BOTH mirrors.
+
+    Token-based rather than adjacency-based, so an intervening global option
+    (``--no-pager``) or a ``git.exe`` spelling cannot hide the unsafe form.
+    """
+    for label, raw in _lead_bodies():
+        snippets = _fenced_git_commands(raw) + _inline_git_commands(raw)
+        assert snippets, f"{label} lead skill shows no git commands at all"
+        offenders = [
+            (lineno, cmd, problems)
+            for lineno, cmd in snippets
+            if (problems := _dash_c_problems(cmd))
+        ]
+        assert not offenders, f"{label} lead skill unquoted/malformed `-C`: {offenders}"
+
+
+# Every bypass below defeated an earlier version of these guards while the whole
+# suite stayed green. They are the mutation controls: each must be REJECTED.
+CLEAN_SHA_BYPASSES = [
+    # --untracked-files=all hidden in a trailing comment
+    ('git -C "<worktree>" status --porcelain   # --untracked-files=all is required',
+     "flag only in a comment"),
+    # a correct flag overridden by a later one; git honours the last
+    ('git -C "<worktree>" status --porcelain --untracked-files=all -uno',
+     "later -uno override"),
+    ('git -C "<worktree>" status --porcelain --untracked-files=all --untracked-files=no',
+     "later long-form override"),
+    # an intervening global option hides the unquoted -C from an adjacency pattern
+    ('git --no-pager -C <worktree> status --porcelain --untracked-files=all',
+     "--no-pager hides unquoted -C"),
+    ('git.exe -C <worktree> status --porcelain --untracked-files=all',
+     "git.exe spelling with unquoted -C"),
+    # partially quoted path
+    ('git -C "<worktree> status --porcelain --untracked-files=all',
+     "partial quote"),
+    # the original placebo
+    ('git -C "<worktree>" status --porcelain',
+     "bare porcelain"),
+]
+
+
+@pytest.mark.parametrize("cmd,why", CLEAN_SHA_BYPASSES, ids=[b[1] for b in CLEAN_SHA_BYPASSES])
+def test_clean_sha_guards_reject_known_bypasses(cmd: str, why: str) -> None:
+    """Each historically-successful bypass must be caught by the token inspectors.
+
+    Without these, the guards only prove they accept today's text - they would not
+    prove they reject a plausible rewording, which is exactly how the previous two
+    attempts failed review.
+    """
+    problems = _untracked_problems(cmd) + _dash_c_problems(cmd)
+    assert problems, f"bypass NOT caught ({why}): {cmd!r}"
 
 
 def _fenced_bare_agenttalk_lines(text: str) -> list[tuple[int, str]]:


### PR DESCRIPTION
Fixes two connector P2s that **I merged past** on GH#91. Both were fresh against the merged head, both are real, and I read them only after merging. The process error is owned at the end.

## Finding 1 — the gate could silently pass

`git status --porcelain` prints **nothing** when a repository or user config sets `status.showUntrackedFiles=no`. So the "empty porcelain proves clean" step passed with uncommitted *new* files present — publishing a commit missing files the worker's tests depended on.

Reproducible: `git -c status.showUntrackedFiles=no status --porcelain`

Now `--untracked-files=all` explicitly, with the reason stated inline so nobody simplifies it back out.

## Finding 2 — `-C` takes exactly one argument

An unquoted `<worktree>` placeholder under a path containing spaces — common on Windows — splits into two arguments and git fails **before** validating anything. Every `-C <worktree>` in both mirrors is now quoted, including the alternate push recipe.

## Both are the shape the section itself warns about

I closed *"is the tree dirty"* for **tracked** files and left **untracked** files open. That is instance seven of the partial-channel-closure pattern recorded in #76 — found in the very artifact that names the rule.

## My process error, and the rule that follows

I put the gate check and the merge in a **single tool call**. The command printed `fresh vs <sha>: 2` and then merged, so the gated action executed before I could read what the gate found.

**A gate check and the action it gates must never be in the same call** — the output has to be read by a decision-maker in between. That is precisely the class the merged section is about, which is why it is fixed here rather than filed.

## Verification

- Skill lint + install suites: **38 passed**
- Both mirrors verified to carry both guards
- Zero unquoted `-C <worktree>` remaining in either mirror
- Pushed by explicit SHA; PR state verified after
