### PR TITLE
ci: supersede stale runs with a concurrency group, exempting master

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,12 @@ on:
     - cron: '17 9 * * 1'
   workflow_dispatch:
 
+# See the matching block in tests.yml. master is exempt from cancellation so a
+# release-gating run is never killed by a following push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,17 @@ on:
     - cron: '17 9 * * 1'
   workflow_dispatch:
 
+# One in-flight run per workflow+ref. A later push to a topic branch supersedes
+# the earlier one, which is otherwise pure waste: without this, every push
+# queued an ADDITIONAL full 13-job matrix and superseded runs kept holding
+# runner slots (measured 2026-07-30: 6 queued / 2 running, ~half superseded,
+# a master commit stuck queued 35+ minutes while its security run finished).
+# master is deliberately EXEMPT from cancellation - a release-gating or
+# version-ratchet run must never be killed by a following push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Neither workflow had a `concurrency` group, so a push did not supersede the previous run on the same ref — it queued an **additional** full matrix. `tests` is a 13-job matrix, so the waste compounds quickly.

## Measured before the change (2026-07-30 ~19:35Z)

| status | created | branch | |
|---|---|---|---|
| queued | 19:15 | `fix/112-watchdog-turn-failure` | newest, wanted |
| queued | 19:04 | `fix/105-health-verdict-surfaces` | newest, wanted |
| queued | 19:01 | `codex/task120-owned-process-tree-final` | newest, wanted |
| queued | 18:57 | `master` | newest, wanted |
| in_progress | 18:46 | `codex/task120-owned-process-tree-final` | **superseded** |
| in_progress | 18:41 | `master` | **superseded** |
| queued | 18:29 | `codex/task120-owned-process-tree-final` | **superseded** |
| queued | 18:29 | `master` | **superseded** |

Four of eight runs were superseded by a later push to the same branch yet still held or waited for runner slots. Across the last 40 runs, every queued or in-progress entry was `tests`; `security` had 20 completed and 0 queued — so the matrix is the bottleneck, not runner capacity in general. A master commit sat `queued` 35+ minutes while its own security run finished promptly.

Each superseded SHA was verified with `git merge-base --is-ancestor` to be an ancestor of its branch's newest run before I cancelled it by hand, so no coverage was lost in clearing the backlog.

## What this does

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

**`master` is deliberately exempt from cancellation.** A release-gating or version-ratchet run must never be killed by a following push; this project cuts releases from master under a standing authorization, so a wrongly cancelled master run costs a bad release rather than a slow one. Topic branches and pull requests do cancel, which is where essentially all of the waste was.

## Verification done

Both files parsed with `yaml.safe_load` after editing: the block is well formed and no jobs section was disturbed (`tests` keeps `dev-gate-leg` + `dev-gate-aggregate`, `security` keeps `codeql`). This is the pattern GitHub documents for conditional cancellation.

**Reviewer, please check this specifically:** the master exemption cannot be proven without two rapid pushes to master, which is the one experiment worth avoiding. If you believe `cancel-in-progress` could coerce the evaluated expression to a truthy string, say so — that is the failure mode that matters here, and it fails in the dangerous direction.

## Why now

The developer fleet doubled to six today, and the standing rule issued fleet-wide — own targeted tests, push, end the turn, let authoritative CI gate — deliberately raises push frequency. The queue therefore degrades as a direct consequence of that directive. Slow CI feedback is also what tempts a wrapped agent to run the gate inside its turn, which is #121 and the cause of ten watchdog wedges measured today. This throttle feeds a failure it looks unrelated to.

## Deliberately not included

Reducing the matrix for draft PRs. That trades coverage for throughput and is an operator decision, not a lead one — the Windows lanes are exactly where today's real defect surfaced (#114's shim-ancestry regression, which a blocked wheel leg had masked), so narrowing them carries genuine risk. Recorded in the tracker.

Refs #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
