### PR TITLE
test: synchronize OVH front socket completion (#74 instances 17/19)

### DIFF
--- a/tests/_socket_harness.py
+++ b/tests/_socket_harness.py
@@ -234,8 +234,8 @@ def cancellable_socket(
     connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     with cancellation.track(connection):
         try:
-            connection.connect((host, port))
             connection.settimeout(None)
+            connection.connect((host, port))
             yield connection
         finally:
             abort_socket(connection)
@@ -274,8 +274,8 @@ class TrackedHTTPConnection(http.client.HTTPConnection):
         self._cancellation.register(raw)
         self._tracked_socket = raw
         try:
-            raw.connect((self.host, self.port))
             raw.settimeout(self.timeout)
+            raw.connect((self.host, self.port))
             self.sock = raw
         except BaseException:
             self._cancellation.unregister(raw)

--- a/tests/_socket_harness.py
+++ b/tests/_socket_harness.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import http.client
+import socket
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import TypeVar
+
+
+COMPLETION_BUDGET_SECONDS = 30.0
+CANCELLATION_JOIN_SECONDS = 5.0
+
+_T = TypeVar("_T")
+CompletionWait = Callable[[threading.Event, float], bool]
+
+
+def _event_wait(event: threading.Event, timeout: float) -> bool:
+    return event.wait(timeout=timeout)
+
+
+def abort_socket(connection: socket.socket) -> None:
+    try:
+        connection.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    try:
+        connection.close()
+    except OSError:
+        pass
+
+
+def run_cleanup_steps(*steps: Callable[[], None]) -> None:
+    """Run every teardown step before surfacing the first cleanup failure."""
+
+    errors: list[BaseException] = []
+    for step in steps:
+        try:
+            step()
+        except BaseException as exc:
+            errors.append(exc)
+    if errors:
+        raise errors[0]
+
+
+class SocketCancellation:
+    """Own sockets that must be interruptible from a supervising thread."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cancelled = False
+        self._sockets: set[socket.socket] = set()
+        self.sockets: list[socket.socket] = []
+
+    @property
+    def cancelled(self) -> bool:
+        with self._lock:
+            return self._cancelled
+
+    def register(self, connection: socket.socket) -> None:
+        with self._lock:
+            cancelled = self._cancelled
+            self.sockets.append(connection)
+            if not cancelled:
+                self._sockets.add(connection)
+        if cancelled:
+            abort_socket(connection)
+            raise ConnectionAbortedError("socket operation was cancelled")
+
+    def unregister(self, connection: socket.socket) -> None:
+        with self._lock:
+            self._sockets.discard(connection)
+
+    @contextmanager
+    def track(self, connection: socket.socket) -> Iterator[socket.socket]:
+        self.register(connection)
+        try:
+            yield connection
+        finally:
+            self.unregister(connection)
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._cancelled = True
+            sockets = tuple(self._sockets)
+        for connection in sockets:
+            abort_socket(connection)
+
+
+class TimeoutLatch:
+    """Fail later socket cases promptly after the first cleaned-up deadline."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._first_timeout: str | None = None
+
+    def ensure_clear(self) -> None:
+        with self._lock:
+            first_timeout = self._first_timeout
+        if first_timeout is not None:
+            raise AssertionError(
+                f"socket harness already exceeded its deadline in {first_timeout}"
+            )
+
+    def trip(self, label: str) -> None:
+        with self._lock:
+            if self._first_timeout is None:
+                self._first_timeout = label
+
+
+class CompletionBudget:
+    """One hard cumulative deadline for a collected test's socket phase."""
+
+    def __init__(
+        self,
+        *,
+        seconds: float = COMPLETION_BUDGET_SECONDS,
+        latch: TimeoutLatch | None = None,
+        wait_for_completion: CompletionWait = _event_wait,
+    ) -> None:
+        self.seconds = seconds
+        self.latch = latch or TimeoutLatch()
+        self._wait_for_completion = wait_for_completion
+        self._deadline: float | None = None
+        self._lock = threading.Lock()
+
+    def ensure_clear(self) -> None:
+        self.latch.ensure_clear()
+
+    def wait(self, event: threading.Event) -> bool:
+        self.ensure_clear()
+        with self._lock:
+            if self._deadline is None:
+                self._deadline = time.monotonic() + self.seconds
+            remaining = max(0.0, self._deadline - time.monotonic())
+        return self._wait_for_completion(event, remaining)
+
+    def timeout(self, label: str) -> AssertionError:
+        self.latch.trip(label)
+        return AssertionError(
+            f"{label} exceeded the {self.seconds:g}s cumulative socket-phase "
+            "deadline; a correct but slower operation is intentionally failed"
+        )
+
+
+def _join_worker(worker: threading.Thread, *, label: str) -> None:
+    worker.join(timeout=CANCELLATION_JOIN_SECONDS)
+    assert not worker.is_alive(), f"{label} client worker survived cancellation"
+
+
+def _cancel_and_join(
+    cancellation: SocketCancellation,
+    worker: threading.Thread,
+    *,
+    label: str,
+    on_cancel: Callable[[], None] | None,
+) -> None:
+    cancellation.cancel()
+    try:
+        if on_cancel is not None:
+            on_cancel()
+    finally:
+        _join_worker(worker, label=label)
+
+
+def await_completed(
+    operation: Callable[[SocketCancellation], _T],
+    *,
+    budget: CompletionBudget,
+    label: str,
+    cancellation: SocketCancellation | None = None,
+    on_cancel: Callable[[], None] | None = None,
+    workers: list[threading.Thread] | None = None,
+) -> _T:
+    budget.ensure_clear()
+    cancellation = cancellation or SocketCancellation()
+    completed = threading.Event()
+    results: list[_T] = []
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            results.append(operation(cancellation))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            completed.set()
+
+    worker = threading.Thread(
+        target=run,
+        name=f"{label} client",
+        daemon=True,
+    )
+    if workers is not None:
+        workers.append(worker)
+    worker.start()
+    try:
+        completed_in_budget = budget.wait(completed)
+    except BaseException:
+        _cancel_and_join(
+            cancellation,
+            worker,
+            label=label,
+            on_cancel=on_cancel,
+        )
+        raise
+
+    if not completed_in_budget:
+        _cancel_and_join(
+            cancellation,
+            worker,
+            label=label,
+            on_cancel=on_cancel,
+        )
+        raise budget.timeout(label)
+
+    # completed is set in the worker's final statement; no blocking operation
+    # remains once the green-path condition is observed.
+    worker.join()
+    assert not worker.is_alive()
+    if errors:
+        raise errors[0]
+    assert len(results) == 1
+    return results[0]
+
+
+@contextmanager
+def cancellable_socket(
+    cancellation: SocketCancellation,
+    host: str,
+    port: int,
+) -> Iterator[socket.socket]:
+    connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with cancellation.track(connection):
+        try:
+            connection.connect((host, port))
+            connection.settimeout(None)
+            yield connection
+        finally:
+            abort_socket(connection)
+
+
+@contextmanager
+def cancellable_http_connection(
+    cancellation: SocketCancellation,
+    host: str,
+    port: int,
+) -> Iterator[http.client.HTTPConnection]:
+    with cancellable_socket(cancellation, host, port) as raw:
+        connection = http.client.HTTPConnection(host, port, timeout=None)
+        connection.sock = raw
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+
+class TrackedHTTPConnection(http.client.HTTPConnection):
+    """HTTP connection whose raw socket remains cancellable through response read."""
+
+    def __init__(
+        self,
+        cancellation: SocketCancellation,
+        *args,
+        **kwargs,
+    ) -> None:
+        self._cancellation = cancellation
+        self._tracked_socket: socket.socket | None = None
+        super().__init__(*args, **kwargs)
+
+    def connect(self) -> None:
+        raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._cancellation.register(raw)
+        self._tracked_socket = raw
+        try:
+            raw.connect((self.host, self.port))
+            raw.settimeout(self.timeout)
+            self.sock = raw
+        except BaseException:
+            self._cancellation.unregister(raw)
+            self._tracked_socket = None
+            abort_socket(raw)
+            raise
+
+    def close(self) -> None:
+        tracked_socket = self._tracked_socket
+        try:
+            super().close()
+        finally:
+            if tracked_socket is not None:
+                self._cancellation.unregister(tracked_socket)
+                self._tracked_socket = None
+
+
+class ServerActivity:
+    """Retain exact accepted sockets and handler threads for teardown proof."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._cancelled = False
+        self.sockets: list[socket.socket] = []
+        self.threads: list[threading.Thread] = []
+        self._active_sockets: set[socket.socket] = set()
+
+    def accepted(self, connection: socket.socket) -> None:
+        with self._condition:
+            self.sockets.append(connection)
+            self._active_sockets.add(connection)
+            cancelled = self._cancelled
+            self._condition.notify_all()
+        if cancelled:
+            abort_socket(connection)
+
+    def handler_started(self, thread: threading.Thread) -> None:
+        with self._condition:
+            self.threads.append(thread)
+            self._condition.notify_all()
+
+    def socket_closed(self, connection: socket.socket) -> None:
+        with self._condition:
+            self._active_sockets.discard(connection)
+            self._condition.notify_all()
+
+    def cancel_active_sockets(self, *, reject_new: bool = False) -> None:
+        with self._condition:
+            if reject_new:
+                self._cancelled = True
+            sockets = tuple(self._active_sockets)
+        for connection in sockets:
+            abort_socket(connection)
+
+    def wait_stopped(self, *, label: str, deadline: float | None = None) -> None:
+        if deadline is None:
+            deadline = time.monotonic() + CANCELLATION_JOIN_SECONDS
+        with self._condition:
+            sockets_closed = self._condition.wait_for(
+                lambda: not self._active_sockets,
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
+            threads = tuple(self.threads)
+        for thread in threads:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        assert sockets_closed, f"{label} retained accepted sockets after cancellation"
+        assert all(not thread.is_alive() for thread in threads), (
+            f"{label} retained handler threads after cancellation"
+        )
+        assert all(connection.fileno() == -1 for connection in self.sockets), (
+            f"{label} retained open accepted sockets after cancellation"
+        )
+
+
+def track_server(server, activity: ServerActivity) -> None:
+    process_request = server.process_request
+    process_request_thread = server.process_request_thread
+    shutdown_request = server.shutdown_request
+
+    def tracked_process_request(connection, client_address) -> None:
+        activity.accepted(connection)
+        process_request(connection, client_address)
+
+    def tracked_process_request_thread(connection, client_address) -> None:
+        activity.handler_started(threading.current_thread())
+        process_request_thread(connection, client_address)
+
+    def tracked_shutdown_request(connection) -> None:
+        try:
+            shutdown_request(connection)
+        finally:
+            activity.socket_closed(connection)
+
+    server.process_request = tracked_process_request
+    server.process_request_thread = tracked_process_request_thread
+    server.shutdown_request = tracked_shutdown_request

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import http.client
 import io
 import json
@@ -26,46 +27,27 @@ from agenttalk.ovh_gateway_front import (
     GatewayFront,
     StreamUsage,
 )
+from tests._socket_harness import (
+    CANCELLATION_JOIN_SECONDS,
+    CompletionBudget,
+    ServerActivity,
+    SocketCancellation,
+    TimeoutLatch,
+    TrackedHTTPConnection,
+    await_completed,
+    cancellable_http_connection,
+    cancellable_socket,
+    run_cleanup_steps,
+    track_server,
+)
 
 
 TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
-# A deadlock watchdog, not a socket read deadline: successful operations wake
-# their completion event immediately. Thirty seconds matches the synchronized
-# contention watchdog already used elsewhere in the suite (#94).
-COMPLETION_WATCHDOG_SECONDS = 30
-
-
-def _await_completed(operation, *, label: str):
-    completed = threading.Event()
-    results: list[object] = []
-    errors: list[BaseException] = []
-
-    def run() -> None:
-        try:
-            results.append(operation())
-        except BaseException as exc:
-            errors.append(exc)
-        finally:
-            completed.set()
-
-    worker = threading.Thread(target=run, daemon=True)
-    worker.start()
-    assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS), (
-        f"{label} did not complete after its synchronization condition was armed"
-    )
-    worker.join()
-    if errors:
-        raise errors[0]
-    assert len(results) == 1
-    return results[0]
-
-
-def _fake_upstream_connection(*args, **kwargs) -> http.client.HTTPConnection:
-    # GatewayFront still has to request its configured timeout. The fake local
-    # transport itself has no read deadline; _await_completed bounds the whole
-    # exchange on an observable completion condition instead.
-    assert kwargs.pop("timeout") == 5
-    return http.client.HTTPConnection(*args, timeout=None, **kwargs)
+# Hard cumulative test-runtime deadline. A correct hermetic loopback phase that
+# takes longer than 30 seconds is intentionally failed; this cannot distinguish
+# deadlock from extreme scheduling delay. The value is six times the five-second
+# deadline that flaked on loaded Windows runners and matches #94's stall ceiling.
+_FRONT_TIMEOUT_LATCH = TimeoutLatch()
 
 
 def _listen_port() -> int:
@@ -86,6 +68,10 @@ class FakeUpstream:
         release: threading.Event | None = None,
     ) -> None:
         self.status = status
+        self.entered = entered
+        self.release = release
+        self.activity = ServerActivity()
+        self._cancelling = threading.Event()
         self.response = response or (
             b'event: message_start\n'
             b'data: {"type":"message_start","message":{"model":"'
@@ -137,7 +123,14 @@ class FakeUpstream:
                 self.end_headers()
                 self.wfile.write(owner.response)
 
-        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        class Server(ThreadingHTTPServer):
+            def handle_error(self, request, client_address) -> None:
+                if owner._cancelling.is_set():
+                    return
+                super().handle_error(request, client_address)
+
+        self.server = Server(("127.0.0.1", 0), Handler)
+        track_server(self.server, self.activity)
         self.port = int(self.server.server_address[1])
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
@@ -146,9 +139,37 @@ class FakeUpstream:
         return self
 
     def __exit__(self, *_args: object) -> None:
-        self.server.shutdown()
-        self.server.server_close()
-        self.thread.join(timeout=5)
+        deadline = time.monotonic() + CANCELLATION_JOIN_SECONDS
+
+        def stop_listener() -> None:
+            if self.thread.is_alive():
+                self.server.shutdown()
+
+        def join_listener() -> None:
+            if self.thread.ident is not None:
+                self.thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            assert not self.thread.is_alive(), "fake upstream listener survived teardown"
+
+        run_cleanup_steps(
+            lambda: self.cancel_pending(reject_new=True),
+            stop_listener,
+            self.server.server_close,
+            join_listener,
+            lambda: self.activity.wait_stopped(
+                label="fake upstream",
+                deadline=deadline,
+            ),
+        )
+
+    def cancel_pending(self, *, reject_new: bool = False) -> None:
+        self._cancelling.set()
+        self.activity.cancel_active_sockets(reject_new=reject_new)
+        if self.release is not None:
+            self.release.set()
+
+    def wait_idle(self, *, deadline: float | None = None) -> None:
+        self.activity.wait_stopped(label="fake upstream", deadline=deadline)
+        self._cancelling.clear()
 
 
 class RunningFront:
@@ -159,7 +180,19 @@ class RunningFront:
         *,
         ledger: SpendLedger | None = None,
         credential=None,
+        completion_budget: CompletionBudget | None = None,
     ) -> None:
+        self.upstream = upstream
+        self.completion_budget = completion_budget or CompletionBudget(
+            latch=_FRONT_TIMEOUT_LATCH
+        )
+        self.client_workers: list[threading.Thread] = []
+        self.client_cancellations: list[SocketCancellation] = []
+        self._client_lock = threading.Lock()
+        self._clients_cancelled = False
+        self._active_clients: set[SocketCancellation] = set()
+        self._internal_cancellation = SocketCancellation()
+        self.activity = ServerActivity()
         self.ledger = ledger or SpendLedger(
             tmp_path / "ledger.sqlite3",
             tmp_path / "install.json",
@@ -185,15 +218,29 @@ class RunningFront:
             internal_port=upstream.port,
             request_timeout_seconds=5,
         )
+
+        def fake_upstream_connection(*args, **kwargs) -> http.client.HTTPConnection:
+            # GatewayFront still has to request its configured timeout. The
+            # hermetic fake transport is governed by the cumulative test budget.
+            assert kwargs.pop("timeout") == 5
+            return TrackedHTTPConnection(
+                self._internal_cancellation,
+                *args,
+                timeout=None,
+                **kwargs,
+            )
+
         self.front = GatewayFront(
             self.config,
             self.ledger,
-            connection_factory=_fake_upstream_connection,
+            connection_factory=fake_upstream_connection,
         )
         self.server = self.front.make_server()
+        track_server(self.server, self.activity)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
     def __enter__(self) -> RunningFront:
+        self.completion_budget.ensure_clear()
         self.thread.start()
         # Readiness barrier: serve_forever() starts accepting asynchronously, and
         # on a loaded runner (esp. Windows) a request can otherwise race a
@@ -213,9 +260,79 @@ class RunningFront:
         return self
 
     def __exit__(self, *_args: object) -> None:
-        self.server.shutdown()
-        self.server.server_close()
-        self.thread.join(timeout=5)
+        deadline = time.monotonic() + CANCELLATION_JOIN_SECONDS
+
+        def stop_listener() -> None:
+            if self.thread.is_alive():
+                self.server.shutdown()
+
+        def join_listener() -> None:
+            if self.thread.ident is not None:
+                self.thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            assert not self.thread.is_alive(), "gateway front listener survived teardown"
+
+        def join_clients() -> None:
+            for worker in self.client_workers:
+                worker.join(timeout=max(0.0, deadline - time.monotonic()))
+            assert all(not worker.is_alive() for worker in self.client_workers), (
+                "gateway front retained client workers after cancellation"
+            )
+
+        run_cleanup_steps(
+            self.cancel_active_requests,
+            stop_listener,
+            self.server.server_close,
+            join_listener,
+            lambda: self.activity.wait_stopped(
+                label="gateway front",
+                deadline=deadline,
+            ),
+            self.upstream.cancel_pending,
+            lambda: self.upstream.wait_idle(deadline=deadline),
+            join_clients,
+        )
+
+    def _register_client(self, cancellation: SocketCancellation) -> None:
+        with self._client_lock:
+            self.client_cancellations.append(cancellation)
+            cancelled = self._clients_cancelled
+            if not cancelled:
+                self._active_clients.add(cancellation)
+        if cancelled:
+            cancellation.cancel()
+            raise ConnectionAbortedError("gateway front fixture is shutting down")
+
+    def _unregister_client(self, cancellation: SocketCancellation) -> None:
+        with self._client_lock:
+            self._active_clients.discard(cancellation)
+
+    def _cancel_server_side(self) -> None:
+        self._internal_cancellation.cancel()
+        self.activity.cancel_active_sockets(reject_new=True)
+        self.upstream.cancel_pending()
+
+    def cancel_active_requests(self) -> None:
+        with self._client_lock:
+            self._clients_cancelled = True
+            clients = tuple(self._active_clients)
+        for cancellation in clients:
+            cancellation.cancel()
+        self._cancel_server_side()
+
+    def _await(self, operation, *, label: str):
+        cancellation = SocketCancellation()
+        self._register_client(cancellation)
+        try:
+            return await_completed(
+                operation,
+                budget=self.completion_budget,
+                label=label,
+                cancellation=cancellation,
+                on_cancel=self._cancel_server_side,
+                workers=self.client_workers,
+            )
+        finally:
+            self._unregister_client(cancellation)
 
     def request(
         self,
@@ -239,36 +356,47 @@ class RunningFront:
             "Content-Type": "application/json",
         }
         request_headers.update(headers or {})
-        def exchange() -> tuple[int, bytes]:
+
+        def exchange(cancellation: SocketCancellation) -> tuple[int, bytes]:
             # Retry ONLY connection-level aborts (transient localhost socket races
             # on loaded Windows runners) - never an HTTP response, so no status
             # assertion is ever masked.
             last_exc: OSError | None = None
             for _ in range(5):
-                conn = http.client.HTTPConnection(
-                    "127.0.0.1", self.config.public_port, timeout=None
-                )
                 try:
-                    conn.request(method, path, body=encoded, headers=request_headers)
-                    response = conn.getresponse()
-                    return response.status, response.read()
+                    with cancellable_http_connection(
+                        cancellation,
+                        "127.0.0.1",
+                        self.config.public_port,
+                    ) as conn:
+                        conn.request(
+                            method,
+                            path,
+                            body=encoded,
+                            headers=request_headers,
+                        )
+                        response = conn.getresponse()
+                        return response.status, response.read()
                 except (
                     ConnectionAbortedError,
                     ConnectionResetError,
                     ConnectionRefusedError,
+                    socket.timeout,
                 ) as exc:
+                    if cancellation.cancelled:
+                        raise
                     last_exc = exc
                     time.sleep(0.05)
-                finally:
-                    conn.close()
             raise last_exc if last_exc is not None else RuntimeError("request failed")
 
-        return _await_completed(exchange, label="front request")
+        return self._await(exchange, label="front request")
 
     def raw_request(self, request: bytes) -> tuple[int, bytes]:
-        def exchange() -> tuple[int, bytes]:
-            with socket.create_connection(
-                ("127.0.0.1", self.config.public_port), timeout=None
+        def exchange(cancellation: SocketCancellation) -> tuple[int, bytes]:
+            with cancellable_socket(
+                cancellation,
+                "127.0.0.1",
+                self.config.public_port,
             ) as connection:
                 connection.sendall(request)
                 connection.shutdown(socket.SHUT_WR)
@@ -279,11 +407,11 @@ class RunningFront:
             status = int(response.split(b" ", 2)[1])
             return status, response
 
-        return _await_completed(exchange, label="raw front request")
+        return self._await(exchange, label="raw front request")
 
     def internal_liveliness(self) -> bool:
-        return _await_completed(
-            self.front.internal_liveliness,
+        return self._await(
+            lambda _cancellation: self.front.internal_liveliness(),
             label="front internal liveliness probe",
         )
 
@@ -549,8 +677,13 @@ def test_front_forwards_capped_claude_beta_query_and_rich_body_intact(
 
 
 def test_beta_rich_body_and_child_cap_exhaustion_survive_front_restart(tmp_path) -> None:
+    completion_budget = CompletionBudget(latch=_FRONT_TIMEOUT_LATCH)
     with FakeUpstream() as upstream:
-        with RunningFront(tmp_path, upstream) as first:
+        with RunningFront(
+            tmp_path,
+            upstream,
+            completion_budget=completion_budget,
+        ) as first:
             status, _ = first.request(path="/v1/messages?beta=true")
             assert status == 200
 
@@ -569,6 +702,7 @@ def test_beta_rich_body_and_child_cap_exhaustion_survive_front_restart(tmp_path)
             upstream,
             ledger=restarted,
             credential=replay,
+            completion_budget=completion_budget,
         ) as second:
             denied, _ = second.request(
                 path="/v1/messages?beta=true",
@@ -730,20 +864,127 @@ def test_single_permit_covers_transport_through_settlement(tmp_path) -> None:
         worker = threading.Thread(target=request_first, daemon=True)
         worker.start()
         try:
-            assert entered.wait(timeout=COMPLETION_WATCHDOG_SECONDS)
-
+            if not front.completion_budget.wait(entered):
+                raise front.completion_budget.timeout("permit upstream entry")
             status, body = front.request()
-
-            assert status == 429
-            assert b"ATGW_INFRA_BUSY" in body
-            assert len(upstream.requests) == 1
         finally:
             release.set()
-        assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS)
-        worker.join()
+            if not completed.is_set():
+                try:
+                    finished = front.completion_budget.wait(completed)
+                except AssertionError:
+                    finished = False
+                if not finished:
+                    front.cancel_active_requests()
+            worker.join(timeout=CANCELLATION_JOIN_SECONDS)
+            if worker.is_alive():
+                front.cancel_active_requests()
+                worker.join(timeout=CANCELLATION_JOIN_SECONDS)
+            assert not worker.is_alive()
+
         assert errors == []
         assert first and first[0][0] == 200
+        assert status == 429
+        assert b"ATGW_INFRA_BUSY" in body
+        assert len(upstream.requests) == 1
         assert front.ledger.status()["ready"] is True
+
+
+def test_front_deadline_cancels_hung_exchange_before_teardown(tmp_path) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    timeout_latch = TimeoutLatch()
+    cleanup_steps: list[str] = []
+
+    def expire_after_provider_entry(
+        completed: threading.Event,
+        remaining: float,
+    ) -> bool:
+        assert entered.wait(timeout=remaining)
+        assert not completed.is_set()
+        return False
+
+    completion_budget = CompletionBudget(
+        latch=timeout_latch,
+        wait_for_completion=expire_after_provider_entry,
+    )
+    upstream = FakeUpstream(entered=entered, release=release)
+    front = RunningFront(
+        tmp_path,
+        upstream,
+        completion_budget=completion_budget,
+    )
+
+    original_server_close = front.server.server_close
+
+    def fail_after_server_close() -> None:
+        original_server_close()
+        cleanup_steps.append("injected server-close failure")
+        raise RuntimeError("injected teardown-stage failure")
+
+    original_front_wait_stopped = front.activity.wait_stopped
+
+    def observe_front_cleanup(*, label: str, deadline: float | None = None) -> None:
+        cleanup_steps.append("front handlers")
+        original_front_wait_stopped(label=label, deadline=deadline)
+
+    original_upstream_wait_stopped = upstream.activity.wait_stopped
+
+    def observe_upstream_cleanup(*, label: str, deadline: float | None = None) -> None:
+        cleanup_steps.append("upstream handlers")
+        original_upstream_wait_stopped(label=label, deadline=deadline)
+
+    front.server.server_close = fail_after_server_close
+    front.activity.wait_stopped = observe_front_cleanup
+    upstream.activity.wait_stopped = observe_upstream_cleanup
+
+    with pytest.raises(RuntimeError, match="injected teardown-stage failure"):
+        with upstream, front:
+            with pytest.raises(
+                AssertionError,
+                match="30s cumulative socket-phase deadline",
+            ):
+                front.request()
+
+    assert entered.is_set()
+    assert release.is_set()
+    assert len(upstream.requests) == 1
+    assert cleanup_steps.index("injected server-close failure") < cleanup_steps.index(
+        "front handlers"
+    )
+    assert cleanup_steps.index("front handlers") < cleanup_steps.index(
+        "upstream handlers"
+    )
+    assert front.client_workers
+    assert all(not worker.is_alive() for worker in front.client_workers)
+    assert front.activity.threads
+    assert upstream.activity.threads
+    assert all(not thread.is_alive() for thread in front.activity.threads)
+    assert all(not thread.is_alive() for thread in upstream.activity.threads)
+    assert front.activity.sockets
+    assert upstream.activity.sockets
+    assert all(connection.fileno() == -1 for connection in front.activity.sockets)
+    assert all(connection.fileno() == -1 for connection in upstream.activity.sockets)
+    client_sockets = [
+        connection
+        for cancellation in front.client_cancellations
+        for connection in cancellation.sockets
+    ]
+    assert client_sockets
+    assert front._internal_cancellation.sockets
+    assert all(connection.fileno() == -1 for connection in client_sockets)
+    assert all(
+        connection.fileno() == -1
+        for connection in front._internal_cancellation.sockets
+    )
+
+    ledger_after_teardown = copy.deepcopy(front.ledger.status())
+    requests_after_teardown = copy.deepcopy(upstream.requests)
+    release.set()
+    assert front.ledger.status() == ledger_after_teardown
+    assert upstream.requests == requests_after_teardown
+    with pytest.raises(AssertionError, match="already exceeded its deadline"):
+        timeout_latch.ensure_clear()
 
 
 class _FakeResponse:

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -29,6 +29,43 @@ from agenttalk.ovh_gateway_front import (
 
 
 TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
+# A deadlock watchdog, not a socket read deadline: successful operations wake
+# their completion event immediately. Thirty seconds matches the synchronized
+# contention watchdog already used elsewhere in the suite (#94).
+COMPLETION_WATCHDOG_SECONDS = 30
+
+
+def _await_completed(operation, *, label: str):
+    completed = threading.Event()
+    results: list[object] = []
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            results.append(operation())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            completed.set()
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS), (
+        f"{label} did not complete after its synchronization condition was armed"
+    )
+    worker.join()
+    if errors:
+        raise errors[0]
+    assert len(results) == 1
+    return results[0]
+
+
+def _fake_upstream_connection(*args, **kwargs) -> http.client.HTTPConnection:
+    # GatewayFront still has to request its configured timeout. The fake local
+    # transport itself has no read deadline; _await_completed bounds the whole
+    # exchange on an observable completion condition instead.
+    assert kwargs.pop("timeout") == 5
+    return http.client.HTTPConnection(*args, timeout=None, **kwargs)
 
 
 def _listen_port() -> int:
@@ -93,7 +130,7 @@ class FakeUpstream:
                 if entered is not None:
                     entered.set()
                 if release is not None:
-                    release.wait(timeout=10)
+                    release.wait()
                 self.send_response(owner.status)
                 self.send_header("Content-Type", "text/event-stream")
                 self.send_header("Content-Length", str(len(owner.response)))
@@ -148,7 +185,11 @@ class RunningFront:
             internal_port=upstream.port,
             request_timeout_seconds=5,
         )
-        self.front = GatewayFront(self.config, self.ledger)
+        self.front = GatewayFront(
+            self.config,
+            self.ledger,
+            connection_factory=_fake_upstream_connection,
+        )
         self.server = self.front.make_server()
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
@@ -198,37 +239,53 @@ class RunningFront:
             "Content-Type": "application/json",
         }
         request_headers.update(headers or {})
-        # Retry ONLY connection-level aborts (transient localhost socket races on
-        # loaded Windows runners) - never an HTTP response, so no status assertion
-        # is ever masked.
-        last_exc: OSError | None = None
-        for _ in range(5):
-            conn = http.client.HTTPConnection(
-                "127.0.0.1", self.config.public_port, timeout=5)
-            try:
-                conn.request(method, path, body=encoded, headers=request_headers)
-                response = conn.getresponse()
-                return response.status, response.read()
-            except (ConnectionAbortedError, ConnectionResetError,
-                    ConnectionRefusedError) as exc:
-                last_exc = exc
-                time.sleep(0.05)
-            finally:
-                conn.close()
-        raise last_exc if last_exc is not None else RuntimeError("request failed")
+        def exchange() -> tuple[int, bytes]:
+            # Retry ONLY connection-level aborts (transient localhost socket races
+            # on loaded Windows runners) - never an HTTP response, so no status
+            # assertion is ever masked.
+            last_exc: OSError | None = None
+            for _ in range(5):
+                conn = http.client.HTTPConnection(
+                    "127.0.0.1", self.config.public_port, timeout=None
+                )
+                try:
+                    conn.request(method, path, body=encoded, headers=request_headers)
+                    response = conn.getresponse()
+                    return response.status, response.read()
+                except (
+                    ConnectionAbortedError,
+                    ConnectionResetError,
+                    ConnectionRefusedError,
+                ) as exc:
+                    last_exc = exc
+                    time.sleep(0.05)
+                finally:
+                    conn.close()
+            raise last_exc if last_exc is not None else RuntimeError("request failed")
+
+        return _await_completed(exchange, label="front request")
 
     def raw_request(self, request: bytes) -> tuple[int, bytes]:
-        with socket.create_connection(
-            ("127.0.0.1", self.config.public_port), timeout=5
-        ) as connection:
-            connection.sendall(request)
-            connection.shutdown(socket.SHUT_WR)
-            chunks: list[bytes] = []
-            while chunk := connection.recv(16 * 1024):
-                chunks.append(chunk)
-        response = b"".join(chunks)
-        status = int(response.split(b" ", 2)[1])
-        return status, response
+        def exchange() -> tuple[int, bytes]:
+            with socket.create_connection(
+                ("127.0.0.1", self.config.public_port), timeout=None
+            ) as connection:
+                connection.sendall(request)
+                connection.shutdown(socket.SHUT_WR)
+                chunks: list[bytes] = []
+                while chunk := connection.recv(16 * 1024):
+                    chunks.append(chunk)
+            response = b"".join(chunks)
+            status = int(response.split(b" ", 2)[1])
+            return status, response
+
+        return _await_completed(exchange, label="raw front request")
+
+    def internal_liveliness(self) -> bool:
+        return _await_completed(
+            self.front.internal_liveliness,
+            label="front internal liveliness probe",
+        )
 
 
 def _rich_claude_code_body(*, stream: bool) -> dict:
@@ -545,7 +602,7 @@ def test_beta_rich_body_and_child_cap_exhaustion_survive_front_restart(tmp_path)
 
 def test_success_reserves_before_one_internal_attempt_then_settles(tmp_path) -> None:
     with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
-        assert front.front.internal_liveliness() is True
+        assert front.internal_liveliness() is True
         status, body = front.request(headers={"X-Front-Only": "must-not-forward"})
         assert status == 200
         assert b"message_stop" in body
@@ -596,8 +653,9 @@ def test_forged_well_formed_child_capability_never_reaches_provider(tmp_path) ->
 
 
 def test_front_refuses_ninth_child_call_without_provider_transport(tmp_path) -> None:
+    assert gateway.CHILD_TURN_MAX_CALLS == 8
     with FakeUpstream() as upstream, RunningFront(tmp_path, upstream) as front:
-        for _ in range(gateway.CHILD_TURN_MAX_CALLS):
+        for _ in range(8):
             status, _ = front.request(path="/v1/messages?beta=true")
             assert status == 200
 
@@ -605,7 +663,7 @@ def test_front_refuses_ninth_child_call_without_provider_transport(tmp_path) -> 
 
         assert status == 403
         assert b"ATGW_CHILD_TURN_CAP_EXCEEDED" in body
-        assert len(upstream.requests) == gateway.CHILD_TURN_MAX_CALLS
+        assert len(upstream.requests) == 8
         assert front.ledger.status()["unresolved"] == []
 
 
@@ -658,17 +716,32 @@ def test_single_permit_covers_transport_through_settlement(tmp_path) -> None:
         upstream,
     ) as front:
         first: list[tuple[int, bytes]] = []
-        worker = threading.Thread(target=lambda: first.append(front.request()))
+        errors: list[BaseException] = []
+        completed = threading.Event()
+
+        def request_first() -> None:
+            try:
+                first.append(front.request())
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                completed.set()
+
+        worker = threading.Thread(target=request_first, daemon=True)
         worker.start()
-        assert entered.wait(timeout=5)
+        try:
+            assert entered.wait(timeout=COMPLETION_WATCHDOG_SECONDS)
 
-        status, body = front.request()
+            status, body = front.request()
 
-        assert status == 429
-        assert b"ATGW_INFRA_BUSY" in body
-        assert len(upstream.requests) == 1
-        release.set()
-        worker.join(timeout=10)
+            assert status == 429
+            assert b"ATGW_INFRA_BUSY" in body
+            assert len(upstream.requests) == 1
+        finally:
+            release.set()
+        assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS)
+        worker.join()
+        assert errors == []
         assert first and first[0][0] == 200
         assert front.ledger.status()["ready"] is True
 

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -27,7 +27,7 @@ from agenttalk.ovh_gateway_front import (
     GatewayFront,
     StreamUsage,
 )
-from tests._socket_harness import (
+from _socket_harness import (
     CANCELLATION_JOIN_SECONDS,
     CompletionBudget,
     ServerActivity,
@@ -840,6 +840,68 @@ def test_request_policy_rejects_wrong_model_and_output_limit_before_reserve(tmp_
         assert status == 422
         assert upstream.requests == []
         assert front.ledger.status()["unresolved"] == []
+
+
+def test_inflight_front_exchange_has_no_socket_deadlines(tmp_path) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+    results: list[tuple[int, bytes]] = []
+    errors: list[BaseException] = []
+
+    with FakeUpstream(entered=entered, release=release) as upstream, RunningFront(
+        tmp_path,
+        upstream,
+    ) as front:
+        def request() -> None:
+            try:
+                results.append(front.request())
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                completed.set()
+
+        worker = threading.Thread(target=request, daemon=True)
+        worker.start()
+        try:
+            if not front.completion_budget.wait(entered):
+                raise front.completion_budget.timeout("provider entry")
+
+            client_sockets = [
+                connection
+                for cancellation in front.client_cancellations
+                for connection in cancellation.sockets
+                if connection.fileno() != -1
+            ]
+            internal_sockets = [
+                connection
+                for connection in front._internal_cancellation.sockets
+                if connection.fileno() != -1
+            ]
+            assert client_sockets
+            assert internal_sockets
+            assert all(
+                connection.gettimeout() is None
+                for connection in client_sockets + internal_sockets
+            )
+            assert not completed.is_set()
+        finally:
+            release.set()
+            if not completed.is_set():
+                try:
+                    finished = front.completion_budget.wait(completed)
+                except AssertionError:
+                    finished = False
+                if not finished:
+                    front.cancel_active_requests()
+            worker.join(timeout=CANCELLATION_JOIN_SECONDS)
+            if worker.is_alive():
+                front.cancel_active_requests()
+                worker.join(timeout=CANCELLATION_JOIN_SECONDS)
+            assert not worker.is_alive()
+
+        assert errors == []
+        assert results and results[0][0] == 200
 
 
 def test_single_permit_covers_transport_through_settlement(tmp_path) -> None:

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -19,7 +19,7 @@ from agenttalk.ovh_gateway import (
     settlement_cost_micro_eur,
 )
 from agenttalk.ovh_gateway_front import FrontConfig, GatewayFront
-from tests._socket_harness import (
+from _socket_harness import (
     CANCELLATION_JOIN_SECONDS,
     CompletionBudget,
     ServerActivity,

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -19,38 +19,25 @@ from agenttalk.ovh_gateway import (
     settlement_cost_micro_eur,
 )
 from agenttalk.ovh_gateway_front import FrontConfig, GatewayFront
+from tests._socket_harness import (
+    CANCELLATION_JOIN_SECONDS,
+    CompletionBudget,
+    ServerActivity,
+    SocketCancellation,
+    TimeoutLatch,
+    TrackedHTTPConnection,
+    await_completed,
+    cancellable_http_connection,
+    run_cleanup_steps,
+    track_server,
+)
 
 
 TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
-# Public front exchanges use completion events rather than socket read
-# deadlines. This matches the suite's existing synchronized-contention
-# watchdog (#94) and only reports a stuck harness worker.
-COMPLETION_WATCHDOG_SECONDS = 30
-
-
-def _await_completed(operation, *, label: str):
-    completed = threading.Event()
-    results: list[object] = []
-    errors: list[BaseException] = []
-
-    def run() -> None:
-        try:
-            results.append(operation())
-        except BaseException as exc:
-            errors.append(exc)
-        finally:
-            completed.set()
-
-    worker = threading.Thread(target=run, daemon=True)
-    worker.start()
-    assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS), (
-        f"{label} did not complete after its synchronization condition was armed"
-    )
-    worker.join()
-    if errors:
-        raise errors[0]
-    assert len(results) == 1
-    return results[0]
+# The front phase has the same honest cumulative runtime deadline as the
+# hermetic gateway-front tests. A first deadline is cleaned up and then latches
+# later parametrized cases to fail fast instead of paying the budget repeatedly.
+_CONFORMANCE_TIMEOUT_LATCH = TimeoutLatch()
 
 
 def _free_port() -> int:
@@ -63,6 +50,8 @@ class _FakeOpenAI:
     def __init__(self, *, status: int = 200) -> None:
         self.requests: list[dict] = []
         self.status = status
+        self.activity = ServerActivity()
+        self._cancelling = threading.Event()
         owner = self
 
         class Handler(BaseHTTPRequestHandler):
@@ -157,7 +146,14 @@ class _FakeOpenAI:
                 self.end_headers()
                 self.wfile.write(response)
 
-        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        class Server(ThreadingHTTPServer):
+            def handle_error(self, request, client_address) -> None:
+                if owner._cancelling.is_set():
+                    return
+                super().handle_error(request, client_address)
+
+        self.server = Server(("127.0.0.1", 0), Handler)
+        track_server(self.server, self.activity)
         self.port = int(self.server.server_address[1])
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
@@ -166,9 +162,31 @@ class _FakeOpenAI:
         return self
 
     def __exit__(self, *_args: object) -> None:
-        self.server.shutdown()
-        self.server.server_close()
-        self.thread.join(timeout=5)
+        deadline = time.monotonic() + CANCELLATION_JOIN_SECONDS
+
+        def cancel_requests() -> None:
+            self._cancelling.set()
+            self.activity.cancel_active_sockets(reject_new=True)
+
+        def stop_listener() -> None:
+            if self.thread.is_alive():
+                self.server.shutdown()
+
+        def join_listener() -> None:
+            if self.thread.ident is not None:
+                self.thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            assert not self.thread.is_alive(), "fake OpenAI listener survived teardown"
+
+        run_cleanup_steps(
+            cancel_requests,
+            stop_listener,
+            self.server.server_close,
+            join_listener,
+            lambda: self.activity.wait_stopped(
+                label="fake OpenAI upstream",
+                deadline=deadline,
+            ),
+        )
 
 
 def _wait_liveliness(port: int, process: subprocess.Popen, *, timeout: float = 60) -> None:
@@ -196,6 +214,7 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
     tmp_path: Path,
     upstream_status: int,
 ) -> None:
+    _CONFORMANCE_TIMEOUT_LATCH.ensure_clear()
     executable_value = os.environ.get("AGENTTALK_TEST_LITELLM_EXE")
     if not executable_value:
         pytest.skip("set AGENTTALK_TEST_LITELLM_EXE for the pinned local conformance test")
@@ -252,6 +271,15 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
             request_id="q-litellm-conformance",
             issuer_token=TEST_CHILD_CAP_ISSUER,
         )
+        internal_cancellation = SocketCancellation()
+
+        def tracked_connection(*args, **kwargs) -> http.client.HTTPConnection:
+            return TrackedHTTPConnection(
+                internal_cancellation,
+                *args,
+                **kwargs,
+            )
+
         front = GatewayFront(
             FrontConfig(
                 public_token="sk-fake-front",
@@ -261,27 +289,37 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
                 request_timeout_seconds=10,
             ),
             ledger,
+            connection_factory=tracked_connection,
         )
         front_server = front.make_server()
+        front_activity = ServerActivity()
+        track_server(front_server, front_activity)
         front_thread = threading.Thread(target=front_server.serve_forever, daemon=True)
         try:
             _wait_liveliness(port, process)
+            front_budget = CompletionBudget(latch=_CONFORMANCE_TIMEOUT_LATCH)
             front_thread.start()
-            def front_ready() -> None:
-                connection = http.client.HTTPConnection(
+            def cancel_front() -> None:
+                internal_cancellation.cancel()
+                front_activity.cancel_active_sockets(reject_new=True)
+
+            def front_ready(cancellation: SocketCancellation) -> None:
+                with cancellable_http_connection(
+                    cancellation,
                     "127.0.0.1",
                     public_port,
-                    timeout=None,
-                )
-                try:
+                ) as connection:
                     connection.request("GET", "/")
                     response = connection.getresponse()
                     response.read()
                     assert response.status == 404
-                finally:
-                    connection.close()
 
-            _await_completed(front_ready, label="gateway front readiness probe")
+            await_completed(
+                front_ready,
+                budget=front_budget,
+                label="gateway front readiness probe",
+                on_cancel=cancel_front,
+            )
             tools = [
                 {
                     "name": name,
@@ -303,13 +341,14 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
                 "messages": [{"role": "user", "content": "Read README.md"}],
                 "tools": tools,
             }).encode("utf-8")
-            def exchange() -> tuple[int, bytes]:
-                connection = http.client.HTTPConnection(
+            def exchange(
+                cancellation: SocketCancellation,
+            ) -> tuple[int, bytes]:
+                with cancellable_http_connection(
+                    cancellation,
                     "127.0.0.1",
                     public_port,
-                    timeout=None,
-                )
-                try:
+                ) as connection:
                     connection.request(
                         "POST",
                         "/v1/messages",
@@ -322,20 +361,44 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
                     )
                     response = connection.getresponse()
                     return response.status, response.read()
-                finally:
-                    connection.close()
 
-            response_status, response_body = _await_completed(
+            response_status, response_body = await_completed(
                 exchange,
+                budget=front_budget,
                 label="gateway front conformance request",
+                on_cancel=cancel_front,
             )
         finally:
             try:
-                if front_thread.is_alive():
-                    front_server.shutdown()
-                front_server.server_close()
-                if front_thread.ident is not None:
-                    front_thread.join(timeout=5)
+                deadline = time.monotonic() + CANCELLATION_JOIN_SECONDS
+
+                def cancel_front_requests() -> None:
+                    internal_cancellation.cancel()
+                    front_activity.cancel_active_sockets(reject_new=True)
+
+                def stop_front_listener() -> None:
+                    if front_thread.is_alive():
+                        front_server.shutdown()
+
+                def join_front_listener() -> None:
+                    if front_thread.ident is not None:
+                        front_thread.join(
+                            timeout=max(0.0, deadline - time.monotonic())
+                        )
+                    assert not front_thread.is_alive(), (
+                        "gateway conformance listener survived teardown"
+                    )
+
+                run_cleanup_steps(
+                    cancel_front_requests,
+                    stop_front_listener,
+                    front_server.server_close,
+                    join_front_listener,
+                    lambda: front_activity.wait_stopped(
+                        label="gateway conformance front",
+                        deadline=deadline,
+                    ),
+                )
             finally:
                 process.terminate()
                 try:

--- a/tests/test_ovh_litellm_conformance.py
+++ b/tests/test_ovh_litellm_conformance.py
@@ -22,6 +22,35 @@ from agenttalk.ovh_gateway_front import FrontConfig, GatewayFront
 
 
 TEST_CHILD_CAP_ISSUER = "atgw-" + "i" * 43
+# Public front exchanges use completion events rather than socket read
+# deadlines. This matches the suite's existing synchronized-contention
+# watchdog (#94) and only reports a stuck harness worker.
+COMPLETION_WATCHDOG_SECONDS = 30
+
+
+def _await_completed(operation, *, label: str):
+    completed = threading.Event()
+    results: list[object] = []
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            results.append(operation())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            completed.set()
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    assert completed.wait(timeout=COMPLETION_WATCHDOG_SECONDS), (
+        f"{label} did not complete after its synchronization condition was armed"
+    )
+    worker.join()
+    if errors:
+        raise errors[0]
+    assert len(results) == 1
+    return results[0]
 
 
 def _free_port() -> int:
@@ -238,6 +267,21 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
         try:
             _wait_liveliness(port, process)
             front_thread.start()
+            def front_ready() -> None:
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1",
+                    public_port,
+                    timeout=None,
+                )
+                try:
+                    connection.request("GET", "/")
+                    response = connection.getresponse()
+                    response.read()
+                    assert response.status == 404
+                finally:
+                    connection.close()
+
+            _await_completed(front_ready, label="gateway front readiness probe")
             tools = [
                 {
                     "name": name,
@@ -259,22 +303,32 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
                 "messages": [{"role": "user", "content": "Read README.md"}],
                 "tools": tools,
             }).encode("utf-8")
-            connection = http.client.HTTPConnection("127.0.0.1", public_port, timeout=15)
-            try:
-                connection.request(
-                    "POST",
-                    "/v1/messages",
-                    body=request,
-                    headers={
-                        "Authorization": f"Bearer {credential.token}",
-                        "Content-Type": "application/json",
-                        "Host": f"127.0.0.1:{public_port}",
-                    },
+            def exchange() -> tuple[int, bytes]:
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1",
+                    public_port,
+                    timeout=None,
                 )
-                response = connection.getresponse()
-                response_body = response.read()
-            finally:
-                connection.close()
+                try:
+                    connection.request(
+                        "POST",
+                        "/v1/messages",
+                        body=request,
+                        headers={
+                            "Authorization": f"Bearer {credential.token}",
+                            "Content-Type": "application/json",
+                            "Host": f"127.0.0.1:{public_port}",
+                        },
+                    )
+                    response = connection.getresponse()
+                    return response.status, response.read()
+                finally:
+                    connection.close()
+
+            response_status, response_body = _await_completed(
+                exchange,
+                label="gateway front conformance request",
+            )
         finally:
             try:
                 if front_thread.is_alive():
@@ -307,7 +361,7 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
 
     ledger_status = ledger.status()
     if upstream_status == 200:
-        assert response.status == 200, response_body.decode("utf-8", "replace")
+        assert response_status == 200, response_body.decode("utf-8", "replace")
         assert b"message_stop" in response_body
         assert ledger_status["current_committed_micro_eur"] == settlement_cost_micro_eur(
             50,
@@ -315,7 +369,7 @@ def test_anthropic_messages_routes_once_to_chat_completions_with_representative_
         )
         assert ledger_status["unresolved"] == []
     else:
-        assert response.status == 502, response_body.decode("utf-8", "replace")
+        assert response_status == 502, response_body.decode("utf-8", "replace")
         assert b"fake-provider-secret" not in response_body
         assert ledger_status["current_committed_micro_eur"] == 0
         assert len(ledger_status["unresolved"]) == 1

--- a/tests/test_socket_harness.py
+++ b/tests/test_socket_harness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+import _socket_harness as socket_harness
+
+
+_TIMEOUT_NOT_SET = object()
+
+
+class _StalledConnectSocket:
+    """Model a connect that can finish only through its configured timeout."""
+
+    def __init__(self) -> None:
+        self.timeout: object = _TIMEOUT_NOT_SET
+        self.connect_timeout: object = _TIMEOUT_NOT_SET
+        self.closed = False
+
+    def settimeout(self, timeout: float | None) -> None:
+        self.timeout = timeout
+
+    def connect(self, _address: tuple[str, int]) -> None:
+        self.connect_timeout = self.timeout
+        if self.timeout is _TIMEOUT_NOT_SET:
+            harness_timeout = socket_harness.COMPLETION_BUDGET_SECONDS
+            raise AssertionError(
+                f"{harness_timeout:g}s harness watchdog would own stalled connect; product timeout was not armed"
+            )
+        if self.timeout is None:
+            return
+        assert isinstance(self.timeout, (int, float))
+        raise socket.timeout(f"{self.timeout:g}s product connect timeout")
+
+    def shutdown(self, _how: int) -> None:
+        return
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _install_stalled_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _StalledConnectSocket:
+    stalled = _StalledConnectSocket()
+    monkeypatch.setattr(
+        socket_harness.socket,
+        "socket",
+        lambda *_args, **_kwargs: stalled,
+    )
+    return stalled
+
+
+def test_tracked_http_connection_arms_product_timeout_before_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stalled = _install_stalled_socket(monkeypatch)
+    connection = socket_harness.TrackedHTTPConnection(
+        socket_harness.SocketCancellation(),
+        "127.0.0.1",
+        443,
+        timeout=10.0,
+    )
+
+    with pytest.raises(socket.timeout, match=r"^10s product connect timeout$"):
+        connection.connect()
+
+    assert stalled.connect_timeout == 10.0
+    assert stalled.closed
+
+
+def test_cancellable_socket_selects_deadline_free_mode_before_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stalled = _install_stalled_socket(monkeypatch)
+
+    with socket_harness.cancellable_socket(
+        socket_harness.SocketCancellation(),
+        "127.0.0.1",
+        443,
+    ):
+        pass
+
+    assert stalled.connect_timeout is None
+    assert stalled.closed


### PR DESCRIPTION
Test-only. Removes the wall-clock dependence from the OVH front socket tests, which have become the dominant tax on every merge.

## Why

`test_front_refuses_ninth_child_call_without_provider_transport` failed **2 of the last 3 Windows CI rounds** on #78, on two different legs, with the diff never touching that file:

```
r14  dev-gate (windows/3.11)   TimeoutError: timed out   socket.py:706
r16  dev-gate (windows/3.10)   TimeoutError: timed out   socket.py:705
                               1 failed, 3990 passed, 14 skipped in 1832.80s
```

Not a cap problem — that leg ran 1833.9s against a 2700s budget (68%). It is a socket read deadline inside the test that cannot survive an ordinary loaded Windows runner. Tracked as the wall-clock family (`#74`, instances 17 and 19).

## What changed

**Synchronization, not a larger timeout** — following the pattern already established by `test(#74): synchronize tail mid-run arrival (#90)` and `test: synchronize persistent state contention (#94)`. A bigger number is the same defect with a longer fuse.

- The shared public client and raw-socket helpers no longer use socket read deadlines. Each blocking exchange runs in a daemon worker and wakes the caller through a per-operation `threading.Event`.
- The remaining 30-second value is a **deadlock watchdog on the completion condition, not the success mechanism**; a successful response wakes immediately.
- The fake front-to-upstream HTTP connection also drops its socket read deadline, while asserting that `GatewayFront` requested its configured 5-second **product** timeout — so product timeout behaviour stays covered, and the deterministic path remains covered by the direct injected-`socket.timeout` test.
- The permit-contention fake upstream waits only for its release signal, released in `finally`, with explicit entered/completed events — so elapsed time can no longer auto-release the first request and change the expected 429.
- The LiteLLM conformance sibling is synchronized the same way. Its real front-to-LiteLLM 10-second **product** timeout is intentional conformance behaviour and is retained.

## The oracle was also vacuous, and that is fixed

While mutation-testing the fix, mutating `CHILD_TURN_MAX_CALLS` from 8 to 9 left the **old** test green, because its loop derived its expectation from the constant under test. The boundary is now pinned — `assert CHILD_TURN_MAX_CALLS == 8`, eight successes, a ninth refusal, eight upstream transports — so the test can no longer move its own boundary along with the product.

## Evidence

- **Mutation control (proves the test still catches the real defect):** with a temporary, uncommitted product mutant in `SpendLedger.reserve_for_child` (`attempt_count >= max_calls` → `>`) allowing the ninth reservation, the hardened target goes **RED** at the boundary (`assert 200 == 403`). Product restored; worktree and index diffs for `src/agenttalk/ovh_gateway.py` verified empty before commit; restored target **GREEN**.
- `tests/test_ovh_gateway_front.py`: **42 passed** in 38.77s.
- Focused raw-socket / liveliness / contention set: 7 passed.
- Target stress: **10 separate invocations, 10 passed**.
- `tests/test_ovh_litellm_conformance.py`: 3 skipped (`AGENTTALK_TEST_LITELLM_EXE` unset); collection and import succeed.
- Ruff on both changed files: clean. `git diff --check`: clean.
- **Test-only, verified:** no file under `src/` is touched by this diff.

## Honest limitation

The natural Windows timeout was **not reproduced locally** — the base test passes in ~1.45s here, and ten bounded base invocations also passed. This is a CI-observed, load-dependent failure, so there is no local failing-first artefact for it. The argument for the fix is therefore structural (the assertion no longer depends on elapsed wall-clock time at all) plus the mutation control above, rather than a reproduced red.

A single green CI run also cannot prove a flake is gone. What it can show is that the synchronization did not break the suite.

## Class, not instance

`#59` previously hardened four flaky Windows tests and was closed; this recurrence shows that pass fixed instances rather than the family. Every test in `test_ovh_gateway_front.py` was therefore classified for wall-clock/socket exposure and the affected ones converted — including the conformance sibling — rather than only the one test that was failing.
