### PR TITLE
test(#74 inst-12): synchronize the supervisor state-contention hold (unblocks GH#92 and GH#93)

### DIFF
--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -3867,16 +3867,19 @@ public static class AgenttalkStateWriteLock
         return thread;
     }
 
-    public static Thread LockExistingForMilliseconds(
-        string path, string readyPath, int milliseconds)
+    public static Thread LockExistingUntilSignaled(
+        string path, EventWaitHandle readySignal, EventWaitHandle releaseSignal)
     {
         Thread thread = new Thread(() =>
         {
             using (FileStream stream = new FileStream(
                 path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                File.WriteAllText(readyPath, "ready");
-                Thread.Sleep(milliseconds);
+                readySignal.Set();
+                if (!releaseSignal.WaitOne(TimeSpan.FromSeconds(30)))
+                {
+                    throw new TimeoutException("state write lock release was not signaled");
+                }
             }
         });
         thread.IsBackground = true;
@@ -4062,18 +4065,28 @@ def test_ps_poll_state_save_warns_and_survives_persistent_contention(
         retry_path=retry_path,
     )
     harness += [
-        "$locker = [AgenttalkStateWriteLock]::LockExistingForMilliseconds(",
-        "  $StatePath, $ReadyPath, 2500)",
-        "while (-not (Microsoft.PowerShell.Management\\Test-Path "
-        "-LiteralPath $ReadyPath)) {",
-        "  Microsoft.PowerShell.Utility\\Start-Sleep -Milliseconds 1",
+        "$readySignal = [Threading.ManualResetEvent]::new($false)",
+        "$releaseSignal = [Threading.ManualResetEvent]::new($false)",
+        "$locker = [AgenttalkStateWriteLock]::LockExistingUntilSignaled(",
+        "  $StatePath, $readySignal, $releaseSignal)",
+        "if (-not $readySignal.WaitOne(10000)) {",
+        "  throw 'state write lock did not become ready'",
         "}",
-        "$next = [pscustomobject]@{ agents = [pscustomobject]@{ worker = "
+        "try {",
+        "  $next = [pscustomobject]@{ agents = [pscustomobject]@{ worker = "
         "[pscustomobject]@{ pid = 202 } } }",
-        "$results = @()",
-        "for ($poll = 0; $poll -lt 2; $poll++) {",
-        "  $results += [bool](Save-StateForPoll $next)",
+        "  $results = @()",
+        "  for ($poll = 0; $poll -lt 2; $poll++) {",
+        "    $results += [bool](Save-StateForPoll $next)",
+        "  }",
+        "} finally {",
+        "  $null = $releaseSignal.Set()",
         "}",
+        "if (-not $locker.Join(10000)) {",
+        "  throw 'state write lock did not release'",
+        "}",
+        "$readySignal.Dispose()",
+        "$releaseSignal.Dispose()",
         "$primary = Read-StateFile $StatePath",
         "@{ polls = $results.Count; saved = @($results | Where-Object { $_ }).Count; "
         "pid = $primary.agents.worker.pid } | ConvertTo-Json | "


### PR DESCRIPTION
Test-only. De-flakes `test_ps_poll_state_save_warns_and_survives_persistent_contention` — **#74 instance 12, which blocked two unrelated PRs today.** 26 insertions, 13 deletions, `tests/test_supervisor.py` only.

This is release infrastructure, not a fifth feature: it unblocks GH#92 and GH#93 rather than adding scope.

## Why it is definitively a test defect

Two independent proofs, from opposite directions:

1. **Byte-identity.** The test does not render the full generated ps1 — it slices only `PS_TEMPLATE[index("# region state-helpers"):index("# endregion state-helpers")]` and appends its own harness. That slice, the target function, and the harness are byte-identical between `d5add08` and GH#92's head (matching sha256 each). Independently re-hashed.
2. **A docs-only PR hit the same test.** GH#93 changes two markdown files and nothing else, and its windows/3.11 wheel leg failed on this exact test with this exact assertion (`assert 1 >= 2`).

Same test, same assertion, two unrelated diffs, one of them pure documentation.

## The mechanism

The C# helper held the primary state file for a **fixed 2,500 ms** while the main thread ran two serial `Save-StateForPoll` calls, each retrying ~565 ms nominal plus JSON conversion, temp allocation, backup replacement and a synchronous `Flush(true)`. A warning emits only when one *complete* save exhausts its window while the independently-ticking lock is still held.

So the assertion assumed both retry budgets finish before a separate wall clock reached 2.5 s. Under load the first save warns, the lock expires *during* the second save, which then succeeds — yielding exactly one warning. The `payload == {"polls": 2, "saved": 0, "pid": 101}` assertion carried the same assumption.

## The fix — a synchronisation edge, not a bigger number

`LockExistingForMilliseconds` → `LockExistingUntilSignaled`. The holder sets a `ManualResetEvent` only **after** acquiring the lock; PowerShell waits on that readiness edge, runs both saves, and signals release from `finally` only after the loop returns. Elapsed time no longer determines when contention ends.

The 10 s ready/join and 30 s holder waits are **deadlock failsafes** a healthy run never approaches — measured healthy runs are 2.75–3.18 s including pytest startup, PowerShell startup and C# compilation.

Deliberately *not* raising 2,500 ms: per #84/#88 a longer wait under contention converts a fast red into a leg that blows its cap and uploads **no evidence artifact at all**.

## Evidence

- **Broken-product proof.** With warning emission temporarily suppressed: `AssertionError: assert 0 >= 2`. The mutation was restored before every positive verification, and `src/agenttalk/supervisor.py` was confirmed to have an empty content diff — the commit contains no product file.
- **Load run, with the load verified.** Four CPU-pressure processes started in the *same command* as all 20 pytest invocations and stopped in `finally`; CPU counters prove they stayed hot (start 0.53–0.67 s → end 32.12–34.33 s). **20/20 passed.**
- Focused 1 passed; contention/error-classification cluster 4 passed; full supervisor module **361 passed, 2 skipped**; `ruff` clean.

## Neighbour sweep — two new #74 candidates

No remaining fixed-duration lock/retry race in the state-write contention family; two neighbours already do it correctly (one releases on an observed retry, the other holds until the supervisor call returns).

New candidates, reported not fixed:
- `test_generated_ps1_survives_malformed_config_poll_with_last_good` (line 3685) — fixed `time.sleep(0.25)` at line 3704 between an observed live-poll condition and a state/config mutation. It does condition-wait for warnings eventually, but the mutation's poll placement stays scheduler-dependent.
- `test_stop_tree_kills_real_two_level_tree_start_guarded` (line 4979) — fixed 200/200/400 ms sleeps at 5014/5018/5021 before process-liveness assertions. Broader scheduler-promptness shape, not a contention race.

Built by `codex-agenttalk-developer-4`. Verified clean before push: one test file, `git status --porcelain --untracked-files=all` empty, `d7fe1b9` an ancestor.
