### PR TITLE
fix(wrapper): unwind watchdog-killed turns (#112)

### DIFF
--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1626,7 +1626,11 @@ class _ProcStream:
                 self.work_heartbeat_result = dict(self._work_hb.result)
             if self._proc.stdout:
                 _close_pipe_suppressing_benign_pipe_teardown(self._proc.stdout)
-            if self._watchdog is not None:
+            # Owner cancellation is authoritative and must stop the watchdog before
+            # it competes with abort cleanup. Natural stdout EOF is not root exit:
+            # keep the watchdog armed through the root wait so an EOF-then-hung
+            # process can still reach the two-factor kill boundary.
+            if self._watchdog is not None and consumer_aborted:
                 self._watchdog.stop()
                 self._watchdog.join(timeout=10.0)
                 self.watchdog_result = self._watchdog.result
@@ -1636,22 +1640,33 @@ class _ProcStream:
                         self._proc.terminate()
                 except Exception:  # noqa: BLE001, S110 - preserve the consumer's failure  # nosec B110
                     pass
-            if self._watchdog_stream_interrupted:
-                if consumer_aborted:
-                    try:
-                        self.returncode = self._proc.wait(timeout=10.0)
-                    except subprocess.TimeoutExpired:
+            try:
+                if self._watchdog_stream_interrupted:
+                    if consumer_aborted:
                         try:
-                            self._proc.kill()
-                            self.returncode = self._proc.wait(timeout=5.0)
-                        except Exception:  # noqa: BLE001 - cleanup must preserve owner failure
-                            self.returncode = self._proc.poll()
+                            self.returncode = self._proc.wait(timeout=10.0)
+                        except subprocess.TimeoutExpired:
+                            try:
+                                self._proc.kill()
+                                self.returncode = self._proc.wait(timeout=5.0)
+                            except Exception:  # noqa: BLE001 - cleanup must preserve owner failure
+                                self.returncode = self._proc.poll()
+                    else:
+                        # A watchdog wake is an exit confirmation, never merely a signal
+                        # report. Fail closed if that invariant is ever violated.
+                        self.returncode = self._proc.wait()
                 else:
-                    # A watchdog wake is an exit confirmation, never merely a signal
-                    # report. Fail closed if that invariant is ever violated.
                     self.returncode = self._proc.wait()
-            else:
-                self.returncode = self._proc.wait()
+            finally:
+                if self._watchdog is not None and not consumer_aborted:
+                    self._watchdog.stop()
+                    # Root exit is not enough to publish this turn while the
+                    # watchdog may still be finishing its start-guarded kill
+                    # pass.  Production snapshot/kill operations are bounded,
+                    # so wait for that pass to finish before exposing its
+                    # result or allowing the next turn to start.
+                    self._watchdog.join()
+                    self.watchdog_result = self._watchdog.result
 
     def _interrupt_watchdog_stream(self) -> None:
         with self._watchdog_stream_condition:
@@ -1670,9 +1685,12 @@ class _ProcStream:
             return True
 
     def _handle_watchdog_fire(self, result: dict) -> None:
-        """Wake once the protected Popen handle confirms that its root has exited."""
+        """Wake a live pipe reader once the protected root has exited."""
         with self._watchdog_stream_condition:
-            if self._watchdog_stream_interrupted:
+            # Natural EOF already handed root-exit confirmation to the owner wait.
+            # Starting a second Popen waiter here is unnecessary and can race the
+            # owner's reap on POSIX.
+            if self._watchdog_stream_interrupted or self._watchdog_stream_done:
                 return
         # kill_targets reports that a start-guarded signal was requested, not that
         # process termination has completed. Never publish an idle turn while this

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -22,8 +22,10 @@ import shutil
 # subprocess spawns ONLY the operator-provided CLI launch command; never shell=True.
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 import uuid
+from collections import deque
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -1509,6 +1511,13 @@ class _ProcStream:
         self.pid_start: str | None = None
         self.watchdog_result: dict | None = None
         self._watchdog = None
+        self._watchdog_stream_condition = threading.Condition()
+        self._watchdog_stream_interrupted = False
+        self._watchdog_stream_lines: deque[str] = deque()
+        self._watchdog_stream_done = False
+        self._watchdog_stream_error: BaseException | None = None
+        self._watchdog_stream_reader: threading.Thread | None = None
+        self._watchdog_root_waiter: threading.Thread | None = None
         self.work_heartbeat_result: dict | None = None
         self._work_hb = None
         try:
@@ -1525,14 +1534,16 @@ class _ProcStream:
                 if stdin_text is not None:
                     self._proc.stdin.write(stdin_text)
                 self._proc.stdin.close()
-            # Per-turn watchdog (off unless an ENABLED config is passed). A structured result
-            # lands on .watchdog_result iff it fires (the kill closes stdout -> __iter__ ends).
+            # Per-turn watchdog (off unless an ENABLED config is passed). A confirmed
+            # root kill wakes the iterator explicitly; inherited writers may keep the
+            # OS pipe open after the protected child is gone.
             if watchdog is not None and watchdog.enabled:
                 from .turn_watchdog import TurnWatchdog
                 self._watchdog = TurnWatchdog(
                     root_pid=self._proc.pid, root_start=self._root_start, cfg=watchdog,
                     snapshot_fn=watchdog_snapshot_fn, kill_fn=watchdog_kill_fn,
-                    clock=watchdog_clock, wall_clock=watchdog_wall_clock)
+                    clock=watchdog_clock, wall_clock=watchdog_wall_clock,
+                    on_fire=self._handle_watchdog_fire)
                 self._watchdog.start()
             # Bounded in-turn work heartbeat (wrapped-Claude false-STUCK fix): stamps the
             # supervisor heartbeat while THIS child is alive, capped at max_turn_seconds.
@@ -1553,9 +1564,17 @@ class _ProcStream:
             raise
 
     def __iter__(self) -> Iterator[str]:
+        consumer_aborted = False
         try:
-            yield from _iter_suppressing_benign_pipe_teardown(self._proc.stdout or [])
+            if self._watchdog is None:
+                yield from _iter_suppressing_benign_pipe_teardown(
+                    self._proc.stdout or []
+                )
+            else:
+                yield from self._iter_until_watchdog_or_eof()
         finally:
+            if self._watchdog is not None:
+                consumer_aborted = self._cancel_watchdog_stream_after_consumer_exit()
             # Stop the work-heartbeat ticker FIRST - before this stream reads as
             # exhausted to the caller - so drive()'s failed-turn clear_heartbeat
             # (which runs after stream exhaustion) can never be overwritten by a
@@ -1566,16 +1585,134 @@ class _ProcStream:
                 self._work_hb.stop()
                 self._work_hb.join(timeout=10.0)
                 self.work_heartbeat_result = dict(self._work_hb.result)
-            if self._proc.stdout:
+            if self._watchdog is None and self._proc.stdout:
                 _close_pipe_suppressing_benign_pipe_teardown(self._proc.stdout)
-            self.returncode = self._proc.wait()
-            # Stop + join the watchdog AFTER the child has exited: a normal turn completion
-            # makes the thread exit its wait immediately (no kill race), and a watchdog that
-            # already fired published its result before we read it here.
             if self._watchdog is not None:
                 self._watchdog.stop()
                 self._watchdog.join(timeout=10.0)
                 self.watchdog_result = self._watchdog.result
+            if consumer_aborted:
+                try:
+                    if self._proc.poll() is None:
+                        self._proc.terminate()
+                except Exception:  # noqa: BLE001, S110 - preserve the consumer's failure  # nosec B110
+                    pass
+            if self._watchdog_stream_interrupted:
+                try:
+                    self.returncode = self._proc.wait(timeout=10.0)
+                except subprocess.TimeoutExpired:
+                    if consumer_aborted:
+                        try:
+                            self._proc.kill()
+                            self.returncode = self._proc.wait(timeout=5.0)
+                        except Exception:  # noqa: BLE001 - cleanup must preserve owner failure
+                            self.returncode = self._proc.poll()
+                    else:
+                        # The start-guarded kill already reported success. Do not replace
+                        # one inherited-pipe wedge with an unbounded process-reap wedge.
+                        self.returncode = self._proc.poll()
+            else:
+                self.returncode = self._proc.wait()
+
+    def _interrupt_watchdog_stream(self) -> None:
+        with self._watchdog_stream_condition:
+            self._watchdog_stream_interrupted = True
+            self._watchdog_stream_condition.notify_all()
+
+    def _cancel_watchdog_stream_after_consumer_exit(self) -> bool:
+        """Cancel the reader only when its owner stopped before EOF or watchdog wake."""
+        with self._watchdog_stream_condition:
+            if self._watchdog_stream_interrupted:
+                return False
+            if self._watchdog_stream_done and self._watchdog_stream_error is None:
+                return False
+            self._watchdog_stream_interrupted = True
+            self._watchdog_stream_condition.notify_all()
+            return True
+
+    def _handle_watchdog_fire(self, result: dict) -> None:
+        """Wake once the protected Popen handle confirms that its root has exited."""
+        with self._watchdog_stream_condition:
+            if self._watchdog_stream_interrupted:
+                return
+        if self.pid in result.get("killed", ()) or self._proc.poll() is not None:
+            self._interrupt_watchdog_stream()
+            return
+        with self._watchdog_stream_condition:
+            if self._watchdog_root_waiter is not None:
+                return
+            self._watchdog_root_waiter = threading.Thread(
+                target=self._wake_after_watchdog_root_exit,
+                name="turn-watchdog-root-waiter",
+                daemon=True,
+            )
+            waiter = self._watchdog_root_waiter
+        waiter.start()
+
+    def _wake_after_watchdog_root_exit(self) -> None:
+        try:
+            self._proc.wait()
+        except Exception:  # noqa: BLE001 - an unconfirmed root exit must stay fail-open
+            return
+        self._interrupt_watchdog_stream()
+
+    def _read_watchdog_stdout(self) -> None:
+        error: BaseException | None = None
+        try:
+            for line in _iter_suppressing_benign_pipe_teardown(
+                self._proc.stdout or []
+            ):
+                with self._watchdog_stream_condition:
+                    while (
+                        self._watchdog_stream_lines
+                        and not self._watchdog_stream_interrupted
+                    ):
+                        self._watchdog_stream_condition.wait()
+                    if self._watchdog_stream_interrupted:
+                        return
+                    self._watchdog_stream_lines.append(line)
+                    self._watchdog_stream_condition.notify_all()
+        except BaseException as exc:  # noqa: BLE001 - propagate reader failure on owner thread
+            error = exc
+        finally:
+            try:
+                if self._proc.stdout:
+                    _close_pipe_suppressing_benign_pipe_teardown(
+                        self._proc.stdout
+                    )
+            except BaseException as exc:  # noqa: BLE001 - propagate close failure on owner thread
+                if error is None:
+                    error = exc
+            with self._watchdog_stream_condition:
+                self._watchdog_stream_error = error
+                self._watchdog_stream_done = True
+                self._watchdog_stream_condition.notify_all()
+
+    def _iter_until_watchdog_or_eof(self) -> Iterator[str]:
+        self._watchdog_stream_reader = threading.Thread(
+            target=self._read_watchdog_stdout,
+            name="turn-stdout-reader",
+            daemon=True,
+        )
+        self._watchdog_stream_reader.start()
+        while True:
+            with self._watchdog_stream_condition:
+                while (
+                    not self._watchdog_stream_interrupted
+                    and not self._watchdog_stream_lines
+                    and not self._watchdog_stream_done
+                ):
+                    self._watchdog_stream_condition.wait()
+                if self._watchdog_stream_interrupted:
+                    return
+                if self._watchdog_stream_lines:
+                    line = self._watchdog_stream_lines.popleft()
+                    self._watchdog_stream_condition.notify_all()
+                elif self._watchdog_stream_error is not None:
+                    raise self._watchdog_stream_error
+                else:
+                    return
+            yield line
 
     def _cleanup_after_constructor_error(self) -> None:
         # Best-effort only: preserve the original constructor failure so make_drive
@@ -2204,12 +2341,13 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         # _ProcStream reports the child exit code (nonzero = failed turn).
         sig["rc"] = getattr(stream, "returncode", None)
         # A fired per-turn watchdog (hung tool descendant killed) is the AUTHORITATIVE
-        # cause of this turn's death - it closed the stream, so rc/partial-stream signals
-        # are downstream noise. Carry it for _classify to check FIRST.
+        # cause of this turn's death. Its explicit wake ended the stream, so
+        # rc/partial-stream signals are downstream noise. Carry it for _classify first.
         sig["watchdog"] = getattr(stream, "watchdog_result", None)
         _finalize_child_output()
         sig["ok"] = (
             sig["completed"]
+            and not sig.get("watchdog")
             and not sig["terminal"]
             and not sig["config_blocked"]
             and sig["bus_failure"] is None
@@ -2220,6 +2358,19 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
 
     def _classify(sig: dict) -> tuple[str, str]:
         return _classify_drive_failure(sig, backend_profile=backend_profile)
+
+    def _finish_watchdog_recovery(sig: dict) -> None:
+        if not sig.get("watchdog"):
+            return
+        if heartbeat is not None:
+            heartbeat()
+        else:
+            store.write_heartbeat(agent)
+        if runtime_writer is not None:
+            # _run_one already published terminal/failed. Release the killed
+            # turn's identity through the existing idle transition so the live
+            # wrapper can own another turn while preserving last_outcome=failed.
+            runtime_writer.idle()
 
     def drive(record: dict) -> DriveOutcome:
         nonlocal active_message_id, active_parent_request_id
@@ -2284,6 +2435,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 if persist is not None:
                     persist(session_state)
                 health_writer.failure(sig, resume_failure_class)
+                _finish_watchdog_recovery(sig)
                 return DriveOutcome(
                     ok=False,
                     failure_class=resume_failure_class,
@@ -2313,6 +2465,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 if persist is not None:
                     persist(session_state)
                 health_writer.failure(sig, CLASS_AMBIGUOUS)
+                _finish_watchdog_recovery(sig)
                 return DriveOutcome(
                     ok=False,
                     failure_class=CLASS_AMBIGUOUS,
@@ -2320,6 +2473,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                     child_output_tail=sig.get("child_output_tail"),
                 )
             health_writer.failure(sig, CLASS_AMBIGUOUS if attributable else resume_failure_class)
+            _finish_watchdog_recovery(sig)
             return DriveOutcome(
                 ok=False,
                 failure_class=CLASS_AMBIGUOUS if attributable else resume_failure_class,
@@ -2384,11 +2538,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
         # the clear above) - otherwise the supervisor would ALSO relaunch a healthy wrapper.
         # Ordinary failures keep the cleared heartbeat. A lost-lease raise from the injected
         # hook is NOT masked (reviewer-1 ask) - it propagates exactly like the success path.
-        if sig.get("watchdog"):
-            if heartbeat is not None:
-                heartbeat()
-            else:
-                store.write_heartbeat(agent)
+        _finish_watchdog_recovery(sig)
         return DriveOutcome(ok=False, failure_class=failure_class, summary=summary,
                             child_output_tail=sig.get("child_output_tail"),
                             bus_action_attempted=bool(sig.get("bus_action_attempted")),

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -12,8 +12,10 @@ a restart-request marker.
 
 from __future__ import annotations
 
-import errno
+import codecs
 import contextlib
+import errno
+import io
 import json
 import os
 from pathlib import Path
@@ -25,7 +27,6 @@ import sys
 import threading
 import time
 import uuid
-from collections import deque
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -58,6 +59,8 @@ WRAPPER_GENERATION_ENV = "AGENTTALK_WRAPPER_GENERATION"
 INBOUND_REQUEST_ID_ENV = "AGENTTALK_INBOUND_REQUEST_ID"
 OVH_QWEN_CLAUDE_MAX_OUTPUT = "4096"
 _BENIGN_PIPE_TEARDOWN_ERRNOS = {errno.EINVAL, errno.EPIPE}
+_WATCHDOG_STREAM_POLL_SECONDS = 0.05
+_WATCHDOG_STREAM_READ_BYTES = 64 * 1024
 
 
 class _GatewayChildCapUnavailable(RuntimeError):
@@ -648,6 +651,45 @@ def _close_pipe_suppressing_benign_pipe_teardown(pipe) -> None:
     except OSError as exc:
         if not _is_benign_pipe_teardown_error(exc):
             raise
+
+
+def _read_ready_pipe_chunk(pipe) -> bytes | None:
+    """Read one available binary chunk without waiting for a line or pipe EOF.
+
+    ``None`` means the pipe is still open but has no bytes ready; ``b""`` means
+    EOF.  The watchdog stream uses this instead of a blocking TextIO iterator so
+    an inherited writer cannot strand a reader thread after the protected root
+    has exited.
+    """
+    buffered = getattr(pipe, "buffer", pipe)
+    raw = getattr(buffered, "raw", buffered)
+    fd = raw.fileno()
+    if os.name == "nt":
+        import _winapi
+        import msvcrt
+
+        try:
+            available, _message_left = _winapi.PeekNamedPipe(
+                msvcrt.get_osfhandle(fd), 0
+            )
+        except BrokenPipeError:
+            return b""
+        if available <= 0:
+            return None
+        size = min(int(available), _WATCHDOG_STREAM_READ_BYTES)
+    else:
+        import select
+
+        readable, _, _ = select.select([fd], [], [], 0.0)
+        if not readable:
+            return None
+        size = _WATCHDOG_STREAM_READ_BYTES
+    try:
+        return os.read(fd, size)
+    except OSError as exc:
+        if _is_benign_pipe_teardown_error(exc):
+            return b""
+        raise
 
 
 def _workspace_root() -> Path:
@@ -1513,10 +1555,7 @@ class _ProcStream:
         self._watchdog = None
         self._watchdog_stream_condition = threading.Condition()
         self._watchdog_stream_interrupted = False
-        self._watchdog_stream_lines: deque[str] = deque()
         self._watchdog_stream_done = False
-        self._watchdog_stream_error: BaseException | None = None
-        self._watchdog_stream_reader: threading.Thread | None = None
         self._watchdog_root_waiter: threading.Thread | None = None
         self.work_heartbeat_result: dict | None = None
         self._work_hb = None
@@ -1585,7 +1624,7 @@ class _ProcStream:
                 self._work_hb.stop()
                 self._work_hb.join(timeout=10.0)
                 self.work_heartbeat_result = dict(self._work_hb.result)
-            if self._watchdog is None and self._proc.stdout:
+            if self._proc.stdout:
                 _close_pipe_suppressing_benign_pipe_teardown(self._proc.stdout)
             if self._watchdog is not None:
                 self._watchdog.stop()
@@ -1598,19 +1637,19 @@ class _ProcStream:
                 except Exception:  # noqa: BLE001, S110 - preserve the consumer's failure  # nosec B110
                     pass
             if self._watchdog_stream_interrupted:
-                try:
-                    self.returncode = self._proc.wait(timeout=10.0)
-                except subprocess.TimeoutExpired:
-                    if consumer_aborted:
+                if consumer_aborted:
+                    try:
+                        self.returncode = self._proc.wait(timeout=10.0)
+                    except subprocess.TimeoutExpired:
                         try:
                             self._proc.kill()
                             self.returncode = self._proc.wait(timeout=5.0)
                         except Exception:  # noqa: BLE001 - cleanup must preserve owner failure
                             self.returncode = self._proc.poll()
-                    else:
-                        # The start-guarded kill already reported success. Do not replace
-                        # one inherited-pipe wedge with an unbounded process-reap wedge.
-                        self.returncode = self._proc.poll()
+                else:
+                    # A watchdog wake is an exit confirmation, never merely a signal
+                    # report. Fail closed if that invariant is ever violated.
+                    self.returncode = self._proc.wait()
             else:
                 self.returncode = self._proc.wait()
 
@@ -1620,11 +1659,11 @@ class _ProcStream:
             self._watchdog_stream_condition.notify_all()
 
     def _cancel_watchdog_stream_after_consumer_exit(self) -> bool:
-        """Cancel the reader only when its owner stopped before EOF or watchdog wake."""
+        """Cancel direct pipe reads when the owner stopped before EOF or watchdog wake."""
         with self._watchdog_stream_condition:
             if self._watchdog_stream_interrupted:
                 return False
-            if self._watchdog_stream_done and self._watchdog_stream_error is None:
+            if self._watchdog_stream_done:
                 return False
             self._watchdog_stream_interrupted = True
             self._watchdog_stream_condition.notify_all()
@@ -1635,7 +1674,10 @@ class _ProcStream:
         with self._watchdog_stream_condition:
             if self._watchdog_stream_interrupted:
                 return
-        if self.pid in result.get("killed", ()) or self._proc.poll() is not None:
+        # kill_targets reports that a start-guarded signal was requested, not that
+        # process termination has completed. Never publish an idle turn while this
+        # Popen handle can still be alive.
+        if self._proc.poll() is not None:
             self._interrupt_watchdog_stream()
             return
         with self._watchdog_stream_condition:
@@ -1652,67 +1694,49 @@ class _ProcStream:
     def _wake_after_watchdog_root_exit(self) -> None:
         try:
             self._proc.wait()
-        except Exception:  # noqa: BLE001 - an unconfirmed root exit must stay fail-open
+        except Exception:  # noqa: BLE001 - an unconfirmed root exit must stay fail-closed
             return
         self._interrupt_watchdog_stream()
 
-    def _read_watchdog_stdout(self) -> None:
-        error: BaseException | None = None
-        try:
-            for line in _iter_suppressing_benign_pipe_teardown(
-                self._proc.stdout or []
-            ):
-                with self._watchdog_stream_condition:
-                    while (
-                        self._watchdog_stream_lines
-                        and not self._watchdog_stream_interrupted
-                    ):
-                        self._watchdog_stream_condition.wait()
-                    if self._watchdog_stream_interrupted:
-                        return
-                    self._watchdog_stream_lines.append(line)
-                    self._watchdog_stream_condition.notify_all()
-        except BaseException as exc:  # noqa: BLE001 - propagate reader failure on owner thread
-            error = exc
-        finally:
-            try:
-                if self._proc.stdout:
-                    _close_pipe_suppressing_benign_pipe_teardown(
-                        self._proc.stdout
-                    )
-            except BaseException as exc:  # noqa: BLE001 - propagate close failure on owner thread
-                if error is None:
-                    error = exc
-            with self._watchdog_stream_condition:
-                self._watchdog_stream_error = error
-                self._watchdog_stream_done = True
-                self._watchdog_stream_condition.notify_all()
-
     def _iter_until_watchdog_or_eof(self) -> Iterator[str]:
-        self._watchdog_stream_reader = threading.Thread(
-            target=self._read_watchdog_stdout,
-            name="turn-stdout-reader",
-            daemon=True,
+        stdout = self._proc.stdout
+        if stdout is None:
+            with self._watchdog_stream_condition:
+                self._watchdog_stream_done = True
+            return
+        decoder = io.IncrementalNewlineDecoder(
+            codecs.getincrementaldecoder("utf-8")("replace"),
+            translate=True,
         )
-        self._watchdog_stream_reader.start()
+        pending = ""
         while True:
             with self._watchdog_stream_condition:
-                while (
-                    not self._watchdog_stream_interrupted
-                    and not self._watchdog_stream_lines
-                    and not self._watchdog_stream_done
-                ):
-                    self._watchdog_stream_condition.wait()
                 if self._watchdog_stream_interrupted:
                     return
-                if self._watchdog_stream_lines:
-                    line = self._watchdog_stream_lines.popleft()
+            chunk = _read_ready_pipe_chunk(stdout)
+            if chunk is None:
+                with self._watchdog_stream_condition:
+                    if self._watchdog_stream_interrupted:
+                        return
+                    self._watchdog_stream_condition.wait(
+                        timeout=_WATCHDOG_STREAM_POLL_SECONDS
+                    )
+                continue
+            if chunk == b"":
+                pending += decoder.decode(b"", final=True)
+                with self._watchdog_stream_condition:
+                    self._watchdog_stream_done = True
                     self._watchdog_stream_condition.notify_all()
-                elif self._watchdog_stream_error is not None:
-                    raise self._watchdog_stream_error
-                else:
-                    return
-            yield line
+                if pending:
+                    yield pending
+                return
+            pending += decoder.decode(chunk)
+            while "\n" in pending:
+                line, pending = pending.split("\n", 1)
+                with self._watchdog_stream_condition:
+                    if self._watchdog_stream_interrupted:
+                        return
+                yield f"{line}\n"
 
     def _cleanup_after_constructor_error(self) -> None:
         # Best-effort only: preserve the original constructor failure so make_drive

--- a/src/agenttalk/wrapper/turn_watchdog.py
+++ b/src/agenttalk/wrapper/turn_watchdog.py
@@ -14,10 +14,10 @@ TWO-FACTOR and BOTH are required:
 Pure reasoning has no live tool descendant, so factor 2 never fires on it. On fire the
 watchdog kills ONLY the per-turn root's process tree (descendants first, start-time
 guarded against pid reuse, then the root); never ancestors/siblings. It NEVER kills on
-a missing/failed snapshot or a root start-time mismatch (FAIL-OPEN). The kill closes
-the child's stdout, so ``_ProcStream``'s stream ends and the turn is classified
-``CLASS_AMBIGUOUS`` (never poison) - the inbound message stays pending and rides the
-high ``K_escalate`` ceiling.
+a missing/failed snapshot or a root start-time mismatch (FAIL-OPEN). A confirmed root
+kill explicitly wakes ``_ProcStream`` rather than assuming every inherited stdout
+writer also disappeared, so the turn is classified ``CLASS_AMBIGUOUS`` (never poison) -
+the inbound message stays pending and rides the high ``K_escalate`` ceiling.
 
 Layering: the discriminator + target selection are PURE (a snapshot dict in, a decision
 out) and fully unit-tested with fake snapshots; only the thin OS adapter
@@ -391,7 +391,8 @@ class TurnWatchdog:
                  snapshot_fn: Callable[[], Snapshot | None] | None = None,
                  kill_fn: Callable[[list[int]], list[int]] | None = None,
                  clock: Callable[[], float] = time.monotonic,
-                 wall_clock: Callable[[], float] = time.time) -> None:
+                 wall_clock: Callable[[], float] = time.time,
+                 on_fire: Callable[[dict], None] | None = None) -> None:
         self._root_pid = root_pid
         self._root_start = root_start
         self._cfg = cfg
@@ -399,6 +400,7 @@ class TurnWatchdog:
         self._kill_fn = kill_fn or kill_targets
         self._clock = clock
         self._wall = wall_clock
+        self._on_fire = on_fire
         self._stop = threading.Event()
         self._first_seen: dict[int, float] = {}
         self.result: dict | None = None
@@ -444,7 +446,7 @@ class TurnWatchdog:
             killed = self._kill_fn(decision.kill_order)
         except Exception as e:  # noqa: BLE001 - a kill failure must not crash the daemon
             kill_error = str(e)
-        self.result = {
+        result = {
             "fired": True,
             "root_pid": self._root_pid,
             "root_start": self._root_start,
@@ -455,6 +457,12 @@ class TurnWatchdog:
             "kill_error": kill_error,
             "summary": _fire_summary(decision, elapsed),
         }
+        self.result = result
+        if self._on_fire is not None:
+            try:
+                self._on_fire(dict(result))
+            except Exception:  # noqa: BLE001, S110 - observer cannot undo the guarded kill  # nosec B110
+                pass
 
 
 def _fire_summary(decision: WatchdogDecision, elapsed: float) -> str:

--- a/tests/test_turn_watchdog.py
+++ b/tests/test_turn_watchdog.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 import pytest
 
 from agenttalk import wrapper_runtime as wr
-from agenttalk.store import Store
+from agenttalk.store import Store, _process_alive
 from agenttalk.wrapper import loop, run
 from agenttalk.wrapper import obligations
 from agenttalk.wrapper import session as wsession
@@ -576,6 +576,24 @@ def test_proc_stream_watchdog_enabled_normal_exit_needs_no_wake() -> None:
     assert stream.watchdog_result is None
 
 
+def test_proc_stream_watchdog_decoder_preserves_text_line_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream = object.__new__(run._ProcStream)
+    stream._proc = SimpleNamespace(stdout=object())
+    stream._watchdog_stream_condition = threading.Condition()
+    stream._watchdog_stream_interrupted = False
+    stream._watchdog_stream_done = False
+    chunks = iter((b"\xe2", b"\x80", b"\x9d\r", b"\ninvalid:\x9d", b"partial", b""))
+    monkeypatch.setattr(run, "_read_ready_pipe_chunk", lambda _pipe: next(chunks))
+
+    assert list(stream._iter_until_watchdog_or_eof()) == [
+        "\u201d\n",
+        "invalid:\ufffdpartial",
+    ]
+    assert stream._watchdog_stream_done
+
+
 def test_proc_stream_watchdog_enabled_consumer_close_is_bounded() -> None:
     stream = run._ProcStream(
         [
@@ -620,6 +638,201 @@ def test_proc_stream_watchdog_enabled_consumer_close_is_bounded() -> None:
     assert stream.returncode is not None
 
 
+class _ObservedWatchdogProcStream(run._ProcStream):
+    """Expose the watchdog callback boundary without changing its behavior."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.watchdog_callback_done = threading.Event()
+        super().__init__(*args, **kwargs)
+
+    def _handle_watchdog_fire(self, result: dict) -> None:
+        try:
+            super()._handle_watchdog_fire(result)
+        finally:
+            self.watchdog_callback_done.set()
+
+
+def _consume_proc_stream(
+    stream: run._ProcStream,
+    *,
+    first_line: list[str],
+    first_line_ready: threading.Event,
+    owner_done: threading.Event,
+    errors: list[BaseException],
+) -> None:
+    try:
+        for line in stream:
+            if not first_line:
+                first_line.append(line)
+                first_line_ready.set()
+    except BaseException as exc:  # noqa: BLE001 - report owner failures on test thread
+        errors.append(exc)
+    finally:
+        owner_done.set()
+
+
+def test_proc_stream_does_not_wake_until_reported_root_kill_is_confirmed() -> None:
+    first_line_ready = threading.Event()
+    owner_done = threading.Event()
+    first_line: list[str] = []
+    errors: list[BaseException] = []
+    spawned: dict[str, int] = {}
+
+    def snapshot():
+        if not first_line_ready.wait(5.0):
+            return None
+        root = spawned["pid"]
+        return _snap(
+            (root, 1, "codex.exe", 1000.0),
+            (root + 1_000_000, root, "node.exe", 0.0),
+        )
+
+    # Model the real signal-vs-exit race: kill_targets reports every requested PID
+    # immediately, while the actual root process remains alive.
+    stream = _ObservedWatchdogProcStream(
+        [
+            sys.executable,
+            "-u",
+            "-c",
+            "import threading; print('ready', flush=True); threading.Event().wait()",
+        ],
+        None,
+        watchdog=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=0.0,
+            tool_descendant_alive_seconds=0.0,
+            poll_seconds=0.01,
+        ),
+        watchdog_snapshot_fn=snapshot,
+        watchdog_kill_fn=lambda targets: [target["pid"] for target in targets],
+        watchdog_wall_clock=lambda: 1000.0,
+        on_spawn=lambda pid, _start: spawned.__setitem__("pid", pid),
+    )
+    owner = threading.Thread(
+        target=_consume_proc_stream,
+        kwargs={
+            "stream": stream,
+            "first_line": first_line,
+            "first_line_ready": first_line_ready,
+            "owner_done": owner_done,
+            "errors": errors,
+        },
+        daemon=True,
+    )
+    owner.start()
+    try:
+        assert stream.watchdog_callback_done.wait(5.0), "watchdog did not fire"
+        assert stream._proc.poll() is None
+        assert not stream._watchdog_stream_interrupted
+        assert not owner_done.is_set()
+        assert stream._watchdog_root_waiter is not None
+    finally:
+        if stream._proc.poll() is None:
+            stream._proc.kill()
+        assert owner_done.wait(5.0), "owner did not resume after confirmed root exit"
+        owner.join(5.0)
+
+    assert first_line == ["ready\n"]
+    assert errors == []
+    assert stream.returncode is not None
+
+
+def test_proc_stream_watchdog_reaps_stdout_when_inherited_writer_survives() -> None:
+    first_line_ready = threading.Event()
+    owner_done = threading.Event()
+    first_line: list[str] = []
+    errors: list[BaseException] = []
+    spawned: dict[str, object] = {}
+    readers_before = {
+        thread.ident
+        for thread in threading.enumerate()
+        if thread.name == "turn-stdout-reader"
+    }
+    writer_pid: int | None = None
+
+    def snapshot():
+        if not first_line_ready.wait(5.0):
+            return None
+        root = int(spawned["pid"])
+        writer = int(first_line[0].strip())
+        return _snap(
+            (root, 1, "codex.exe", 1000.0),
+            (writer, root, "conhost.exe", 1000.0),
+            (root + 1_000_000, root, "node.exe", 0.0),
+        )
+
+    def kill(targets):
+        stream = spawned["stream"]
+        assert isinstance(stream, run._ProcStream)
+        stream._proc.kill()
+        stream._proc.wait(timeout=5.0)
+        return [target["pid"] for target in targets]
+
+    writer_code = "import threading; threading.Event().wait(30.0)"
+    root_code = (
+        "import subprocess, sys, threading; "
+        f"writer = subprocess.Popen([sys.executable, '-c', {writer_code!r}], "
+        "stdout=sys.stdout, stderr=sys.stderr); "
+        "print(writer.pid, flush=True); "
+        "threading.Event().wait()"
+    )
+    stream = _ObservedWatchdogProcStream(
+        [sys.executable, "-u", "-c", root_code],
+        None,
+        watchdog=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=0.0,
+            tool_descendant_alive_seconds=0.0,
+            poll_seconds=0.01,
+        ),
+        watchdog_snapshot_fn=snapshot,
+        watchdog_kill_fn=kill,
+        watchdog_wall_clock=lambda: 1000.0,
+        on_spawn=lambda pid, _start: spawned.__setitem__("pid", pid),
+    )
+    spawned["stream"] = stream
+    owner = threading.Thread(
+        target=_consume_proc_stream,
+        kwargs={
+            "stream": stream,
+            "first_line": first_line,
+            "first_line_ready": first_line_ready,
+            "owner_done": owner_done,
+            "errors": errors,
+        },
+        daemon=True,
+    )
+    owner.start()
+    try:
+        assert stream.watchdog_callback_done.wait(5.0), "watchdog did not fire"
+        assert owner_done.wait(5.0), "owner stayed blocked on the inherited writer"
+        owner.join(5.0)
+        writer_pid = int(first_line[0].strip())
+        assert _process_alive(writer_pid), "fixture writer did not outlive the root"
+        readers_after = {
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.name == "turn-stdout-reader"
+        }
+        assert readers_after <= readers_before
+        assert stream._proc.stdout is not None
+        assert stream._proc.stdout.closed
+    finally:
+        if stream._proc.poll() is None:
+            stream._proc.kill()
+            stream._proc.wait(timeout=5.0)
+        if writer_pid is None and first_line:
+            writer_pid = int(first_line[0].strip())
+        if writer_pid is not None and _process_alive(writer_pid):
+            twd._kill_one(writer_pid)
+        reader = getattr(stream, "_watchdog_stream_reader", None)
+        if reader is not None:
+            reader.join(5.0)
+
+    assert errors == []
+    assert stream.returncode is not None
+
+
 def test_proc_stream_waits_for_root_exit_when_kill_result_omits_root() -> None:
     root_exited = threading.Event()
     stream = object.__new__(run._ProcStream)
@@ -644,12 +857,11 @@ def test_proc_stream_waits_for_root_exit_when_kill_result_omits_root() -> None:
     assert stream._watchdog_stream_interrupted
 
 
-def test_proc_stream_reader_error_is_cancelled_not_normal_eof() -> None:
+def test_proc_stream_incomplete_owner_exit_is_cancelled() -> None:
     stream = object.__new__(run._ProcStream)
     stream._watchdog_stream_condition = threading.Condition()
     stream._watchdog_stream_interrupted = False
-    stream._watchdog_stream_done = True
-    stream._watchdog_stream_error = OSError("read failed")
+    stream._watchdog_stream_done = False
 
     assert stream._cancel_watchdog_stream_after_consumer_exit() is True
     assert stream._watchdog_stream_interrupted
@@ -686,32 +898,31 @@ class _HarnessStdin:
         return None
 
 
-class _HeldOpenStdout:
-    """Model an inherited writer that survives the kill without reporting progress."""
-
-    def __init__(self, stream_blocked, pipe_release) -> None:
-        self._stream_blocked = stream_blocked
-        self._pipe_release = pipe_release
-
-    def __iter__(self):
-        self._stream_blocked.set()
-        if not self._pipe_release.wait(10.0):
-            raise RuntimeError("watchdog regression pipe was not released")
-        return iter(())
-
-    def close(self) -> None:
-        # Closing the wrapper's read object is deliberately not the synchronizer:
-        # the production failure is an independently held write handle.
-        return None
-
-
 class _HarnessProc:
     def __init__(self, stream_blocked, pipe_release, child_killed) -> None:
         self.pid = ROOT
         self.stdin = _HarnessStdin()
-        self.stdout = _HeldOpenStdout(stream_blocked, pipe_release)
+        read_fd, write_fd = os.pipe()
+        self.stdout = os.fdopen(
+            read_fd,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+        )
+        self._stdout_writer = os.fdopen(write_fd, "wb", buffering=0)
         self.returncode = None
         self._child_killed = child_killed
+        stream_blocked.set()
+        self._writer_closer = threading.Thread(
+            target=self._close_writer_after_release,
+            args=(pipe_release,),
+            daemon=True,
+        )
+        self._writer_closer.start()
+
+    def _close_writer_after_release(self, pipe_release) -> None:
+        if pipe_release.wait(10.0):
+            self._stdout_writer.close()
 
     def poll(self):
         return -9 if self._child_killed.is_set() else None

--- a/tests/test_turn_watchdog.py
+++ b/tests/test_turn_watchdog.py
@@ -576,6 +576,108 @@ def test_proc_stream_watchdog_enabled_normal_exit_needs_no_wake() -> None:
     assert stream.watchdog_result is None
 
 
+def test_proc_stream_watchdog_stays_armed_after_stdout_eof_until_root_exit() -> None:
+    wait_entered = threading.Event()
+    owner_done = threading.Event()
+    errors: list[BaseException] = []
+    spawned: dict[str, object] = {}
+    root_alive_at_wait: list[bool] = []
+
+    def snapshot():
+        if not wait_entered.is_set():
+            return None
+        root = int(spawned["pid"])
+        return _snap(
+            (root, 1, "codex.exe", 1000.0),
+            (root + 1_000_000, root, "node.exe", 0.0),
+        )
+
+    def kill(targets):
+        stream = spawned["stream"]
+        assert isinstance(stream, run._ProcStream)
+        stream._proc.kill()
+        return [target["pid"] for target in targets]
+
+    stream = _ObservedWatchdogProcStream(
+        [
+            sys.executable,
+            "-u",
+            "-c",
+            "import threading; threading.Event().wait()",
+        ],
+        None,
+        watchdog=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=0.0,
+            tool_descendant_alive_seconds=0.0,
+            poll_seconds=0.01,
+        ),
+        watchdog_snapshot_fn=snapshot,
+        watchdog_kill_fn=kill,
+        watchdog_wall_clock=lambda: 1000.0,
+        on_spawn=lambda pid, _start: spawned.__setitem__("pid", pid),
+    )
+    spawned["stream"] = stream
+    watchdog_join_timeouts: list[float | None] = []
+    real_watchdog_join = stream._watchdog.join
+
+    def observed_watchdog_join(timeout=None):
+        watchdog_join_timeouts.append(timeout)
+        return real_watchdog_join(timeout)
+
+    stream._watchdog.join = observed_watchdog_join
+    original_stdout = stream._proc.stdout
+    read_fd, write_fd = os.pipe()
+    stream._proc.stdout = os.fdopen(
+        read_fd,
+        "r",
+        encoding="utf-8",
+        errors="replace",
+    )
+    if original_stdout is not None:
+        original_stdout.close()
+    os.close(write_fd)
+    real_wait = stream._proc.wait
+
+    def observed_wait(timeout=None):
+        if timeout is None:
+            root_alive_at_wait.append(stream._proc.poll() is None)
+            wait_entered.set()
+        return real_wait(timeout=timeout)
+
+    stream._proc.wait = observed_wait
+
+    def consume() -> None:
+        try:
+            list(stream)
+        except BaseException as exc:  # noqa: BLE001 - report owner failures on test thread
+            errors.append(exc)
+        finally:
+            owner_done.set()
+
+    owner = threading.Thread(target=consume, daemon=True)
+    owner.start()
+    try:
+        assert wait_entered.wait(5.0), "stdout EOF did not reach the root wait"
+        assert stream.watchdog_callback_done.wait(5.0), (
+            "watchdog stopped at stdout EOF while the protected root remained alive"
+        )
+        assert owner_done.wait(5.0), "owner stayed blocked after the watchdog killed the root"
+        owner.join(5.0)
+    finally:
+        if stream._proc.poll() is None:
+            stream._proc.kill()
+        stream._proc.wait(timeout=5.0)
+        owner.join(5.0)
+
+    assert root_alive_at_wait and root_alive_at_wait[0] is True
+    assert errors == []
+    assert stream.watchdog_result is not None
+    assert stream.returncode is not None
+    assert stream._watchdog_root_waiter is None
+    assert watchdog_join_timeouts == [None]
+
+
 def test_proc_stream_watchdog_decoder_preserves_text_line_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -839,6 +941,7 @@ def test_proc_stream_waits_for_root_exit_when_kill_result_omits_root() -> None:
     stream.pid = ROOT
     stream._watchdog_stream_condition = threading.Condition()
     stream._watchdog_stream_interrupted = False
+    stream._watchdog_stream_done = False
     stream._watchdog_root_waiter = None
 
     def wait_for_root():

--- a/tests/test_turn_watchdog.py
+++ b/tests/test_turn_watchdog.py
@@ -7,21 +7,30 @@ resolution, the daemon controller's clean stop/join (no kill race) + fire/kill p
 make_drive fake-watchdog classification (CLASS_AMBIGUOUS wins over rc/partial-stream noise),
 the narrow watchdog-recovery heartbeat stamp vs the ordinary-failure clear, and the loop
 invariant (cursor unchanged + message pending + one ambiguous attempt after a watchdog kill).
+The held-open-pipe regression runs the real watchdog/stream/drive/loop stack in a separate
+wrapper process and proves both recovery and the old no-wake failure direction.
 """
 from __future__ import annotations
 
 import contextlib
 import json
+import multiprocessing
 import os
 from pathlib import Path
+import queue
 import signal
 import subprocess
 import sys
+import threading
+import time
+from types import SimpleNamespace
 
 import pytest
 
+from agenttalk import wrapper_runtime as wr
 from agenttalk.store import Store
 from agenttalk.wrapper import loop, run
+from agenttalk.wrapper import obligations
 from agenttalk.wrapper import session as wsession
 from agenttalk.wrapper import turn_watchdog as twd
 from agenttalk.wrapper.loop import CLASS_AMBIGUOUS, DriveOutcome
@@ -304,6 +313,32 @@ def test_controller_fires_and_kills_when_descendant_hangs() -> None:
     assert "watchdog killed" in wd.result["summary"]
 
 
+def test_controller_publishes_fire_when_root_kill_is_unconfirmed() -> None:
+    callbacks: list[dict] = []
+    snap = _snap((ROOT, 1, "codex.exe", 0.0), (2001, ROOT, "node.exe", 0.0))
+    wd = twd.TurnWatchdog(
+        root_pid=ROOT,
+        root_start=0.0,
+        cfg=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=0.0,
+            tool_descendant_alive_seconds=0.0,
+            poll_seconds=0.01,
+        ),
+        snapshot_fn=lambda: snap,
+        kill_fn=lambda targets: [target["pid"] for target in targets if target["pid"] != ROOT],
+        wall_clock=lambda: 10_000.0,
+        on_fire=callbacks.append,
+    )
+
+    wd.start()
+    wd.join(timeout=5.0)
+
+    assert wd.result is not None and wd.result["fired"] is True
+    assert ROOT not in wd.result["killed"]
+    assert callbacks == [wd.result]
+
+
 # ----------------------------------------------------------- kill-time start guard (Issue A)
 
 def test_kill_one_windows_uses_sigterm_without_subprocess_or_sigkill_lookup(
@@ -442,6 +477,10 @@ def _store(tmp_path: Path) -> Store:
 
 
 _PARTIAL = [json.dumps({"type": "turn.started"})]   # started, never completed
+_COMPLETED = [
+    json.dumps({"type": "turn.started"}),
+    json.dumps({"type": "turn.completed"}),
+]
 _WD_RESULT = {"fired": True, "summary": "turn watchdog killed hung tool descendant: "
               "name=node.exe pid=2002 age=900s elapsed=1800s", "trigger": {"name": "node.exe"}}
 
@@ -460,6 +499,28 @@ def test_make_drive_watchdog_classifies_ambiguous_and_wins_over_noise(tmp_path: 
     assert isinstance(outcome, DriveOutcome) and outcome.ok is False
     assert outcome.failure_class == CLASS_AMBIGUOUS
     assert "node.exe" in outcome.summary                # the watchdog summary, not "partial stream"
+
+
+def test_make_drive_watchdog_overrides_clean_completion(tmp_path: Path) -> None:
+    s = _store(tmp_path)
+    st = wsession.load_session(s, "beta", "codex")
+    drive = run.make_drive(
+        s,
+        "beta",
+        "codex",
+        st,
+        ["codex"],
+        spawn=lambda _argv, _stdin: _FakeStream(
+            _COMPLETED,
+            returncode=0,
+            watchdog_result=_WD_RESULT,
+        ),
+    )
+
+    outcome = drive({"id": "m1", "body": "hi"})
+
+    assert isinstance(outcome, DriveOutcome) and outcome.ok is False
+    assert outcome.failure_class == CLASS_AMBIGUOUS
 
 
 def test_make_drive_watchdog_recovery_stamps_heartbeat(tmp_path: Path) -> None:
@@ -498,6 +559,102 @@ def test_make_drive_watchdog_default_path_stamps_store_heartbeat(tmp_path: Path)
     assert s.read_heartbeat("beta") is not None
 
 
+def test_proc_stream_watchdog_enabled_normal_exit_needs_no_wake() -> None:
+    stream = run._ProcStream(
+        [sys.executable, "-c", "print('done', flush=True)"],
+        None,
+        watchdog=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=30.0,
+            poll_seconds=1.0,
+        ),
+        watchdog_snapshot_fn=lambda: None,
+    )
+
+    assert list(stream) == ["done\n"]
+    assert stream.returncode == 0
+    assert stream.watchdog_result is None
+
+
+def test_proc_stream_watchdog_enabled_consumer_close_is_bounded() -> None:
+    stream = run._ProcStream(
+        [
+            sys.executable,
+            "-u",
+            "-c",
+            "while True:\n print('output', flush=True)",
+        ],
+        None,
+        watchdog=TurnWatchdogConfig(
+            enabled=True,
+            turn_elapsed_seconds=30.0,
+            poll_seconds=1.0,
+        ),
+        watchdog_snapshot_fn=lambda: None,
+    )
+    iterator = iter(stream)
+    assert next(iterator) == "output\n"
+    close_done = threading.Event()
+    close_errors: list[BaseException] = []
+
+    def close_owner() -> None:
+        try:
+            iterator.close()
+        except BaseException as exc:  # noqa: BLE001 - report cleanup failures on test thread
+            close_errors.append(exc)
+        finally:
+            close_done.set()
+
+    closer = threading.Thread(target=close_owner, daemon=True)
+    closer.start()
+    try:
+        assert close_done.wait(5.0), "watchdog-enabled consumer cleanup wedged"
+    finally:
+        if stream._proc.poll() is None:
+            stream._proc.kill()
+            stream._proc.wait(timeout=5.0)
+        closer.join(5.0)
+
+    assert not closer.is_alive()
+    assert close_errors == []
+    assert stream.returncode is not None
+
+
+def test_proc_stream_waits_for_root_exit_when_kill_result_omits_root() -> None:
+    root_exited = threading.Event()
+    stream = object.__new__(run._ProcStream)
+    stream.pid = ROOT
+    stream._watchdog_stream_condition = threading.Condition()
+    stream._watchdog_stream_interrupted = False
+    stream._watchdog_root_waiter = None
+
+    def wait_for_root():
+        if not root_exited.wait(5.0):
+            raise subprocess.TimeoutExpired("watchdog-root", 5.0)
+        return -9
+
+    stream._proc = SimpleNamespace(poll=lambda: None, wait=wait_for_root)
+    stream._handle_watchdog_fire({"killed": [2001]})
+
+    assert stream._watchdog_root_waiter is not None
+    assert not stream._watchdog_stream_interrupted
+    root_exited.set()
+    stream._watchdog_root_waiter.join(5.0)
+    assert not stream._watchdog_root_waiter.is_alive()
+    assert stream._watchdog_stream_interrupted
+
+
+def test_proc_stream_reader_error_is_cancelled_not_normal_eof() -> None:
+    stream = object.__new__(run._ProcStream)
+    stream._watchdog_stream_condition = threading.Condition()
+    stream._watchdog_stream_interrupted = False
+    stream._watchdog_stream_done = True
+    stream._watchdog_stream_error = OSError("read failed")
+
+    assert stream._cancel_watchdog_stream_after_consumer_exit() is True
+    assert stream._watchdog_stream_interrupted
+
+
 # ----------------------------------------------------------- loop integration
 
 def test_loop_watchdog_failure_keeps_message_pending_one_ambiguous_attempt(tmp_path: Path) -> None:
@@ -517,3 +674,288 @@ def test_loop_watchdog_failure_keeps_message_pending_one_ambiguous_attempt(tmp_p
     assert int(rec["attempts_started"]) == 1           # exactly one attempt recorded
     assert int(rec.get("poison_eligible_failures") or 0) == 0   # ambiguous, NOT poison
     assert s.dead_lettered_count("beta") == 0
+
+
+# ----------------------------------------------------------- held-open stdout regression
+
+class _HarnessStdin:
+    def write(self, text: str) -> int:
+        return len(text)
+
+    def close(self) -> None:
+        return None
+
+
+class _HeldOpenStdout:
+    """Model an inherited writer that survives the kill without reporting progress."""
+
+    def __init__(self, stream_blocked, pipe_release) -> None:
+        self._stream_blocked = stream_blocked
+        self._pipe_release = pipe_release
+
+    def __iter__(self):
+        self._stream_blocked.set()
+        if not self._pipe_release.wait(10.0):
+            raise RuntimeError("watchdog regression pipe was not released")
+        return iter(())
+
+    def close(self) -> None:
+        # Closing the wrapper's read object is deliberately not the synchronizer:
+        # the production failure is an independently held write handle.
+        return None
+
+
+class _HarnessProc:
+    def __init__(self, stream_blocked, pipe_release, child_killed) -> None:
+        self.pid = ROOT
+        self.stdin = _HarnessStdin()
+        self.stdout = _HeldOpenStdout(stream_blocked, pipe_release)
+        self.returncode = None
+        self._child_killed = child_killed
+
+    def poll(self):
+        return -9 if self._child_killed.is_set() else None
+
+    def wait(self, timeout=None):
+        if not self._child_killed.wait(5.0 if timeout is None else timeout):
+            raise subprocess.TimeoutExpired("watchdog-harness", timeout)
+        self.returncode = -9
+        return self.returncode
+
+    def terminate(self) -> None:
+        self._child_killed.set()
+
+    def kill(self) -> None:
+        self._child_killed.set()
+
+
+def _run_held_pipe_wrapper(
+    root: str,
+    stream_blocked,
+    pipe_release,
+    child_killed,
+    failure_accounted,
+    wrapper_release,
+    wake_callback_reached,
+    disable_wake,
+    errors,
+) -> None:
+    """Run the real wrapper stack in a separate process with only Popen/OS probes faked."""
+    try:
+        store = Store(root)
+        state = wsession.SessionState(
+            cli="codex",
+            codex_thread_id="thread-held-pipe",
+            turns=1,
+        )
+        generation = "watchdog-held-pipe"
+        writer = wr.WrapperRuntimeWriter(
+            store.state_dir,
+            "beta",
+            generation,
+        )
+        proc = _HarnessProc(stream_blocked, pipe_release, child_killed)
+        run.subprocess = SimpleNamespace(
+            Popen=lambda *_args, **_kwargs: proc,
+            PIPE=subprocess.PIPE,
+            STDOUT=subprocess.STDOUT,
+            CREATE_NO_WINDOW=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            TimeoutExpired=subprocess.TimeoutExpired,
+        )
+        wr.process_start_token = lambda _pid: None
+        wake = run._ProcStream._handle_watchdog_fire
+
+        def observed_wake(self, result):
+            wake_callback_reached.set()
+            if not disable_wake:
+                wake(self, result)
+
+        run._ProcStream._handle_watchdog_fire = observed_wake
+        twd._START_EPS = float("inf")
+
+        def snapshot():
+            if not stream_blocked.wait(5.0):
+                return None
+            now = time.time()
+            return _snap(
+                (ROOT, 1, "codex.exe", now),
+                (2001, ROOT, "node.exe", 0.0),
+            )
+
+        def kill(targets):
+            child_killed.set()
+            # The protected root can exit while its descendants are killed and
+            # therefore be absent from kill_targets' return value.
+            return [target["pid"] for target in targets if target["pid"] != ROOT]
+
+        drive = run.make_drive(
+            store,
+            "beta",
+            "codex",
+            state,
+            ["codex"],
+            render=False,
+            agenttalk_preflight=lambda: None,
+            runtime_writer=writer,
+            turn_watchdog=TurnWatchdogConfig(
+                enabled=True,
+                turn_elapsed_seconds=0.0,
+                tool_descendant_alive_seconds=0.0,
+                poll_seconds=0.01,
+            ),
+            watchdog_snapshot_fn=snapshot,
+            watchdog_kill_fn=kill,
+        )
+        store.write_waiting("beta", {
+            "mode": "wrapper-loop",
+            "wrapper_generation": generation,
+            "wait_token": generation,
+            "pid": os.getpid(),
+        })
+        policy = obligations.PolicySnapshot.from_mapping({
+            "schema_version": 1,
+            "agents": {"beta": {"grade": obligations.DETECTION_GRADE}},
+        }, "beta")
+        gate = obligations.DetectionCommitGate(
+            store,
+            "beta",
+            policy,
+            fence=generation,
+        )
+
+        def backoff(_seconds: float) -> None:
+            failure_accounted.set()
+            if not wrapper_release.wait(10.0):
+                raise RuntimeError("watchdog regression wrapper was not released")
+
+        loop.run_loop(
+            store,
+            "beta",
+            drive,
+            clock=lambda: 0.0,
+            sleep=backoff,
+            max_polls=1,
+            k_poison=3,
+            k_escalate=20,
+            on_runtime_idle=writer.idle,
+            wrapper_generation=generation,
+            commit_gate=gate,
+        )
+    except BaseException as exc:  # noqa: BLE001 - propagate subprocess diagnostics
+        errors.put(f"{type(exc).__name__}: {exc}")
+
+
+def _assert_watchdog_failure_accounted(failure_accounted, timeout: float) -> None:
+    assert failure_accounted.wait(timeout), (
+        "watchdog killed the child but the wrapper stayed wedged on inherited stdout"
+    )
+
+
+@pytest.mark.subprocess
+@pytest.mark.parametrize("disable_wake", [False, True], ids=["recovers", "no-wake-control"])
+def test_watchdog_kill_held_pipe_wrapper_state(
+    tmp_path: Path,
+    disable_wake: bool,
+) -> None:
+    store = _store(tmp_path)
+    store.set_operator_facing("lead")
+    inbound = store.send(
+        sender="lead",
+        recipient="beta",
+        kind="question",
+        body="held stdout after watchdog kill",
+        meta={"request_id": f"q-watchdog-{'no-wake' if disable_wake else 'recovers'}"},
+    )
+    store.write_heartbeat("beta")
+    heartbeat_path = store.state_dir / "beta.heartbeat"
+    old_ns = 946_684_800_000_000_000
+    os.utime(heartbeat_path, ns=(old_ns, old_ns))
+    heartbeat_before = heartbeat_path.stat().st_mtime_ns
+
+    ctx = multiprocessing.get_context("spawn")
+    stream_blocked = ctx.Event()
+    pipe_release = ctx.Event()
+    child_killed = ctx.Event()
+    failure_accounted = ctx.Event()
+    wrapper_release = ctx.Event()
+    wake_callback_reached = ctx.Event()
+    errors = ctx.Queue()
+    wrapper = ctx.Process(
+        target=_run_held_pipe_wrapper,
+        args=(
+            str(tmp_path),
+            stream_blocked,
+            pipe_release,
+            child_killed,
+            failure_accounted,
+            wrapper_release,
+            wake_callback_reached,
+            disable_wake,
+            errors,
+        ),
+    )
+    wrapper.start()
+    try:
+        assert child_killed.wait(5.0), "watchdog did not fire"
+        assert wake_callback_reached.wait(5.0), "watchdog result was not published"
+        assert wrapper.is_alive()
+        if disable_wake:
+            with pytest.raises(AssertionError, match="wrapper stayed wedged"):
+                _assert_watchdog_failure_accounted(failure_accounted, 0.0)
+            assert not failure_accounted.is_set()
+            assert heartbeat_path.stat().st_mtime_ns == heartbeat_before
+            runtime = wr.read_runtime(store.state_dir, "beta")
+            assert runtime["status"] == wr.STATUS_VALID
+            record = runtime["record"]
+            assert record["phase"] == wr.PHASE_ACTIVE
+            assert record["last_outcome"] is None
+            assert record["turn_id"] is not None
+            assert record["message_id"] == inbound.id
+            assert record["cli_launcher_pid"] == ROOT
+        else:
+            _assert_watchdog_failure_accounted(failure_accounted, 5.0)
+            assert wrapper.is_alive()
+            assert heartbeat_path.stat().st_mtime_ns > heartbeat_before
+            runtime = wr.read_runtime(store.state_dir, "beta")
+            assert runtime["status"] == wr.STATUS_VALID
+            record = runtime["record"]
+            assert record["phase"] == wr.PHASE_IDLE
+            assert record["last_outcome"] == wr.OUTCOME_FAILED
+            assert record["turn_id"] is None
+            assert record["message_id"] is None
+            assert record["cli_launcher_pid"] is None
+            assert record["cli_launcher_start"] is None
+
+        assert store.cursor("beta") == ""
+        assert store.dead_letter_attempts("beta")["messages"] == {}
+        ledger = json.loads(
+            (store.state_dir / "owed-action" / "ledger.json").read_text(encoding="utf-8")
+        )
+        admission = next(iter(ledger["obligations"].values()))
+        assert admission["paid_dispatches_total"] == 1
+        reservation = next(iter(admission["reservations"].values()))
+        transitions = [row["transition"] for row in ledger["transitions"]]
+        if disable_wake:
+            assert reservation["state"] == "dispatching"
+            assert "DISPATCH_ATTEMPT_STARTED" in transitions
+            assert "OWED_ACTION_MISSING" not in transitions
+        else:
+            assert reservation["state"] == "completed"
+            assert reservation["action_attempted"] is False
+            assert transitions.index("DISPATCH_ATTEMPT_STARTED") < transitions.index(
+                "OWED_ACTION_MISSING"
+            )
+            assert any(message.id == inbound.id for message in store.valid_messages())
+    finally:
+        pipe_release.set()
+        wrapper_release.set()
+        wrapper.join(5.0)
+        if wrapper.is_alive():
+            wrapper.terminate()
+            wrapper.join(5.0)
+    assert wrapper.exitcode == 0
+    try:
+        error = errors.get_nowait()
+    except queue.Empty:
+        error = None
+    assert error is None


### PR DESCRIPTION
## Summary

- wake the wrapper independently of inherited stdout writers after a watchdog fire, while requiring either a reported root kill or direct `Popen` exit confirmation
- bound reader/child cleanup when a watchdog-enabled stream consumer aborts, and make a watchdog result authoritative over clean-looking output or exit status
- route fresh and resumed watchdog failures through heartbeat restoration plus the existing runtime idle transition, preserving `last_outcome=failed` while clearing turn/launcher identity
- retain the inbound message and complete its durable owed-action dispatch reservation so retry/dead-letter ceilings can account for the failed turn

## Regression coverage

- real wrapper process remains alive after the synthetic watchdog kill
- heartbeat mtime advances after the kill
- runtime becomes `idle` / `failed` and clears message, turn, launcher PID, and launcher start
- tracked-question paid dispatch is completed with `OWED_ACTION_MISSING`; the inbound remains pending for the bounded retry policy
- no-wake direction control proves the same recovery assertion fails and observes the old active/frozen/unaccounted state
- early consumer close, reader error, root-exit race, and clean-completion/watchdog race are bounded and deterministic

## Local evidence

- `tests/test_turn_watchdog.py` plus the ordinary `drive_failure` runtime boundary: **50 passed in 1.96s**
- touched-file Ruff check: **passed**
- staged diff check: **passed**

Only focused tests were run locally; the authoritative OS/Python matrix is left to CI.

## Base note

This branch was created from the requested current local `master` at `38313e2`. At PR creation time, `origin/master` was still at `a2fc175`, so the two already-existing local master documentation commits (`f21f246`, `38313e2`) may appear temporarily until master catches up.
