### PR TITLE
fix(#105): surface the strict supervisor verdict on status/doctor/web

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -327,6 +327,33 @@ two parallel ownership concepts.
   errored, unknown) that degrades safely and never authorizes a kill by itself;
   `deadman.py` is an independent mail-age SLO alarm over owed work, derived
   from the thread projector and not from supervisor state.
+- **Operator-surface health composition contract (#105).** **Audience:**
+  contributors changing `status`, `doctor`, `/api/state`, or Team Console
+  health rendering. **Goal:** present wrapper observations and strict
+  supervisor decisions together without inventing, erasing, or relabelling
+  either source. Observation and decision remain immutable, source-labelled
+  facts. Classify each independently; combined urgency is monotone (the
+  maximum), never a downgrade, on the ordered lattice `fine < unknown <
+  attention < danger`. Wrapper idle/working observations are `fine`; an unknown
+  or unreadable observation is `unknown`; suspected-stuck, poison-message, and
+  exited observations are `attention`; rate-limit/outage, degraded-output, and
+  ambiguous/fatal-error observations are `danger`. Supervisor healthy and grace
+  decisions are `fine`; administrative, cooldown, and provisional decisions
+  are `attention`; live-stalled/no-progress, failed-turn/readiness,
+  unconfirmed/stuck-or-dead, and positively lost-binding decisions are
+  `danger`; unavailable evidence is `attention` and never healthy.
+
+  On an equal-urgency tie the observation supplies primary wording, and every
+  presentation appends the other fact with its source. Healthy and grace
+  decisions never erase a concerning or unknown observation; a supervisor
+  `action` describes recovery intent, not severity; child-loss wording is used
+  only when the producer state actually establishes lost binding.
+  Administrative decisions, cooldown, a live stalled/no-progress child, and a
+  failed turn retain those meanings rather than entering one dead/not-dead
+  bucket. Projection and rendering compose facts only; they do not change
+  supervisor decisions or owned-tree predicates. Cross-product expectations
+  derive from these clauses, independently of implementation; downgrade and
+  dropped-unavailable mutations must make named cells fail.
 - **Why:** real hangs and resume-wake churn happened in the field. A wrapper
   can keep heartbeating after its CLI child dies or wedges, so heartbeat alone
   cannot authorize wrapped health. Strict turn lifecycle plus real child/progress
@@ -928,6 +955,15 @@ Append new decisions here (dated). Keep each short: decision, why, alternatives.
   That design treats direct and console ancestry as insufficient, binds the
   live host to the canonical `-File supervisor.ps1` launch plus generated-shim
   shape and artifact generation, and preserves the same-user trust ceiling.
+- **D-30 Operator health surfaces compose independent evidence monotonically
+  (2026-08-04).** *Why:* wrapper observations and supervisor decisions can
+  disagree; decision-only and last-writer-wins rendering produced both
+  false-green and false-death claims. *Decision:* `status`, `doctor`, the web
+  projection, and Team Console follow the §4.6 composition contract. *Rejected:*
+  decision-overwrites-observation, action-as-severity, and a generic
+  dead/not-dead bucket. This governs presentation only; it does not change
+  supervisor decisions or owned-tree predicates. *Proof:* invariant-derived
+  cross-product tables plus downgrade and unavailable-case mutation controls.
 
 ## 6. How we work (process)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -339,21 +339,29 @@ two parallel ownership concepts.
   exited observations are `attention`; rate-limit/outage, degraded-output, and
   ambiguous/fatal-error observations are `danger`. Supervisor healthy and grace
   decisions are `fine`; administrative, cooldown, and provisional decisions
-  are `attention`; live-stalled/no-progress, failed-turn/readiness,
-  unconfirmed/stuck-or-dead, and positively lost-binding decisions are
-  `danger`; unavailable evidence is `attention` and never healthy.
+  are `attention`; live-stalled/no-progress, failed-turn, launch-readiness
+  exhaustion, unconfirmed/stuck-or-dead, and positively lost-binding decisions
+  are distinct `danger` facts; unavailable evidence is `attention` and never
+  healthy.
 
   On an equal-urgency tie the observation supplies primary wording, and every
   presentation appends the other fact with its source. Healthy and grace
   decisions never erase a concerning or unknown observation; a supervisor
   `action` describes recovery intent, not severity; child-loss wording is used
   only when the producer state actually establishes lost binding.
-  Administrative decisions, cooldown, a live stalled/no-progress child, and a
-  failed turn retain those meanings rather than entering one dead/not-dead
-  bucket. Projection and rendering compose facts only; they do not change
-  supervisor decisions or owned-tree predicates. Cross-product expectations
-  derive from these clauses, independently of implementation; downgrade and
-  dropped-unavailable mutations must make named cells fail.
+  Administrative decisions, cooldown, a live stalled/no-progress child, a
+  failed turn, and exhausted launch readiness retain those meanings rather
+  than entering one dead/not-dead bucket. Before composition, every operator
+  surface normalizes wrapper health through one configured path: one sample
+  time and heartbeat read feed the same per-agent/global TTL and heartbeat-skew
+  policy into the health reader. A missing supervisor configuration selects
+  documented defaults; an existing but unreadable configuration makes that
+  timing policy explicitly unavailable, so surfaces report `unknown` rather
+  than silently guessing with defaults. Projection and rendering compose facts
+  only; they do not change supervisor decisions or owned-tree predicates.
+  Cross-product expectations derive from these clauses, independently of
+  implementation; downgrade and dropped-unavailable mutations must make named
+  cells fail.
 - **Why:** real hangs and resume-wake churn happened in the field. A wrapper
   can keep heartbeating after its CLI child dies or wedges, so heartbeat alone
   cannot authorize wrapped health. Strict turn lifecycle plus real child/progress

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -605,7 +605,8 @@ def _gather_status(store: Store) -> dict:
                 # own self-report still reads "fine" while the supervisor's
                 # strict, positively-bound verdict does not.
                 if (
-                    decision.get("state") not in
+                    cfg_agent.get("wrapped") is True
+                    and decision.get("state") not in
                     (sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES)
                     and health.get("state") in ("idle_waiting", "working_turn")
                 ):
@@ -1315,12 +1316,9 @@ def cmd_status(args: argparse.Namespace) -> int:
         dec = sv.get("decision") if isinstance(sv.get("decision"), dict) else None
         if dec:
             seen += f" supervisor={dec.get('state', '?')}/{dec.get('action', '?')}"
-            # Never let the two verdicts silently disagree in favour of the
-            # cheerful one: a wrapper that still self-reports "fine" while the
-            # supervisor's strict, positively-bound verdict says otherwise.
-            dec_state = dec.get("state")
-            if (dec_state not in sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES
-                    and h_state in ("idle_waiting", "working_turn")):
+            # Use the already-scoped JSON fact rather than re-deriving it here;
+            # only wrapped agents have a strict wrapper-child disagreement.
+            if sv.get("disagreement") is True:
                 seen += " [DISAGREEMENT]"
         elif sv.get("decision_unavailable") is True:
             seen += " supervisor=UNAVAILABLE(not auto_restart)"

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -538,16 +538,27 @@ def _gather_status(store: Store) -> dict:
     # Resolve the lead-loop heartbeat window from supervisor.json (if present) so the
     # status view uses the SAME threshold as the steal path - never the 120s default
     # for a wrapped agent (WP1 contract; avoids armed/heartbeat_stale skew).
-    sup_cfg = _load_supervisor_config(store)
-    from agenttalk import supervisor as _sup
+    health_policy = operator_health.load_health_timing_policy(store)
+    sup_cfg = health_policy.config
     sup_agents = (
         sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
     )
-    supervisor_rows, supervisor_warnings = _status_supervisor_summaries(
-        store, now.timestamp(), sup_cfg)
+    if health_policy.unavailable_reason is None:
+        supervisor_rows, supervisor_warnings = _status_supervisor_summaries(
+            store, now.timestamp(), sup_cfg)
+    else:
+        supervisor_rows = {}
+        supervisor_warnings = [health_policy.unavailable_reason]
     agents = []
     for a in cfg.get("agents", []):
-        hb = store.read_heartbeat(a)
+        cfg_agent = sup_agents.get(a) if isinstance(sup_agents.get(a), dict) else {}
+        normalized_health = operator_health.read_health_observation(
+            store,
+            a,
+            now_epoch=now.timestamp(),
+            health_policy=health_policy,
+        )
+        hb = normalized_health.heartbeat
         if hb is None:
             heartbeat_iso: str | None = None
             last_seen_s: float | None = None
@@ -574,15 +585,7 @@ def _gather_status(store: Store) -> dict:
                 isinstance(dl, (int, float))
                 and time.time() > dl + STALE_THRESHOLD_SECONDS
             )
-        cfg_agent = sup_agents.get(a) if isinstance(sup_agents.get(a), dict) else {}
-        health_timing = _sup.resolve_health_timing(sup_cfg or {}, cfg_agent)
-        health = store.read_health(
-            a,
-            now_epoch=now.timestamp(),
-            heartbeat=hb,
-            ttl_seconds=health_timing["ttl_seconds"],
-            heartbeat_skew_seconds=health_timing["heartbeat_skew_seconds"],
-        )
+        health = normalized_health.health
         row = {
             "name": a,
             "role": roles.get(a),

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -600,6 +600,16 @@ def _gather_status(store: Store) -> dict:
             decision = sup_row.get("decision")
             if isinstance(decision, dict):
                 row["supervisor"] = {"decision": decision}
+                # Never let the two verdicts silently disagree in favour of the
+                # cheerful one: additive flag, present only when the wrapper's
+                # own self-report still reads "fine" while the supervisor's
+                # strict, positively-bound verdict does not.
+                if (
+                    decision.get("state") not in
+                    (sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES)
+                    and health.get("state") in ("idle_waiting", "working_turn")
+                ):
+                    row["supervisor"]["disagreement"] = True
             if isinstance(sup_row.get("lead_liveness"), dict):
                 row["lead_liveness"] = sup_row["lead_liveness"]
             effective = sup_row.get("health_effective_state")
@@ -1283,6 +1293,13 @@ def cmd_status(args: argparse.Namespace) -> int:
         dec = sv.get("decision") if isinstance(sv.get("decision"), dict) else None
         if dec:
             seen += f" supervisor={dec.get('state', '?')}/{dec.get('action', '?')}"
+            # Never let the two verdicts silently disagree in favour of the
+            # cheerful one: a wrapper that still self-reports "fine" while the
+            # supervisor's strict, positively-bound verdict says otherwise.
+            dec_state = dec.get("state")
+            if (dec_state not in sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES
+                    and h_state in ("idle_waiting", "working_turn")):
+                seen += " [DISAGREEMENT]"
         role = f" role={a['role']}" if a.get("role") else ""
         of = " [operator-facing]" if a.get("operator_facing") else ""
         print(f"  {a['name']:<10}{role}{of} cursor={cursor:<32} unread={a['unread']:<3} {seen}")

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -56,6 +56,7 @@ from agenttalk import lanes as lane_mod
 from agenttalk import install_skills as iskl
 from agenttalk import lead_loop_runtime
 from agenttalk import onboarding as ob
+from agenttalk import operator_health
 from agenttalk import signing as _signing
 from agenttalk import threads as th
 from agenttalk import supervisor as sup
@@ -600,22 +601,28 @@ def _gather_status(store: Store) -> dict:
             decision = sup_row.get("decision")
             if isinstance(decision, dict):
                 row["supervisor"] = {"decision": decision}
-                # Never let the two verdicts silently disagree in favour of the
-                # cheerful one: additive flag, present only when the wrapper's
-                # own self-report still reads "fine" while the supervisor's
-                # strict, positively-bound verdict does not.
-                if (
-                    cfg_agent.get("wrapped") is True
-                    and decision.get("state") not in
-                    (sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES)
-                    and health.get("state") in ("idle_waiting", "working_turn")
-                ):
-                    row["supervisor"]["disagreement"] = True
+                if cfg_agent.get("wrapped") is True:
+                    composition = operator_health.compose_health_evidence(
+                        health.get("state"), decision=decision)
+                    row["health_composition"] = composition
+                    if composition["disagreement"]:
+                        row["supervisor"]["disagreement"] = True
             elif sup_row.get("decision_unavailable") is True:
                 # A wrapped agent this supervisor cannot compute a strict
-                # decision for (e.g. not configured auto_restart) — say so
-                # rather than silently showing only the self-report.
-                row["supervisor"] = {"decision_unavailable": True}
+                # decision for — say why rather than silently showing only the
+                # self-report or assuming every unavailable verdict is disabled.
+                reason = sup_row.get("decision_unavailable_reason")
+                reason = reason if isinstance(reason, str) else "decision_missing"
+                row["supervisor"] = {
+                    "decision_unavailable": True,
+                    "decision_unavailable_reason": reason,
+                }
+                if cfg_agent.get("wrapped") is True:
+                    composition = operator_health.compose_health_evidence(
+                        health.get("state"), unavailable_reason=reason)
+                    row["health_composition"] = composition
+                    if composition["disagreement"]:
+                        row["supervisor"]["disagreement"] = True
             if isinstance(sup_row.get("lead_liveness"), dict):
                 row["lead_liveness"] = sup_row["lead_liveness"]
             effective = sup_row.get("health_effective_state")
@@ -760,6 +767,11 @@ def _read_supervisor_snapshot(store: Store, path_value: str | None = None) -> li
 
 def _status_supervisor_summaries(store: Store, now_epoch: float,
                                  sup_cfg: dict) -> tuple[dict[str, dict], list[str]]:
+    sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
+    wrapped_names = {
+        name for name, cfg_agent in sup_agents.items()
+        if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
+    }
     try:
         obs = sup.build_supervisor_observation(
             store,
@@ -775,12 +787,14 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
             lead_liveness_stale_after_seconds=STALE_THRESHOLD_SECONDS,
         )
     except Exception as exc:
-        return {}, [f"supervisor_assessment_unavailable:{type(exc).__name__}"]
-    sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
-    wrapped_names = {
-        name for name, cfg_agent in sup_agents.items()
-        if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
-    }
+        rows = {
+            name: {
+                "decision_unavailable": True,
+                "decision_unavailable_reason": "assessment_failed",
+            }
+            for name in wrapped_names
+        }
+        return rows, [f"supervisor_assessment_unavailable:{type(exc).__name__}"]
     rows: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
@@ -803,6 +817,12 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
             row["decision"] = decision
         elif wrapped_without_decision:
             row["decision_unavailable"] = True
+            cfg_agent = sup_agents.get(name)
+            row["decision_unavailable_reason"] = (
+                "auto_restart_disabled"
+                if isinstance(cfg_agent, dict) and cfg_agent.get("auto_restart") is not True
+                else "decision_missing"
+            )
         if isinstance(effective, str) and effective != raw_state:
             row["health_effective_state"] = effective
         if lead_liveness is not None:
@@ -1321,7 +1341,8 @@ def cmd_status(args: argparse.Namespace) -> int:
             if sv.get("disagreement") is True:
                 seen += " [DISAGREEMENT]"
         elif sv.get("decision_unavailable") is True:
-            seen += " supervisor=UNAVAILABLE(not auto_restart)"
+            reason = sv.get("decision_unavailable_reason") or "decision_missing"
+            seen += f" supervisor=UNAVAILABLE({reason})"
         role = f" role={a['role']}" if a.get("role") else ""
         of = " [operator-facing]" if a.get("operator_facing") else ""
         print(f"  {a['name']:<10}{role}{of} cursor={cursor:<32} unread={a['unread']:<3} {seen}")

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -765,7 +765,11 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
             now_epoch=now_epoch,
             state=_read_supervisor_state(store),
             supervisor_config=sup_cfg,
-            snapshot=_read_supervisor_snapshot(store),
+            snapshot=sup.read_supervisor_snapshot_if_fresh(
+                store.dir / "supervisor-snapshot.json",
+                now_epoch=now_epoch,
+                stale_after_seconds=sup.resolve_snapshot_stale_after_seconds(sup_cfg),
+            ),
             event_limit=0,
             lead_liveness_stale_after_seconds=STALE_THRESHOLD_SECONDS,
         )

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -610,6 +610,11 @@ def _gather_status(store: Store) -> dict:
                     and health.get("state") in ("idle_waiting", "working_turn")
                 ):
                     row["supervisor"]["disagreement"] = True
+            elif sup_row.get("decision_unavailable") is True:
+                # A wrapped agent this supervisor cannot compute a strict
+                # decision for (e.g. not configured auto_restart) — say so
+                # rather than silently showing only the self-report.
+                row["supervisor"] = {"decision_unavailable": True}
             if isinstance(sup_row.get("lead_liveness"), dict):
                 row["lead_liveness"] = sup_row["lead_liveness"]
             effective = sup_row.get("health_effective_state")
@@ -766,25 +771,38 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
         )
     except Exception as exc:
         return {}, [f"supervisor_assessment_unavailable:{type(exc).__name__}"]
+    sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
+    wrapped_names = {
+        name for name, cfg_agent in sup_agents.items()
+        if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
+    }
     rows: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
             continue
+        name = item["name"]
         decision = item.get("decision") if isinstance(item.get("decision"), dict) else None
         health = item.get("health") if isinstance(item.get("health"), dict) else {}
         lead_liveness = item.get("lead_liveness") if isinstance(item.get("lead_liveness"), dict) else None
         effective = health.get("effective_state")
         raw_state = health.get("state")
-        if decision is None and lead_liveness is None and effective == raw_state:
+        # A WRAPPED agent with no computable decision (e.g. not configured
+        # auto_restart) must say so visibly rather than silently falling back
+        # to the self-report — the same honesty doctor already has.
+        wrapped_without_decision = decision is None and name in wrapped_names
+        if (decision is None and lead_liveness is None and effective == raw_state
+                and not wrapped_without_decision):
             continue
         row: dict[str, object] = {}
         if decision is not None:
             row["decision"] = decision
+        elif wrapped_without_decision:
+            row["decision_unavailable"] = True
         if isinstance(effective, str) and effective != raw_state:
             row["health_effective_state"] = effective
         if lead_liveness is not None:
             row["lead_liveness"] = lead_liveness
-        rows[item["name"]] = row
+        rows[name] = row
     warnings = []
     ring = obs.get("event_ring") if isinstance(obs.get("event_ring"), dict) else {}
     for warning in ring.get("warnings") or []:
@@ -1300,6 +1318,8 @@ def cmd_status(args: argparse.Namespace) -> int:
             if (dec_state not in sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES
                     and h_state in ("idle_waiting", "working_turn")):
                 seen += " [DISAGREEMENT]"
+        elif sv.get("decision_unavailable") is True:
+            seen += " supervisor=UNAVAILABLE(not auto_restart)"
         role = f" role={a['role']}" if a.get("role") else ""
         of = " [operator-facing]" if a.get("operator_facing") else ""
         print(f"  {a['name']:<10}{role}{of} cursor={cursor:<32} unread={a['unread']:<3} {seen}")

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1804,11 +1804,19 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
         return []
+    health_policy = operator_health.load_health_timing_policy(store)
+    if health_policy.unavailable_reason is not None:
+        return [Check(
+            name="wrapper_child_health.supervisor_config",
+            status="warn",
+            details=(
+                "supervisor health timing policy is unavailable; "
+                "wrapper observations cannot be freshness-checked"
+            ),
+            fix="repair .agenttalk/supervisor.json",
+        )]
     assessment_problem: str | None = None
-    try:
-        sup_cfg = sup.load_supervisor_config(sup_path)
-    except (ValueError, OSError):
-        return []
+    sup_cfg = health_policy.config
     sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
     wrapped_names = [
         name for name, cfg_agent in sup_agents.items()
@@ -1849,9 +1857,15 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
     out: list[Check] = []
     for name in wrapped_names:
         item = obs_by_name.get(name) or {}
+        cfg_agent = sup_agents.get(name) if isinstance(sup_agents.get(name), dict) else {}
         health = item.get("health") if isinstance(item.get("health"), dict) else {}
         if not health:
-            health = store.read_health(name, now_epoch=now_epoch)
+            health = operator_health.read_health_observation(
+                store,
+                name,
+                now_epoch=now_epoch,
+                health_policy=health_policy,
+            ).health
         self_state = health.get("state", "unknown")
         self_age = health.get("age_seconds")
         self_age_str = f"{self_age:.0f}s" if isinstance(self_age, (int, float)) else "n/a"
@@ -1871,7 +1885,6 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
             )
 
         decision = item.get("decision") if isinstance(item.get("decision"), dict) else None
-        cfg_agent = sup_agents.get(name) if isinstance(sup_agents.get(name), dict) else {}
         unavailable_reason: str | None = None
         if decision is None:
             if assessment_problem is not None:

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1825,14 +1825,10 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
         # degrade the SAME way a bad observation does — a diagnostic tool
         # that dies on bad state is worst-useless exactly when state is bad.
         state = sup.load_supervisor_state(store.dir / "supervisor-state.json")
-        snapshot_path = store.dir / "supervisor-snapshot.json"
-        snapshot: list[dict] | None = None
-        if snapshot_path.exists():
-            try:
-                raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
-            except (ValueError, OSError):
-                raw = None
-            snapshot = raw if isinstance(raw, list) else None
+        # A stale snapshot must not be read as a live liveness fact (see
+        # read_supervisor_snapshot_if_fresh's docstring).
+        snapshot = sup.read_supervisor_snapshot_if_fresh(
+            store.dir / "supervisor-snapshot.json", now_epoch=now_epoch)
         obs = sup.build_supervisor_observation(
             store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
             snapshot=snapshot, event_limit=0,
@@ -1887,9 +1883,17 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
         d_state = decision.get("state")
         d_action = decision.get("action")
         d_reason = decision.get("reason") or ""
+        # `action` is a RECOVERY-INTENT signal, not a severity signal: backoff_wait
+        # (cooldown), suspect_warn (rate-limited, unconfirmed), refuse_protected
+        # (administrative refusal of a manual restart) etc. all pair with states
+        # OUTSIDE the confirmed-dead family and must not be escalated to `error`
+        # just for existing — that made a normal RESTART_COOLDOWN/backoff_wait or
+        # ACTIVE_OR_BUSY/suspect_warn cry wolf. `error` is reserved for the state
+        # itself being in the confirmed unbound/dead family (RELAUNCH/STUCK_RECOVER
+        # already pair with such a state, so this loses no real severity).
         if d_state in _HEALTHY_DECISION_STATES:
             status = "ok"
-        elif d_state in sup.UNBOUND_OR_DEAD_DECISION_STATES or d_action not in (None, sup.NONE):
+        elif d_state in sup.UNBOUND_OR_DEAD_DECISION_STATES:
             status = "error"
         else:
             status = "warn"

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -27,6 +27,7 @@ from agenttalk import signing as _signing
 from agenttalk import supervisor as sup
 from agenttalk import powershell_host as psh
 from agenttalk import supervisor_lifecycle
+from agenttalk import wrapper_runtime as runtime_obs
 from agenttalk.store import (
     STORE_SCHEMA_CAPABILITIES,
     Store,
@@ -156,6 +157,7 @@ def run(project_root: Path | None = None) -> Report:
         report.checks.append(_check_codex_config(root))
         report.checks.append(_check_hmac(store, root))
         report.checks.extend(_check_heartbeats(store))
+        report.checks.extend(_check_wrapper_child_health(store))
         waiters = _check_active_waiters(store)
         if waiters is not None:  # additive: absent unless a live waiter exists
             report.checks.append(waiters)
@@ -1779,6 +1781,129 @@ def _check_heartbeats(store: Store) -> list[Check]:
                 status="ok",
                 details=f"last seen {int(age)}s ago",
             ))
+    return out
+
+
+_HEALTHY_DECISION_STATES = sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES
+_SELF_REPORT_LOOKS_FINE = frozenset({"idle_waiting", "working_turn"})
+
+
+def _check_wrapper_child_health(store: Store) -> list[Check]:
+    """One check per wrapped agent — does the SUPERVISOR's strict verdict agree
+    with the wrapper's own self-report, and is progress actually moving?
+
+    The wrapper's self-reported ``health`` (idle_waiting/working_turn/...) is
+    advisory and can go on saying "working" after its CLI child has died. The
+    supervisor's live decision (CLI_CHILD_UNKNOWN/CLI_CHILD_DEAD/...) is the
+    strict, positively-bound verdict, but until now it reached no operator
+    surface `doctor` covers. This check surfaces BOTH observations side by
+    side — never collapsing them into one adjective — plus the raw
+    ``last_progress_at`` age from the wrapper-runtime record, which is the
+    cheapest signal for "the counter is frozen" independent of any verdict.
+
+    Absent entirely when no agent is configured ``wrapped`` in
+    supervisor.json (nothing to check).
+    """
+    sup_path = store.dir / "supervisor.json"
+    if not sup_path.exists():
+        return []
+    try:
+        sup_cfg = sup.load_supervisor_config(sup_path)
+    except (ValueError, OSError):
+        return []
+    sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
+    wrapped_names = [
+        name for name, cfg_agent in sup_agents.items()
+        if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
+    ]
+    if not wrapped_names:
+        return []
+
+    now_epoch = datetime.now(timezone.utc).timestamp()
+    state_path = store.dir / "supervisor-state.json"
+    state = sup.load_supervisor_state(state_path)
+    snapshot_path = store.dir / "supervisor-snapshot.json"
+    snapshot: list[dict] | None = None
+    if snapshot_path.exists():
+        try:
+            raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
+        except (ValueError, OSError):
+            raw = None
+        snapshot = raw if isinstance(raw, list) else None
+    try:
+        obs = sup.build_supervisor_observation(
+            store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
+            snapshot=snapshot, event_limit=0,
+        )
+        obs_by_name = {
+            a["name"]: a for a in obs.get("agents", []) if isinstance(a, dict)
+        }
+    except Exception as exc:  # noqa: BLE001 - doctor stays fail-safe
+        return [Check(
+            name="wrapper_child_health",
+            status="warn",
+            details=f"could not compute the supervisor's decision: "
+                    f"{type(exc).__name__}: {exc}",
+        )]
+
+    out: list[Check] = []
+    for name in wrapped_names:
+        item = obs_by_name.get(name) or {}
+        health = item.get("health") if isinstance(item.get("health"), dict) else {}
+        self_state = health.get("state", "unknown")
+        self_age = health.get("age_seconds")
+        self_age_str = f"{self_age:.0f}s" if isinstance(self_age, (int, float)) else "n/a"
+
+        runtime = runtime_obs.read_runtime(store.state_dir, name, now_epoch=now_epoch)
+        progress_bit = ""
+        if runtime.get("status") == runtime_obs.STATUS_VALID:
+            record = runtime.get("record") or {}
+            progress_age = runtime.get("progress_age_seconds")
+            progress_age_str = (
+                f"{progress_age:.0f}s" if isinstance(progress_age, (int, float))
+                else "never"
+            )
+            progress_bit = (
+                f"; wrapper-runtime phase={record.get('phase')} "
+                f"last_progress_age={progress_age_str}"
+            )
+
+        decision = item.get("decision") if isinstance(item.get("decision"), dict) else None
+        if decision is None:
+            out.append(Check(
+                name=f"wrapper_child_health.{name}",
+                status="warn",
+                details=(
+                    f"self-reported health={self_state} (age={self_age_str}){progress_bit}; "
+                    "no supervisor decision is available for this agent (it is not "
+                    "configured auto_restart, so the strict CLI-child-bound verdict "
+                    "cannot be computed here — this is the wrapper's own self-report only)"
+                ),
+            ))
+            continue
+
+        d_state = decision.get("state")
+        d_action = decision.get("action")
+        d_reason = decision.get("reason") or ""
+        if d_state in _HEALTHY_DECISION_STATES:
+            status = "ok"
+        elif d_state in sup.UNBOUND_OR_DEAD_DECISION_STATES or d_action not in (None, sup.NONE):
+            status = "error"
+        else:
+            status = "warn"
+        mismatch = ""
+        if status != "ok" and self_state in _SELF_REPORT_LOOKS_FINE:
+            mismatch = " [DISAGREEMENT: self-report looks fine, supervisor verdict does not]"
+        out.append(Check(
+            name=f"wrapper_child_health.{name}",
+            status=status,
+            details=(
+                f"supervisor={d_state}/{d_action} ({d_reason}); "
+                f"self-reported health={self_state} (age={self_age_str})"
+                f"{progress_bit}{mismatch}"
+            ),
+            fix=d_reason if status != "ok" else "",
+        ))
     return out
 
 

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1820,17 +1820,19 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
         return []
 
     now_epoch = datetime.now(timezone.utc).timestamp()
-    state_path = store.dir / "supervisor-state.json"
-    state = sup.load_supervisor_state(state_path)
-    snapshot_path = store.dir / "supervisor-snapshot.json"
-    snapshot: list[dict] | None = None
-    if snapshot_path.exists():
-        try:
-            raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
-        except (ValueError, OSError):
-            raw = None
-        snapshot = raw if isinstance(raw, list) else None
     try:
+        # Corrupt/invalid primary+backup state (load_supervisor_state) must
+        # degrade the SAME way a bad observation does — a diagnostic tool
+        # that dies on bad state is worst-useless exactly when state is bad.
+        state = sup.load_supervisor_state(store.dir / "supervisor-state.json")
+        snapshot_path = store.dir / "supervisor-snapshot.json"
+        snapshot: list[dict] | None = None
+        if snapshot_path.exists():
+            try:
+                raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
+            except (ValueError, OSError):
+                raw = None
+            snapshot = raw if isinstance(raw, list) else None
         obs = sup.build_supervisor_observation(
             store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
             snapshot=snapshot, event_limit=0,

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1828,7 +1828,10 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
         # A stale snapshot must not be read as a live liveness fact (see
         # read_supervisor_snapshot_if_fresh's docstring).
         snapshot = sup.read_supervisor_snapshot_if_fresh(
-            store.dir / "supervisor-snapshot.json", now_epoch=now_epoch)
+            store.dir / "supervisor-snapshot.json",
+            now_epoch=now_epoch,
+            stale_after_seconds=sup.resolve_snapshot_stale_after_seconds(sup_cfg),
+        )
         obs = sup.build_supervisor_observation(
             store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
             snapshot=snapshot, event_limit=0,

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from agenttalk import __version__
 from agenttalk import codex_config as cxc
 from agenttalk import install_skills as iskl
+from agenttalk import operator_health
 from agenttalk import signing as _signing
 from agenttalk import supervisor as sup
 from agenttalk import powershell_host as psh
@@ -1784,10 +1785,6 @@ def _check_heartbeats(store: Store) -> list[Check]:
     return out
 
 
-_HEALTHY_DECISION_STATES = sup.HEALTHY_DECISION_STATES | sup.GRACE_DECISION_STATES
-_SELF_REPORT_LOOKS_FINE = frozenset({"idle_waiting", "working_turn"})
-
-
 def _check_wrapper_child_health(store: Store) -> list[Check]:
     """One check per wrapped agent — does the SUPERVISOR's strict verdict agree
     with the wrapper's own self-report, and is progress actually moving?
@@ -1807,6 +1804,7 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
         return []
+    assessment_problem: str | None = None
     try:
         sup_cfg = sup.load_supervisor_config(sup_path)
     except (ValueError, OSError):
@@ -1840,17 +1838,20 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
             a["name"]: a for a in obs.get("agents", []) if isinstance(a, dict)
         }
     except Exception as exc:  # noqa: BLE001 - doctor stays fail-safe
-        return [Check(
-            name="wrapper_child_health",
-            status="warn",
-            details=f"could not compute the supervisor's decision: "
-                    f"{type(exc).__name__}: {exc}",
-        )]
+        # Unavailable evidence composes with EACH wrapped agent's observation.
+        # A global warning would lose a persisted degraded/error report.
+        obs_by_name = {}
+        assessment_problem = (
+            "could not compute the supervisor's decision: "
+            f"{type(exc).__name__}: {exc}"
+        )
 
     out: list[Check] = []
     for name in wrapped_names:
         item = obs_by_name.get(name) or {}
         health = item.get("health") if isinstance(item.get("health"), dict) else {}
+        if not health:
+            health = store.read_health(name, now_epoch=now_epoch)
         self_state = health.get("state", "unknown")
         self_age = health.get("age_seconds")
         self_age_str = f"{self_age:.0f}s" if isinstance(self_age, (int, float)) else "n/a"
@@ -1870,48 +1871,53 @@ def _check_wrapper_child_health(store: Store) -> list[Check]:
             )
 
         decision = item.get("decision") if isinstance(item.get("decision"), dict) else None
+        cfg_agent = sup_agents.get(name) if isinstance(sup_agents.get(name), dict) else {}
+        unavailable_reason: str | None = None
         if decision is None:
-            out.append(Check(
-                name=f"wrapper_child_health.{name}",
-                status="warn",
-                details=(
-                    f"self-reported health={self_state} (age={self_age_str}){progress_bit}; "
-                    "no supervisor decision is available for this agent (it is not "
-                    "configured auto_restart, so the strict CLI-child-bound verdict "
-                    "cannot be computed here — this is the wrapper's own self-report only)"
-                ),
-            ))
-            continue
-
-        d_state = decision.get("state")
-        d_action = decision.get("action")
-        d_reason = decision.get("reason") or ""
-        # `action` is a RECOVERY-INTENT signal, not a severity signal: backoff_wait
-        # (cooldown), suspect_warn (rate-limited, unconfirmed), refuse_protected
-        # (administrative refusal of a manual restart) etc. all pair with states
-        # OUTSIDE the confirmed-dead family and must not be escalated to `error`
-        # just for existing — that made a normal RESTART_COOLDOWN/backoff_wait or
-        # ACTIVE_OR_BUSY/suspect_warn cry wolf. `error` is reserved for the state
-        # itself being in the confirmed unbound/dead family (RELAUNCH/STUCK_RECOVER
-        # already pair with such a state, so this loses no real severity).
-        if d_state in _HEALTHY_DECISION_STATES:
-            status = "ok"
-        elif d_state in sup.UNBOUND_OR_DEAD_DECISION_STATES:
-            status = "error"
+            if assessment_problem is not None:
+                unavailable_reason = "assessment_failed"
+            elif cfg_agent.get("auto_restart") is not True:
+                unavailable_reason = "auto_restart_disabled"
+            else:
+                unavailable_reason = "decision_missing"
+        composition = operator_health.compose_health_evidence(
+            self_state,
+            decision=decision,
+            unavailable_reason=unavailable_reason,
+        )
+        status = operator_health.doctor_status(composition)
+        self_fact = (
+            f"self-reported health={self_state} (age={self_age_str}){progress_bit}"
+        )
+        d_reason = ""
+        if decision is not None:
+            d_state = decision.get("state")
+            d_action = decision.get("action")
+            d_reason = decision.get("reason") or ""
+            supervisor_fact = f"supervisor={d_state}/{d_action} ({d_reason})"
         else:
-            status = "warn"
-        mismatch = ""
-        if status != "ok" and self_state in _SELF_REPORT_LOOKS_FINE:
-            mismatch = " [DISAGREEMENT: self-report looks fine, supervisor verdict does not]"
+            supervisor_fact = f"supervisor=UNAVAILABLE({unavailable_reason})"
+            if assessment_problem is not None:
+                supervisor_fact += f" ({assessment_problem})"
+            else:
+                supervisor_fact += " (no supervisor decision is available for this agent)"
+        facts = (
+            (self_fact, supervisor_fact)
+            if composition["primary_source"] == "observation"
+            else (supervisor_fact, self_fact)
+        )
+        mismatch = (
+            " [DISAGREEMENT: wrapper observation and supervisor evidence have "
+            "different urgency]"
+            if composition["disagreement"]
+            else ""
+        )
         out.append(Check(
             name=f"wrapper_child_health.{name}",
             status=status,
-            details=(
-                f"supervisor={d_state}/{d_action} ({d_reason}); "
-                f"self-reported health={self_state} (age={self_age_str})"
-                f"{progress_bit}{mismatch}"
-            ),
-            fix=d_reason if status != "ok" else "",
+            details=f"{facts[0]}; {facts[1]}{mismatch}",
+            fix=(d_reason if status != "ok" and
+                 composition["primary_source"] == "supervisor" else ""),
         ))
     return out
 

--- a/src/agenttalk/operator_health.py
+++ b/src/agenttalk/operator_health.py
@@ -8,10 +8,15 @@ to choose urgency and primary wording without changing either fact.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 from agenttalk import health as health_model
 from agenttalk import supervisor as supervisor_model
+
+if TYPE_CHECKING:
+    from agenttalk.store import Store
 
 
 URGENCY_FINE = "fine"
@@ -56,6 +61,8 @@ _LIVE_STALLED_DECISION_STATES = frozenset({
 })
 _FAILED_DECISION_STATES = frozenset({
     "TURN_FAILED",
+})
+_READINESS_EXHAUSTED_DECISION_STATES = frozenset({
     "READINESS_GAVE_UP",
 })
 _UNCONFIRMED_DANGER_DECISION_STATES = frozenset({
@@ -77,6 +84,81 @@ def classify_observation_state(state: object) -> str:
     return URGENCY_UNKNOWN
 
 
+@dataclass(frozen=True)
+class HealthTimingPolicy:
+    """Loaded supervisor timing policy, or an explicit unavailable result."""
+
+    config: dict[str, Any]
+    unavailable_reason: str | None = None
+    problem: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizedHealth:
+    """One configured wrapper-health read and its heartbeat input."""
+
+    health: dict[str, Any]
+    heartbeat: datetime | None
+
+
+def load_health_timing_policy(store: Store) -> HealthTimingPolicy:
+    """Load health timing without substituting defaults for invalid config.
+
+    A missing supervisor file legitimately selects documented defaults.  An
+    existing but unreadable file is different: its configured policy is
+    unknowable, so every operator surface must report that fact instead of
+    guessing with defaults.
+    """
+    path = store.dir / "supervisor.json"
+    if not path.exists():
+        return HealthTimingPolicy(config={})
+    try:
+        config = supervisor_model.load_supervisor_config(path)
+    except (OSError, ValueError) as exc:
+        return HealthTimingPolicy(
+            config={},
+            unavailable_reason="health_timing_policy_unavailable",
+            problem=f"{type(exc).__name__}: {exc}",
+        )
+    return HealthTimingPolicy(config=config)
+
+
+def read_health_observation(
+    store: Store,
+    agent: str,
+    *,
+    now_epoch: float,
+    health_policy: HealthTimingPolicy,
+) -> NormalizedHealth:
+    """Read one wrapper observation under the supervisor's timing policy.
+
+    Operator surfaces must not independently choose TTL, heartbeat skew, or
+    whether to compare the heartbeat.  Resolve those inputs here once and
+    return the heartbeat used so callers cannot accidentally reread a
+    different value for display.
+    """
+    heartbeat = store.read_heartbeat(agent)
+    if health_policy.unavailable_reason is not None:
+        return NormalizedHealth(
+            health=health_model.unknown(agent, health_policy.unavailable_reason),
+            heartbeat=heartbeat,
+        )
+    config = health_policy.config
+    agents = config.get("agents")
+    agents = agents if isinstance(agents, dict) else {}
+    candidate = agents.get(agent)
+    agent_config = candidate if isinstance(candidate, dict) else {}
+    timing = supervisor_model.resolve_health_timing(config, agent_config)
+    health = store.read_health(
+        agent,
+        now_epoch=now_epoch,
+        heartbeat=heartbeat,
+        ttl_seconds=timing["ttl_seconds"],
+        heartbeat_skew_seconds=timing["heartbeat_skew_seconds"],
+    )
+    return NormalizedHealth(health=health, heartbeat=heartbeat)
+
+
 def _supervisor_kind_and_urgency(state: object) -> tuple[str, str]:
     if not isinstance(state, str):
         return "advisory", URGENCY_ATTENTION
@@ -90,6 +172,8 @@ def _supervisor_kind_and_urgency(state: object) -> tuple[str, str]:
         return "live_stalled", URGENCY_DANGER
     if state in _FAILED_DECISION_STATES:
         return "failed", URGENCY_DANGER
+    if state in _READINESS_EXHAUSTED_DECISION_STATES:
+        return "readiness_exhausted", URGENCY_DANGER
     if state in _UNCONFIRMED_DANGER_DECISION_STATES:
         return "unconfirmed", URGENCY_DANGER
     return "advisory", URGENCY_ATTENTION

--- a/src/agenttalk/operator_health.py
+++ b/src/agenttalk/operator_health.py
@@ -1,0 +1,163 @@
+"""Monotone composition of wrapper observations and supervisor decisions.
+
+This module governs presentation only.  The two evidence producers remain the
+authorities for their own facts; operator surfaces use the derived fields here
+to choose urgency and primary wording without changing either fact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from agenttalk import health as health_model
+from agenttalk import supervisor as supervisor_model
+
+
+URGENCY_FINE = "fine"
+URGENCY_UNKNOWN = "unknown"
+URGENCY_ATTENTION = "attention"
+URGENCY_DANGER = "danger"
+
+_URGENCY_RANK = {
+    URGENCY_FINE: 0,
+    URGENCY_UNKNOWN: 1,
+    URGENCY_ATTENTION: 2,
+    URGENCY_DANGER: 3,
+}
+
+_FINE_OBSERVATION_STATES = frozenset({
+    health_model.STATE_IDLE_WAITING,
+    health_model.STATE_WORKING_TURN,
+    health_model.STATE_WORKING_SILENT,
+})
+_DANGER_OBSERVATION_STATES = frozenset({
+    health_model.STATE_RATE_LIMITED_OR_OUTAGE,
+    health_model.STATE_DEGRADED_OUTPUT,
+    health_model.STATE_ERRORED_AMBIGUOUS,
+    # Older snapshots and the console vocabulary still carry this state.
+    "errored_fatal",
+})
+_ATTENTION_OBSERVATION_STATES = frozenset({
+    health_model.STATE_STUCK_SUSPECTED,
+    health_model.STATE_ERRORED_POISON,
+    health_model.STATE_CRASHED_OR_EXITED,
+    # Older snapshots and the console vocabulary still carry this state.
+    "errored_recoverable",
+})
+
+_LOST_BINDING_DECISION_STATES = frozenset({
+    "CLI_CHILD_DEAD",
+    "WRAPPER_MISSING",
+})
+_LIVE_STALLED_DECISION_STATES = frozenset({
+    "CLI_CHILD_STALLED",
+    "CLI_CHILD_NO_PROGRESS",
+})
+_FAILED_DECISION_STATES = frozenset({
+    "TURN_FAILED",
+    "READINESS_GAVE_UP",
+})
+_UNCONFIRMED_DANGER_DECISION_STATES = frozenset({
+    "CLI_CHILD_UNKNOWN",
+    "STUCK_OR_DEAD",
+})
+
+
+def classify_observation_state(state: object) -> str:
+    """Return the operator urgency of one wrapper-health observation."""
+    if not isinstance(state, str):
+        return URGENCY_UNKNOWN
+    if state in _FINE_OBSERVATION_STATES:
+        return URGENCY_FINE
+    if state in _DANGER_OBSERVATION_STATES:
+        return URGENCY_DANGER
+    if state in _ATTENTION_OBSERVATION_STATES:
+        return URGENCY_ATTENTION
+    return URGENCY_UNKNOWN
+
+
+def _supervisor_kind_and_urgency(state: object) -> tuple[str, str]:
+    if not isinstance(state, str):
+        return "advisory", URGENCY_ATTENTION
+    if state in supervisor_model.HEALTHY_DECISION_STATES:
+        return "healthy", URGENCY_FINE
+    if state in supervisor_model.GRACE_DECISION_STATES:
+        return "grace", URGENCY_FINE
+    if state in _LOST_BINDING_DECISION_STATES:
+        return "lost_binding", URGENCY_DANGER
+    if state in _LIVE_STALLED_DECISION_STATES:
+        return "live_stalled", URGENCY_DANGER
+    if state in _FAILED_DECISION_STATES:
+        return "failed", URGENCY_DANGER
+    if state in _UNCONFIRMED_DANGER_DECISION_STATES:
+        return "unconfirmed", URGENCY_DANGER
+    return "advisory", URGENCY_ATTENTION
+
+
+def compose_health_evidence(
+    observation_state: object,
+    *,
+    decision: Mapping[str, Any] | None = None,
+    unavailable_reason: str | None = None,
+) -> dict[str, Any]:
+    """Compose source-labelled facts using their maximum operator urgency.
+
+    Equal-urgency ties deliberately keep the observation primary.  A decision
+    and an unavailable reason are mutually exclusive producer outcomes.
+    """
+    if decision is not None and unavailable_reason is not None:
+        raise ValueError("decision and unavailable_reason are mutually exclusive")
+
+    state = observation_state if isinstance(observation_state, str) else "unknown"
+    observation = {
+        "source": "wrapper_health",
+        "state": state,
+        "urgency": classify_observation_state(state),
+    }
+    result: dict[str, Any] = {
+        "observation": observation,
+        "urgency": observation["urgency"],
+        "primary_source": "observation",
+        "disagreement": False,
+    }
+
+    supervisor: dict[str, Any] | None = None
+    if decision is not None:
+        decision_state = decision.get("state")
+        kind, urgency = _supervisor_kind_and_urgency(decision_state)
+        supervisor = {
+            "source": "supervisor_decision",
+            "kind": kind,
+            "state": decision_state,
+            "action": decision.get("action"),
+            "reason": decision.get("reason"),
+            "urgency": urgency,
+        }
+    elif unavailable_reason is not None:
+        supervisor = {
+            "source": "supervisor_decision",
+            "kind": "unavailable",
+            "reason": unavailable_reason,
+            "urgency": URGENCY_ATTENTION,
+        }
+
+    if supervisor is None:
+        return result
+
+    result["supervisor"] = supervisor
+    result["disagreement"] = supervisor["urgency"] != observation["urgency"]
+    if _URGENCY_RANK[supervisor["urgency"]] > _URGENCY_RANK[observation["urgency"]]:
+        result["urgency"] = supervisor["urgency"]
+        result["primary_source"] = "supervisor"
+    return result
+
+
+def doctor_status(composition: Mapping[str, Any]) -> str:
+    """Project composed urgency onto doctor's ok/warn/error vocabulary."""
+    urgency = composition.get("urgency")
+    if urgency == URGENCY_FINE:
+        return "ok"
+    if urgency == URGENCY_DANGER:
+        return "error"
+    return "warn"

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -1839,10 +1839,34 @@ def _redacted_observation_plan(plan: dict) -> dict:
 # stopped polling, or one running with actions disabled after an enabled run,
 # leaves a stale file on disk indefinitely. Reading it unconditionally would
 # let a caller present old process facts as a FRESH strict verdict - lying
-# with MORE authority than the raw self-report did. 300s generously covers
-# any normal poll cadence (default 15s) while still catching a truly-stopped
-# daemon quickly.
+# with MORE authority than the raw self-report did. The 300s floor generously
+# covers the default 15s cadence; slower configured cadences need an allowance
+# derived from that cadence or a healthy snapshot becomes stale between polls.
 SNAPSHOT_STALE_AFTER_SECONDS = 300.0
+
+
+def resolve_snapshot_stale_after_seconds(supervisor_config: dict | None) -> float:
+    """Return a freshness window compatible with the configured poll cadence.
+
+    Two complete intervals cover one scheduled sleep plus the following
+    observation/action cycle. The 300s floor preserves the existing default
+    behavior and still rejects snapshots left behind by a stopped supervisor.
+    Malformed cadence values never expand the trust window.
+    """
+    config = supervisor_config if isinstance(supervisor_config, dict) else {}
+    poll = config.get("poll_seconds", _DEFAULTS["poll_seconds"])
+    if not isinstance(poll, (int, float)) or isinstance(poll, bool):
+        return SNAPSHOT_STALE_AFTER_SECONDS
+    try:
+        poll_seconds = float(poll)
+    except (OverflowError, ValueError):
+        return SNAPSHOT_STALE_AFTER_SECONDS
+    if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+        return SNAPSHOT_STALE_AFTER_SECONDS
+    allowance = poll_seconds * 2.0
+    if not math.isfinite(allowance):
+        return SNAPSHOT_STALE_AFTER_SECONDS
+    return max(SNAPSHOT_STALE_AFTER_SECONDS, allowance)
 
 
 def read_supervisor_snapshot_if_fresh(
@@ -1851,16 +1875,22 @@ def read_supervisor_snapshot_if_fresh(
 ) -> list[dict] | None:
     """Read ``supervisor-snapshot.json``, but only if its FILE mtime is fresh.
 
-    A stale, absent, or malformed file returns ``None`` — the SAME "capture
-    failed" signal a genuinely missing snapshot already produces, so a
-    downstream wrapped-agent classification fails closed (CLI_CHILD_UNKNOWN)
-    rather than silently trusting old process facts.
+    A stale, implausibly future-dated, absent, or malformed file returns
+    ``None`` — the SAME "capture failed" signal a genuinely missing snapshot
+    already produces, so a downstream wrapped-agent classification fails
+    closed (CLI_CHILD_UNKNOWN) rather than silently trusting old process
+    facts. The shared heartbeat skew allowance covers the small race where
+    callers capture ``now_epoch`` immediately before a concurrent refresh.
     """
     try:
         mtime = path.stat().st_mtime
     except OSError:
         return None
-    if now_epoch - mtime > stale_after_seconds:
+    age = now_epoch - mtime
+    if (
+        age < -health_model.DEFAULT_HEARTBEAT_SKEW_SECONDS
+        or age > stale_after_seconds
+    ):
         return None
     try:
         raw = json.loads(path.read_text(encoding="utf-8-sig"))

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -80,9 +80,15 @@ GRACE_DECISION_STATES = frozenset({"CLI_CHILD_STARTING", "LAUNCHING"})
 # verdict this exists to surface. Everything else non-green (cooldowns,
 # refusals, rate-limited suspect warnings) is a real but lower-urgency
 # observation, not silence.
+# NOTE: CLI_CHILD_MISSING is deliberately EXCLUDED — it is the provisional
+# first-poll state of the two-poll anti-false-positive confirmation policy
+# (see `_CLI_CHILD_CONFIRM_POLLS`): the child is absent on this poll, but the
+# planner withholds any recovery action and waits for a second same-turn poll
+# before declaring CLI_CHILD_DEAD. Treating the provisional poll as already
+# confirmed-dead would bypass that policy from the operator-surface side.
 UNBOUND_OR_DEAD_DECISION_STATES = frozenset({
     "CLI_CHILD_UNKNOWN", "CLI_CHILD_DEAD", "CLI_CHILD_STALLED",
-    "CLI_CHILD_NO_PROGRESS", "CLI_CHILD_MISSING", "STUCK_OR_DEAD",
+    "CLI_CHILD_NO_PROGRESS", "STUCK_OR_DEAD",
     "WRAPPER_MISSING", "TURN_FAILED", "READINESS_GAVE_UP",
 })
 
@@ -1825,6 +1831,42 @@ def _redacted_observation_plan(plan: dict) -> dict:
             if isinstance(agent_plan, dict)
         }
     }
+
+
+# Positive process binding requires a CURRENT snapshot. The generated PS
+# supervisor only refreshes supervisor-snapshot.json while actions are
+# enabled (`if (Actions-Enabled) { Get-ProcSnapshot ... }`), so a daemon that
+# stopped polling, or one running with actions disabled after an enabled run,
+# leaves a stale file on disk indefinitely. Reading it unconditionally would
+# let a caller present old process facts as a FRESH strict verdict - lying
+# with MORE authority than the raw self-report did. 300s generously covers
+# any normal poll cadence (default 15s) while still catching a truly-stopped
+# daemon quickly.
+SNAPSHOT_STALE_AFTER_SECONDS = 300.0
+
+
+def read_supervisor_snapshot_if_fresh(
+    path: Path, *, now_epoch: float,
+    stale_after_seconds: float = SNAPSHOT_STALE_AFTER_SECONDS,
+) -> list[dict] | None:
+    """Read ``supervisor-snapshot.json``, but only if its FILE mtime is fresh.
+
+    A stale, absent, or malformed file returns ``None`` — the SAME "capture
+    failed" signal a genuinely missing snapshot already produces, so a
+    downstream wrapped-agent classification fails closed (CLI_CHILD_UNKNOWN)
+    rather than silently trusting old process facts.
+    """
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    if now_epoch - mtime > stale_after_seconds:
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (ValueError, OSError):
+        return None
+    return raw if isinstance(raw, list) else None
 
 
 def build_supervisor_observation(store: Store, *, now_epoch: float,

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -72,7 +72,10 @@ HEALTHY_DECISION_STATES = frozenset({"HEALTHY_IDLE", "HEALTHY_WORKING"})
 # A fresh CLI spawn inside its bounded handoff grace renders healthy too -
 # it is expected, not a fault - but kept separate so a caller that only wants
 # the two POSITIVELY CONFIRMED states can use HEALTHY_DECISION_STATES alone.
-GRACE_DECISION_STATES = frozenset({"CLI_CHILD_STARTING"})
+# LAUNCHING is the broader "still in grace, readiness unresolved" state (see
+# the "1) LAUNCHING" branch below); CLI_CHILD_STARTING is its narrower wrapped-
+# CLI-spawn sibling. Both are expected, bounded, and not a fault.
+GRACE_DECISION_STATES = frozenset({"CLI_CHILD_STARTING", "LAUNCHING"})
 # The child-cannot-be-positively-bound / confirmed-dead family: the strict
 # verdict this exists to surface. Everything else non-green (cooldowns,
 # refusals, rate-limited suspect warnings) is a real but lower-urgency

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -63,6 +63,26 @@ SNAPSHOT_UNAVAILABLE = "snapshot_unavailable"  # legacy token; no longer emitted
 READINESS_FAILED = "readiness_failed"  # legacy token; folded into stale heartbeat recovery
 READINESS_GAVE_UP = "readiness_gave_up"  # never-ready past the retry cap - STOP relaunching, await operator
 NONE = "none"                    # healthy, nothing to do
+
+# ---- decision.state operator-surface classification ------------------------
+# `status`/`doctor`/the web console all need the same answer to "is this
+# decision.state safely green?" - a single source of truth so the three
+# surfaces can never silently drift apart on what counts as healthy.
+HEALTHY_DECISION_STATES = frozenset({"HEALTHY_IDLE", "HEALTHY_WORKING"})
+# A fresh CLI spawn inside its bounded handoff grace renders healthy too -
+# it is expected, not a fault - but kept separate so a caller that only wants
+# the two POSITIVELY CONFIRMED states can use HEALTHY_DECISION_STATES alone.
+GRACE_DECISION_STATES = frozenset({"CLI_CHILD_STARTING"})
+# The child-cannot-be-positively-bound / confirmed-dead family: the strict
+# verdict this exists to surface. Everything else non-green (cooldowns,
+# refusals, rate-limited suspect warnings) is a real but lower-urgency
+# observation, not silence.
+UNBOUND_OR_DEAD_DECISION_STATES = frozenset({
+    "CLI_CHILD_UNKNOWN", "CLI_CHILD_DEAD", "CLI_CHILD_STALLED",
+    "CLI_CHILD_NO_PROGRESS", "CLI_CHILD_MISSING", "STUCK_OR_DEAD",
+    "WRAPPER_MISSING", "TURN_FAILED", "READINESS_GAVE_UP",
+})
+
 EPHEMERAL_LAUNCH = eph.ACTION_LAUNCH
 EPHEMERAL_DENY = eph.ACTION_DENY
 EPHEMERAL_COMPLETE = eph.ACTION_COMPLETE

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -9940,27 +9940,29 @@ function Invoke-StateFileSwapWithRetry([string]$tmp, [string]$path) {
     }
   }
 }
-function Write-StateFileAtomic([string]$path, $state) {
-  if (-not (Test-StateObject $state)) { throw "supervisor state must be a JSON object" }
-  $json = $state | ConvertTo-Json -Depth 8
-  $utf8 = New-Object System.Text.UTF8Encoding($false)
-  $bytes = $utf8.GetBytes($json)
+function Write-FileAtomic([string]$path, [byte[]]$bytes) {
   $tmpName = ".at-{0}-{1}.tmp" -f $PID, ([Guid]::NewGuid().ToString('N'))
   $tmp = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($path), $tmpName)
-  $stream = [System.IO.FileStream]::new(
-    $tmp, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write,
-    [System.IO.FileShare]::None)
   try {
-    $stream.Write($bytes, 0, $bytes.Length)
-    $stream.Flush($true)
-  } finally {
-    $stream.Dispose()
-  }
-  try {
+    $stream = [System.IO.FileStream]::new(
+      $tmp, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write,
+      [System.IO.FileShare]::None)
+    try {
+      $stream.Write($bytes, 0, $bytes.Length)
+      $stream.Flush($true)
+    } finally {
+      $stream.Dispose()
+    }
     Invoke-StateFileSwapWithRetry $tmp $path
   } finally {
     if (Test-Path -LiteralPath $tmp) { Remove-Item -LiteralPath $tmp -Force }
   }
+}
+function Write-StateFileAtomic([string]$path, $state) {
+  if (-not (Test-StateObject $state)) { throw "supervisor state must be a JSON object" }
+  $json = $state | ConvertTo-Json -Depth 8
+  $utf8 = New-Object System.Text.UTF8Encoding($false)
+  Write-FileAtomic $path ($utf8.GetBytes($json))
 }
 function Set-AgentState($state, $name, $value) {
   $state.agents | Add-Member -NotePropertyName $name -NotePropertyValue $value -Force
@@ -10175,11 +10177,14 @@ function Get-ProcSnapshot($path) {
     # emits a UTF-8 BOM under Windows PowerShell 5.1, which every JSON write in
     # this template must avoid so a strict Python reader never chokes.
     $u8 = New-Object System.Text.UTF8Encoding($false)
-    if ($arr.Count -eq 0) { [System.IO.File]::WriteAllText($path, '[]', $u8) }
-    else { [System.IO.File]::WriteAllText($path, (ConvertTo-Json -InputObject $arr -Depth 4), $u8) }
+    $json = if ($arr.Count -eq 0) { '[]' }
+            else { ConvertTo-Json -InputObject $arr -Depth 4 }
+    Write-FileAtomic $path ($u8.GetBytes([string]$json))
     return $true
   } catch {
-    [System.IO.File]::WriteAllText($path, (@{ unavailable = $true } | ConvertTo-Json), (New-Object System.Text.UTF8Encoding($false)))
+    $u8 = New-Object System.Text.UTF8Encoding($false)
+    $json = @{ unavailable = $true } | ConvertTo-Json
+    Write-FileAtomic $path ($u8.GetBytes([string]$json))
     return $false
   }
 }

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -122,7 +122,9 @@ from agenttalk import knowledge as _knowledge
 from agenttalk import lesson_context as _lesson_context
 from agenttalk import onboarding as _onboarding
 from agenttalk import signing as _signing
+from agenttalk import supervisor as _supervisor
 from agenttalk import threads as th
+from agenttalk import wrapper_runtime as _wrapper_runtime
 from agenttalk.store import COMPOSING_INTENT_STALE_SECONDS, Message, Store
 from agenttalk.threads import Thread, derive_threads
 
@@ -1440,6 +1442,42 @@ class HealthTimelineRing:
             return []
 
 
+def _supervisor_decisions(store: Store, *, now_epoch: float) -> dict[str, dict]:
+    """The live supervisor decision per wrapped agent (best-effort, read-only).
+
+    This is the STRICT verdict (e.g. ``CLI_CHILD_UNKNOWN``) — distinct from the
+    wrapper's own self-reported ``health`` (idle_waiting/working_turn/...),
+    which can keep reporting "fine" after the CLI child has died. Computed
+    fresh from the same on-disk supervisor.json/state/snapshot cli.py reads for
+    `agenttalk status`; empty (never raises) when no supervisor is configured
+    or the read fails, so a root with no supervisor stays unaffected."""
+    sup_path = store.dir / "supervisor.json"
+    if not sup_path.exists():
+        return {}
+    try:
+        sup_cfg = _supervisor.load_supervisor_config(sup_path)
+        state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
+        snapshot_path = store.dir / "supervisor-snapshot.json"
+        snapshot: list[dict] | None = None
+        if snapshot_path.exists():
+            raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
+            snapshot = raw if isinstance(raw, list) else None
+        obs = _supervisor.build_supervisor_observation(
+            store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
+            snapshot=snapshot, event_limit=0,
+        )
+    except Exception:  # noqa: BLE001 — advisory arm; never fail the root
+        return {}
+    out: dict[str, dict] = {}
+    for item in obs.get("agents") or []:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            continue
+        decision = item.get("decision")
+        if isinstance(decision, dict):
+            out[item["name"]] = decision
+    return out
+
+
 def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                    liaison: str | None, *,
                    threads_rows: list[dict] | None = None,
@@ -1447,7 +1485,8 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                    avatar_prefs: dict[str, str] | None = None,
                    history: "HealthTimelineRing | None" = None,
                    root_label: str | None = None,
-                   managed_loop: set[str] | None = None) -> list[dict]:
+                   managed_loop: set[str] | None = None,
+                   supervisor_decisions: dict[str, dict] | None = None) -> list[dict]:
     """Per-agent presence rows (data-model §3). Absent-not-null keys.
 
     0.58.0 additive fields (all OMITTED when not determinable): ``cli``,
@@ -1460,6 +1499,16 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     An agent in this set is wrapped/restartable even when its health mode is
     unknown (stale/missing snapshot) — that is exactly when the restart signal
     matters most, so health mode must not be the sole arm.
+
+    ``supervisor_decisions``: the live per-agent supervisor verdict
+    (name -> decision), computed ONCE per root by the caller via
+    :func:`_supervisor_decisions`. Surfaced as ``supervisor_decision``
+    (additive, absent when no decision is computable for that agent) —
+    deliberately alongside ``health``, never folded into it, so a wrapper
+    whose self-report still says "working" while its verdict says
+    ``CLI_CHILD_UNKNOWN`` shows BOTH facts rather than one adjective.
+    ``wrapper_child`` (additive) carries the raw wrapper-runtime phase and
+    ``last_progress_at`` age directly, independent of any verdict.
     """
     roles = cfg.get("roles", {}) or {}
     groups = cfg.get("groups", {}) or {}
@@ -1467,6 +1516,7 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     owned_domains = owned_domains or {}
     avatar_prefs = avatar_prefs or {}
     managed_loop = managed_loop or set()
+    supervisor_decisions = supervisor_decisions or {}
     now = datetime.now(timezone.utc)
     now_epoch = now.timestamp()
     # 0.19.0 (FR-001): per-agent message counts from the SAME validated `msgs`
@@ -1546,6 +1596,35 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
             e["wrapped"] = wrapped
             # restartable mirrors wrapped for v1 (only wrapped agents restart).
             e["restartable"] = wrapped
+        # supervisor_decision: the STRICT, positively-bound verdict (e.g.
+        # CLI_CHILD_UNKNOWN), shown ALONGSIDE `health` (the wrapper's own
+        # self-report) — never merged into it, so the two can visibly disagree.
+        decision = supervisor_decisions.get(a)
+        if decision is not None:
+            e["supervisor_decision"] = {
+                "state": decision.get("state"),
+                "action": decision.get("action"),
+                "reason": decision.get("reason"),
+            }
+        # wrapper_child: the raw wrapper-runtime observation (phase +
+        # last_progress_at age) — the cheapest "is the counter frozen" signal,
+        # independent of any verdict. Absent when no runtime record exists.
+        rt_obs = _wrapper_runtime.read_runtime(store.state_dir, a, now_epoch=now_epoch)
+        if rt_obs.get("status") == _wrapper_runtime.STATUS_VALID:
+            record = rt_obs.get("record") or {}
+            progress_age = rt_obs.get("progress_age_seconds")
+            updated_age = rt_obs.get("updated_age_seconds")
+            e["wrapper_child"] = {
+                "phase": record.get("phase"),
+                "progress_age_seconds": (
+                    round(progress_age, 3)
+                    if isinstance(progress_age, (int, float)) else None
+                ),
+                "updated_age_seconds": (
+                    round(updated_age, 3)
+                    if isinstance(updated_age, (int, float)) else None
+                ),
+            }
         owned = owned_domains.get(a)
         if owned:
             e["owned_domains"] = owned
@@ -1628,6 +1707,7 @@ def _root_state(desc: RootDescriptor,
                     managed_loop.add(a)
         except Exception:  # noqa: BLE001 — advisory arm; never fail the root
             managed_loop = set()
+        supervisor_decisions = _supervisor_decisions(store, now_epoch=time.time())
         out: dict[str, Any] = {
             "label": label,
             "path": path,
@@ -1659,7 +1739,7 @@ def _root_state(desc: RootDescriptor,
             store, cfg, msgs, liaison,
             threads_rows=threads_rows, owned_domains=owned_domains,
             avatar_prefs=avatar_prefs, history=history, root_label=label,
-            managed_loop=managed_loop)
+            managed_loop=managed_loop, supervisor_decisions=supervisor_decisions)
         out["retired"] = store.retired_agents()
         out["threads"] = threads_rows
         out["broadcasts"] = broadcasts

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -1455,23 +1455,19 @@ def _supervisor_decisions(store: Store, *,
 
     Returns ``(decisions, decision_unavailable)`` — the second set is every
     agent configured ``wrapped: true`` for which no decision could be computed
-    (e.g. it is not ``auto_restart``), so the caller can surface that fact
-    explicitly rather than silently falling back to the self-report."""
+    (e.g. it is not ``auto_restart``, OR the observation itself failed), so
+    the caller can surface that fact explicitly rather than silently falling
+    back to the self-report. "Cannot verify" must never render as "verified
+    good": a state/snapshot/observation failure below still returns every
+    wrapped name in the unavailable set — it does NOT go silent — while a
+    failure to even load supervisor.json (so the wrapped set itself is
+    unknowable) returns both empty, matching doctor's own config-load
+    fallback."""
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
         return {}, set()
     try:
         sup_cfg = _supervisor.load_supervisor_config(sup_path)
-        state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
-        snapshot_path = store.dir / "supervisor-snapshot.json"
-        snapshot: list[dict] | None = None
-        if snapshot_path.exists():
-            raw = json.loads(snapshot_path.read_text(encoding="utf-8-sig"))
-            snapshot = raw if isinstance(raw, list) else None
-        obs = _supervisor.build_supervisor_observation(
-            store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
-            snapshot=snapshot, event_limit=0,
-        )
     except Exception:  # noqa: BLE001 — advisory arm; never fail the root
         return {}, set()
     sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
@@ -1479,6 +1475,22 @@ def _supervisor_decisions(store: Store, *,
         name for name, cfg_agent in sup_agents.items()
         if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
     }
+    if not wrapped_names:
+        return {}, set()
+    try:
+        state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
+        # A stale snapshot must not be read as a live liveness fact (see
+        # read_supervisor_snapshot_if_fresh's docstring).
+        snapshot = _supervisor.read_supervisor_snapshot_if_fresh(
+            store.dir / "supervisor-snapshot.json", now_epoch=now_epoch)
+        obs = _supervisor.build_supervisor_observation(
+            store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
+            snapshot=snapshot, event_limit=0,
+        )
+    except Exception:  # noqa: BLE001 — advisory arm; never fail the root, but
+        # every wrapped agent becomes explicitly unavailable rather than
+        # vanishing (the #105 defect reintroduced through this error path).
+        return {}, wrapped_names
     decisions: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -845,12 +845,17 @@ def status_payload(store: Store) -> dict:
     health = _signing.inspect_key(store.project_id(), store.root)
     now = datetime.now(timezone.utc).timestamp()
     agents = cfg.get("agents", []) or []
+    health_policy = _operator_health.load_health_timing_policy(store)
     agent_health = {}
     for a in agents:
         if not isinstance(a, str):
             continue
-        hb = store.read_heartbeat(a)
-        agent_health[a] = store.read_health(a, now_epoch=now, heartbeat=hb)
+        agent_health[a] = _operator_health.read_health_observation(
+            store,
+            a,
+            now_epoch=now,
+            health_policy=health_policy,
+        ).health
     return {
         "agenttalk_version": __version__,
         "project_root": str(store.root),
@@ -1443,8 +1448,15 @@ class HealthTimelineRing:
             return []
 
 
-def _supervisor_decisions(store: Store, *,
-                          now_epoch: float) -> tuple[dict[str, dict], dict[str, str]]:
+def _supervisor_decisions(
+    store: Store,
+    *,
+    now_epoch: float,
+) -> tuple[
+    dict[str, dict],
+    dict[str, str],
+    _operator_health.HealthTimingPolicy,
+]:
     """The live supervisor decision per wrapped agent (best-effort, read-only).
 
     This is the STRICT verdict (e.g. ``CLI_CHILD_UNKNOWN``) — distinct from the
@@ -1454,7 +1466,8 @@ def _supervisor_decisions(store: Store, *,
     `agenttalk status`; empty (never raises) when no supervisor is configured
     or the read fails, so a root with no supervisor stays unaffected.
 
-    Returns ``(decisions, decision_unavailable)`` — the second mapping gives
+    Returns ``(decisions, decision_unavailable, health_timing_policy)`` — the
+    second mapping gives
     every agent configured ``wrapped: true`` for which no decision could be
     computed a stable reason code (disabled auto-restart, missing decision, or
     failed assessment), so the caller can surface the actual cause rather than
@@ -1463,22 +1476,22 @@ def _supervisor_decisions(store: Store, *,
     returns every wrapped name in the unavailable mapping — it does NOT go
     silent — while a
     failure to even load supervisor.json (so the wrapped set itself is
-    unknowable) returns both empty, matching doctor's own config-load
-    fallback."""
+    unknowable) returns empty decision maps plus an explicitly unavailable
+    health-timing policy; doctor reports the same policy failure as a warning."""
+    health_policy = _operator_health.load_health_timing_policy(store)
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
-        return {}, {}
-    try:
-        sup_cfg = _supervisor.load_supervisor_config(sup_path)
-    except Exception:  # noqa: BLE001 — advisory arm; never fail the root
-        return {}, {}
+        return {}, {}, health_policy
+    if health_policy.unavailable_reason is not None:
+        return {}, {}, health_policy
+    sup_cfg = health_policy.config
     sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
     wrapped_names = {
         name for name, cfg_agent in sup_agents.items()
         if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
     }
     if not wrapped_names:
-        return {}, {}
+        return {}, {}, health_policy
     try:
         state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
         # A stale snapshot must not be read as a live liveness fact (see
@@ -1495,7 +1508,7 @@ def _supervisor_decisions(store: Store, *,
     except Exception:  # noqa: BLE001 — advisory arm; never fail the root, but
         # every wrapped agent becomes explicitly unavailable rather than
         # vanishing (the #105 defect reintroduced through this error path).
-        return {}, dict.fromkeys(wrapped_names, "assessment_failed")
+        return {}, dict.fromkeys(wrapped_names, "assessment_failed"), health_policy
     decisions: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
@@ -1513,7 +1526,7 @@ def _supervisor_decisions(store: Store, *,
         )
         for name in wrapped_names - set(decisions)
     }
-    return decisions, unavailable
+    return decisions, unavailable, health_policy
 
 
 def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
@@ -1525,7 +1538,9 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                    root_label: str | None = None,
                    managed_loop: set[str] | None = None,
                    supervisor_decisions: dict[str, dict] | None = None,
-                   decision_unavailable: dict[str, str] | None = None) -> list[dict]:
+                   decision_unavailable: dict[str, str] | None = None,
+                   health_policy: _operator_health.HealthTimingPolicy | None = None,
+                   now_epoch: float | None = None) -> list[dict]:
     """Per-agent presence rows (data-model §3). Absent-not-null keys.
 
     0.58.0 additive fields (all OMITTED when not determinable): ``cli``,
@@ -1566,7 +1581,12 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     managed_loop = managed_loop or set()
     supervisor_decisions = supervisor_decisions or {}
     decision_unavailable = decision_unavailable or {}
-    now = datetime.now(timezone.utc)
+    health_policy = health_policy or _operator_health.load_health_timing_policy(store)
+    now = (
+        datetime.now(timezone.utc)
+        if now_epoch is None
+        else datetime.fromtimestamp(float(now_epoch), timezone.utc)
+    )
     now_epoch = now.timestamp()
     # 0.19.0 (FR-001): per-agent message counts from the SAME validated `msgs`
     # already passed in — no extra scan. Always-present integers (0 is data).
@@ -1585,13 +1605,19 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
             e["groups"] = in_groups
         if a == liaison:
             e["operator_facing"] = True
-        hb = store.read_heartbeat(a)
+        normalized_health = _operator_health.read_health_observation(
+            store,
+            a,
+            now_epoch=now_epoch,
+            health_policy=health_policy,
+        )
+        hb = normalized_health.heartbeat
         if hb is not None:
             e["last_seen"] = hb.isoformat()
             heartbeat_age = _heartbeat_age_seconds(hb, now_epoch=now_epoch)
             if heartbeat_age is not None:
                 e["last_seen_age_seconds"] = round(heartbeat_age, 3)
-        health = store.read_health(a, now_epoch=now_epoch, heartbeat=hb)
+        health = normalized_health.health
         e["health"] = health
         e["unread"] = _unread_count(msgs, a, store.cursor(a))
         e["sent"] = sent_counts.get(a, 0)
@@ -1633,13 +1659,15 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
         cap = _capacity_entry(snap, now=now)
         if cap is not None:
             e["capacity"] = cap
+        decision = supervisor_decisions.get(a)
+        known_wrapped = decision is not None or a in decision_unavailable
         # wrapped/restartable arm on EITHER the health mode OR the managed
-        # lead-loop set (review P2-1): health mode alone omits the field exactly
-        # when a wrapped agent's health goes stale/missing (mode unknown),
-        # losing the restart signal when the agent is down. Keep absent-not-null
-        # only when NEITHER signal is determinable.
+        # lead-loop set OR strict-supervisor evidence (review P2-1): health mode
+        # alone omits the field exactly when a wrapped agent's health normalizes
+        # to unknown, losing the restart signal when the agent is down. Keep
+        # absent-not-null only when no source determines the answer.
         wrapped = _is_wrapped(health)
-        if a in managed_loop:
+        if a in managed_loop or known_wrapped:
             wrapped = True
         if wrapped is not None:
             e["wrapped"] = wrapped
@@ -1648,7 +1676,6 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
         # supervisor_decision: the STRICT, positively-bound verdict (e.g.
         # CLI_CHILD_UNKNOWN), shown ALONGSIDE `health` (the wrapper's own
         # self-report) — never merged into it, so the two can visibly disagree.
-        decision = supervisor_decisions.get(a)
         if decision is not None:
             e["supervisor_decision"] = {
                 "state": decision.get("state"),
@@ -1767,8 +1794,9 @@ def _root_state(desc: RootDescriptor,
                     managed_loop.add(a)
         except Exception:  # noqa: BLE001 — advisory arm; never fail the root
             managed_loop = set()
-        supervisor_decisions, decision_unavailable = _supervisor_decisions(
-            store, now_epoch=time.time())
+        now_epoch = time.time()
+        (supervisor_decisions, decision_unavailable,
+         health_policy) = _supervisor_decisions(store, now_epoch=now_epoch)
         out: dict[str, Any] = {
             "label": label,
             "path": path,
@@ -1801,7 +1829,8 @@ def _root_state(desc: RootDescriptor,
             threads_rows=threads_rows, owned_domains=owned_domains,
             avatar_prefs=avatar_prefs, history=history, root_label=label,
             managed_loop=managed_loop, supervisor_decisions=supervisor_decisions,
-            decision_unavailable=decision_unavailable)
+            decision_unavailable=decision_unavailable,
+            health_policy=health_policy, now_epoch=now_epoch)
         out["retired"] = store.retired_agents()
         out["threads"] = threads_rows
         out["broadcasts"] = broadcasts
@@ -2734,7 +2763,10 @@ def build_attention(desc: RootDescriptor,
             try:
                 agents = _agent_entries(store, cfg,
                                         _validated_for_state(store, cfg)[0],
-                                        for_agent)
+                                        for_agent,
+                                        health_policy=(
+                                            _operator_health.load_health_timing_policy(store)),
+                                        now_epoch=now.timestamp())
             except Exception:  # noqa: BLE001 — stuck items are best-effort
                 agents = []
         wire.extend(_derive_stuck_items(agents, now=now))

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -121,6 +121,7 @@ from agenttalk import health as _health
 from agenttalk import knowledge as _knowledge
 from agenttalk import lesson_context as _lesson_context
 from agenttalk import onboarding as _onboarding
+from agenttalk import operator_health as _operator_health
 from agenttalk import signing as _signing
 from agenttalk import supervisor as _supervisor
 from agenttalk import threads as th
@@ -1552,6 +1553,10 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     which no decision could be computed to a stable reason code. The API keeps
     the existing boolean and adds the reason so the console can distinguish a
     disabled verdict from a failed assessment.
+
+    ``health_composition``: an additive, presentation-only composition of the
+    two source-labelled facts.  Raw ``health`` and ``supervisor_decision`` stay
+    unchanged; the console consumes the shared urgency/provenance contract.
     """
     roles = cfg.get("roles", {}) or {}
     groups = cfg.get("groups", {}) or {}
@@ -1650,6 +1655,8 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                 "action": decision.get("action"),
                 "reason": decision.get("reason"),
             }
+            e["health_composition"] = _operator_health.compose_health_evidence(
+                health.get("state"), decision=e["supervisor_decision"])
         elif a in decision_unavailable:
             # A wrapped agent this supervisor cannot compute a strict decision
             # for (e.g. not configured auto_restart) — say so visibly, as
@@ -1657,6 +1664,8 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
             # showing only the self-report.
             e["supervisor_decision_unavailable"] = True
             e["supervisor_decision_unavailable_reason"] = decision_unavailable[a]
+            e["health_composition"] = _operator_health.compose_health_evidence(
+                health.get("state"), unavailable_reason=decision_unavailable[a])
         # wrapper_child: the raw wrapper-runtime observation (phase +
         # last_progress_at age) — the cheapest "is the counter frozen" signal,
         # independent of any verdict. Absent when no runtime record exists.

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -1482,7 +1482,10 @@ def _supervisor_decisions(store: Store, *,
         # A stale snapshot must not be read as a live liveness fact (see
         # read_supervisor_snapshot_if_fresh's docstring).
         snapshot = _supervisor.read_supervisor_snapshot_if_fresh(
-            store.dir / "supervisor-snapshot.json", now_epoch=now_epoch)
+            store.dir / "supervisor-snapshot.json",
+            now_epoch=now_epoch,
+            stale_after_seconds=_supervisor.resolve_snapshot_stale_after_seconds(sup_cfg),
+        )
         obs = _supervisor.build_supervisor_observation(
             store, now_epoch=now_epoch, state=state, supervisor_config=sup_cfg,
             snapshot=snapshot, event_limit=0,
@@ -1494,6 +1497,8 @@ def _supervisor_decisions(store: Store, *,
     decisions: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            continue
+        if item["name"] not in wrapped_names:
             continue
         decision = item.get("decision")
         if isinstance(decision, dict):

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -1442,7 +1442,8 @@ class HealthTimelineRing:
             return []
 
 
-def _supervisor_decisions(store: Store, *, now_epoch: float) -> dict[str, dict]:
+def _supervisor_decisions(store: Store, *,
+                          now_epoch: float) -> tuple[dict[str, dict], set[str]]:
     """The live supervisor decision per wrapped agent (best-effort, read-only).
 
     This is the STRICT verdict (e.g. ``CLI_CHILD_UNKNOWN``) — distinct from the
@@ -1450,10 +1451,15 @@ def _supervisor_decisions(store: Store, *, now_epoch: float) -> dict[str, dict]:
     which can keep reporting "fine" after the CLI child has died. Computed
     fresh from the same on-disk supervisor.json/state/snapshot cli.py reads for
     `agenttalk status`; empty (never raises) when no supervisor is configured
-    or the read fails, so a root with no supervisor stays unaffected."""
+    or the read fails, so a root with no supervisor stays unaffected.
+
+    Returns ``(decisions, decision_unavailable)`` — the second set is every
+    agent configured ``wrapped: true`` for which no decision could be computed
+    (e.g. it is not ``auto_restart``), so the caller can surface that fact
+    explicitly rather than silently falling back to the self-report."""
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
-        return {}
+        return {}, set()
     try:
         sup_cfg = _supervisor.load_supervisor_config(sup_path)
         state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
@@ -1467,15 +1473,20 @@ def _supervisor_decisions(store: Store, *, now_epoch: float) -> dict[str, dict]:
             snapshot=snapshot, event_limit=0,
         )
     except Exception:  # noqa: BLE001 — advisory arm; never fail the root
-        return {}
-    out: dict[str, dict] = {}
+        return {}, set()
+    sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
+    wrapped_names = {
+        name for name, cfg_agent in sup_agents.items()
+        if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
+    }
+    decisions: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
             continue
         decision = item.get("decision")
         if isinstance(decision, dict):
-            out[item["name"]] = decision
-    return out
+            decisions[item["name"]] = decision
+    return decisions, wrapped_names - set(decisions)
 
 
 def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
@@ -1486,7 +1497,8 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                    history: "HealthTimelineRing | None" = None,
                    root_label: str | None = None,
                    managed_loop: set[str] | None = None,
-                   supervisor_decisions: dict[str, dict] | None = None) -> list[dict]:
+                   supervisor_decisions: dict[str, dict] | None = None,
+                   decision_unavailable: set[str] | None = None) -> list[dict]:
     """Per-agent presence rows (data-model §3). Absent-not-null keys.
 
     0.58.0 additive fields (all OMITTED when not determinable): ``cli``,
@@ -1509,6 +1521,11 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     ``CLI_CHILD_UNKNOWN`` shows BOTH facts rather than one adjective.
     ``wrapper_child`` (additive) carries the raw wrapper-runtime phase and
     ``last_progress_at`` age directly, independent of any verdict.
+
+    ``decision_unavailable``: the set of agents configured ``wrapped: true``
+    for which no decision could be computed (not ``auto_restart``) — surfaced
+    as ``supervisor_decision_unavailable: true`` so this reads as visibly as
+    doctor's equivalent WARN, rather than silently showing only `health`.
     """
     roles = cfg.get("roles", {}) or {}
     groups = cfg.get("groups", {}) or {}
@@ -1517,6 +1534,7 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     avatar_prefs = avatar_prefs or {}
     managed_loop = managed_loop or set()
     supervisor_decisions = supervisor_decisions or {}
+    decision_unavailable = decision_unavailable or set()
     now = datetime.now(timezone.utc)
     now_epoch = now.timestamp()
     # 0.19.0 (FR-001): per-agent message counts from the SAME validated `msgs`
@@ -1606,6 +1624,12 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                 "action": decision.get("action"),
                 "reason": decision.get("reason"),
             }
+        elif a in decision_unavailable:
+            # A wrapped agent this supervisor cannot compute a strict decision
+            # for (e.g. not configured auto_restart) — say so visibly, as
+            # doctor's equivalent WARN already does, rather than silently
+            # showing only the self-report.
+            e["supervisor_decision_unavailable"] = True
         # wrapper_child: the raw wrapper-runtime observation (phase +
         # last_progress_at age) — the cheapest "is the counter frozen" signal,
         # independent of any verdict. Absent when no runtime record exists.
@@ -1707,7 +1731,8 @@ def _root_state(desc: RootDescriptor,
                     managed_loop.add(a)
         except Exception:  # noqa: BLE001 — advisory arm; never fail the root
             managed_loop = set()
-        supervisor_decisions = _supervisor_decisions(store, now_epoch=time.time())
+        supervisor_decisions, decision_unavailable = _supervisor_decisions(
+            store, now_epoch=time.time())
         out: dict[str, Any] = {
             "label": label,
             "path": path,
@@ -1739,7 +1764,8 @@ def _root_state(desc: RootDescriptor,
             store, cfg, msgs, liaison,
             threads_rows=threads_rows, owned_domains=owned_domains,
             avatar_prefs=avatar_prefs, history=history, root_label=label,
-            managed_loop=managed_loop, supervisor_decisions=supervisor_decisions)
+            managed_loop=managed_loop, supervisor_decisions=supervisor_decisions,
+            decision_unavailable=decision_unavailable)
         out["retired"] = store.retired_agents()
         out["threads"] = threads_rows
         out["broadcasts"] = broadcasts

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -1443,7 +1443,7 @@ class HealthTimelineRing:
 
 
 def _supervisor_decisions(store: Store, *,
-                          now_epoch: float) -> tuple[dict[str, dict], set[str]]:
+                          now_epoch: float) -> tuple[dict[str, dict], dict[str, str]]:
     """The live supervisor decision per wrapped agent (best-effort, read-only).
 
     This is the STRICT verdict (e.g. ``CLI_CHILD_UNKNOWN``) — distinct from the
@@ -1453,30 +1453,31 @@ def _supervisor_decisions(store: Store, *,
     `agenttalk status`; empty (never raises) when no supervisor is configured
     or the read fails, so a root with no supervisor stays unaffected.
 
-    Returns ``(decisions, decision_unavailable)`` — the second set is every
-    agent configured ``wrapped: true`` for which no decision could be computed
-    (e.g. it is not ``auto_restart``, OR the observation itself failed), so
-    the caller can surface that fact explicitly rather than silently falling
-    back to the self-report. "Cannot verify" must never render as "verified
-    good": a state/snapshot/observation failure below still returns every
-    wrapped name in the unavailable set — it does NOT go silent — while a
+    Returns ``(decisions, decision_unavailable)`` — the second mapping gives
+    every agent configured ``wrapped: true`` for which no decision could be
+    computed a stable reason code (disabled auto-restart, missing decision, or
+    failed assessment), so the caller can surface the actual cause rather than
+    silently falling back to the self-report. "Cannot verify" must never render
+    as "verified good": a state/snapshot/observation failure below still
+    returns every wrapped name in the unavailable mapping — it does NOT go
+    silent — while a
     failure to even load supervisor.json (so the wrapped set itself is
     unknowable) returns both empty, matching doctor's own config-load
     fallback."""
     sup_path = store.dir / "supervisor.json"
     if not sup_path.exists():
-        return {}, set()
+        return {}, {}
     try:
         sup_cfg = _supervisor.load_supervisor_config(sup_path)
     except Exception:  # noqa: BLE001 — advisory arm; never fail the root
-        return {}, set()
+        return {}, {}
     sup_agents = sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
     wrapped_names = {
         name for name, cfg_agent in sup_agents.items()
         if isinstance(cfg_agent, dict) and cfg_agent.get("wrapped") is True
     }
     if not wrapped_names:
-        return {}, set()
+        return {}, {}
     try:
         state = _supervisor.load_supervisor_state(store.dir / "supervisor-state.json")
         # A stale snapshot must not be read as a live liveness fact (see
@@ -1493,7 +1494,7 @@ def _supervisor_decisions(store: Store, *,
     except Exception:  # noqa: BLE001 — advisory arm; never fail the root, but
         # every wrapped agent becomes explicitly unavailable rather than
         # vanishing (the #105 defect reintroduced through this error path).
-        return {}, wrapped_names
+        return {}, dict.fromkeys(wrapped_names, "assessment_failed")
     decisions: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
@@ -1503,7 +1504,15 @@ def _supervisor_decisions(store: Store, *,
         decision = item.get("decision")
         if isinstance(decision, dict):
             decisions[item["name"]] = decision
-    return decisions, wrapped_names - set(decisions)
+    unavailable = {
+        name: (
+            "auto_restart_disabled"
+            if sup_agents[name].get("auto_restart") is not True
+            else "decision_missing"
+        )
+        for name in wrapped_names - set(decisions)
+    }
+    return decisions, unavailable
 
 
 def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
@@ -1515,7 +1524,7 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
                    root_label: str | None = None,
                    managed_loop: set[str] | None = None,
                    supervisor_decisions: dict[str, dict] | None = None,
-                   decision_unavailable: set[str] | None = None) -> list[dict]:
+                   decision_unavailable: dict[str, str] | None = None) -> list[dict]:
     """Per-agent presence rows (data-model §3). Absent-not-null keys.
 
     0.58.0 additive fields (all OMITTED when not determinable): ``cli``,
@@ -1539,10 +1548,10 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     ``wrapper_child`` (additive) carries the raw wrapper-runtime phase and
     ``last_progress_at`` age directly, independent of any verdict.
 
-    ``decision_unavailable``: the set of agents configured ``wrapped: true``
-    for which no decision could be computed (not ``auto_restart``) — surfaced
-    as ``supervisor_decision_unavailable: true`` so this reads as visibly as
-    doctor's equivalent WARN, rather than silently showing only `health`.
+    ``decision_unavailable``: maps agents configured ``wrapped: true`` for
+    which no decision could be computed to a stable reason code. The API keeps
+    the existing boolean and adds the reason so the console can distinguish a
+    disabled verdict from a failed assessment.
     """
     roles = cfg.get("roles", {}) or {}
     groups = cfg.get("groups", {}) or {}
@@ -1551,7 +1560,7 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
     avatar_prefs = avatar_prefs or {}
     managed_loop = managed_loop or set()
     supervisor_decisions = supervisor_decisions or {}
-    decision_unavailable = decision_unavailable or set()
+    decision_unavailable = decision_unavailable or {}
     now = datetime.now(timezone.utc)
     now_epoch = now.timestamp()
     # 0.19.0 (FR-001): per-agent message counts from the SAME validated `msgs`
@@ -1647,6 +1656,7 @@ def _agent_entries(store: Store, cfg: dict, msgs: list[Message],
             # doctor's equivalent WARN already does, rather than silently
             # showing only the self-report.
             e["supervisor_decision_unavailable"] = True
+            e["supervisor_decision_unavailable_reason"] = decision_unavailable[a]
         # wrapper_child: the raw wrapper-runtime observation (phase +
         # last_progress_at age) — the cheapest "is the counter frozen" signal,
         # independent of any verdict. Absent when no runtime record exists.

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -707,6 +707,20 @@ body {
 .status-unknown.tc-dot,
 .status-unknown.tc-legend-dot { background: var(--gray); }
 
+/* Supervisor decision.state overrides (#105) - a self-report that still says
+   "fine" while the supervisor's strict, positively-bound verdict does not. */
+.status-supervisor_unbound.tc-chip { color: var(--danger); background: var(--danger-soft); }
+.status-supervisor_unbound.tc-dot,
+.status-supervisor_unbound.tc-legend-dot { background: var(--danger); }
+
+.status-supervisor_unconfirmed.tc-chip { color: var(--attn); background: var(--attn-soft); }
+.status-supervisor_unconfirmed.tc-dot,
+.status-supervisor_unconfirmed.tc-legend-dot { background: var(--attn); }
+
+.status-supervisor_unavailable.tc-chip { color: var(--attn); background: var(--attn-soft); }
+.status-supervisor_unavailable.tc-dot,
+.status-supervisor_unavailable.tc-legend-dot { background: var(--attn); }
+
 /* --- Kind chip color map (message kinds) --- */
 .kind-review-request { color: var(--accent); background: var(--accent-soft); }
 .kind-review-result  { color: var(--ok); background: var(--ok-soft); }

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -707,13 +707,22 @@ body {
 .status-unknown.tc-dot,
 .status-unknown.tc-legend-dot { background: var(--gray); }
 
-/* Supervisor decision.state overrides (#105) - a self-report that still says
-   "fine" while the supervisor's strict, positively-bound verdict does not. */
+/* Shared operator-health composition (#105).  Semantic wording comes from the
+   source-labelled fact; these keys carry only the derived urgency. */
+.status-supervisor_alert.tc-chip,
+.status-supervisor_lost_binding.tc-chip,
 .status-supervisor_unbound.tc-chip { color: var(--danger); background: var(--danger-soft); }
+.status-supervisor_alert.tc-dot,
+.status-supervisor_alert.tc-legend-dot,
+.status-supervisor_lost_binding.tc-dot,
+.status-supervisor_lost_binding.tc-legend-dot,
 .status-supervisor_unbound.tc-dot,
 .status-supervisor_unbound.tc-legend-dot { background: var(--danger); }
 
+.status-supervisor_advisory.tc-chip,
 .status-supervisor_unconfirmed.tc-chip { color: var(--attn); background: var(--attn-soft); }
+.status-supervisor_advisory.tc-dot,
+.status-supervisor_advisory.tc-legend-dot,
 .status-supervisor_unconfirmed.tc-dot,
 .status-supervisor_unconfirmed.tc-legend-dot { background: var(--attn); }
 

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -449,11 +449,54 @@
     var age = Number(agent && agent.last_seen_age_seconds);
     return Number.isFinite(age) && age >= 0 && age <= UNWRAPPED_LIVE_STALE_AFTER_SECONDS;
   }
+  // decision.state operator-surface classification (#105) - MUST mirror
+  // supervisor.py's HEALTHY_DECISION_STATES / GRACE_DECISION_STATES /
+  // UNBOUND_OR_DEAD_DECISION_STATES (Python is the source of truth; this is
+  // the browser-side render of the same vocabulary).
+  var SUP_HEALTHY_STATES = nullMap({ HEALTHY_IDLE: 1, HEALTHY_WORKING: 1 });
+  var SUP_GRACE_STATES = nullMap({ CLI_CHILD_STARTING: 1, LAUNCHING: 1 });
+  var SUP_UNBOUND_OR_DEAD_STATES = nullMap({
+    CLI_CHILD_UNKNOWN: 1, CLI_CHILD_DEAD: 1, CLI_CHILD_STALLED: 1,
+    CLI_CHILD_NO_PROGRESS: 1, CLI_CHILD_MISSING: 1, STUCK_OR_DEAD: 1,
+    WRAPPER_MISSING: 1, TURN_FAILED: 1, READINESS_GAVE_UP: 1,
+  });
   function agentStateInfo(agent) {
     var raw = ((agent && agent.health) || {}).state;
     var info = stateInfo(raw);
     if (info.key === 'unknown' && freshHeartbeat(agent) && agent && agent.wrapped !== true) {
-      return { label: 'Active', key: 'unwrapped_live', color: 'teal', grp: 'work', heartbeatOnly: true, desc: 'Alive and checking in, but not running under the supervisor' };
+      info = { label: 'Active', key: 'unwrapped_live', color: 'teal', grp: 'work', heartbeatOnly: true, desc: 'Alive and checking in, but not running under the supervisor' };
+    }
+    // The supervisor's strict, positively-bound decision is a SEPARATE fact
+    // from the wrapper's self-report above (`info`) - never let a cheerful
+    // self-report hide a confirmed-bad verdict. Grace states (CLI_CHILD_
+    // STARTING / LAUNCHING) and the two HEALTHY_* states never override.
+    var decision = agent && agent.supervisor_decision;
+    if (decision && typeof decision === 'object') {
+      var dstate = decision.state;
+      if (!SUP_HEALTHY_STATES[dstate] && !SUP_GRACE_STATES[dstate]) {
+        var isDead = !!SUP_UNBOUND_OR_DEAD_STATES[dstate];
+        return {
+          label: isDead ? 'Child unconfirmed' : 'Supervisor: ' + (dstate || 'unknown'),
+          key: isDead ? 'supervisor_unbound' : 'supervisor_unconfirmed',
+          color: isDead ? 'danger' : 'attn',
+          grp: 'attn',
+          desc: 'Supervisor verdict: ' + (dstate || 'unknown') +
+                ' — self-report says "' + info.label + '", but the CLI child ' +
+                'could not be confirmed',
+          selfReport: info,
+        };
+      }
+    } else if (agent && agent.supervisor_decision_unavailable === true) {
+      return {
+        label: 'No verdict',
+        key: 'supervisor_unavailable',
+        color: 'attn',
+        grp: 'attn',
+        desc: 'Wrapped, but the supervisor has no computable verdict for this ' +
+              'agent (not configured auto_restart) — self-report only: "' +
+              info.label + '"',
+        selfReport: info,
+      };
     }
     return info;
   }

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -449,83 +449,113 @@
     var age = Number(agent && agent.last_seen_age_seconds);
     return Number.isFinite(age) && age >= 0 && age <= UNWRAPPED_LIVE_STALE_AFTER_SECONDS;
   }
-  // decision.state operator-surface classification (#105) - MUST mirror
-  // supervisor.py's HEALTHY_DECISION_STATES / GRACE_DECISION_STATES /
-  // UNBOUND_OR_DEAD_DECISION_STATES (Python is the source of truth; this is
-  // the browser-side render of the same vocabulary).
-  var SUP_HEALTHY_STATES = nullMap({ HEALTHY_IDLE: 1, HEALTHY_WORKING: 1 });
-  var SUP_GRACE_STATES = nullMap({ CLI_CHILD_STARTING: 1, LAUNCHING: 1 });
-  // CLI_CHILD_MISSING is deliberately excluded - it is the provisional
-  // first-poll state of the supervisor's two-poll confirmation policy, not a
-  // confirmed-dead state (mirrors supervisor.py's own exclusion).
-  var SUP_UNBOUND_OR_DEAD_STATES = nullMap({
-    CLI_CHILD_UNKNOWN: 1, CLI_CHILD_DEAD: 1, CLI_CHILD_STALLED: 1,
-    CLI_CHILD_NO_PROGRESS: 1, STUCK_OR_DEAD: 1,
-    WRAPPER_MISSING: 1, TURN_FAILED: 1, READINESS_GAVE_UP: 1,
-  });
+  var OPERATOR_URGENCY_RANK = nullMap({ fine: 0, unknown: 1, attention: 2, danger: 3 });
+  function observationUrgency(info) {
+    if (info.color === 'danger') return 'danger';
+    if (info.key === 'unknown') return 'unknown';
+    if (info.grp === 'attn') return 'attention';
+    return 'fine';
+  }
+  function legacyHealthComposition(agent, raw, info) {
+    // API/asset skew fallback: old API payloads do not carry the shared Python
+    // classification. Keep each independent strict fact visibly non-green,
+    // but never invent child-loss semantics from an unclassified token.
+    var observation = {
+      source: 'wrapper_health', state: raw || 'unknown', urgency: observationUrgency(info),
+    };
+    var supervisor = null;
+    var decision = agent && agent.supervisor_decision;
+    if (decision && typeof decision === 'object') {
+      supervisor = {
+        source: 'supervisor_decision', kind: 'unclassified', state: decision.state,
+        action: decision.action, reason: decision.reason, urgency: 'attention',
+        classification_reason: 'composition_missing',
+      };
+    } else if (agent && agent.supervisor_decision_unavailable === true) {
+      supervisor = {
+        source: 'supervisor_decision', kind: 'unavailable',
+        reason: agent.supervisor_decision_unavailable_reason || 'decision_missing',
+        urgency: 'attention',
+      };
+    }
+    if (!supervisor) return null;
+    var supervisorWins = OPERATOR_URGENCY_RANK[supervisor.urgency] >
+      OPERATOR_URGENCY_RANK[observation.urgency];
+    return {
+      observation: observation,
+      supervisor: supervisor,
+      urgency: supervisorWins ? supervisor.urgency : observation.urgency,
+      primary_source: supervisorWins ? 'supervisor' : 'observation',
+      disagreement: supervisor.urgency !== observation.urgency,
+    };
+  }
+  function supervisorFactSummary(fact) {
+    if (fact.kind === 'unclassified') {
+      return 'Supervisor decision (urgency classification unavailable): ' +
+        (fact.state || 'unknown') +
+        (fact.action ? '/' + fact.action : '') +
+        (fact.reason ? ' (' + fact.reason + ')' : '');
+    }
+    if (fact.kind === 'unavailable') {
+      if (fact.reason === 'auto_restart_disabled') {
+        return 'Supervisor verdict unavailable: auto-restart is disabled';
+      }
+      if (fact.reason === 'assessment_failed') {
+        return 'Supervisor verdict unavailable: assessment failed';
+      }
+      if (fact.reason === 'decision_missing') {
+        return 'Supervisor verdict unavailable: assessment returned no decision';
+      }
+      return 'Supervisor verdict unavailable: ' + (fact.reason || 'reason unknown');
+    }
+    return 'Supervisor verdict: ' + (fact.state || 'unknown') +
+      (fact.action ? '/' + fact.action : '') +
+      (fact.reason ? ' (' + fact.reason + ')' : '');
+  }
+  function supervisorPresentation(fact, observation, observationInfo) {
+    var label = 'Supervisor: ' + (fact.state || 'unknown');
+    var key = fact.urgency === 'danger' ? 'supervisor_alert' : 'supervisor_advisory';
+    if (fact.kind === 'unavailable') {
+      label = 'No verdict';
+      key = 'supervisor_unavailable';
+    } else if (fact.kind === 'unclassified') {
+      label = 'Verdict unclassified';
+    } else if (fact.kind === 'lost_binding') {
+      label = 'Child binding lost';
+      key = 'supervisor_lost_binding';
+    } else if (fact.kind === 'live_stalled') {
+      label = 'Child stalled';
+    } else if (fact.kind === 'failed') {
+      label = 'Turn failed';
+    }
+    return {
+      label: label,
+      key: key,
+      color: fact.urgency === 'danger' ? 'danger' : 'attn',
+      grp: 'attn',
+      desc: supervisorFactSummary(fact) + ' · Wrapper observation: ' +
+        (observation.state || 'unknown') + ' (' + observationInfo.desc + ')',
+      healthComposition: { observation: observation, supervisor: fact },
+    };
+  }
   function agentStateInfo(agent) {
     var raw = ((agent && agent.health) || {}).state;
     var info = stateInfo(raw);
     if (info.key === 'unknown' && freshHeartbeat(agent) && agent && agent.wrapped !== true) {
       info = { label: 'Active', key: 'unwrapped_live', color: 'teal', grp: 'work', heartbeatOnly: true, desc: 'Alive and checking in, but not running under the supervisor' };
     }
-    // The supervisor's strict, positively-bound decision is a SEPARATE fact
-    // from the wrapper's self-report above (`info`) - never let a cheerful
-    // self-report hide a confirmed-bad verdict. Grace states (CLI_CHILD_
-    // STARTING / LAUNCHING) and the two HEALTHY_* states never override.
-    var decision = agent && agent.supervisor_decision;
-    if (decision && typeof decision === 'object') {
-      var dstate = decision.state;
-      if (!SUP_HEALTHY_STATES[dstate] && !SUP_GRACE_STATES[dstate]) {
-        var isDead = !!SUP_UNBOUND_OR_DEAD_STATES[dstate];
-        var verdictSummary = 'Supervisor verdict: ' + (dstate || 'unknown') +
-          (decision.reason ? ' (' + decision.reason + ')' : '');
-        // A non-dead/advisory verdict is attention-level. It must not soften
-        // an already-dangerous wrapper report; keep the worse presentation
-        // while retaining the separate strict fact in its description.
-        if (!isDead && info.color === 'danger') {
-          info.desc += ' · ' + verdictSummary;
-          info.supervisorDecision = decision;
-          return info;
-        }
-        return {
-          label: isDead ? 'Child unconfirmed' : 'Supervisor: ' + (dstate || 'unknown'),
-          key: isDead ? 'supervisor_unbound' : 'supervisor_unconfirmed',
-          color: isDead ? 'danger' : 'attn',
-          grp: 'attn',
-          desc: verdictSummary + ' — self-report says "' + info.label +
-                '", but the CLI child ' +
-                'could not be confirmed',
-          selfReport: info,
-        };
-      }
-    } else if (agent && agent.supervisor_decision_unavailable === true) {
-      var unavailableReason = agent.supervisor_decision_unavailable_reason;
-      var unavailableDesc = unavailableReason === 'auto_restart_disabled'
-        ? 'Wrapped, but the supervisor has no computable verdict for this agent ' +
-          '(not configured auto_restart)'
-        : unavailableReason === 'assessment_failed'
-          ? 'Wrapped, but the supervisor assessment failed, so no verdict is available'
-          : unavailableReason === 'decision_missing'
-            ? 'Wrapped, but the supervisor returned no decision for this agent'
-            : 'Wrapped, but no supervisor verdict is available (reason unknown)';
-      // Unavailability is attention-level evidence, not permission to soften
-      // an already-dangerous self-report. Keep the worse presentation and
-      // append why the independent strict fact could not be computed.
-      if (info.color === 'danger') {
-        info.desc += ' · ' + unavailableDesc;
-        info.supervisorDecisionUnavailableReason = unavailableReason;
-        return info;
-      }
-      return {
-        label: 'No verdict',
-        key: 'supervisor_unavailable',
-        color: 'attn',
-        grp: 'attn',
-        desc: unavailableDesc + ' — self-report only: "' + info.label + '"',
-        selfReport: info,
-      };
+    var composition = agent && agent.health_composition;
+    if (!composition || typeof composition !== 'object' ||
+        !composition.observation || !composition.supervisor) {
+      composition = legacyHealthComposition(agent, raw, info);
     }
+    if (!composition) return info;
+    var supervisor = composition.supervisor;
+    if (composition.primary_source === 'supervisor') {
+      return supervisorPresentation(supervisor, composition.observation, info);
+    }
+    info.desc += ' · ' + supervisorFactSummary(supervisor);
+    info.healthComposition = composition;
     return info;
   }
   function stateInfoFrom(value) {

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -478,26 +478,51 @@
       var dstate = decision.state;
       if (!SUP_HEALTHY_STATES[dstate] && !SUP_GRACE_STATES[dstate]) {
         var isDead = !!SUP_UNBOUND_OR_DEAD_STATES[dstate];
+        var verdictSummary = 'Supervisor verdict: ' + (dstate || 'unknown') +
+          (decision.reason ? ' (' + decision.reason + ')' : '');
+        // A non-dead/advisory verdict is attention-level. It must not soften
+        // an already-dangerous wrapper report; keep the worse presentation
+        // while retaining the separate strict fact in its description.
+        if (!isDead && info.color === 'danger') {
+          info.desc += ' · ' + verdictSummary;
+          info.supervisorDecision = decision;
+          return info;
+        }
         return {
           label: isDead ? 'Child unconfirmed' : 'Supervisor: ' + (dstate || 'unknown'),
           key: isDead ? 'supervisor_unbound' : 'supervisor_unconfirmed',
           color: isDead ? 'danger' : 'attn',
           grp: 'attn',
-          desc: 'Supervisor verdict: ' + (dstate || 'unknown') +
-                ' — self-report says "' + info.label + '", but the CLI child ' +
+          desc: verdictSummary + ' — self-report says "' + info.label +
+                '", but the CLI child ' +
                 'could not be confirmed',
           selfReport: info,
         };
       }
     } else if (agent && agent.supervisor_decision_unavailable === true) {
+      var unavailableReason = agent.supervisor_decision_unavailable_reason;
+      var unavailableDesc = unavailableReason === 'auto_restart_disabled'
+        ? 'Wrapped, but the supervisor has no computable verdict for this agent ' +
+          '(not configured auto_restart)'
+        : unavailableReason === 'assessment_failed'
+          ? 'Wrapped, but the supervisor assessment failed, so no verdict is available'
+          : unavailableReason === 'decision_missing'
+            ? 'Wrapped, but the supervisor returned no decision for this agent'
+            : 'Wrapped, but no supervisor verdict is available (reason unknown)';
+      // Unavailability is attention-level evidence, not permission to soften
+      // an already-dangerous self-report. Keep the worse presentation and
+      // append why the independent strict fact could not be computed.
+      if (info.color === 'danger') {
+        info.desc += ' · ' + unavailableDesc;
+        info.supervisorDecisionUnavailableReason = unavailableReason;
+        return info;
+      }
       return {
         label: 'No verdict',
         key: 'supervisor_unavailable',
         color: 'attn',
         grp: 'attn',
-        desc: 'Wrapped, but the supervisor has no computable verdict for this ' +
-              'agent (not configured auto_restart) — self-report only: "' +
-              info.label + '"',
+        desc: unavailableDesc + ' — self-report only: "' + info.label + '"',
         selfReport: info,
       };
     }

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -455,9 +455,12 @@
   // the browser-side render of the same vocabulary).
   var SUP_HEALTHY_STATES = nullMap({ HEALTHY_IDLE: 1, HEALTHY_WORKING: 1 });
   var SUP_GRACE_STATES = nullMap({ CLI_CHILD_STARTING: 1, LAUNCHING: 1 });
+  // CLI_CHILD_MISSING is deliberately excluded - it is the provisional
+  // first-poll state of the supervisor's two-poll confirmation policy, not a
+  // confirmed-dead state (mirrors supervisor.py's own exclusion).
   var SUP_UNBOUND_OR_DEAD_STATES = nullMap({
     CLI_CHILD_UNKNOWN: 1, CLI_CHILD_DEAD: 1, CLI_CHILD_STALLED: 1,
-    CLI_CHILD_NO_PROGRESS: 1, CLI_CHILD_MISSING: 1, STUCK_OR_DEAD: 1,
+    CLI_CHILD_NO_PROGRESS: 1, STUCK_OR_DEAD: 1,
     WRAPPER_MISSING: 1, TURN_FAILED: 1, READINESS_GAVE_UP: 1,
   });
   function agentStateInfo(agent) {

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -527,6 +527,8 @@
       label = 'Child stalled';
     } else if (fact.kind === 'failed') {
       label = 'Turn failed';
+    } else if (fact.kind === 'readiness_exhausted') {
+      label = 'Readiness retries exhausted';
     }
     return {
       label: label,
@@ -539,15 +541,22 @@
     };
   }
   function agentStateInfo(agent) {
-    var raw = ((agent && agent.health) || {}).state;
+    var health = (agent && agent.health) || {};
+    var raw = health.state;
     var info = stateInfo(raw);
-    if (info.key === 'unknown' && freshHeartbeat(agent) && agent && agent.wrapped !== true) {
-      info = { label: 'Active', key: 'unwrapped_live', color: 'teal', grp: 'work', heartbeatOnly: true, desc: 'Alive and checking in, but not running under the supervisor' };
-    }
     var composition = agent && agent.health_composition;
     if (!composition || typeof composition !== 'object' ||
         !composition.observation || !composition.supervisor) {
       composition = legacyHealthComposition(agent, raw, info);
+    }
+    if (info.key === 'unknown' && freshHeartbeat(agent) && agent) {
+      if (!composition && agent.wrapped !== true &&
+          health.reason_code !== 'health_timing_policy_unavailable') {
+        info = { label: 'Active', key: 'unwrapped_live', color: 'teal', grp: 'work', heartbeatOnly: true, desc: 'Alive and checking in, but not running under the supervisor' };
+      } else {
+        var healthReason = health.reason_code ? ' (' + health.reason_code + ')' : '';
+        info = { label: 'Unknown', key: 'unknown', color: 'gray', grp: 'unknown', desc: 'Wrapper health is unknown' + healthReason + ' despite a recent heartbeat' };
+      }
     }
     if (!composition) return info;
     var supervisor = composition.supervisor;

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -584,6 +584,78 @@ def test_status_no_disagreement_flag_for_a_genuinely_healthy_agent(
     assert "[DISAGREEMENT]" not in line
 
 
+@pytest.mark.parametrize("grace_state", ["CLI_CHILD_STARTING", "LAUNCHING"])
+def test_status_no_disagreement_flag_for_grace_states(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    grace_state: str,
+) -> None:
+    """No false-DOWN, both grace states: a freshly launched agent still inside
+    its bounded handoff grace must not be flagged — reproduces the reviewer's
+    LAUNCHING regression (`supervisor=LAUNCHING/none [DISAGREEMENT]`)."""
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s = Store(store_root)
+    s.write_heartbeat("alpha")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_IDLE_WAITING,
+        updated_at=now_iso, since=now_iso,
+        reason_code="idle_waiting",
+    ))
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation",
+                        lambda *_a, **_k: _fake_decision(grace_state))
+
+    rc = _run(["status", "--json"], store_root)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert "disagreement" not in alpha["supervisor"]
+
+    rc = _run(["status"], store_root)
+    assert rc == 0
+    out = capsys.readouterr().out
+    line = next(ln for ln in out.splitlines() if ln.strip().startswith("alpha"))
+    assert "[DISAGREEMENT]" not in line, line
+
+
+def test_status_flags_decision_unavailable_for_non_auto_restart_wrapped_agent(
+    store_root: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A wrapped agent that is not `auto_restart` has no computable strict
+    decision — real (unpatched) build_supervisor_observation behavior. status
+    must say so visibly (both JSON and text), not silently show only the
+    self-report with no supervisor field at all."""
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s = Store(store_root)
+    s.write_heartbeat("alpha")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN,
+        updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": False}},
+    }), encoding="utf-8")
+
+    rc = _run(["status", "--json"], store_root)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert alpha["supervisor"]["decision_unavailable"] is True
+
+    rc = _run(["status"], store_root)
+    assert rc == 0
+    out = capsys.readouterr().out
+    line = next(ln for ln in out.splitlines() if ln.strip().startswith("alpha"))
+    assert "supervisor=UNAVAILABLE" in line, line
+
+
 def test_supervisor_cli_read_fail_safe(
     store_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,6 +493,19 @@ def test_status_supervisor_assessment_fail_safe(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture,
 ) -> None:
+    s = Store(store_root)
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN, updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+
     def boom(*_args, **_kwargs):
         raise ValueError("bad supervisor report")
 
@@ -503,6 +516,14 @@ def test_status_supervisor_assessment_fail_safe(
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert "supervisor_assessment_unavailable:ValueError" in payload["warnings"]
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert alpha["supervisor"] == {
+        "decision_unavailable": True,
+        "decision_unavailable_reason": "assessment_failed",
+        "disagreement": True,
+    }
+    assert alpha["health_composition"]["urgency"] == "attention"
+    assert alpha["health_composition"]["supervisor"]["reason"] == "assessment_failed"
 
 
 def _fake_decision(state: str, *, action: str = "none",
@@ -704,6 +725,45 @@ def test_status_no_disagreement_flag_for_a_genuinely_healthy_agent(
     assert "[DISAGREEMENT]" not in line
 
 
+def test_status_healthy_decision_does_not_mask_degraded_observation(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s = Store(store_root)
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_DEGRADED_OUTPUT, updated_at=now_iso, since=now_iso,
+        reason_code="degraded_output_detected",
+    ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation",
+                        lambda *_a, **_k: _fake_decision("HEALTHY_WORKING"))
+
+    assert _run(["status", "--json"], store_root) == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+
+    assert alpha["health"]["state"] == "degraded_output"
+    assert alpha["health_composition"]["urgency"] == "danger"
+    assert alpha["health_composition"]["primary_source"] == "observation"
+    assert alpha["supervisor"]["disagreement"] is True
+
+    assert _run(["status"], store_root) == 0
+    line = next(
+        line for line in capsys.readouterr().out.splitlines()
+        if line.strip().startswith("alpha")
+    )
+    assert "health=degraded_output" in line
+    assert "supervisor=HEALTHY_WORKING/none" in line
+    assert "[DISAGREEMENT]" in line
+
+
 @pytest.mark.parametrize("grace_state", ["CLI_CHILD_STARTING", "LAUNCHING"])
 def test_status_no_disagreement_flag_for_grace_states(
     store_root: Path,
@@ -768,12 +828,16 @@ def test_status_flags_decision_unavailable_for_non_auto_restart_wrapped_agent(
     payload = json.loads(capsys.readouterr().out)
     alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
     assert alpha["supervisor"]["decision_unavailable"] is True
+    assert alpha["supervisor"][
+        "decision_unavailable_reason"] == "auto_restart_disabled"
+    assert alpha["health_composition"]["supervisor"][
+        "reason"] == "auto_restart_disabled"
 
     rc = _run(["status"], store_root)
     assert rc == 0
     out = capsys.readouterr().out
     line = next(ln for ln in out.splitlines() if ln.strip().startswith("alpha"))
-    assert "supervisor=UNAVAILABLE" in line, line
+    assert "supervisor=UNAVAILABLE(auto_restart_disabled)" in line, line
 
 
 def test_supervisor_cli_read_fail_safe(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,6 +505,85 @@ def test_status_supervisor_assessment_fail_safe(
     assert "supervisor_assessment_unavailable:ValueError" in payload["warnings"]
 
 
+def _fake_decision(state: str, *, action: str = "none",
+                   reason: str = "test") -> dict:
+    return {"agents": [{"name": "alpha",
+                        "decision": {"state": state, "action": action,
+                                     "reason": reason}}]}
+
+
+def test_status_flags_disagreement_between_self_report_and_strict_verdict(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A wrapper's self-report can keep saying "fine" after its CLI child has
+    died; the supervisor's strict decision.state is the one #105 exists to
+    surface. `status` must show BOTH facts, and flag when they disagree,
+    rather than silently resolving in favour of the cheerful self-report."""
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s = Store(store_root)
+    s.write_heartbeat("alpha")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN,
+        updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation",
+                        lambda *_a, **_k: _fake_decision("CLI_CHILD_UNKNOWN"))
+
+    rc = _run(["status", "--json"], store_root)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert alpha["health"]["state"] == "working_turn"  # self-report: looks fine
+    assert alpha["supervisor"]["decision"]["state"] == "CLI_CHILD_UNKNOWN"
+    assert alpha["supervisor"]["disagreement"] is True
+
+    rc = _run(["status"], store_root)
+    assert rc == 0
+    out = capsys.readouterr().out
+    line = next(ln for ln in out.splitlines() if ln.strip().startswith("alpha"))
+    assert "health=working_turn" in line
+    assert "supervisor=CLI_CHILD_UNKNOWN/none" in line
+    assert "[DISAGREEMENT]" in line  # direction control: absent before the fix
+
+
+def test_status_no_disagreement_flag_for_a_genuinely_healthy_agent(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """No false-DOWN: a wrapped agent the supervisor confirms HEALTHY_WORKING
+    must not be flagged, even though its state differs from HEALTHY_IDLE."""
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s = Store(store_root)
+    s.write_heartbeat("alpha")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN,
+        updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation",
+                        lambda *_a, **_k: _fake_decision("HEALTHY_WORKING"))
+
+    rc = _run(["status", "--json"], store_root)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert "disagreement" not in alpha["supervisor"]
+
+    rc = _run(["status"], store_root)
+    assert rc == 0
+    out = capsys.readouterr().out
+    line = next(ln for ln in out.splitlines() if ln.strip().startswith("alpha"))
+    assert "[DISAGREEMENT]" not in line
+
+
 def test_supervisor_cli_read_fail_safe(
     store_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -551,6 +551,78 @@ def test_status_flags_disagreement_between_self_report_and_strict_verdict(
     assert "[DISAGREEMENT]" in line  # direction control: absent before the fix
 
 
+def test_status_rejects_stale_snapshot_before_computing_strict_verdict(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A stale process row must not turn a strict non-green assessment into
+    HEALTHY_WORKING while raw wrapper health is still cheerfully green."""
+    s = Store(store_root)
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
+    s.write_heartbeat("alpha")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN, updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    snapshot_path = s.dir / "supervisor-snapshot.json"
+    snapshot_path.write_text(json.dumps([{"pid": 123}]), encoding="utf-8")
+    os.utime(snapshot_path, (1.0, 1.0))
+    observed_snapshots: list[object] = []
+
+    def assessment(_store, **kwargs):
+        snapshot = kwargs.get("snapshot")
+        observed_snapshots.append(snapshot)
+        state = "CLI_CHILD_UNKNOWN" if snapshot is None else "HEALTHY_WORKING"
+        return _fake_decision(state)
+
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation", assessment)
+
+    assert _run(["status", "--json"], store_root) == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+
+    assert observed_snapshots == [None]
+    assert alpha["health"]["state"] == "working_turn"
+    assert alpha["supervisor"]["decision"]["state"] == "CLI_CHILD_UNKNOWN"
+    assert alpha["supervisor"]["disagreement"] is True
+
+
+def test_status_snapshot_freshness_respects_configured_poll_interval(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    s = Store(store_root)
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "poll_seconds": 600,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    snapshot_path = s.dir / "supervisor-snapshot.json"
+    rows = [{"pid": 123}]
+    snapshot_path.write_text(json.dumps(rows), encoding="utf-8")
+    snapshot_epoch = time.time() - 400.0
+    os.utime(snapshot_path, (snapshot_epoch, snapshot_epoch))
+    observed_snapshots: list[object] = []
+
+    def assessment(_store, **kwargs):
+        observed_snapshots.append(kwargs.get("snapshot"))
+        return _fake_decision("HEALTHY_WORKING")
+
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation", assessment)
+
+    assert _run(["status", "--json"], store_root) == 0
+    capsys.readouterr()
+    assert observed_snapshots == [rows]
+
+
 def test_status_no_disagreement_flag_for_a_genuinely_healthy_agent(
     store_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -531,6 +531,10 @@ def test_status_flags_disagreement_between_self_report_and_strict_verdict(
         updated_at=now_iso, since=now_iso,
         reason_code="progress_event",
     ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
     monkeypatch.setattr(cli.sup, "build_supervisor_observation",
                         lambda *_a, **_k: _fake_decision("CLI_CHILD_UNKNOWN"))
 
@@ -549,6 +553,50 @@ def test_status_flags_disagreement_between_self_report_and_strict_verdict(
     assert "health=working_turn" in line
     assert "supervisor=CLI_CHILD_UNKNOWN/none" in line
     assert "[DISAGREEMENT]" in line  # direction control: absent before the fix
+
+
+def test_status_does_not_flag_wrapped_disagreement_for_unwrapped_agent(
+    store_root: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Manual auto-restart agents keep their useful advisory decision, but it
+    is not the wrapped-child strict verdict and must not get that verdict's
+    disagreement label."""
+    s = Store(store_root)
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat(timespec="microseconds").replace("+00:00", "Z")
+    old_iso = (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    (s.state_dir / "alpha.heartbeat").write_text(old_iso, encoding="utf-8")
+    s.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="manual",
+        state=hm.STATE_WORKING_TURN,
+        updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {
+            "wrapped": False,
+            "auto_restart": True,
+            "activity_hook": False,
+            "cli": "claude",
+        }},
+    }), encoding="utf-8")
+
+    assert _run(["status", "--json"], store_root) == 0
+    payload = json.loads(capsys.readouterr().out)
+    alpha = next(a for a in payload["agents"] if a["name"] == "alpha")
+    assert alpha["supervisor"]["decision"]["state"] == "ACTIVE_OR_BUSY"
+    assert alpha["supervisor"]["decision"]["action"] == "suspect_warn"
+    assert "disagreement" not in alpha["supervisor"]
+
+    assert _run(["status"], store_root) == 0
+    line = next(
+        line for line in capsys.readouterr().out.splitlines()
+        if line.strip().startswith("alpha")
+    )
+    assert "supervisor=ACTIVE_OR_BUSY/suspect_warn" in line
+    assert "[DISAGREEMENT]" not in line
 
 
 def test_status_rejects_stale_snapshot_before_computing_strict_verdict(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,13 +4,28 @@ from __future__ import annotations
 
 import json
 import os
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from agenttalk import cli, doctor, install_skills as iskl, ovh_gateway_service, signing
+from agenttalk import (
+    cli,
+    doctor,
+    health as hm,
+    install_skills as iskl,
+    ovh_gateway_service,
+    signing,
+    wrapper_runtime as wrt,
+)
 from agenttalk.store import Store
 from agenttalk.wrapper.obligations import POLICY_ENV
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z")
 
 
 def test_doctor_on_uninitialized_project_reports_error(tmp_path: Path) -> None:
@@ -39,6 +54,140 @@ def test_doctor_on_initialized_project_includes_all_check_categories(
     assert "codex_config" in names
     assert "heartbeat.alpha" in names
     assert "heartbeat.beta" in names
+
+
+def test_check_wrapper_child_health_absent_without_supervisor_json(
+    tmp_path: Path,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    assert doctor._check_wrapper_child_health(store) == []
+
+
+def test_check_wrapper_child_health_absent_without_wrapped_agents(
+    tmp_path: Path,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2, "agents": {"alpha": {"auto_restart": True}},
+    }), encoding="utf-8")
+    assert doctor._check_wrapper_child_health(store) == []
+
+
+def test_check_wrapper_child_health_surfaces_strict_verdict_over_self_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper's own self-report can keep reading "working" long after its
+    CLI child has died. The supervisor's decision.state is the strict,
+    positively-bound verdict; this check must show BOTH, plus the raw
+    last_progress_at age, rather than collapsing them into one adjective."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_heartbeat("alpha")
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN, updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    # A real wrapper-runtime record whose progress_sequence has been frozen
+    # for 10 minutes — the cheapest "is the counter frozen" signal, read
+    # independently of any computed verdict.
+    now = time.time()
+    writer = wrt.WrapperRuntimeWriter(
+        store.state_dir, "alpha", "test-wrapper-1", wrapper_pid=300,
+        wrapper_start="2020-01-01T00:00:00.000000Z", clock=lambda: now - 600,
+    )
+    writer.starting(message_id="m1", turn_id="t1")
+    writer.active(301, "2020-01-01T00:00:00.000000Z")
+    writer.progress()
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "working_turn", "age_seconds": 1.0},
+            "decision": {"state": "CLI_CHILD_UNKNOWN", "action": "none",
+                        "reason": "wrapper runtime could not be bound"},
+        }],
+    })
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    check = checks[0]
+    assert check.name == "wrapper_child_health.alpha"
+    assert check.status == "error"
+    assert "CLI_CHILD_UNKNOWN" in check.details
+    assert "working_turn" in check.details
+    assert "last_progress_age=600s" in check.details
+    assert "DISAGREEMENT" in check.details
+
+    # Direction control: the PRE-EXISTING heartbeat-only check stays green for
+    # this exact scenario — this is the "dead agent reads GREEN" bug; without
+    # the new check, doctor's report has nothing that would have caught it.
+    heartbeat_checks = doctor._check_heartbeats(store)
+    hb_alpha = next(c for c in heartbeat_checks if c.name == "heartbeat.alpha")
+    assert hb_alpha.status == "ok"
+
+
+def test_check_wrapper_child_health_no_false_down_when_healthy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No false-DOWN: a wrapped agent the supervisor confirms as
+    HEALTHY_WORKING must read `ok`, with no spurious disagreement flag."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_heartbeat("alpha")
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN, updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "working_turn", "age_seconds": 1.0},
+            "decision": {"state": "HEALTHY_WORKING", "action": "none", "reason": "ok"},
+        }],
+    })
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "ok"
+    assert "DISAGREEMENT" not in checks[0].details
+
+
+def test_check_wrapper_child_health_reports_absent_decision_honestly(
+    tmp_path: Path,
+) -> None:
+    """A wrapped agent that is not `auto_restart` has no computable strict
+    decision — real (unpatched) `build_supervisor_observation` behavior. The
+    check must say so plainly rather than silently reading only self-report."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    store.write_heartbeat("alpha")
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": False}},
+    }), encoding="utf-8")
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "warn"
+    assert "no supervisor decision is available" in checks[0].details
 
 
 def test_doctor_warns_when_supervisor_deadman_config_is_ignored(tmp_path: Path) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -135,6 +135,41 @@ def test_check_wrapper_child_health_surfaces_strict_verdict_over_self_report(
     assert hb_alpha.status == "ok"
 
 
+def test_check_wrapper_child_health_snapshot_freshness_respects_configured_poll(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "poll_seconds": 600,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    snapshot_path = store.dir / "supervisor-snapshot.json"
+    rows = [{"pid": 123}]
+    snapshot_path.write_text(json.dumps(rows), encoding="utf-8")
+    snapshot_epoch = time.time() - 400.0
+    os.utime(snapshot_path, (snapshot_epoch, snapshot_epoch))
+    observed_snapshots: list[object] = []
+
+    def assessment(_store, **kwargs):
+        observed_snapshots.append(kwargs.get("snapshot"))
+        return {"agents": [{
+            "name": "alpha",
+            "health": {"state": "working_turn", "age_seconds": 1.0},
+            "decision": {"state": "HEALTHY_WORKING", "action": "none", "reason": "bound"},
+        }]}
+
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", assessment)
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert observed_snapshots == [rows]
+    assert len(checks) == 1
+    assert checks[0].status == "ok"
+
+
 def test_check_wrapper_child_health_no_false_down_when_healthy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -169,6 +169,75 @@ def test_check_wrapper_child_health_no_false_down_when_healthy(
     assert "DISAGREEMENT" not in checks[0].details
 
 
+@pytest.mark.parametrize("grace_state", ["CLI_CHILD_STARTING", "LAUNCHING"])
+def test_check_wrapper_child_health_no_false_down_for_grace_states(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    grace_state: str,
+) -> None:
+    """No false-DOWN, both grace states: a freshly launched agent still inside
+    its bounded handoff grace (CLI_CHILD_STARTING, the wrapped-CLI-spawn
+    state, or the broader LAUNCHING state the planner also returns "in launch
+    grace") must read `ok`, not `warn`/`[DISAGREEMENT]` — reproduces the
+    reviewer's LAUNCHING regression."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_heartbeat("alpha")
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_IDLE_WAITING, updated_at=now_iso, since=now_iso,
+        reason_code="idle_waiting",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "idle_waiting", "age_seconds": 1.0},
+            "decision": {"state": grace_state, "action": "none",
+                        "reason": "in launch grace"},
+        }],
+    })
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "ok", checks[0].details
+    assert "DISAGREEMENT" not in checks[0].details
+
+
+def test_check_wrapper_child_health_fail_safe_on_corrupt_supervisor_state(
+    tmp_path: Path,
+) -> None:
+    """A diagnostic tool that dies on bad state is worst-useless exactly when
+    state is bad: a corrupt supervisor-state.json must degrade to a WARN
+    check, not abort doctor entirely (SupervisorPersistenceError)."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    (store.dir / "supervisor-state.json").write_text("not valid json {{{", encoding="utf-8")
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "warn"
+    assert "could not compute the supervisor's decision" in checks[0].details
+
+    # Full doctor.run() must also survive it end-to-end (the actual failure
+    # mode reported: an unguarded load_supervisor_state() call ABORTED the
+    # whole report with SupervisorPersistenceError instead of degrading).
+    report = doctor.run(tmp_path)
+    names = {c.name for c in report.checks}
+    assert "store.initialized" in names
+    assert "heartbeat.alpha" in names
+
+
 def test_check_wrapper_child_health_reports_absent_decision_honestly(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -209,6 +209,87 @@ def test_check_wrapper_child_health_no_false_down_for_grace_states(
     assert "DISAGREEMENT" not in checks[0].details
 
 
+def test_check_wrapper_child_health_no_false_error_for_provisional_cli_child_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI_CHILD_MISSING is the PROVISIONAL first-poll state of the
+    supervisor's two-poll anti-false-positive confirmation policy (the child
+    is absent on this poll, but no recovery action is queued yet, pending a
+    second same-turn poll). It must read `warn`, not `error` — `error` would
+    bypass that confirmation policy from the operator-surface side, exactly
+    the reviewer's correction of my own earlier over-inclusion."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_heartbeat("alpha")
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_WORKING_TURN, updated_at=now_iso, since=now_iso,
+        reason_code="progress_event",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "working_turn", "age_seconds": 1.0},
+            "decision": {"state": "CLI_CHILD_MISSING", "action": "none",
+                        "reason": "active CLI brain absent on first confirming poll"},
+        }],
+    })
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "warn", checks[0].details
+    assert "CLI_CHILD_MISSING" in checks[0].details
+
+
+@pytest.mark.parametrize(
+    ("decision_state", "action"),
+    [("RESTART_COOLDOWN", "backoff_wait"), ("ACTIVE_OR_BUSY", "suspect_warn")],
+)
+def test_check_wrapper_child_health_action_alone_does_not_escalate_to_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    decision_state: str,
+    action: str,
+) -> None:
+    """`action` is a recovery-INTENT signal, not a severity signal: a normal
+    RESTART_COOLDOWN/backoff_wait or ACTIVE_OR_BUSY/suspect_warn must read
+    `warn`, not `error` — the live fleet repro the reviewer cited (a diagnostic
+    that cries wolf on a state the supervisor is handling exactly as designed).
+    """
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_heartbeat("alpha")
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_IDLE_WAITING, updated_at=now_iso, since=now_iso,
+        reason_code="idle_waiting",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "idle_waiting", "age_seconds": 1.0},
+            "decision": {"state": decision_state, "action": action, "reason": "x"},
+        }],
+    })
+
+    checks = doctor._check_wrapper_child_health(store)
+
+    assert len(checks) == 1
+    assert checks[0].status == "warn", checks[0].details
+
+
 def test_check_wrapper_child_health_fail_safe_on_corrupt_supervisor_state(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -204,6 +204,43 @@ def test_check_wrapper_child_health_no_false_down_when_healthy(
     assert "DISAGREEMENT" not in checks[0].details
 
 
+def test_check_wrapper_child_health_healthy_decision_preserves_degraded_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful turn cannot overwrite the wrapper's persisted degraded
+    output observation.  The two facts disagree, and the maximum urgency wins."""
+    store = Store(tmp_path)
+    store.init(["alpha", "beta"])
+    now_iso = _now_iso()
+    store.write_health("alpha", hm.build_snapshot(
+        agent="alpha", cli="claude", mode="wrapper-loop",
+        state=hm.STATE_DEGRADED_OUTPUT, updated_at=now_iso, since=now_iso,
+        reason_code="degraded_output_detected",
+    ))
+    (store.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(doctor.sup, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "health": {"state": "degraded_output", "age_seconds": 1.0},
+            "decision": {
+                "state": "HEALTHY_WORKING", "action": "none", "reason": "turn succeeded",
+            },
+        }],
+    })
+
+    (check,) = doctor._check_wrapper_child_health(store)
+
+    assert check.status == "error"
+    assert check.details.startswith("self-reported health=degraded_output")
+    assert "degraded_output" in check.details
+    assert "HEALTHY_WORKING" in check.details
+    assert "DISAGREEMENT" in check.details
+
+
 @pytest.mark.parametrize("grace_state", ["CLI_CHILD_STARTING", "LAUNCHING"])
 def test_check_wrapper_child_health_no_false_down_for_grace_states(
     tmp_path: Path,

--- a/tests/test_operator_health.py
+++ b/tests/test_operator_health.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from itertools import product
+
 import pytest
 
-from agenttalk import operator_health as oh
+from agenttalk import cli, doctor, health as health_model, operator_health as oh, web
+from agenttalk.store import Store
 
 
 OBSERVATIONS = {
@@ -23,8 +28,16 @@ SUPERVISORS = {
         "state": "CLI_CHILD_STALLED", "action": "stuck_recover", "reason": "live stalled",
     },
     "failed": {"state": "TURN_FAILED", "action": "none", "reason": "turn failed"},
+    "readiness_exhausted": {
+        "state": "READINESS_GAVE_UP",
+        "action": "readiness_gave_up",
+        "reason": "never reached first heartbeat",
+    },
     "lost_binding": {
         "state": "CLI_CHILD_DEAD", "action": "relaunch", "reason": "binding lost",
+    },
+    "unconfirmed": {
+        "state": "CLI_CHILD_UNKNOWN", "action": "none", "reason": "binding unknown",
     },
 }
 SUPERVISOR_URGENCIES = {
@@ -33,6 +46,7 @@ SUPERVISOR_URGENCIES = {
     "advisory": "attention",
     "live_stalled": "danger",
     "failed": "danger",
+    "readiness_exhausted": "danger",
     "lost_binding": "danger",
     "unconfirmed": "danger",
     "unavailable": "attention",
@@ -46,21 +60,27 @@ COMPOSITION_CASES = (
     ("fine", "advisory", "attention", "supervisor", "warn", "maximum_urgency"),
     ("fine", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
     ("fine", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("fine", "readiness_exhausted", "danger", "supervisor", "error", "maximum_urgency"),
     ("fine", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("fine", "unconfirmed", "danger", "supervisor", "error", "maximum_urgency"),
     ("fine", "unavailable", "attention", "supervisor", "warn", "unavailable_never_healthy"),
     ("unknown", "healthy", "unknown", "observation", "warn", "healthy_never_erases"),
     ("unknown", "grace", "unknown", "observation", "warn", "grace_never_erases"),
     ("unknown", "advisory", "attention", "supervisor", "warn", "maximum_urgency"),
     ("unknown", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
     ("unknown", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("unknown", "readiness_exhausted", "danger", "supervisor", "error", "maximum_urgency"),
     ("unknown", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("unknown", "unconfirmed", "danger", "supervisor", "error", "maximum_urgency"),
     ("unknown", "unavailable", "attention", "supervisor", "warn", "unavailable_never_healthy"),
     ("attention", "healthy", "attention", "observation", "warn", "healthy_never_erases"),
     ("attention", "grace", "attention", "observation", "warn", "grace_never_erases"),
     ("attention", "advisory", "attention", "observation", "warn", "equal_urgency_observation_tie"),
     ("attention", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
     ("attention", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("attention", "readiness_exhausted", "danger", "supervisor", "error", "maximum_urgency"),
     ("attention", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("attention", "unconfirmed", "danger", "supervisor", "error", "maximum_urgency"),
     ("attention", "unavailable", "attention", "observation", "warn",
      "equal_urgency_observation_tie+facts_remain_visible"),
     ("danger", "healthy", "danger", "observation", "error", "healthy_never_erases"),
@@ -68,7 +88,11 @@ COMPOSITION_CASES = (
     ("danger", "advisory", "danger", "observation", "error", "maximum_urgency"),
     ("danger", "live_stalled", "danger", "observation", "error", "equal_urgency_observation_tie"),
     ("danger", "failed", "danger", "observation", "error", "equal_urgency_observation_tie"),
+    ("danger", "readiness_exhausted", "danger", "observation", "error",
+     "equal_urgency_observation_tie"),
     ("danger", "lost_binding", "danger", "observation", "error", "equal_urgency_observation_tie"),
+    ("danger", "unconfirmed", "danger", "observation", "error",
+     "equal_urgency_observation_tie"),
     ("danger", "unavailable", "danger", "observation", "error",
      "maximum_urgency+facts_remain_visible"),
 )
@@ -114,6 +138,13 @@ def test_composition_cross_product_is_invariant_derived(
             **decision,
             "urgency": got["supervisor"]["urgency"],
         }
+
+
+def test_composition_cross_product_covers_every_declared_semantic_kind() -> None:
+    expected = set(product(OBSERVATIONS, SUPERVISOR_URGENCIES))
+    actual = {(observation, supervisor) for observation, supervisor, *_ in COMPOSITION_CASES}
+
+    assert actual == expected
 
 
 def test_action_does_not_change_supervisor_urgency() -> None:
@@ -165,7 +196,7 @@ def test_composition_copies_producer_facts_instead_of_mutating_them() -> None:
         ("CLI_CHILD_STALLED", "live_stalled"),
         ("CLI_CHILD_NO_PROGRESS", "live_stalled"),
         ("TURN_FAILED", "failed"),
-        ("READINESS_GAVE_UP", "failed"),
+        ("READINESS_GAVE_UP", "readiness_exhausted"),
         ("CLI_CHILD_DEAD", "lost_binding"),
         ("WRAPPER_MISSING", "lost_binding"),
         ("CLI_CHILD_UNKNOWN", "unconfirmed"),
@@ -192,3 +223,168 @@ def test_supervisor_kind_preserves_producer_meaning(state: str, kind: str) -> No
 
     assert got["supervisor"]["kind"] == kind
     assert got["supervisor"]["urgency"] == SUPERVISOR_URGENCIES[kind]
+
+
+_SURFACE_NOW = 1_700_000_000.0
+
+
+class _FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        fixed = datetime.fromtimestamp(_SURFACE_NOW, timezone.utc)
+        return fixed if tz is not None else fixed.replace(tzinfo=None)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _freeze_surface_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "datetime", _FixedDateTime)
+    monkeypatch.setattr(doctor, "datetime", _FixedDateTime)
+    monkeypatch.setattr(web, "datetime", _FixedDateTime)
+    monkeypatch.setattr(web.time, "time", lambda: _SURFACE_NOW)
+
+
+def _surface_views(
+    store: Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict, dict, dict, object]:
+    _freeze_surface_time(monkeypatch)
+
+    def assessment_failed(*_args, **_kwargs):
+        raise ValueError("forced assessment failure")
+
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation", assessment_failed)
+
+    cli_row = cli._gather_status(store)["agents"][0]
+    web_root = web.build_state([
+        web.RootDescriptor(store=store, label="root"),
+    ])["roots"][0]
+    web_row = web_root["agents"][0]
+    api_status_health = web.status_payload(store)["agent_health"]["alpha"]
+    (doctor_check,) = doctor._check_wrapper_child_health(store)
+    return cli_row, web_row, api_status_health, doctor_check
+
+
+def _configured_surface_store(tmp_path, *, health_age: float,
+                              heartbeat_age: float | None,
+                              ttl_seconds: float,
+                              heartbeat_skew_seconds: float,
+                              per_agent_health: bool = False) -> Store:
+    store = Store(tmp_path)
+    store.init(["alpha"])
+    updated_at = _iso(_SURFACE_NOW - health_age)
+    store.write_health("alpha", health_model.build_snapshot(
+        agent="alpha",
+        cli="claude",
+        mode="wrapper-loop",
+        state=health_model.STATE_DEGRADED_OUTPUT,
+        updated_at=updated_at,
+        since=updated_at,
+        reason_code="degraded_output_detected",
+    ))
+    if heartbeat_age is not None:
+        (store.state_dir / "alpha.heartbeat").write_text(
+            _iso(_SURFACE_NOW - heartbeat_age), encoding="utf-8")
+    health_timing = {
+        "ttl_seconds": ttl_seconds,
+        "heartbeat_skew_seconds": heartbeat_skew_seconds,
+    }
+    agent_config = {"wrapped": True, "auto_restart": True}
+    supervisor_config = {
+        "schema_version": 2,
+        "agents": {"alpha": agent_config},
+    }
+    if per_agent_health:
+        agent_config["health"] = health_timing
+    else:
+        supervisor_config["health"] = health_timing
+    (store.dir / "supervisor.json").write_text(
+        json.dumps(supervisor_config), encoding="utf-8")
+    return store
+
+
+def test_operator_surfaces_share_configured_health_ttl_on_assessment_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _configured_surface_store(
+        tmp_path,
+        health_age=400.0,
+        heartbeat_age=None,
+        ttl_seconds=600.0,
+        heartbeat_skew_seconds=30.0,
+        per_agent_health=True,
+    )
+
+    cli_row, web_row, api_status_health, doctor_check = _surface_views(store, monkeypatch)
+
+    assert cli_row["health"] == web_row["health"] == api_status_health
+    assert cli_row["health"]["state"] == "degraded_output"
+    assert cli_row["health"]["age_seconds"] == 400.0
+    assert cli_row["health"]["stale"] is False
+    assert cli_row["health_composition"] == web_row["health_composition"]
+    assert cli_row["health_composition"]["urgency"] == "danger"
+    assert cli_row["health_composition"]["primary_source"] == "observation"
+    assert web_row["wrapped"] is True
+    assert doctor_check.status == "error"
+    assert doctor_check.details.startswith("self-reported health=degraded_output")
+
+
+def test_operator_surfaces_share_configured_heartbeat_skew_on_assessment_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _configured_surface_store(
+        tmp_path,
+        health_age=20.0,
+        heartbeat_age=0.0,
+        ttl_seconds=600.0,
+        heartbeat_skew_seconds=0.0,
+    )
+
+    cli_row, web_row, api_status_health, doctor_check = _surface_views(store, monkeypatch)
+
+    assert cli_row["health"] == web_row["health"] == api_status_health
+    assert cli_row["health"]["state"] == "unknown"
+    assert cli_row["health"]["reason_code"] == "health_older_than_heartbeat"
+    assert cli_row["health_composition"] == web_row["health_composition"]
+    assert cli_row["health_composition"]["urgency"] == "attention"
+    assert cli_row["health_composition"]["primary_source"] == "supervisor"
+    assert web_row["wrapped"] is True
+    assert doctor_check.status == "warn"
+    assert doctor_check.details.startswith("supervisor=UNAVAILABLE(assessment_failed)")
+    assert "self-reported health=unknown" in doctor_check.details
+
+
+def test_operator_surfaces_do_not_guess_when_health_timing_policy_is_invalid(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = Store(tmp_path)
+    store.init(["alpha"])
+    updated_at = _iso(_SURFACE_NOW - 20.0)
+    store.write_health("alpha", health_model.build_snapshot(
+        agent="alpha",
+        cli="claude",
+        mode="wrapper-loop",
+        state=health_model.STATE_DEGRADED_OUTPUT,
+        updated_at=updated_at,
+        since=updated_at,
+        reason_code="degraded_output_detected",
+    ))
+    (store.dir / "supervisor.json").write_text("{not valid json", encoding="utf-8")
+    _freeze_surface_time(monkeypatch)
+
+    cli_row = cli._gather_status(store)["agents"][0]
+    web_root = web.build_state([
+        web.RootDescriptor(store=store, label="root"),
+    ])["roots"][0]
+    web_row = web_root["agents"][0]
+    api_status_health = web.status_payload(store)["agent_health"]["alpha"]
+    (doctor_check,) = doctor._check_wrapper_child_health(store)
+
+    assert cli_row["health"] == web_row["health"] == api_status_health
+    assert cli_row["health"]["state"] == "unknown"
+    assert cli_row["health"]["reason_code"] == "health_timing_policy_unavailable"
+    assert doctor_check.name == "wrapper_child_health.supervisor_config"
+    assert doctor_check.status == "warn"
+    assert "health timing policy is unavailable" in doctor_check.details

--- a/tests/test_operator_health.py
+++ b/tests/test_operator_health.py
@@ -1,0 +1,194 @@
+"""Specification tests for operator-surface health composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from agenttalk import operator_health as oh
+
+
+OBSERVATIONS = {
+    "fine": "working_turn",
+    "unknown": "unknown",
+    "attention": "stuck_suspected",
+    "danger": "degraded_output",
+}
+SUPERVISORS = {
+    "healthy": {"state": "HEALTHY_WORKING", "action": "none", "reason": "bound"},
+    "grace": {"state": "LAUNCHING", "action": "none", "reason": "launch grace"},
+    "advisory": {
+        "state": "RESTART_COOLDOWN", "action": "backoff_wait", "reason": "cooldown",
+    },
+    "live_stalled": {
+        "state": "CLI_CHILD_STALLED", "action": "stuck_recover", "reason": "live stalled",
+    },
+    "failed": {"state": "TURN_FAILED", "action": "none", "reason": "turn failed"},
+    "lost_binding": {
+        "state": "CLI_CHILD_DEAD", "action": "relaunch", "reason": "binding lost",
+    },
+}
+SUPERVISOR_URGENCIES = {
+    "healthy": "fine",
+    "grace": "fine",
+    "advisory": "attention",
+    "live_stalled": "danger",
+    "failed": "danger",
+    "lost_binding": "danger",
+    "unconfirmed": "danger",
+    "unavailable": "attention",
+}
+
+# Literal expectations are derived from the prose invariant, not from the
+# implementation.  Each row names the clause that determines its outcome.
+COMPOSITION_CASES = (
+    ("fine", "healthy", "fine", "observation", "ok", "equal_urgency_observation_tie"),
+    ("fine", "grace", "fine", "observation", "ok", "equal_urgency_observation_tie"),
+    ("fine", "advisory", "attention", "supervisor", "warn", "maximum_urgency"),
+    ("fine", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
+    ("fine", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("fine", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("fine", "unavailable", "attention", "supervisor", "warn", "unavailable_never_healthy"),
+    ("unknown", "healthy", "unknown", "observation", "warn", "healthy_never_erases"),
+    ("unknown", "grace", "unknown", "observation", "warn", "grace_never_erases"),
+    ("unknown", "advisory", "attention", "supervisor", "warn", "maximum_urgency"),
+    ("unknown", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
+    ("unknown", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("unknown", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("unknown", "unavailable", "attention", "supervisor", "warn", "unavailable_never_healthy"),
+    ("attention", "healthy", "attention", "observation", "warn", "healthy_never_erases"),
+    ("attention", "grace", "attention", "observation", "warn", "grace_never_erases"),
+    ("attention", "advisory", "attention", "observation", "warn", "equal_urgency_observation_tie"),
+    ("attention", "live_stalled", "danger", "supervisor", "error", "maximum_urgency"),
+    ("attention", "failed", "danger", "supervisor", "error", "maximum_urgency"),
+    ("attention", "lost_binding", "danger", "supervisor", "error", "maximum_urgency"),
+    ("attention", "unavailable", "attention", "observation", "warn",
+     "equal_urgency_observation_tie+facts_remain_visible"),
+    ("danger", "healthy", "danger", "observation", "error", "healthy_never_erases"),
+    ("danger", "grace", "danger", "observation", "error", "grace_never_erases"),
+    ("danger", "advisory", "danger", "observation", "error", "maximum_urgency"),
+    ("danger", "live_stalled", "danger", "observation", "error", "equal_urgency_observation_tie"),
+    ("danger", "failed", "danger", "observation", "error", "equal_urgency_observation_tie"),
+    ("danger", "lost_binding", "danger", "observation", "error", "equal_urgency_observation_tie"),
+    ("danger", "unavailable", "danger", "observation", "error",
+     "maximum_urgency+facts_remain_visible"),
+)
+
+
+@pytest.mark.parametrize(
+    ("observation", "supervisor", "urgency", "primary_source", "doctor_status", "clause"),
+    COMPOSITION_CASES,
+)
+def test_composition_cross_product_is_invariant_derived(
+    observation: str,
+    supervisor: str,
+    urgency: str,
+    primary_source: str,
+    doctor_status: str,
+    clause: str,
+) -> None:
+    decision = SUPERVISORS.get(supervisor)
+    unavailable_reason = "assessment_failed" if supervisor == "unavailable" else None
+
+    got = oh.compose_health_evidence(
+        OBSERVATIONS[observation],
+        decision=decision,
+        unavailable_reason=unavailable_reason,
+    )
+
+    assert got["observation"] == {
+        "source": "wrapper_health",
+        "state": OBSERVATIONS[observation],
+        "urgency": observation,
+    }
+    assert got["urgency"] == urgency, clause
+    assert got["primary_source"] == primary_source, clause
+    assert oh.doctor_status(got) == doctor_status, clause
+    assert got["supervisor"]["urgency"] == SUPERVISOR_URGENCIES[supervisor]
+    assert got["supervisor"]["kind"] == supervisor
+    if supervisor == "unavailable":
+        assert got["supervisor"]["reason"] == "assessment_failed"
+    else:
+        assert got["supervisor"] == {
+            "source": "supervisor_decision",
+            "kind": supervisor,
+            **decision,
+            "urgency": got["supervisor"]["urgency"],
+        }
+
+
+def test_action_does_not_change_supervisor_urgency() -> None:
+    base = {"state": "RESTART_COOLDOWN", "reason": "cooldown"}
+
+    none = oh.compose_health_evidence("working_turn", decision={**base, "action": "none"})
+    relaunch = oh.compose_health_evidence(
+        "working_turn", decision={**base, "action": "relaunch"})
+
+    assert none["urgency"] == relaunch["urgency"] == "attention"
+    assert none["supervisor"]["kind"] == relaunch["supervisor"]["kind"] == "advisory"
+
+
+@pytest.mark.parametrize(
+    ("state", "urgency"),
+    [
+        ("idle_waiting", "fine"),
+        ("working_turn", "fine"),
+        ("working_silent", "fine"),
+        ("unknown", "unknown"),
+        ("stuck_suspected", "attention"),
+        ("errored_poison", "attention"),
+        ("crashed_or_exited", "attention"),
+        ("rate_limited_or_outage", "danger"),
+        ("degraded_output", "danger"),
+        ("errored_ambiguous", "danger"),
+    ],
+)
+def test_observation_vocabulary_has_explicit_urgency(state: str, urgency: str) -> None:
+    assert oh.classify_observation_state(state) == urgency
+
+
+def test_composition_copies_producer_facts_instead_of_mutating_them() -> None:
+    decision = {"state": "HEALTHY_WORKING", "action": "none", "reason": "bound"}
+
+    got = oh.compose_health_evidence("degraded_output", decision=decision)
+    got["supervisor"]["state"] = "CHANGED_IN_PRESENTATION"
+
+    assert decision == {"state": "HEALTHY_WORKING", "action": "none", "reason": "bound"}
+
+
+@pytest.mark.parametrize(
+    ("state", "kind"),
+    [
+        ("HEALTHY_IDLE", "healthy"),
+        ("HEALTHY_WORKING", "healthy"),
+        ("CLI_CHILD_STARTING", "grace"),
+        ("LAUNCHING", "grace"),
+        ("CLI_CHILD_STALLED", "live_stalled"),
+        ("CLI_CHILD_NO_PROGRESS", "live_stalled"),
+        ("TURN_FAILED", "failed"),
+        ("READINESS_GAVE_UP", "failed"),
+        ("CLI_CHILD_DEAD", "lost_binding"),
+        ("WRAPPER_MISSING", "lost_binding"),
+        ("CLI_CHILD_UNKNOWN", "unconfirmed"),
+        ("STUCK_OR_DEAD", "unconfirmed"),
+        ("CLI_CHILD_MISSING", "advisory"),
+        ("CLI_CHILD_STALL_SUSPECT", "advisory"),
+        ("RESTART_COOLDOWN", "advisory"),
+        ("ACTIVE_OR_BUSY", "advisory"),
+        ("REFUSE_PROTECTED", "advisory"),
+        ("RESTART_UNAUTHORIZED", "advisory"),
+        ("LIVE_PROTECTED_REFUSED", "advisory"),
+        ("MANUAL_RESTART", "advisory"),
+        ("CONFIG_BLOCKED", "advisory"),
+        ("LEAD_LOOP_STOOD_DOWN", "advisory"),
+        ("LEAD_LOOP_BLOCKED", "advisory"),
+        ("UNACCOUNTED_LIVE_DESCENDANT", "advisory"),
+        ("PROCESS_TREE_INVALID", "advisory"),
+        ("PROCESS_TREE_TRUNCATED", "advisory"),
+    ],
+)
+def test_supervisor_kind_preserves_producer_meaning(state: str, kind: str) -> None:
+    got = oh.compose_health_evidence(
+        "working_turn", decision={"state": state, "action": "none", "reason": "test"})
+
+    assert got["supervisor"]["kind"] == kind
+    assert got["supervisor"]["urgency"] == SUPERVISOR_URGENCIES[kind]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1106,6 +1106,19 @@ def test_ps_state_helpers_are_atomic_backed_up_and_fail_closed() -> None:
     assert "[System.IO.File]::Replace" in block
     assert "[System.IO.File]::Move" in block
     assert "function Invoke-StateFileSwapWithRetry" in block
+    file_atomic = block[
+        block.index("function Write-FileAtomic"):
+        block.index("function Write-StateFileAtomic")
+    ]
+    # Temp cleanup must cover creation and writing as well as replacement.
+    # Otherwise a partial-write/disk-full exception strands the unique temp.
+    assert (
+        file_atomic.index("try {")
+        < file_atomic.index("$stream =")
+        < file_atomic.index("Invoke-StateFileSwapWithRetry")
+        < file_atomic.rindex("} finally {")
+        < file_atomic.rindex("if (Test-Path -LiteralPath $tmp)")
+    )
     assert "Test-IsRetryableStateWriteException $_.Exception" in block
     assert "for ($attempt = 1; $attempt -le 8; $attempt++)" in block
     assert "$delayMs = [Math]::Min(250, $delayMs * 2)" in block
@@ -5060,6 +5073,79 @@ def test_generated_proc_snapshot_emits_exact_live_filetime(tmp_path: Path) -> No
     assert "foreach ($liveProc in @(Get-Process" in helpers
 
 
+def test_generated_proc_snapshot_replaces_destination_atomically(tmp_path: Path) -> None:
+    """A concurrent reader must see the complete previous snapshot while the
+    generated writer publishes the complete replacement, never an in-progress
+    truncate/write of the live path."""
+    shell = _pick_powershell()
+    if not shell:
+        return
+    helpers = _exec_helpers(tmp_path)
+    snapshot_path = tmp_path / "process-snapshot.json"
+    out = tmp_path / "process-snapshot-atomic-result.json"
+    initial = '[{"pid":777,"name":"previous"}]'
+    harness = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        helpers,
+        f"$snapshotPath = {_pslit(str(snapshot_path))}",
+        f"$resultPath = {_pslit(str(out))}",
+        "$u8 = New-Object System.Text.UTF8Encoding($false)",
+        f"[IO.File]::WriteAllText($snapshotPath, {_pslit(initial)}, $u8)",
+        "$held = [IO.FileStream]::new($snapshotPath, [IO.FileMode]::Open, "
+        "[IO.FileAccess]::Read, ([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete))",
+        "$script:liveStart = (Microsoft.PowerShell.Management\\Get-Process "
+        "-Id $PID -ErrorAction Stop).StartTime",
+        "function Get-CimInstance { [CmdletBinding()] param([string]$ClassName); "
+        "[pscustomobject]@{ ProcessId = [int]$PID; ParentProcessId = 0; "
+        "Name = 'pwsh.exe'; CommandLine = $null; CreationDate = $script:liveStart } }",
+        "function Get-Process { [CmdletBinding()] param([int]$Id); "
+        "[pscustomobject]@{ Id = [int]$PID; StartTime = $script:liveStart } }",
+        "$heldFailure = $null",
+        "try {",
+        "  if (-not (Get-ProcSnapshot $snapshotPath)) { throw 'snapshot unavailable' }",
+        "  $held.Position = 0",
+        "  $oldBytes = New-Object byte[] ([int]$held.Length)",
+        "  [void]$held.Read($oldBytes, 0, $oldBytes.Length)",
+        "  $heldText = $u8.GetString($oldBytes)",
+        "  $currentText = [IO.File]::ReadAllText($snapshotPath, $u8)",
+        "  $current = @($currentText | ConvertFrom-Json)",
+        "  $held.Dispose(); $held = $null",
+        "  $heldFailure = [IO.FileStream]::new($snapshotPath, [IO.FileMode]::Open, "
+        "[IO.FileAccess]::Read, ([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete))",
+        "  function Get-CimInstance { throw 'injected capture failure' }",
+        "  if (Get-ProcSnapshot $snapshotPath) { throw 'capture unexpectedly succeeded' }",
+        "  $heldFailure.Position = 0",
+        "  $failureOldBytes = New-Object byte[] ([int]$heldFailure.Length)",
+        "  [void]$heldFailure.Read($failureOldBytes, 0, $failureOldBytes.Length)",
+        "  $heldFailureText = $u8.GetString($failureOldBytes)",
+        "  $marker = [IO.File]::ReadAllText($snapshotPath, $u8) | ConvertFrom-Json",
+        "  @{ held = $heldText; current_pid = [int]$current[0].pid; "
+        "writer_pid = [int]$PID; held_failure = $heldFailureText; "
+        "prior_current = $currentText; unavailable = [bool]$marker.unavailable } | "
+        "ConvertTo-Json | Set-Content $resultPath -Encoding utf8",
+        "} finally {",
+        "  if ($null -ne $held) { $held.Dispose() }",
+        "  if ($null -ne $heldFailure) { $heldFailure.Dispose() }",
+        "}",
+    ])
+    script = tmp_path / "proc-snapshot-atomic.ps1"
+    script.write_text(harness, encoding="utf-8-sig")
+
+    result = subprocess.run(
+        [shell, "-NoProfile", "-File", str(script)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+    payload = json.loads(out.read_text(encoding="utf-8-sig"))
+    assert payload["held"] == initial
+    assert payload["current_pid"] == payload["writer_pid"]
+    assert payload["held_failure"] == payload["prior_current"]
+    assert payload["unavailable"] is True
+
+
 def test_stop_tree_rejects_rounded_start_collision_by_exact_filetime(
     tmp_path: Path,
 ) -> None:
@@ -6831,16 +6917,22 @@ def test_manual_restart_marker_clears_only_after_readiness(tmp_path: Path) -> No
 
 
 def _exec_helpers(tmp_path: Path) -> str:
-    """Extract the verbatim exec-helpers (Proc-Start/Get-ProcSnapshot/Stop-Tree/
-    Seed-CodexHome) from a freshly generated supervisor.ps1, so the runtime tests
-    drive the EXACT shipped PowerShell."""
+    """Extract the state + exec helpers from a freshly generated supervisor.ps1.
+
+    The runtime tests drive the EXACT shipped PowerShell. State helpers are
+    included because Get-ProcSnapshot publishes through their atomic file
+    primitive.
+    """
     s = _team(tmp_path)
     (s.dir / "supervisor.json").write_text(json.dumps(_CONFIG), encoding="utf-8")
     assert _run(["supervise", "--init"], tmp_path) == 0
     text = (s.dir / "supervisor.ps1").read_text(encoding="utf-8-sig")
+    state = text[
+        text.index("# region state-helpers"):text.index("# endregion state-helpers")
+    ]
     block = text[text.index("# region exec-helpers"):text.index("# endregion exec-helpers")]
     assert "function Stop-Tree" in block and "function Seed-CodexHome" in block
-    return "function Assert-ActionsEnabled([string]$what) { return $true }\n" + block
+    return "function Assert-ActionsEnabled([string]$what) { return $true }\n" + state + block
 
 
 # Round 23: Complete-WrapperLogTargets is gone - marking a generation

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -740,6 +740,50 @@ def test_python_supervisor_state_recovers_only_from_validated_backup(tmp_path: P
         sup.load_supervisor_state(path)
 
 
+def test_read_supervisor_snapshot_if_fresh_returns_the_real_rows_when_current(
+    tmp_path: Path,
+) -> None:
+    """The GOOD state is present: a fresh snapshot file's ACTUAL rows come
+    back, not merely "something not-None" — count the thing that should be
+    there, per the review bar."""
+    path = tmp_path / "supervisor-snapshot.json"
+    rows = [{"pid": 123, "start": "t0", "name": "python.exe"}]
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    now = path.stat().st_mtime + 1.0
+
+    got = sup.read_supervisor_snapshot_if_fresh(path, now_epoch=now)
+
+    assert got == rows
+
+
+def test_read_supervisor_snapshot_if_fresh_rejects_a_stale_file(
+    tmp_path: Path,
+) -> None:
+    """Positive process binding requires a CURRENT snapshot: a supervisor that
+    stopped refreshing observations (or runs with actions disabled after an
+    enabled run) leaves a stale file on disk. It must be treated as if the
+    capture had failed (None) — the SAME degrade-safe signal a genuinely
+    missing snapshot produces — not read as a live liveness fact."""
+    path = tmp_path / "supervisor-snapshot.json"
+    path.write_text(json.dumps([{"pid": 1, "start": "t0", "name": "x"}]), encoding="utf-8")
+    stale_now = path.stat().st_mtime + sup.SNAPSHOT_STALE_AFTER_SECONDS + 1.0
+
+    assert sup.read_supervisor_snapshot_if_fresh(path, now_epoch=stale_now) is None
+
+
+def test_read_supervisor_snapshot_if_fresh_absent_and_malformed(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    assert sup.read_supervisor_snapshot_if_fresh(missing, now_epoch=time.time()) is None
+
+    malformed = tmp_path / "supervisor-snapshot.json"
+    malformed.write_text("not valid json {{{", encoding="utf-8")
+    assert sup.read_supervisor_snapshot_if_fresh(malformed, now_epoch=time.time()) is None
+
+    not_a_list = tmp_path / "supervisor-snapshot2.json"
+    not_a_list.write_text(json.dumps({"agents": {}}), encoding="utf-8")
+    assert sup.read_supervisor_snapshot_if_fresh(not_a_list, now_epoch=time.time()) is None
+
+
 def test_python_supervisor_state_interrupted_replace_preserves_primary(
     tmp_path: Path, monkeypatch,
 ) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -756,6 +756,64 @@ def test_read_supervisor_snapshot_if_fresh_returns_the_real_rows_when_current(
     assert got == rows
 
 
+def test_read_supervisor_snapshot_if_fresh_bounds_future_mtime(
+    tmp_path: Path,
+) -> None:
+    """Allow the stat-after-clock-read race, but never trust rows timestamped
+    beyond the project's explicit clock-skew allowance."""
+    path = tmp_path / "supervisor-snapshot.json"
+    rows = [{"pid": 123, "start": "t0", "name": "python.exe"}]
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    mtime = path.stat().st_mtime
+
+    assert sup.read_supervisor_snapshot_if_fresh(
+        path,
+        now_epoch=mtime - 1.0,
+    ) == rows
+    assert sup.read_supervisor_snapshot_if_fresh(
+        path,
+        now_epoch=mtime - hm.DEFAULT_HEARTBEAT_SKEW_SECONDS - 1.0,
+    ) is None
+
+
+def test_snapshot_freshness_allowance_covers_a_configured_slow_poll(
+    tmp_path: Path,
+) -> None:
+    """A supported 600s supervisor cadence must not make its own snapshot
+    stale halfway between polls. The default 300s floor still applies to the
+    normal 15s cadence; slower configured cadences get two full intervals."""
+    path = tmp_path / "supervisor-snapshot.json"
+    rows = [{"pid": 123, "start": "t0", "name": "python.exe"}]
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    allowance = sup.resolve_snapshot_stale_after_seconds({"poll_seconds": 600})
+
+    got = sup.read_supervisor_snapshot_if_fresh(
+        path,
+        now_epoch=path.stat().st_mtime + 900,
+        stale_after_seconds=allowance,
+    )
+
+    assert allowance == 1200.0
+    assert got == rows
+    assert sup.read_supervisor_snapshot_if_fresh(
+        path,
+        now_epoch=path.stat().st_mtime + allowance + 1.0,
+        stale_after_seconds=allowance,
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "poll_seconds",
+    [None, True, -1, float("inf"), 1e308, 10**400, "600"],
+)
+def test_snapshot_freshness_allowance_rejects_malformed_poll_values(
+    poll_seconds: object,
+) -> None:
+    assert sup.resolve_snapshot_stale_after_seconds({
+        "poll_seconds": poll_seconds,
+    }) == sup.SNAPSHOT_STALE_AFTER_SECONDS
+
+
 def test_read_supervisor_snapshot_if_fresh_rejects_a_stale_file(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2755,6 +2755,115 @@ assert(hooks.freshHeartbeat({ last_seen_age_seconds: -1 }) === false, 'negative 
                    capture_output=True, text=True)
 
 
+def test_console_agent_state_info_reflects_supervisor_decision(tmp_path: Path) -> None:
+    """A REAL render control: drives the actual browser-side `agentStateInfo()`
+    (not `/api/state`) for the exact scenario #105 exists to fix — a wrapper
+    whose self-report still says "working" while the supervisor's decision
+    says the CLI child could not be confirmed. Without the console.js fix,
+    `agentStateInfo` classified this purely from `health.state` and returned
+    `color: 'ok'` — a browser-visible false-GREEN. This asserts it does not.
+
+    Also a no-false-DOWN control for BOTH grace states (`CLI_CHILD_STARTING`
+    and `LAUNCHING`) and the two green states, and the `supervisor_decision_
+    unavailable` case (a wrapped, non-auto_restart agent) renders visibly
+    rather than silently as plain self-report.
+    """
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the console render-control test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    agentStateInfo: agentStateInfo\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented2.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-agent-state-supervisor.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(process.argv[2], 'utf8');
+const ctx = {
+  console,
+  document: { readyState: 'loading', addEventListener() {} },
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  setInterval() {},
+  clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkConsoleTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+ctx.__agenttalkConsoleTestHooks = {};
+vm.createContext(ctx);
+vm.runInContext(source, ctx, { filename: 'console.instrumented2.js' });
+const hooks = ctx.__agenttalkConsoleTestHooks;
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+// B1 direction control: the dead-child case, self-report still "working".
+// Before the console.js fix this returned color:'ok' (the browser-visible bug).
+const dead = hooks.agentStateInfo({
+  health: { state: 'working_turn' }, wrapped: true,
+  supervisor_decision: { state: 'CLI_CHILD_UNKNOWN', action: 'none', reason: 'x' },
+});
+assert(dead.color !== 'ok', `dead-child must not render ok, got ${dead.color}`);
+assert(dead.key === 'supervisor_unbound', `expected supervisor_unbound, got ${dead.key}`);
+assert(dead.color === 'danger', `expected danger, got ${dead.color}`);
+
+// Same for a confirmed-dead sibling state (not just CLI_CHILD_UNKNOWN).
+const stuck = hooks.agentStateInfo({
+  health: { state: 'idle_waiting' }, wrapped: true,
+  supervisor_decision: { state: 'STUCK_OR_DEAD', action: 'stuck_recover', reason: 'x' },
+});
+assert(stuck.color === 'danger', `STUCK_OR_DEAD must render danger, got ${stuck.color}`);
+
+// B2 no-false-DOWN control: BOTH grace states render as the self-report says
+// (no override), not attn/danger.
+for (const graceState of ['CLI_CHILD_STARTING', 'LAUNCHING']) {
+  const grace = hooks.agentStateInfo({
+    health: { state: 'idle_waiting' }, wrapped: true,
+    supervisor_decision: { state: graceState, action: 'none', reason: 'x' },
+  });
+  assert(grace.key === 'idle_waiting', `${graceState} must not override self-report, got ${grace.key}`);
+  assert(grace.color !== 'danger' && grace.color !== 'attn', `${graceState} false-DOWN: ${grace.color}`);
+}
+
+// Positive control: HEALTHY_WORKING never overrides either.
+const healthy = hooks.agentStateInfo({
+  health: { state: 'working_turn' }, wrapped: true,
+  supervisor_decision: { state: 'HEALTHY_WORKING', action: 'none', reason: 'ok' },
+});
+assert(healthy.key === 'working_turn', `HEALTHY_WORKING false-DOWN: ${healthy.key}`);
+assert(healthy.color === 'ok', `HEALTHY_WORKING must stay ok, got ${healthy.color}`);
+
+// B3: supervisor_decision_unavailable (wrapped, not auto_restart) renders
+// visibly rather than silently falling back to plain self-report.
+const unavailable = hooks.agentStateInfo({
+  health: { state: 'working_turn' }, wrapped: true,
+  supervisor_decision_unavailable: true,
+});
+assert(unavailable.key === 'supervisor_unavailable', `expected supervisor_unavailable, got ${unavailable.key}`);
+assert(unavailable.color === 'attn', `expected attn, got ${unavailable.color}`);
+
+// No supervisor_decision at all (unwrapped / no supervisor configured) is
+// unaffected — plain self-report, no false alarm.
+const plain = hooks.agentStateInfo({ health: { state: 'working_turn' }, wrapped: true });
+assert(plain.key === 'working_turn', `plain self-report must be unaffected, got ${plain.key}`);
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_all_dashboard_views_render_smoke_non_empty_main(tmp_path: Path) -> None:
     if shutil.which("node") is None:
         pytest.skip("node is required for console all-views render smoke test")
@@ -4381,6 +4490,33 @@ def test_api_state_supervisor_decision_absent_when_not_computable(
         alpha = next(a for a in root["agents"] if a["name"] == "alpha")
         assert "supervisor_decision" not in alpha
         assert "wrapper_child" not in alpha
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_supervisor_decision_unavailable_for_non_auto_restart_wrapped_agent(
+    tmp_path: Path,
+) -> None:
+    """A wrapped agent that is not `auto_restart` has no computable strict
+    decision — real (unpatched) build_supervisor_observation behavior. The
+    web console must say so visibly (`supervisor_decision_unavailable: true`),
+    not silently show only `health` with no other signal at all — the
+    "dishonest on the two human surfaces" gap the reviewer found on web+status."""
+    s = _make_store(tmp_path)
+    s.write_heartbeat("alpha")
+    _write_health(s, "alpha", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": False}},
+    }), encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        (root,) = _state(base)["roots"]
+        alpha = next(a for a in root["agents"] if a["name"] == "alpha")
+        assert alpha.get("supervisor_decision_unavailable") is True
+        assert "supervisor_decision" not in alpha
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -12,6 +12,7 @@ import hashlib
 import http.client
 import inspect
 import json
+import os
 import re
 import shutil
 import socket
@@ -2865,6 +2866,17 @@ const unavailable = hooks.agentStateInfo({
 assert(unavailable.key === 'supervisor_unavailable', `expected supervisor_unavailable, got ${unavailable.key}`);
 assert(unavailable.color === 'attn', `expected attn, got ${unavailable.color}`);
 
+// Current-master process-tree HOLDs are strict supervisor verdicts too. Raw
+// wrapper health may remain green, but either HOLD must stay visibly non-green.
+for (const holdState of ['PROCESS_TREE_INVALID', 'PROCESS_TREE_TRUNCATED']) {
+  const held = hooks.agentStateInfo({
+    health: { state: 'working_turn' }, wrapped: true,
+    supervisor_decision: { state: holdState, action: 'warn_only', reason: 'HOLDING' },
+  });
+  assert(held.key === 'supervisor_unconfirmed', `${holdState} must be strict, got ${held.key}`);
+  assert(held.color === 'attn', `${holdState} must not render green, got ${held.color}`);
+}
+
 // No supervisor_decision at all (unwrapped / no supervisor configured) is
 // unaffected — plain self-report, no false alarm.
 const plain = hooks.agentStateInfo({ health: { state: 'working_turn' }, wrapped: true });
@@ -4480,6 +4492,75 @@ def test_api_state_supervisor_decision_surfaces_strict_verdict_over_self_report(
         }
         assert alpha["wrapper_child"]["phase"] == "active"
         assert alpha["wrapper_child"]["progress_age_seconds"] >= 599.0
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_filters_supervisor_decisions_to_wrapped_agents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _make_store(tmp_path)
+    _write_health(s, "alpha", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+    _write_health(s, "beta", _hm.STATE_WORKING_TURN, cli="claude", mode="manual")
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {
+            "alpha": {"wrapped": True, "auto_restart": True},
+            "beta": {"wrapped": False, "auto_restart": True},
+        },
+    }), encoding="utf-8")
+    monkeypatch.setattr(web._supervisor, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [
+            {"name": "alpha", "decision": {
+                "state": "PROCESS_TREE_INVALID", "action": "warn_only", "reason": "HOLDING"}},
+            {"name": "beta", "decision": {
+                "state": "CLI_CHILD_UNKNOWN", "action": "none", "reason": "manual agent"}},
+        ],
+    })
+
+    srv, _t, base = _serve(s)
+    try:
+        (root,) = _state(base)["roots"]
+        by_name = {a["name"]: a for a in root["agents"]}
+        assert by_name["alpha"]["supervisor_decision"]["state"] == "PROCESS_TREE_INVALID"
+        assert by_name["alpha"]["health"]["state"] == "working_turn"
+        assert "supervisor_decision" not in by_name["beta"]
+        assert "supervisor_decision_unavailable" not in by_name["beta"]
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_snapshot_freshness_respects_configured_poll_interval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _make_store(tmp_path)
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "poll_seconds": 600,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    snapshot_path = s.dir / "supervisor-snapshot.json"
+    rows = [{"pid": 123}]
+    snapshot_path.write_text(json.dumps(rows), encoding="utf-8")
+    snapshot_epoch = time.time() - 400.0
+    os.utime(snapshot_path, (snapshot_epoch, snapshot_epoch))
+    observed_snapshots: list[object] = []
+
+    def assessment(_store, **kwargs):
+        observed_snapshots.append(kwargs.get("snapshot"))
+        return {"agents": [{"name": "alpha", "decision": {
+            "state": "HEALTHY_WORKING", "action": "none", "reason": "bound"}}]}
+
+    monkeypatch.setattr(web._supervisor, "build_supervisor_observation", assessment)
+
+    srv, _t, base = _serve(s)
+    try:
+        _state(base)
+        assert observed_snapshots == [rows]
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2757,17 +2757,12 @@ assert(hooks.freshHeartbeat({ last_seen_age_seconds: -1 }) === false, 'negative 
 
 
 def test_console_agent_state_info_reflects_supervisor_decision(tmp_path: Path) -> None:
-    """A REAL render control: drives the actual browser-side `agentStateInfo()`
-    (not `/api/state`) for the exact scenario #105 exists to fix — a wrapper
-    whose self-report still says "working" while the supervisor's decision
-    says the CLI child could not be confirmed. Without the console.js fix,
-    `agentStateInfo` classified this purely from `health.state` and returned
-    `color: 'ok'` — a browser-visible false-GREEN. This asserts it does not.
+    """Drive the real browser-side compositor projection, not just `/api/state`.
 
-    Also a no-false-DOWN control for BOTH grace states (`CLI_CHILD_STARTING`
-    and `LAUNCHING`) and the two green states, and the `supervisor_decision_
-    unavailable` case (a wrapped, non-auto_restart agent) renders visibly
-    rather than silently as plain self-report.
+    The cases cover both directions of #105: strict evidence escalates a fine
+    observation, but healthy/grace evidence cannot erase a worse observation.
+    They also keep advisory, live-stalled, failed-turn, unconfirmed, unavailable,
+    and confirmed lost-binding wording distinct.
     """
     if shutil.which("node") is None:
         pytest.skip("node is required for the console render-control test")
@@ -2811,59 +2806,93 @@ function assert(cond, msg) {
   if (!cond) throw new Error(msg);
 }
 
-// B1 direction control: the dead-child case, self-report still "working".
-// Before the console.js fix this returned color:'ok' (the browser-visible bug).
-const dead = hooks.agentStateInfo({
-  health: { state: 'working_turn' }, wrapped: true,
-  supervisor_decision: { state: 'CLI_CHILD_UNKNOWN', action: 'none', reason: 'x' },
-});
-assert(dead.color !== 'ok', `dead-child must not render ok, got ${dead.color}`);
-assert(dead.key === 'supervisor_unbound', `expected supervisor_unbound, got ${dead.key}`);
-assert(dead.color === 'danger', `expected danger, got ${dead.color}`);
+function composedAgent(raw, observationUrgency, decision, kind, supervisorUrgency,
+                       primarySource) {
+  const observation = {
+    source: 'wrapper_health', state: raw, urgency: observationUrgency,
+  };
+  const supervisor = {
+    source: 'supervisor_decision', kind: kind,
+    state: decision.state, action: decision.action, reason: decision.reason,
+    urgency: supervisorUrgency,
+  };
+  return {
+    health: { state: raw }, wrapped: true, supervisor_decision: decision,
+    health_composition: {
+      observation: observation, supervisor: supervisor,
+      urgency: primarySource === 'supervisor' ? supervisorUrgency : observationUrgency,
+      primary_source: primarySource,
+      disagreement: observationUrgency !== supervisorUrgency,
+    },
+  };
+}
+function unavailableAgent(raw, observationUrgency, primarySource) {
+  const observation = {
+    source: 'wrapper_health', state: raw, urgency: observationUrgency,
+  };
+  const supervisor = {
+    source: 'supervisor_decision', kind: 'unavailable',
+    reason: 'assessment_failed', urgency: 'attention',
+  };
+  return {
+    health: { state: raw }, wrapped: true,
+    supervisor_decision_unavailable: true,
+    supervisor_decision_unavailable_reason: 'assessment_failed',
+    health_composition: {
+      observation: observation, supervisor: supervisor,
+      urgency: primarySource === 'supervisor' ? 'attention' : observationUrgency,
+      primary_source: primarySource,
+      disagreement: observationUrgency !== 'attention',
+    },
+  };
+}
 
-// Same for a confirmed-dead sibling state (not just CLI_CHILD_UNKNOWN).
-const stuck = hooks.agentStateInfo({
-  health: { state: 'idle_waiting' }, wrapped: true,
-  supervisor_decision: { state: 'STUCK_OR_DEAD', action: 'stuck_recover', reason: 'x' },
-});
-assert(stuck.color === 'danger', `STUCK_OR_DEAD must render danger, got ${stuck.color}`);
+// An unconfirmed child is danger evidence, but it is not confirmed child loss.
+const unconfirmed = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'CLI_CHILD_UNKNOWN', action: 'none', reason: 'binding unknown' },
+  'unconfirmed', 'danger', 'supervisor'));
+assert(unconfirmed.key === 'supervisor_alert',
+       `expected supervisor_alert, got ${unconfirmed.key}`);
+assert(unconfirmed.color === 'danger', `expected danger, got ${unconfirmed.color}`);
+assert(!unconfirmed.label.toLowerCase().includes('lost'),
+       `unconfirmed verdict claimed confirmed loss: ${unconfirmed.label}`);
 
-// CLI_CHILD_MISSING is the PROVISIONAL first-poll state of the supervisor's
-// two-poll confirmation policy, not confirmed-dead - must render attn
-// (supervisor_unconfirmed), never danger (mirrors the doctor.py fix).
-const missing = hooks.agentStateInfo({
-  health: { state: 'working_turn' }, wrapped: true,
-  supervisor_decision: { state: 'CLI_CHILD_MISSING', action: 'none', reason: 'x' },
-});
-assert(missing.key === 'supervisor_unconfirmed', `expected supervisor_unconfirmed, got ${missing.key}`);
-assert(missing.color === 'attn', `CLI_CHILD_MISSING must render attn not danger, got ${missing.color}`);
+// CLI_CHILD_MISSING is a provisional first-poll observation, so it is attention.
+const missing = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'CLI_CHILD_MISSING', action: 'none', reason: 'first poll' },
+  'advisory', 'attention', 'supervisor'));
+assert(missing.key === 'supervisor_advisory',
+       `expected supervisor_advisory, got ${missing.key}`);
+assert(missing.color === 'attn', `CLI_CHILD_MISSING must render attention: ${missing.color}`);
 
 // B2 no-false-DOWN control: BOTH grace states render as the self-report says
 // (no override), not attn/danger.
 for (const graceState of ['CLI_CHILD_STARTING', 'LAUNCHING']) {
   const grace = hooks.agentStateInfo({
-    health: { state: 'idle_waiting' }, wrapped: true,
-    supervisor_decision: { state: graceState, action: 'none', reason: 'x' },
+    ...composedAgent(
+      'idle_waiting', 'fine',
+      { state: graceState, action: 'none', reason: 'launch grace' },
+      'grace', 'fine', 'observation'),
   });
   assert(grace.key === 'idle_waiting', `${graceState} must not override self-report, got ${grace.key}`);
   assert(grace.color !== 'danger' && grace.color !== 'attn', `${graceState} false-DOWN: ${grace.color}`);
+  assert(grace.desc.includes(graceState), `${graceState} fact disappeared: ${grace.desc}`);
 }
 
 // Positive control: HEALTHY_WORKING never overrides either.
-const healthy = hooks.agentStateInfo({
-  health: { state: 'working_turn' }, wrapped: true,
-  supervisor_decision: { state: 'HEALTHY_WORKING', action: 'none', reason: 'ok' },
-});
+const healthy = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'HEALTHY_WORKING', action: 'none', reason: 'ok' },
+  'healthy', 'fine', 'observation'));
 assert(healthy.key === 'working_turn', `HEALTHY_WORKING false-DOWN: ${healthy.key}`);
 assert(healthy.color === 'ok', `HEALTHY_WORKING must stay ok, got ${healthy.color}`);
+assert(healthy.desc.includes('HEALTHY_WORKING'), `healthy fact disappeared: ${healthy.desc}`);
 
 // B3: supervisor_decision_unavailable (wrapped, not auto_restart) renders
 // visibly rather than silently falling back to plain self-report.
-const unavailable = hooks.agentStateInfo({
-  health: { state: 'working_turn' }, wrapped: true,
-  supervisor_decision_unavailable: true,
-  supervisor_decision_unavailable_reason: 'assessment_failed',
-});
+const unavailable = hooks.agentStateInfo(unavailableAgent('working_turn', 'fine', 'supervisor'));
 assert(unavailable.key === 'supervisor_unavailable', `expected supervisor_unavailable, got ${unavailable.key}`);
 assert(unavailable.color === 'attn', `expected attn, got ${unavailable.color}`);
 assert(unavailable.desc.includes('assessment failed'), `missing failure reason: ${unavailable.desc}`);
@@ -2871,11 +2900,8 @@ assert(!unavailable.desc.includes('not configured auto_restart'), `false disable
 
 // Losing the strict verdict must not soften an already-dangerous wrapper
 // self-report either. The unavailable cause remains visible alongside it.
-const unavailableDanger = hooks.agentStateInfo({
-  health: { state: 'rate_limited_or_outage' }, wrapped: true,
-  supervisor_decision_unavailable: true,
-  supervisor_decision_unavailable_reason: 'assessment_failed',
-});
+const unavailableDanger = hooks.agentStateInfo(
+  unavailableAgent('rate_limited_or_outage', 'danger', 'observation'));
 assert(unavailableDanger.key === 'rate_limited_or_outage',
        `unavailable verdict downgraded danger to ${unavailableDanger.key}`);
 assert(unavailableDanger.color === 'danger',
@@ -2888,10 +2914,10 @@ assert(unavailableDanger.desc.includes('assessment failed'),
 // the separate supervisor fact in its description.
 for (const rawState of ['rate_limited_or_outage', 'errored_fatal']) {
   const rawDanger = hooks.agentStateInfo({
-    health: { state: rawState }, wrapped: true,
-    supervisor_decision: {
-      state: 'PROCESS_TREE_INVALID', action: 'warn_only', reason: 'HOLDING',
-    },
+    ...composedAgent(
+      rawState, 'danger',
+      { state: 'PROCESS_TREE_INVALID', action: 'warn_only', reason: 'HOLDING' },
+      'advisory', 'attention', 'observation'),
   });
   assert(rawDanger.key === rawState, `${rawState} was downgraded to ${rawDanger.key}`);
   assert(rawDanger.color === 'danger', `${rawState} was downgraded to ${rawDanger.color}`);
@@ -2902,11 +2928,77 @@ for (const rawState of ['rate_limited_or_outage', 'errored_fatal']) {
 // wrapper health may remain green, but either HOLD must stay visibly non-green.
 for (const holdState of ['PROCESS_TREE_INVALID', 'PROCESS_TREE_TRUNCATED']) {
   const held = hooks.agentStateInfo({
-    health: { state: 'working_turn' }, wrapped: true,
-    supervisor_decision: { state: holdState, action: 'warn_only', reason: 'HOLDING' },
+    ...composedAgent(
+      'working_turn', 'fine',
+      { state: holdState, action: 'warn_only', reason: 'HOLDING' },
+      'advisory', 'attention', 'supervisor'),
   });
-  assert(held.key === 'supervisor_unconfirmed', `${holdState} must be strict, got ${held.key}`);
+  assert(held.key === 'supervisor_advisory', `${holdState} must be strict, got ${held.key}`);
   assert(held.color === 'attn', `${holdState} must not render green, got ${held.color}`);
+}
+
+// Administrative recovery policy is not liveness evidence.  It may raise
+// attention, but it must never be narrated as a missing/dead child.
+const cooldown = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'RESTART_COOLDOWN', action: 'backoff_wait', reason: 'cooldown active' },
+  'advisory', 'attention', 'supervisor'));
+assert(cooldown.color === 'attn', `cooldown must render attention, got ${cooldown.color}`);
+assert(!cooldown.label.toLowerCase().includes('child'),
+       `cooldown invented child loss in label: ${cooldown.label}`);
+assert(!cooldown.desc.toLowerCase().includes('could not be confirmed'),
+       `cooldown invented child loss in description: ${cooldown.desc}`);
+
+// A stalled child is explicitly live; preserve that producer meaning instead
+// of routing it through a generic dead/unbound bucket.
+const stalled = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'CLI_CHILD_STALLED', action: 'stuck_recover', reason: 'live child stalled' },
+  'live_stalled', 'danger', 'supervisor'));
+assert(stalled.color === 'danger', `stalled child must render danger, got ${stalled.color}`);
+assert(stalled.desc.toLowerCase().includes('stalled'),
+       `stalled-child meaning disappeared: ${stalled.desc}`);
+assert(!stalled.desc.toLowerCase().includes('could not be confirmed'),
+       `live stalled child was described as lost: ${stalled.desc}`);
+
+// Failed turns and confirmed lost bindings retain different producer meanings.
+const failed = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'TURN_FAILED', action: 'none', reason: 'turn outcome failed' },
+  'failed', 'danger', 'supervisor'));
+assert(failed.label === 'Turn failed', `failed-turn meaning disappeared: ${failed.label}`);
+assert(!failed.label.toLowerCase().includes('child'),
+       `failed turn was described as child loss: ${failed.label}`);
+
+const lost = hooks.agentStateInfo(composedAgent(
+  'working_turn', 'fine',
+  { state: 'CLI_CHILD_DEAD', action: 'relaunch', reason: 'binding lost' },
+  'lost_binding', 'danger', 'supervisor'));
+assert(lost.key === 'supervisor_lost_binding', `lost binding key: ${lost.key}`);
+assert(lost.label === 'Child binding lost', `lost binding wording: ${lost.label}`);
+
+// Asset/API version skew remains fail-safe without duplicating Python's state
+// vocabulary. It preserves the raw decision, explicitly says its urgency is
+// unclassified, and never pretends healthy/dead/advisory semantics are known.
+for (const legacyDecision of [
+  { state: 'HEALTHY_WORKING', action: 'none', reason: 'bound' },
+  { state: 'LAUNCHING', action: 'none', reason: 'launch grace' },
+  { state: 'CLI_CHILD_DEAD', action: 'relaunch', reason: 'producer says dead' },
+  { state: 'RESTART_COOLDOWN', action: 'backoff_wait', reason: 'cooldown' },
+]) {
+  const legacy = hooks.agentStateInfo({
+    health: { state: 'working_turn' }, wrapped: true,
+    supervisor_decision: legacyDecision,
+  });
+  assert(legacy.color === 'attn', `legacy strict fact disappeared: ${legacy.color}`);
+  assert(legacy.label === 'Verdict unclassified',
+         `legacy state was falsely classified: ${legacy.label}`);
+  assert(legacy.desc.includes('urgency classification unavailable'),
+         `missing classification gap: ${legacy.desc}`);
+  assert(legacy.desc.includes(legacyDecision.state),
+         `raw decision disappeared: ${legacy.desc}`);
+  assert(!legacy.desc.toLowerCase().includes('binding lost'),
+         `legacy fallback invented lost-binding semantics: ${legacy.desc}`);
 }
 
 // No supervisor_decision at all (unwrapped / no supervisor configured) is
@@ -4471,7 +4563,8 @@ def test_api_state_new_agent_fields_absent_when_no_data(tmp_path: Path) -> None:
         for agent in root["agents"]:
             for absent in ("capacity", "cli", "wrapped", "restartable",
                            "owned_domains", "task", "health_timeline",
-                           "supervisor_decision", "wrapper_child"):
+                           "supervisor_decision", "health_composition",
+                           "wrapper_child"):
                 assert absent not in agent, absent
         _assert_no_body_keys(_state(base))
     finally:
@@ -4522,6 +4615,10 @@ def test_api_state_supervisor_decision_surfaces_strict_verdict_over_self_report(
             "state": "CLI_CHILD_UNKNOWN", "action": "none",
             "reason": "wrapper runtime could not be bound",
         }
+        assert alpha["health_composition"]["urgency"] == "danger"
+        assert alpha["health_composition"]["primary_source"] == "supervisor"
+        assert alpha["health_composition"]["observation"]["state"] == "working_turn"
+        assert alpha["health_composition"]["supervisor"]["kind"] == "unconfirmed"
         assert alpha["wrapper_child"]["phase"] == "active"
         assert alpha["wrapper_child"]["progress_age_seconds"] >= 599.0
     finally:
@@ -4640,6 +4737,13 @@ def test_api_state_supervisor_decision_unavailable_for_non_auto_restart_wrapped_
         alpha = next(a for a in root["agents"] if a["name"] == "alpha")
         assert alpha.get("supervisor_decision_unavailable") is True
         assert alpha.get("supervisor_decision_unavailable_reason") == "auto_restart_disabled"
+        assert alpha["health_composition"]["urgency"] == "attention"
+        assert alpha["health_composition"]["supervisor"] == {
+            "source": "supervisor_decision",
+            "kind": "unavailable",
+            "reason": "auto_restart_disabled",
+            "urgency": "attention",
+        }
         assert "supervisor_decision" not in alpha
     finally:
         srv.shutdown()
@@ -4682,6 +4786,10 @@ def test_api_state_supervisor_decision_unavailable_for_every_wrapped_agent_on_ob
             "supervisor_decision_unavailable_reason") == "assessment_failed"
         assert by_name["beta"].get(
             "supervisor_decision_unavailable_reason") == "assessment_failed"
+        assert by_name["alpha"]["health_composition"]["supervisor"][
+            "reason"] == "assessment_failed"
+        assert by_name["beta"]["health_composition"]["supervisor"][
+            "reason"] == "assessment_failed"
         assert "supervisor_decision" not in by_name["alpha"]
         assert "supervisor_decision" not in by_name["beta"]
     finally:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2862,9 +2862,41 @@ assert(healthy.color === 'ok', `HEALTHY_WORKING must stay ok, got ${healthy.colo
 const unavailable = hooks.agentStateInfo({
   health: { state: 'working_turn' }, wrapped: true,
   supervisor_decision_unavailable: true,
+  supervisor_decision_unavailable_reason: 'assessment_failed',
 });
 assert(unavailable.key === 'supervisor_unavailable', `expected supervisor_unavailable, got ${unavailable.key}`);
 assert(unavailable.color === 'attn', `expected attn, got ${unavailable.color}`);
+assert(unavailable.desc.includes('assessment failed'), `missing failure reason: ${unavailable.desc}`);
+assert(!unavailable.desc.includes('not configured auto_restart'), `false disabled claim: ${unavailable.desc}`);
+
+// Losing the strict verdict must not soften an already-dangerous wrapper
+// self-report either. The unavailable cause remains visible alongside it.
+const unavailableDanger = hooks.agentStateInfo({
+  health: { state: 'rate_limited_or_outage' }, wrapped: true,
+  supervisor_decision_unavailable: true,
+  supervisor_decision_unavailable_reason: 'assessment_failed',
+});
+assert(unavailableDanger.key === 'rate_limited_or_outage',
+       `unavailable verdict downgraded danger to ${unavailableDanger.key}`);
+assert(unavailableDanger.color === 'danger',
+       `unavailable verdict downgraded danger to ${unavailableDanger.color}`);
+assert(unavailableDanger.desc.includes('assessment failed'),
+       `unavailable cause disappeared: ${unavailableDanger.desc}`);
+
+// A merely advisory strict verdict must not downgrade an already-dangerous
+// wrapper self-report. Preserve the worse visible state while still naming
+// the separate supervisor fact in its description.
+for (const rawState of ['rate_limited_or_outage', 'errored_fatal']) {
+  const rawDanger = hooks.agentStateInfo({
+    health: { state: rawState }, wrapped: true,
+    supervisor_decision: {
+      state: 'PROCESS_TREE_INVALID', action: 'warn_only', reason: 'HOLDING',
+    },
+  });
+  assert(rawDanger.key === rawState, `${rawState} was downgraded to ${rawDanger.key}`);
+  assert(rawDanger.color === 'danger', `${rawState} was downgraded to ${rawDanger.color}`);
+  assert(rawDanger.desc.includes('PROCESS_TREE_INVALID'), `strict fact disappeared: ${rawDanger.desc}`);
+}
 
 // Current-master process-tree HOLDs are strict supervisor verdicts too. Raw
 // wrapper health may remain green, but either HOLD must stay visibly non-green.
@@ -4607,6 +4639,7 @@ def test_api_state_supervisor_decision_unavailable_for_non_auto_restart_wrapped_
         (root,) = _state(base)["roots"]
         alpha = next(a for a in root["agents"] if a["name"] == "alpha")
         assert alpha.get("supervisor_decision_unavailable") is True
+        assert alpha.get("supervisor_decision_unavailable_reason") == "auto_restart_disabled"
         assert "supervisor_decision" not in alpha
     finally:
         srv.shutdown()
@@ -4645,6 +4678,10 @@ def test_api_state_supervisor_decision_unavailable_for_every_wrapped_agent_on_ob
         by_name = {a["name"]: a for a in root["agents"]}
         assert by_name["alpha"].get("supervisor_decision_unavailable") is True
         assert by_name["beta"].get("supervisor_decision_unavailable") is True
+        assert by_name["alpha"].get(
+            "supervisor_decision_unavailable_reason") == "assessment_failed"
+        assert by_name["beta"].get(
+            "supervisor_decision_unavailable_reason") == "assessment_failed"
         assert "supervisor_decision" not in by_name["alpha"]
         assert "supervisor_decision" not in by_name["beta"]
     finally:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2827,6 +2827,16 @@ const stuck = hooks.agentStateInfo({
 });
 assert(stuck.color === 'danger', `STUCK_OR_DEAD must render danger, got ${stuck.color}`);
 
+// CLI_CHILD_MISSING is the PROVISIONAL first-poll state of the supervisor's
+// two-poll confirmation policy, not confirmed-dead - must render attn
+// (supervisor_unconfirmed), never danger (mirrors the doctor.py fix).
+const missing = hooks.agentStateInfo({
+  health: { state: 'working_turn' }, wrapped: true,
+  supervisor_decision: { state: 'CLI_CHILD_MISSING', action: 'none', reason: 'x' },
+});
+assert(missing.key === 'supervisor_unconfirmed', `expected supervisor_unconfirmed, got ${missing.key}`);
+assert(missing.color === 'attn', `CLI_CHILD_MISSING must render attn not danger, got ${missing.color}`);
+
 // B2 no-false-DOWN control: BOTH grace states render as the self-report says
 // (no override), not attn/danger.
 for (const graceState of ['CLI_CHILD_STARTING', 'LAUNCHING']) {
@@ -4517,6 +4527,45 @@ def test_api_state_supervisor_decision_unavailable_for_non_auto_restart_wrapped_
         alpha = next(a for a in root["agents"] if a["name"] == "alpha")
         assert alpha.get("supervisor_decision_unavailable") is True
         assert "supervisor_decision" not in alpha
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_supervisor_decision_unavailable_for_every_wrapped_agent_on_observation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """"Cannot verify" must never render as "verified good": when the
+    observation itself fails (corrupt state / unreadable snapshot), EVERY
+    configured-wrapped agent must still show `supervisor_decision_unavailable`
+    — count the thing that should be there (both alpha AND beta), not merely
+    confirm the absence of a false-green marker. Reproduces the
+    "#105 defect reintroduced through the error path" finding."""
+    s = _make_store(tmp_path)
+    _write_health(s, "alpha", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+    _write_health(s, "beta", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {
+            "alpha": {"wrapped": True, "auto_restart": True},
+            "beta": {"wrapped": True, "auto_restart": True},
+        },
+    }), encoding="utf-8")
+
+    def boom(*_a, **_k):
+        raise ValueError("injected supervisor-state corruption")
+
+    monkeypatch.setattr(web._supervisor, "build_supervisor_observation", boom)
+
+    srv, _t, base = _serve(s)
+    try:
+        (root,) = _state(base)["roots"]
+        by_name = {a["name"]: a for a in root["agents"]}
+        assert by_name["alpha"].get("supervisor_decision_unavailable") is True
+        assert by_name["beta"].get("supervisor_decision_unavailable") is True
+        assert "supervisor_decision" not in by_name["alpha"]
+        assert "supervisor_decision" not in by_name["beta"]
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -22,12 +22,14 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 
 import pytest
 
-from agenttalk import avatars, intents, knowledge as kn, lesson_context as lc
+from agenttalk import avatars, health as health_model, intents, knowledge as kn
+from agenttalk import lesson_context as lc, operator_health
 from agenttalk import onboarding as ob
 from agenttalk import signing, web
 from agenttalk.store import Store
@@ -2740,6 +2742,17 @@ check({ last_seen_age_seconds: 5 },
   { key: 'unwrapped_live', label: 'Active', color: 'teal', grp: 'work', heartbeatOnly: true });
 check({ health: { state: 'unknown' }, last_seen_age_seconds: 5, wrapped: false },
   { key: 'unwrapped_live', label: 'Active', color: 'teal', grp: 'work', heartbeatOnly: true });
+const unavailablePolicy = hooks.agentStateInfo({
+  health: { state: 'unknown', reason_code: 'health_timing_policy_unavailable' },
+  last_seen_age_seconds: 5,
+});
+assert(unavailablePolicy.key === 'unknown' && unavailablePolicy.color === 'gray',
+       `unavailable policy was repainted ${unavailablePolicy.key}/${unavailablePolicy.color}`);
+assert(unavailablePolicy.noHb !== true,
+       'fresh heartbeat was falsely described as absent');
+assert(unavailablePolicy.desc.includes('health_timing_policy_unavailable') &&
+       unavailablePolicy.desc.includes('recent heartbeat'),
+       `unavailable policy reason disappeared: ${unavailablePolicy.desc}`);
 check({ health: { state: 'unknown' }, last_seen_age_seconds: 121 },
   { key: 'unknown', label: 'Unknown', color: 'gray', grp: 'unknown' });
 check({ health: { state: 'unknown' } },
@@ -2766,6 +2779,90 @@ def test_console_agent_state_info_reflects_supervisor_decision(tmp_path: Path) -
     """
     if shutil.which("node") is None:
         pytest.skip("node is required for the console render-control test")
+
+    now_epoch = 1_700_000_000.0
+    decision = {
+        "state": "HEALTHY_WORKING",
+        "action": "none",
+        "reason": "bound child is healthy",
+    }
+    payload_rows = []
+    for name, health_age, ttl_seconds, heartbeat_skew_seconds, reason_code in (
+        ("ttl", 400.0, 300.0, 1000.0, "health_stale_ttl"),
+        ("skew", 20.0, 600.0, 0.0, "health_older_than_heartbeat"),
+    ):
+        store = Store(tmp_path / name)
+        store.init(["alpha"])
+        updated_at = datetime.fromtimestamp(
+            now_epoch - health_age, timezone.utc,
+        ).isoformat().replace("+00:00", "Z")
+        store.write_health("alpha", health_model.build_snapshot(
+            agent="alpha",
+            cli="claude",
+            mode="wrapper-loop",
+            state=health_model.STATE_DEGRADED_OUTPUT,
+            updated_at=updated_at,
+            since=updated_at,
+            reason_code="degraded_output_detected",
+        ))
+        (store.state_dir / "alpha.heartbeat").write_text(
+            datetime.fromtimestamp(now_epoch, timezone.utc).isoformat().replace(
+                "+00:00", "Z"),
+            encoding="utf-8",
+        )
+        (store.dir / "supervisor.json").write_text(json.dumps({
+            "schema_version": 2,
+            "health": {
+                "ttl_seconds": ttl_seconds,
+                "heartbeat_skew_seconds": heartbeat_skew_seconds,
+            },
+            "agents": {
+                "alpha": {"wrapped": True, "auto_restart": True},
+            },
+        }), encoding="utf-8")
+        policy = operator_health.load_health_timing_policy(store)
+        row = web._agent_entries(
+            store,
+            store.load_config(),
+            [],
+            None,
+            supervisor_decisions={"alpha": decision},
+            health_policy=policy,
+            now_epoch=now_epoch,
+        )[0]
+        assert row["health"]["reason_code"] == reason_code
+        assert row["wrapped"] is True
+        assert row["health_composition"]["primary_source"] == "observation"
+        payload_rows.append(row)
+    composition_without_wrapped = dict(payload_rows[0])
+    composition_without_wrapped.pop("wrapped")
+    composition_without_wrapped.pop("restartable")
+    payload_rows.append(composition_without_wrapped)
+    invalid_store = Store(tmp_path / "invalid-policy")
+    invalid_store.init(["alpha"])
+    (invalid_store.state_dir / "alpha.heartbeat").write_text(
+        datetime.fromtimestamp(now_epoch, timezone.utc).isoformat().replace(
+            "+00:00", "Z"),
+        encoding="utf-8",
+    )
+    (invalid_store.dir / "supervisor.json").write_text(
+        "{not valid json", encoding="utf-8")
+    invalid_policy = operator_health.load_health_timing_policy(invalid_store)
+    invalid_row = web._agent_entries(
+        invalid_store,
+        invalid_store.load_config(),
+        [],
+        None,
+        health_policy=invalid_policy,
+        now_epoch=now_epoch,
+    )[0]
+    assert invalid_row["health"]["reason_code"] == (
+        "health_timing_policy_unavailable"
+    )
+    assert "health_composition" not in invalid_row
+    payload_rows.append(invalid_row)
+    payload_path = tmp_path / "configured-unknown-rows.json"
+    payload_path.write_text(json.dumps(payload_rows), encoding="utf-8")
 
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")
@@ -2801,6 +2898,7 @@ ctx.__agenttalkConsoleTestHooks = {};
 vm.createContext(ctx);
 vm.runInContext(source, ctx, { filename: 'console.instrumented2.js' });
 const hooks = ctx.__agenttalkConsoleTestHooks;
+const configuredUnknownRows = JSON.parse(fs.readFileSync(process.argv[3], 'utf8'));
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg);
@@ -2890,6 +2988,23 @@ assert(healthy.key === 'working_turn', `HEALTHY_WORKING false-DOWN: ${healthy.ke
 assert(healthy.color === 'ok', `HEALTHY_WORKING must stay ok, got ${healthy.color}`);
 assert(healthy.desc.includes('HEALTHY_WORKING'), `healthy fact disappeared: ${healthy.desc}`);
 
+// These are real API rows produced under configured TTL/heartbeat-skew
+// boundaries and an invalid timing policy. One preserves its real composition
+// while deliberately omitting `wrapped` to direction-control API/asset skew.
+// A fresh heartbeat must not repaint any normalized unknown observation teal.
+for (const row of configuredUnknownRows) {
+  const configuredUnknown = hooks.agentStateInfo(row);
+  assert(configuredUnknown.key === 'unknown',
+         `configured unknown was repainted ${configuredUnknown.key}`);
+  assert(configuredUnknown.color === 'gray',
+         `configured unknown was repainted ${configuredUnknown.color}`);
+  assert(configuredUnknown.noHb !== true,
+         'configured unknown falsely claimed no heartbeat');
+  assert(configuredUnknown.desc.includes(row.health.reason_code) &&
+         configuredUnknown.desc.includes('recent heartbeat'),
+         `configured unknown wording lost producer facts: ${configuredUnknown.desc}`);
+}
+
 // B3: supervisor_decision_unavailable (wrapped, not auto_restart) renders
 // visibly rather than silently falling back to plain self-report.
 const unavailable = hooks.agentStateInfo(unavailableAgent('working_turn', 'fine', 'supervisor'));
@@ -2970,6 +3085,21 @@ assert(failed.label === 'Turn failed', `failed-turn meaning disappeared: ${faile
 assert(!failed.label.toLowerCase().includes('child'),
        `failed turn was described as child loss: ${failed.label}`);
 
+// Readiness exhaustion means launches never produced a first heartbeat; no
+// turn necessarily ran, so it must not inherit failed-turn wording.
+for (const readinessAction of ['readiness_gave_up', 'none']) {
+  const readiness = hooks.agentStateInfo(composedAgent(
+    'working_turn', 'fine',
+    { state: 'READINESS_GAVE_UP', action: readinessAction, reason: 'never ready' },
+    'readiness_exhausted', 'danger', 'supervisor'));
+  assert(readiness.label === 'Readiness retries exhausted',
+         `readiness meaning disappeared: ${readiness.label}`);
+  assert(!readiness.label.toLowerCase().includes('turn failed'),
+         `readiness was relabelled as a failed turn: ${readiness.label}`);
+  assert(readiness.desc.includes('READINESS_GAVE_UP'),
+         `readiness producer state disappeared: ${readiness.desc}`);
+}
+
 const lost = hooks.agentStateInfo(composedAgent(
   'working_turn', 'fine',
   { state: 'CLI_CHILD_DEAD', action: 'relaunch', reason: 'binding lost' },
@@ -3006,7 +3136,7 @@ for (const legacyDecision of [
 const plain = hooks.agentStateInfo({ health: { state: 'working_turn' }, wrapped: true });
 assert(plain.key === 'working_turn', `plain self-report must be unaffected, got ${plain.key}`);
 """, encoding="utf-8")
-    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+    subprocess.run(["node", str(runner), str(instrumented), str(payload_path)], check=True,
                    capture_output=True, text=True)
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4307,9 +4307,80 @@ def test_api_state_new_agent_fields_absent_when_no_data(tmp_path: Path) -> None:
         (root,) = _state(base)["roots"]
         for agent in root["agents"]:
             for absent in ("capacity", "cli", "wrapped", "restartable",
-                           "owned_domains", "task", "health_timeline"):
+                           "owned_domains", "task", "health_timeline",
+                           "supervisor_decision", "wrapper_child"):
                 assert absent not in agent, absent
         _assert_no_body_keys(_state(base))
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_supervisor_decision_surfaces_strict_verdict_over_self_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper's own self-report can keep saying "working" long after its
+    CLI child has died. The web console must show BOTH the self-report
+    (``health``) and the supervisor's strict, positively-bound decision
+    (``supervisor_decision``) side by side, plus the raw wrapper-runtime
+    progress age (``wrapper_child``) — never collapsed into one adjective."""
+    from agenttalk import wrapper_runtime as wrt
+
+    s = _make_store(tmp_path)
+    s.write_heartbeat("alpha")
+    _write_health(s, "alpha", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+    (s.dir / "supervisor.json").write_text(json.dumps({
+        "schema_version": 2,
+        "agents": {"alpha": {"wrapped": True, "auto_restart": True}},
+    }), encoding="utf-8")
+    now = time.time()
+    writer = wrt.WrapperRuntimeWriter(
+        s.state_dir, "alpha", "test-wrapper-1", wrapper_pid=300,
+        wrapper_start="2020-01-01T00:00:00.000000Z", clock=lambda: now - 600,
+    )
+    writer.starting(message_id="m1", turn_id="t1")
+    writer.active(301, "2020-01-01T00:00:00.000000Z")
+    writer.progress()
+    monkeypatch.setattr(web._supervisor, "build_supervisor_observation", lambda *_a, **_k: {
+        "agents": [{
+            "name": "alpha",
+            "decision": {"state": "CLI_CHILD_UNKNOWN", "action": "none",
+                        "reason": "wrapper runtime could not be bound"},
+        }],
+    })
+
+    srv, _t, base = _serve(s)
+    try:
+        (root,) = _state(base)["roots"]
+        alpha = next(a for a in root["agents"] if a["name"] == "alpha")
+        assert alpha["health"]["state"] == "working_turn"  # self-report: looks fine
+        assert alpha["supervisor_decision"] == {
+            "state": "CLI_CHILD_UNKNOWN", "action": "none",
+            "reason": "wrapper runtime could not be bound",
+        }
+        assert alpha["wrapper_child"]["phase"] == "active"
+        assert alpha["wrapper_child"]["progress_age_seconds"] >= 599.0
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_state_supervisor_decision_absent_when_not_computable(
+    tmp_path: Path,
+) -> None:
+    """No false-DOWN, and no fabricated verdict: an agent with no supervisor
+    configured gets no ``supervisor_decision`` key at all (absent-not-null),
+    not a manufactured "unknown" or "healthy"."""
+    s = _make_store(tmp_path)
+    _write_health(s, "alpha", _hm.STATE_WORKING_TURN, cli="claude", mode="wrapper-loop")
+
+    srv, _t, base = _serve(s)
+    try:
+        (root,) = _state(base)["roots"]
+        alpha = next(a for a in root["agents"] if a["name"] == "alpha")
+        assert "supervisor_decision" not in alpha
+        assert "wrapper_child" not in alpha
     finally:
         srv.shutdown()
         srv.server_close()


### PR DESCRIPTION
## Summary
- The supervisor's strict CLI-child-bound decision (`CLI_CHILD_UNKNOWN` and siblings) never reached `doctor` or the web console; `doctor` had no per-agent check beyond heartbeat-file age, and the web console rendered only the wrapper's own self-reported `health`. `status` already computed the decision fresh but gave no signal when it disagreed with the self-report.
- Adds a shared decision-state vocabulary in `supervisor.py` (`HEALTHY_DECISION_STATES`/`GRACE_DECISION_STATES`/`UNBOUND_OR_DEAD_DECISION_STATES`) so the three surfaces can't silently drift on what counts as green.
- `doctor.py`: new `_check_wrapper_child_health`, one Check per `wrapped` agent — surfaces the self-report AND the live decision side by side (never collapsed into one adjective), plus the raw wrapper-runtime `last_progress_at` age. Flags `[DISAGREEMENT]` when self-report looks fine but the decision doesn't. `ok` for HEALTHY_*/launch-grace (no false-DOWN), `error` for the CLI-child-dead family, `warn` otherwise, and an honest "no decision computable" message for wrapped-but-not-`auto_restart` agents.
- `web.py`: additive, absent-not-null `supervisor_decision` and `wrapper_child` fields on per-agent rows. Read-only, GET-only, no new endpoints.
- `cli.py`: `status` (JSON + plain text) now flags the same disagreement explicitly instead of printing both facts side by side with no call-out.

## Test plan
- [x] `pytest tests/test_cli.py tests/test_doctor.py` — 311 passed
- [x] `pytest tests/test_web.py` — 180 passed
- [x] `pytest tests/test_supervisor.py` — 361 passed, 2 skipped
- [x] `ruff check` on all 7 changed files — clean
- [x] Direction control: core doctor test asserts the pre-existing heartbeat-only check still reads `ok` for the same dead-child scenario, proving the gap this closes
- [x] Positive control: HEALTHY_WORKING scenario reads `ok`/no disagreement flag on all three surfaces (no false-DOWN)
- [ ] Did not run the full local dev-gate/build/wheel/security suite (targeted-tests-only per standing rule) — authoritative CI gates this

🤖 Generated with [Claude Code](https://claude.com/claude-code)