### PR TITLE
feat(#126): recognize a provider quota/billing refusal as its own terminal class

### DIFF
--- a/src/agenttalk/attention.py
+++ b/src/agenttalk/attention.py
@@ -53,6 +53,7 @@ _MAX_AFFECTED = 20
 # --- sources ---
 SOURCE_NEEDS_OPERATOR = "needs_operator"
 SOURCE_CONFIG_BLOCKED = "config_blocked"
+SOURCE_QUOTA_BLOCKED = "quota_blocked"
 SOURCE_DEAD_LETTER = "dead_letter"
 SOURCE_GATE_HOLD = "gate_hold"
 SOURCE_CLOSE_HOLD = "close_hold"
@@ -65,6 +66,7 @@ SOURCE_ERROR = "source_error"
 _SOURCE_WEIGHT = {
     SOURCE_NEEDS_OPERATOR: 100,
     SOURCE_CONFIG_BLOCKED: 90,
+    SOURCE_QUOTA_BLOCKED: 88,
     SOURCE_COORDINATION_STALL: 85,
     SOURCE_DEAD_LETTER: 80,
     SOURCE_GATE_HOLD: 70,
@@ -80,6 +82,7 @@ _SOURCE_WEIGHT = {
 _ALWAYS_BLOCKING = frozenset({SOURCE_NEEDS_OPERATOR, SOURCE_DEAD_LETTER})
 _ADVISORY_CAPABLE = frozenset({
     SOURCE_CONFIG_BLOCKED,
+    SOURCE_QUOTA_BLOCKED,
     SOURCE_GATE_HOLD,
     SOURCE_CLOSE_HOLD,
     SOURCE_LEAD_UNARMED,
@@ -674,6 +677,30 @@ def config_blocked_items(holds: list[dict]) -> list[dict]:
                               "priority": "high", "risk_severity": "high"},
                       source_refs=[{"kind": "config_blocked", "agent": ag}])
         it["dedupe_key"] = dedupe_key(SOURCE_CONFIG_BLOCKED, identity=ag)
+        out.append(it)
+    return out
+
+
+def quota_blocked_items(holds: list[dict]) -> list[dict]:
+    """Each hold: {agent, summary, reset_at, at} (task #126). Content-bound on
+    summary+reset_at, so a NEW quota window for the same agent resurfaces despite
+    a prior disposition. ``human_can_unblock_now=False``: unlike config_blocked,
+    there is no operator repair - only the provider's own reset instant clears it."""
+    out = []
+    for h in holds:
+        ag = h.get("agent", "")
+        reset_at = h.get("reset_at")
+        why = h.get("summary") or "provider quota/billing refusal"
+        title = (f"quota-blocked: {ag} (until {reset_at})" if reset_at
+                else f"quota-blocked: {ag} (reset time unknown)")
+        it = _mk_item(SOURCE_QUOTA_BLOCKED, item_id(SOURCE_QUOTA_BLOCKED, ag),
+                      title=title,
+                      ident_content={"agent": ag, "summary": why, "reset_at": reset_at},
+                      human_can_unblock_now=False,
+                      fields={"why_it_matters": why, "priority": "normal",
+                              "risk_severity": "low"},
+                      source_refs=[{"kind": "quota_blocked", "agent": ag}])
+        it["dedupe_key"] = dedupe_key(SOURCE_QUOTA_BLOCKED, identity=ag)
         out.append(it)
     return out
 

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -6197,6 +6197,12 @@ def _collect_attention_items(store: Store, *, for_agent: str | None, roster: lis
         items += A.config_blocked_items(holds)
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("config_blocked", str(e)))
+    # quota_blocked holds (per roster agent, task #126)
+    try:
+        quota_holds = [h for a in roster if (h := store.read_quota_blocked_hold(a))]
+        items += A.quota_blocked_items(quota_holds)
+    except Exception as e:  # noqa: BLE001
+        items.append(A.source_error_item("quota_blocked", str(e)))
     # dead-letter (ALL; build_queue hides resolved via the resolve_dead_letter disposition)
     try:
         items += A.dead_letter_items(store.list_dead_letters())

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -9894,6 +9894,30 @@ def _dead_letter_notifier(store, agent: str):
                                  "dl_disposed": "false",
                                  "request_id": "esc-" + uuid.uuid4().hex[:12]})
                 return True
+            if info.get("failure_class") == "quota_blocked":
+                # #126: a quota park is NOT a dead-letter (nothing was dead-lettered,
+                # committed, or even disposed) and NEEDS no operator action - it
+                # self-heals on the provider's own reset instant. The generic
+                # dead-letter-notice branch below would otherwise send "repeatedly
+                # FAILING... Inspect: agenttalk dead-letter show" for a message that
+                # has no dead-letter entry at all (connector P2 on PR #104).
+                summary = str(info.get("summary") or "provider quota/billing refusal")
+                reset_at = info.get("reset_at")
+                until = f" until {reset_at}" if reset_at else " (reset time unknown)"
+                body = (
+                    f"[wrapper-quota-blocked] agent {ag} is PARKED on message {mid} "
+                    f"from {info.get('from')} (kind={info.get('kind')}). Cursor is "
+                    "unchanged; the message was NOT committed, dead-lettered, or "
+                    f"disposed - it is valid work waiting on the provider{until}. "
+                    f"{summary}. No operator action needed - this self-heals once the "
+                    "provider's reset instant passes (see `agenttalk doctor` / "
+                    "`agenttalk attention` for the live hold)."
+                )
+                store.send(sender=agent, recipient=target, kind="note",
+                           subject="wrapper quota-blocked", body=body,
+                           meta={"quota_blocked": "true", "dl_msg_id": str(mid),
+                                 "request_id": "esc-" + uuid.uuid4().hex[:12]})
+                return True
             state = A.dead_letter_notice_state(info, disposed=disposed)
             generation = str(
                 info.get("requeue_generation")

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -174,6 +174,9 @@ def run(project_root: Path | None = None) -> Report:
         holds = _check_config_blocked_holds(store)
         if holds is not None:  # additive: absent unless a valid config-blocked hold exists
             report.checks.append(holds)
+        quota_holds = _check_quota_blocked_holds(store)
+        if quota_holds is not None:  # additive: absent unless a valid quota-blocked hold exists
+            report.checks.append(quota_holds)
         report.checks.append(_check_detection_commit_gate(store))
         external_gate = _check_external_worker_commit_gate(store)
         if external_gate is not None:
@@ -2256,5 +2259,40 @@ def _check_config_blocked_holds(store: Store) -> Check | None:
              "where supported, explicitly opt in to the pinned Python directory with Codex --add-dir "
              "<python-dir> / writable_roots if workspace-write denies it, then run "
              "`agenttalk request-restart --for <agent>`."),
+        data={"holds": holds},
+    )
+
+
+def _check_quota_blocked_holds(store: Store) -> Check | None:
+    """Surface a provider quota/billing refusal distinctly (task #126): `warn`,
+    NEVER `error` - the block self-heals on the provider's own reset instant, no
+    operator repair needed, so this must never read as a crashed/stuck agent."""
+    try:
+        cfg = store.load_config()
+    except Exception:  # noqa: BLE001 - init check owns corrupt config
+        return None
+    holds: list[dict] = []
+    for agent in cfg.get("agents", []) or []:
+        try:
+            hold = store.read_quota_blocked_hold(str(agent))
+        except Exception:  # noqa: BLE001 - doctor never crashes on state files
+            hold = None
+        if hold is not None:
+            holds.append(hold)
+    if not holds:
+        return None
+    details = "; ".join(
+        f"{h['agent']}: quota-blocked"
+        f"{' until ' + h['reset_at'] if h.get('reset_at') else ' (reset time unknown)'}"
+        f" ({h.get('summary') or 'provider quota/billing refusal'})"
+        for h in holds
+    )
+    return Check(
+        name="quota_blocked_holds",
+        status="warn",
+        details=details,
+        fix=("no operator action needed - this self-heals once the provider's stated "
+             "reset instant passes. If it does not, run `agenttalk dead-letter list` to "
+             "confirm the provider is actually still refusing before restarting anything."),
         data={"holds": holds},
     )

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -5147,6 +5147,82 @@ class Store:
             except (FileNotFoundError, OSError):
                 pass
 
+    # ------------------------------------------- durable quota-blocked hold
+    #
+    # A provider quota/billing refusal (task #126) is a distinct terminal class
+    # from ambiguous_or_unknown: retrying against a wall that cannot clear burns
+    # attempts and dead-letters valid work. Unlike config_blocked (which sticky-
+    # parks until an operator repairs/restarts), this hold SELF-EXPIRES once the
+    # stated reset instant passes - `read_quota_blocked_hold` returns None past
+    # that instant, with no explicit clear required, so the wrapper naturally
+    # re-drives and the operator surfaces naturally stop showing it.
+
+    def quota_blocked_hold_path(self, agent: str) -> Path:
+        return self.state_dir / "quota-blocked-hold" / f"{validate_agent_name(agent)}.json"
+
+    def write_quota_blocked_hold(self, agent: str, *, summary: str = "",
+                                 reset_at: str | None = None) -> None:
+        """Atomically record that ``agent`` is blocked on a provider quota/billing
+        refusal. ``reset_at`` is the parsed reset instant (ISO UTC) when the
+        provider's own text stated one, else None (still a hold, just with an
+        unknown clear time - the caller falls back to bounded backoff)."""
+        payload = {
+            "agent": validate_agent_name(agent),
+            "state": "quota_blocked",
+            "summary": str(summary or ""),
+            "reset_at": reset_at if isinstance(reset_at, str) else None,
+            "at": _now_iso(),
+        }
+        with self._config_lock():
+            p = self.quota_blocked_hold_path(agent)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_text(p, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def read_quota_blocked_hold(self, agent: str, *,
+                                now_epoch: float | None = None) -> dict | None:
+        """Return the validated quota-blocked hold marker, or None if absent,
+        invalid, or SELF-EXPIRED (``now_epoch`` at/after ``reset_at``) - the
+        expiry check that lets a quota hold clear without operator action."""
+        expected = validate_agent_name(agent)
+        p = self.quota_blocked_hold_path(agent)
+        if not p.exists():
+            return None
+        try:
+            data = json.loads(p.read_text(encoding="utf-8").strip() or "null")
+        except (OSError, json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        if data.get("agent") != expected or data.get("state") != "quota_blocked":
+            return None
+        summary = data.get("summary") if isinstance(data.get("summary"), str) else ""
+        at = data.get("at") if isinstance(data.get("at"), str) else None
+        reset_at = data.get("reset_at") if isinstance(data.get("reset_at"), str) else None
+        if reset_at is not None:
+            from agenttalk.health import parse_iso
+            parsed = parse_iso(reset_at)
+            if parsed is None:
+                reset_at = None  # torn/unparseable - keep the hold, drop the stale instant
+            else:
+                now = time.time() if now_epoch is None else float(now_epoch)
+                if now >= parsed.timestamp():
+                    return None  # self-expired: the reset instant has passed
+        return {
+            "agent": expected,
+            "state": "quota_blocked",
+            "summary": summary,
+            "reset_at": reset_at,
+            "at": at,
+        }
+
+    def clear_quota_blocked_hold(self, agent: str) -> None:
+        """Remove the quota-blocked hold marker (best-effort; never raises)."""
+        with self._config_lock():
+            try:
+                self.quota_blocked_hold_path(agent).unlink()
+            except (FileNotFoundError, OSError):
+                pass
+
     # ----------------------------------------- managed lead-loop (Slice 1)
     #
     # A managed lead-loop identity is a wrapped controller that OWNS its team

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -5157,6 +5157,13 @@ class Store:
     # that instant, with no explicit clear required, so the wrapper naturally
     # re-drives and the operator surfaces naturally stop showing it.
 
+    # A refusal with no parseable reset instant (or one the parser rejected as
+    # implausible) must still eventually re-probe the provider - without this, an
+    # unknown-reset hold would return non-None FOREVER and permanently wedge the
+    # mailbox (connector P1 on PR #104: an "insufficient quota" refusal, or a
+    # rejected timestamp, has reset_at=None with no other expiry mechanism).
+    QUOTA_UNKNOWN_RESET_REPROBE_SECONDS = 1800.0
+
     def quota_blocked_hold_path(self, agent: str) -> Path:
         return self.state_dir / "quota-blocked-hold" / f"{validate_agent_name(agent)}.json"
 
@@ -5198,15 +5205,21 @@ class Store:
         summary = data.get("summary") if isinstance(data.get("summary"), str) else ""
         at = data.get("at") if isinstance(data.get("at"), str) else None
         reset_at = data.get("reset_at") if isinstance(data.get("reset_at"), str) else None
+        now = time.time() if now_epoch is None else float(now_epoch)
+        from agenttalk.health import parse_iso
         if reset_at is not None:
-            from agenttalk.health import parse_iso
             parsed = parse_iso(reset_at)
             if parsed is None:
                 reset_at = None  # torn/unparseable - keep the hold, drop the stale instant
-            else:
-                now = time.time() if now_epoch is None else float(now_epoch)
-                if now >= parsed.timestamp():
-                    return None  # self-expired: the reset instant has passed
+            elif now >= parsed.timestamp():
+                return None  # self-expired: the reset instant has passed
+        if reset_at is None:
+            # No known clear time (never stated, or dropped above): bounded re-probe
+            # anchored to when this hold was first written, so an unknown-reset
+            # refusal still eventually re-drives rather than wedging the mailbox.
+            written = parse_iso(at) if at is not None else None
+            if written is None or now - written.timestamp() >= self.QUOTA_UNKNOWN_RESET_REPROBE_SECONDS:
+                return None
         return {
             "agent": expected,
             "state": "quota_blocked",

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2324,6 +2324,10 @@ def build_onboarding(desc: RootDescriptor, *,
 _ATTENTION_SOURCE_MAP: dict[str, tuple[str, str, str]] = {
     _attention.SOURCE_NEEDS_OPERATOR: ("escalation", "ESCALATION", "high"),
     _attention.SOURCE_CONFIG_BLOCKED: ("gate", "GATE HOLD", "high"),
+    # Distinct from GATE HOLD (#126): no operator repair clears this - only the
+    # provider's own reset instant does. "low" severity, its own label, so it never
+    # reads as urgent/actionable the way a config-blocked gate hold does.
+    _attention.SOURCE_QUOTA_BLOCKED: ("quota_blocked", "QUOTA BLOCKED", "low"),
     _attention.SOURCE_GATE_HOLD: ("gate", "GATE HOLD", "high"),
     _attention.SOURCE_CLOSE_HOLD: ("gate", "GATE HOLD", "high"),
     _attention.SOURCE_DEAD_LETTER: ("deadletter", "DEAD LETTER", "med"),
@@ -2362,6 +2366,11 @@ def _collect_web_attention_items(store: Store, roster: list[str],
         items += A.config_blocked_items(holds)
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("config_blocked", str(e)))
+    try:
+        quota_holds = [h for a in roster if (h := store.read_quota_blocked_hold(a))]
+        items += A.quota_blocked_items(quota_holds)
+    except Exception as e:  # noqa: BLE001
+        items.append(A.source_error_item("quota_blocked", str(e)))
     try:
         items += A.dead_letter_items(store.list_dead_letters())
     except Exception as e:  # noqa: BLE001

--- a/src/agenttalk/wrapper/health.py
+++ b/src/agenttalk/wrapper/health.py
@@ -122,17 +122,29 @@ class WrapperHealthWriter:
         )
 
     def parked(self, record: dict[str, Any] | None, reason_code: str = "config_blocked") -> None:
-        """The loop is HOLDING a config-blocked head without driving it (deterministic local
-        exec/config denial - e.g. a held gateway, an exec-denied bus write). Surface it as a
-        distinct advisory state carrying the parked head's ids, so ``status``/``doctor`` show
-        the worker as blocked-on-a-message instead of a frozen last state (the health-freeze
-        that hid the wedge, #58). Not forced: the first park is a state change (written at once)
-        and repeats throttle, so a long park is one visible transition, not a write storm."""
+        """The loop is HOLDING a head without driving it. Surface it as a distinct advisory
+        state carrying the parked head's ids, so ``status``/``doctor`` show the worker as
+        blocked-on-a-message instead of a frozen last state (the health-freeze that hid the
+        wedge, #58). Not forced: the first park is a state change (written at once) and
+        repeats throttle, so a long park is one visible transition, not a write storm.
+
+        ``reason_code == "quota_blocked"`` (#126) writes STATE_RATE_LIMITED_OR_OUTAGE, never
+        errored: a provider quota/billing refusal is a pure billing condition, not a crashed
+        or deterministically-denied agent (config_blocked's own default). This re-asserts the
+        quota state on EVERY park cycle, including the first poll after a wrapper restart -
+        unlike gateway_held (which re-drives every poll and so re-writes health via a fresh
+        failed drive() naturally), a quota park explicitly does NOT re-drive, so nothing else
+        would refresh this health past the loop's own startup on_health_idle() reset."""
         record = record if isinstance(record, dict) else {}
         request_id = resolve_request_id(record)
         msg_id = record.get("id")
+        state = (
+            health_model.STATE_RATE_LIMITED_OR_OUTAGE
+            if reason_code == "quota_blocked"
+            else health_model.STATE_ERRORED_AMBIGUOUS
+        )
         self._write(
-            health_model.STATE_ERRORED_AMBIGUOUS,
+            state,
             reason_code=reason_code,
             request_id=request_id if isinstance(request_id, str) else None,
             msg_id=msg_id if isinstance(msg_id, str) else None,

--- a/src/agenttalk/wrapper/health.py
+++ b/src/agenttalk/wrapper/health.py
@@ -15,6 +15,7 @@ from .loop import (
     CLASS_GATEWAY_HELD,
     CLASS_INFRA,
     CLASS_POISON,
+    CLASS_QUOTA_BLOCKED,
 )
 
 
@@ -196,6 +197,13 @@ def classify_failure(sig: dict[str, Any], failure_class: str | None) -> tuple[st
         # blocked-on-a-held-gateway (that will self-heal on clear), not a frozen or dead one.
         # Checked before the sig["error"] branch below, which the hold also sets.
         return health_model.STATE_RATE_LIMITED_OR_OUTAGE, "gateway_held"
+    if failure_class == CLASS_QUOTA_BLOCKED:
+        # Provider quota/billing refusal (#126): a pure billing condition, NOT a crashed or
+        # stuck agent - honestly rate-limited/outage-like and self-healing on the provider's
+        # own reset instant. Distinct reason_code so status/doctor never render this as
+        # errored_ambiguous (the #126 incident: a wrapper burned 20 retries and got
+        # dead-lettered while surfacing as a crashed agent).
+        return health_model.STATE_RATE_LIMITED_OR_OUTAGE, "quota_blocked"
     if sig.get("error"):
         return health_model.STATE_RATE_LIMITED_OR_OUTAGE, "spawn_exec_error"
     rc = sig.get("rc")

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -1150,7 +1150,14 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # the instant passes), so this naturally stops firing the moment quota clears - no
         # explicit clear, no operator action. Checked BEFORE record_attempt_start: never
         # consumes an attempt while blocked.
-        now_epoch = datetime.fromisoformat(now_iso().replace("Z", "+00:00")).timestamp()
+        # `now_iso` is used elsewhere in this loop purely as an OPAQUE stamp (never parsed
+        # back) - some callers inject a bare placeholder ("t") rather than a real ISO
+        # string. Fall back to the real wall clock on anything unparseable rather than
+        # letting a non-ISO stamp crash the loop.
+        try:
+            now_epoch = datetime.fromisoformat(now_iso().replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            now_epoch = time.time()
         quota_hold = store.read_quota_blocked_hold(agent, now_epoch=now_epoch)
         if quota_hold is not None:
             _quota_park(record, reset_at=quota_hold.get("reset_at"),

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -42,6 +42,18 @@ CLASS_INFRA_RETRY_EXHAUSTED = "infra_retry_exhausted"
 # ceiling trips -> NEVER dead-lettered) yet re-drives every poll, so the worker self-heals the
 # instant the operator clears the hold. See _hold_park + the failed-turn branch below (#62).
 CLASS_GATEWAY_HELD = "gateway_held"
+# A provider quota/billing refusal (task #126): the account-level wall a relaunch or a
+# retry cannot clear (retrying burns attempts toward K_escalate and dead-letters valid
+# work; a relaunched agent fails identically in seconds). Distinct from CLASS_INFRA
+# (a transient outage that DOES clear with retry) and CLASS_GATEWAY_HELD (a mint-time,
+# no-child-spawned hold): a quota refusal only reveals itself after a real turn ran and
+# the provider refused. Like gateway_held, the write-ahead attempt is cleared (no
+# counter climbs -> never dead-lettered) and the head stays UNCOMMITTED so it
+# self-heals - but unlike gateway_held (cheap to recheck every poll), re-driving means
+# spawning the real CLI again, so a DURABLE per-agent hold (store.write_quota_blocked_hold)
+# gates re-driving until the parsed reset instant passes, rather than hammering the
+# provider every poll. See _quota_park + the failed-turn/pre-drive branches below.
+CLASS_QUOTA_BLOCKED = "quota_blocked"
 
 
 @dataclass(frozen=True)
@@ -58,6 +70,9 @@ class DriveOutcome:
     bus_action_attempted: bool = False
     bus_action_infra: bool = False
     bus_action_rejected: bool = False
+    # The provider's own stated reset instant (ISO UTC), when CLASS_QUOTA_BLOCKED and the
+    # refusal text carried one (see run.py's _parse_quota_refusal). None otherwise.
+    quota_reset_at: str | None = None
 
 
 def _as_outcome(ret: object) -> DriveOutcome:
@@ -553,6 +568,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
 
     config_blocked_ids: set[str] = set()
     gateway_held_escalated: set[str] = set()
+    quota_blocked_escalated: set[str] = set()
 
     def _park_config_blocked(record: dict, *, reason_code: str = "config_blocked") -> None:
         """Hold a deterministic local config denial (e.g. a held gateway, an exec-denied bus
@@ -611,6 +627,37 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     on_escalate(_info(record, {}, CLASS_GATEWAY_HELD))
             except Exception:  # noqa: BLE001, S110  # nosec
                 pass
+        store.clear_attempt(agent, head_id)
+        stamp()                          # blocked != dead: keep heartbeat + lead-loop lease fresh
+        last_hb = clock()
+        sleep(fail_sleep)
+        fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
+
+    def _quota_park(record: dict, *, reset_at: str | None, summary: str) -> None:
+        """Blocked-but-alive park for a PROVIDER QUOTA/BILLING REFUSAL (CLASS_QUOTA_BLOCKED,
+        #126): the turn ran and the provider refused with an account-level wall that a retry
+        cannot clear. CLEAR the write-ahead attempt (mirrors _hold_park) so no failure counter
+        climbs and attempts_started never reaches K_escalate -> never dead-lettered. Write a
+        DURABLE per-agent hold (reset_at when the provider's text stated one) so status/doctor/
+        web/console surface "quota-blocked until <instant>" instead of the self-report's
+        cheerful/errored guess, and so the PRE-DRIVE check below (unlike gateway_held's cheap
+        mint-time recheck) can skip re-driving - spawning the real CLI again - until that
+        instant passes, rather than hammering the provider every poll. The heartbeat is
+        re-stamped (blocked != dead), so the supervisor does not restart it. Health is surfaced
+        by drive()'s health_writer.failure (STATE_RATE_LIMITED_OR_OUTAGE + 'quota_blocked'), so
+        this park does not also write health. Escalate ONCE per head, same dedup shape as
+        _hold_park (gateway_held_escalated) but keyed on quota_blocked_escalated - a silent
+        20-retry-then-dead-letter loop is exactly the incident this exists to stop."""
+        nonlocal last_hb, fail_sleep
+        head_id = record.get("id")
+        if isinstance(head_id, str) and head_id not in quota_blocked_escalated:
+            quota_blocked_escalated.add(head_id)
+            try:                              # a notification must never crash the loop
+                if on_escalate is not None:
+                    on_escalate(_info(record, {}, CLASS_QUOTA_BLOCKED))
+            except Exception:  # noqa: BLE001, S110  # nosec
+                pass
+        store.write_quota_blocked_hold(agent, summary=summary, reset_at=reset_at)
         store.clear_attempt(agent, head_id)
         stamp()                          # blocked != dead: keep heartbeat + lead-loop lease fresh
         last_hb = clock()
@@ -1096,6 +1143,19 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 config_blocked_ids.add(head_id)
             _park_config_blocked(record)
             continue
+        # PRE-DRIVE quota check (#126): unlike gateway_held (cheap to recheck every poll
+        # inside the mint call, no child spawned), re-driving a quota-blocked head means
+        # spawning the real CLI again - so gate on the DURABLE hold's reset instant instead
+        # of blind per-poll retry. `read_quota_blocked_hold` self-expires (returns None once
+        # the instant passes), so this naturally stops firing the moment quota clears - no
+        # explicit clear, no operator action. Checked BEFORE record_attempt_start: never
+        # consumes an attempt while blocked.
+        now_epoch = datetime.fromisoformat(now_iso().replace("Z", "+00:00")).timestamp()
+        quota_hold = store.read_quota_blocked_hold(agent, now_epoch=now_epoch)
+        if quota_hold is not None:
+            _quota_park(record, reset_at=quota_hold.get("reset_at"),
+                       summary=quota_hold.get("summary") or "")
+            continue
         # AUTO-DISPOSE WITHOUT DRIVE if a cap is already reached on entry (covers the
         # relaunch/crash-accumulation path - test #3).
         if rec.get("last_failure_class") != CLASS_CONFIG_BLOCKED:
@@ -1264,6 +1324,14 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             # clears. Must precede record_attempt_result so gateway_held is never written to the
             # ledger (and so it can never reach a dispose ceiling). See _hold_park.
             _hold_park(record)
+            continue
+        if outcome.failure_class == CLASS_QUOTA_BLOCKED:
+            # PROVIDER QUOTA/BILLING REFUSAL (#126): do NOT persist an attempt result - the
+            # account-level wall a retry cannot clear would otherwise climb toward K_escalate
+            # and dead-letter valid work (the exact incident this exists to stop). Must precede
+            # record_attempt_result so quota_blocked is never written to the ledger. See
+            # _quota_park.
+            _quota_park(record, reset_at=outcome.quota_reset_at, summary=outcome.summary)
             continue
         # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -464,7 +464,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             return
 
     def _info(record: dict, rec: dict, failure_class: str, *,
-              infra_exhausted: bool = False, quarantined: bool = False) -> dict:
+              infra_exhausted: bool = False, quarantined: bool = False,
+              reset_at: str | None = None) -> dict:
         attempts = _safe_int((rec or {}).get("attempts_started"))
         bucket = "below_backstop"
         if quarantined:
@@ -473,17 +474,20 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             bucket = "infra_exhausted"
         elif k_escalate > 0 and attempts >= k_escalate:
             bucket = "escalate_backstop"
-        return {"agent": agent, "msg_id": record.get("id"), "from": record.get("from"),
-                "subject": record.get("subject"), "kind": record.get("kind"),
-                "request_id": record.get("request_id"),
-                "attempts": attempts,  # degrade-low
-                "attempts_bucket": bucket,
-                "first_started_at": (rec or {}).get("first_started_at"),
-                "requeue_generation": (rec or {}).get("requeue_generation"),
-                "infra_exhausted": infra_exhausted,
-                "quarantined": quarantined,
-                "failure_class": failure_class,
-                "summary": (rec or {}).get("last_failure_summary") or ""}
+        out = {"agent": agent, "msg_id": record.get("id"), "from": record.get("from"),
+               "subject": record.get("subject"), "kind": record.get("kind"),
+               "request_id": record.get("request_id"),
+               "attempts": attempts,  # degrade-low
+               "attempts_bucket": bucket,
+               "first_started_at": (rec or {}).get("first_started_at"),
+               "requeue_generation": (rec or {}).get("requeue_generation"),
+               "infra_exhausted": infra_exhausted,
+               "quarantined": quarantined,
+               "failure_class": failure_class,
+               "summary": (rec or {}).get("last_failure_summary") or ""}
+        if reset_at is not None:  # #126: the provider's own stated clear time, when known
+            out["reset_at"] = reset_at
+        return out
 
     def _dispose(record: dict, *, failure_class: str, reason: str | None,
                  infra_exhausted: bool = False,
@@ -643,22 +647,34 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         cheerful/errored guess, and so the PRE-DRIVE check below (unlike gateway_held's cheap
         mint-time recheck) can skip re-driving - spawning the real CLI again - until that
         instant passes, rather than hammering the provider every poll. The heartbeat is
-        re-stamped (blocked != dead), so the supervisor does not restart it. Health is surfaced
-        by drive()'s health_writer.failure (STATE_RATE_LIMITED_OR_OUTAGE + 'quota_blocked'), so
-        this park does not also write health. Escalate ONCE per head, same dedup shape as
-        _hold_park (gateway_held_escalated) but keyed on quota_blocked_escalated - a silent
-        20-retry-then-dead-letter loop is exactly the incident this exists to stop."""
+        re-stamped (blocked != dead), so the supervisor does not restart it.
+
+        Health is re-asserted via ``on_health_parked`` on EVERY park cycle (connector P2 on
+        PR #104): unlike gateway_held (which re-drives every poll, so a fresh failed drive()
+        naturally re-writes health), a quota park deliberately does NOT re-drive - so nothing
+        else refreshes health after the loop's own startup on_health_idle() reset, and a
+        wrapper restart mid-hold would otherwise report cheerful idle health for the rest of
+        the hold despite doctor/attention seeing the quota marker underneath. Escalate ONCE
+        per head, same dedup shape as _hold_park (gateway_held_escalated) but keyed on
+        quota_blocked_escalated - a silent 20-retry-then-dead-letter loop is exactly the
+        incident this exists to stop."""
         nonlocal last_hb, fail_sleep
         head_id = record.get("id")
         if isinstance(head_id, str) and head_id not in quota_blocked_escalated:
             quota_blocked_escalated.add(head_id)
             try:                              # a notification must never crash the loop
                 if on_escalate is not None:
-                    on_escalate(_info(record, {}, CLASS_QUOTA_BLOCKED))
+                    on_escalate(_info(record, {"last_failure_summary": summary},
+                                     CLASS_QUOTA_BLOCKED, reset_at=reset_at))
             except Exception:  # noqa: BLE001, S110  # nosec
                 pass
         store.write_quota_blocked_hold(agent, summary=summary, reset_at=reset_at)
         store.clear_attempt(agent, head_id)
+        if on_health_parked is not None:
+            try:  # advisory health must never break loop progress
+                on_health_parked(record, "quota_blocked")
+            except Exception:  # noqa: BLE001, S110  # nosec
+                pass
         stamp()                          # blocked != dead: keep heartbeat + lead-loop lease fresh
         last_hb = clock()
         sleep(fail_sleep)

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1883,7 +1883,9 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                wrapper_generation: str | None = None,
                backend_profile: str | None = None,
                profile_env: dict[str, str] | None = None,
-               lease_lost_exceptions: tuple = ()) -> Callable[[dict], object]:
+               lease_lost_exceptions: tuple = (),
+               now_wall: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+               ) -> Callable[[dict], object]:
     """Build the per-turn ``drive(record)`` callback for loop.run_loop. Each call
     drives ONE real CLI turn and returns a :class:`loop.DriveOutcome` (ok + a failure
     CLASS on failure, for dead-letter). A turn fails if it produced no progress event or
@@ -2356,7 +2358,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             after_spawn=_record_lesson_exposure,
         )
         if not sig["ok"] and sig.get("terminal"):
-            quota = _parse_quota_refusal(sig.get("terminal_text"))
+            quota = _parse_quota_refusal(sig.get("terminal_text"), now=now_wall())
             if quota is not None:
                 # A provider quota/billing refusal (#126) is a distinct terminal class,
                 # not session-continuity or dead-letter material - short-circuit BEFORE

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .turn_watchdog import TurnWatchdogConfig
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from agenttalk import health as health_model
 from agenttalk.redaction import normalize_child_output_tail
@@ -1152,6 +1152,95 @@ def _looks_like_infra(text: str | None) -> bool:
     return any(m in t for m in _INFRA_ERROR_MARKERS)
 
 
+# Provider quota/billing refusal (task #126): a distinct terminal class from
+# ambiguous_or_unknown - retrying against a wall that cannot clear burns
+# attempts and dead-letters valid work. Confirmed against 13 REAL dead-letter
+# records (4 agents), all the identical Codex template: "You've hit your usage
+# limit. Visit https://chatgpt.com/codex/settings/usage to purchase more
+# credits or try again at <TIME>." Narrow, high-confidence markers only - this
+# must never fire on an unrelated infra string that happens to share a word.
+_QUOTA_REFUSAL_MARKERS = (
+    "usage limit",
+    "quota exceeded",
+    "insufficient quota",
+    "purchase more credits",
+)
+_QUOTA_RESET_RE = re.compile(r"try again at\s+(.+?)\s*\.?\s*$", re.IGNORECASE)
+_QUOTA_FULL_DATE_RE = re.compile(
+    r"^([A-Za-z]{3,})\s+(\d{1,2})(?:st|nd|rd|th)?,\s*(\d{4})\s+"
+    r"(\d{1,2}):(\d{2})\s*([AP]M)$",
+    re.IGNORECASE,
+)
+_QUOTA_TIME_ONLY_RE = re.compile(r"^(\d{1,2}):(\d{2})\s*([AP]M)$", re.IGNORECASE)
+_QUOTA_MONTHS = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+# A parsed instant further out than this is far more likely a parse/timezone
+# mistake than a genuine quota window - discard it rather than stranding the
+# hold near-indefinitely on a misread.
+_QUOTA_MAX_HOLD_SECONDS = 30 * 24 * 3600.0
+
+
+def _parse_quota_reset_instant(raw: str, *, now: datetime) -> str | None:
+    """Best-effort parse of the provider's own "try again at <TIME>" text into
+    an ISO UTC instant. Returns None (never raises) on anything ambiguous,
+    unparseable, in the past, or implausibly far out - the caller still
+    classifies as quota_blocked without a reset instant; it just falls back
+    to bounded backoff instead of a known clear time. The provider's text
+    carries NO timezone marker, so this is a best-effort UTC-clock assumption,
+    bounded by ``_QUOTA_MAX_HOLD_SECONDS`` against a bad guess."""
+    raw = raw.strip()
+    m = _QUOTA_FULL_DATE_RE.match(raw)
+    if m:
+        month_name, day, year, hour, minute, meridiem = m.groups()
+        month = _QUOTA_MONTHS.get(month_name[:3].lower())
+        if month is None:
+            return None
+        hour_i = int(hour) % 12
+        if meridiem.upper() == "PM":
+            hour_i += 12
+        try:
+            dt = datetime(int(year), month, int(day), hour_i, int(minute),
+                          tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    else:
+        m = _QUOTA_TIME_ONLY_RE.match(raw)
+        if not m:
+            return None
+        hour, minute, meridiem = m.groups()
+        hour_i = int(hour) % 12
+        if meridiem.upper() == "PM":
+            hour_i += 12
+        # No date stated - the provider means the NEXT occurrence of this
+        # time-of-day. If that time-of-day has already passed today, it must
+        # mean tomorrow.
+        candidate = now.replace(hour=hour_i, minute=int(minute), second=0, microsecond=0)
+        dt = candidate if candidate > now else candidate + timedelta(days=1)
+    if dt <= now or (dt - now).total_seconds() > _QUOTA_MAX_HOLD_SECONDS:
+        return None
+    return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_quota_refusal(text: str | None, *, now: datetime | None = None) -> dict | None:
+    """Recognize a provider quota/billing refusal and retain its stated reset
+    instant when present. Returns None when ``text`` is not a quota refusal."""
+    t = text or ""
+    tl = t.lower()
+    if not any(marker in tl for marker in _QUOTA_REFUSAL_MARKERS):
+        return None
+    reset_at = None
+    m = _QUOTA_RESET_RE.search(t)
+    if m:
+        reset_at = _parse_quota_reset_instant(
+            m.group(1), now=now or datetime.now(timezone.utc))
+    return {
+        "reason": f"provider quota/billing refusal: {t[:160]}",
+        "reset_at": reset_at,
+    }
+
+
 def _int_status(value: object) -> int | None:
     if isinstance(value, bool):
         return None
@@ -1827,6 +1916,7 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
     from .loop import (
         CLASS_AMBIGUOUS,
         CLASS_CONFIG_BLOCKED,
+        CLASS_QUOTA_BLOCKED,
         DriveOutcome,
     )
 
@@ -2265,6 +2355,36 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
             turn_id=lesson_turn_id,
             after_spawn=_record_lesson_exposure,
         )
+        if not sig["ok"] and sig.get("terminal"):
+            quota = _parse_quota_refusal(sig.get("terminal_text"))
+            if quota is not None:
+                # A provider quota/billing refusal (#126) is a distinct terminal class,
+                # not session-continuity or dead-letter material - short-circuit BEFORE
+                # the resume-continuity branch below (a quota wall has nothing to do with
+                # whether THIS session is broken) and before the generic ambiguous
+                # classifier (which would otherwise bucket it as "terminal ambiguous
+                # infra-like text" - the #126 incident).
+                if attempted_resume:
+                    _session.clear_resume_attempt(session_state)
+                    if persist is not None:
+                        persist(session_state)
+                health_writer.failure(sig, CLASS_QUOTA_BLOCKED)
+                if runtime_writer is not None:
+                    # _run_one already finalized this turn's runtime record to
+                    # phase=terminal/outcome=failed. A quota park suppresses
+                    # retries for potentially hours (unlike a normal failure,
+                    # which retries again within one backoff cycle and quickly
+                    # moves phase off "terminal"), so left as terminal/failed
+                    # it reads to #105's supervisor decision as TURN_FAILED -
+                    # exactly the "errored/stuck" rendering #126 forbids. The
+                    # wrapper genuinely IS idle while parked (not mid-turn), so
+                    # reflect that honestly.
+                    runtime_writer.idle()
+                return DriveOutcome(
+                    ok=False, failure_class=CLASS_QUOTA_BLOCKED,
+                    summary=quota["reason"], quota_reset_at=quota["reset_at"],
+                    child_output_tail=sig.get("child_output_tail"),
+                )
         if not sig["ok"] and attempted_resume:
             try:
                 resume_failure_class, resume_summary = _classify(sig)

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -425,6 +425,51 @@ def test_needs_operator_item_carries_typed_fields_and_surfaces_malformed() -> No
     assert bad[0]["item_id"] == "needs_operator:esc-2"          # still surfaces
 
 
+def test_quota_blocked_items_shape_has_no_operator_remedy() -> None:
+    # #126: unlike config_blocked, nothing an operator does clears this early - only the
+    # provider's own reset instant does.
+    items = att.quota_blocked_items([{
+        "agent": "codex-agenttalk-developer-4",
+        "summary": "provider quota/billing refusal: usage limit",
+        "reset_at": "2026-08-05T06:10:00Z",
+        "at": "2026-07-30T20:36:01Z",
+    }])
+    assert len(items) == 1
+    it = items[0]
+    assert it["source"] == att.SOURCE_QUOTA_BLOCKED
+    assert it["human_can_unblock_now"] is False
+    assert it["priority"] == "normal"
+    assert it["risk_severity"] == "low"
+    assert "codex-agenttalk-developer-4" in it["title"]
+    assert "2026-08-05T06:10:00Z" in it["title"]
+    assert it["why_it_matters"] == "provider quota/billing refusal: usage limit"
+
+
+def test_quota_blocked_items_without_reset_at_still_surfaces() -> None:
+    items = att.quota_blocked_items([{"agent": "beta", "summary": "usage limit hit",
+                                      "reset_at": None, "at": "2026-07-30T20:36:01Z"}])
+    assert len(items) == 1
+    assert "reset time unknown" in items[0]["title"]
+
+
+def test_build_queue_dedupes_quota_blocked_holds_for_the_same_agent() -> None:
+    # Mirrors config_blocked's own dedup test: two quota-blocked notices for the same
+    # agent+window collapse to one representative + one duplicate ref (gate 1).
+    holds = att.quota_blocked_items([{"agent": "beta", "summary": "usage limit hit",
+                                      "reset_at": "2026-08-05T06:10:00Z"}])
+    dup = att.quota_blocked_items([{"agent": "beta", "summary": "usage limit hit",
+                                    "reset_at": "2026-08-05T06:10:00Z"}])
+    q = att.build_queue(holds + dup, [], now_iso=_now())
+    qb = [i for i in q["items"] if i["source"] == att.SOURCE_QUOTA_BLOCKED]
+    assert len(qb) == 1 and len(qb[0]["duplicates"]) == 1   # one rep, one duplicate ref
+
+    # A DIFFERENT reset window is content-DIFFERENT (source_hash differs), so a prior
+    # disposition on the first window does not silently carry over to it.
+    later = att.quota_blocked_items([{"agent": "beta", "summary": "usage limit hit again",
+                                      "reset_at": "2026-08-06T09:00:00Z"}])[0]
+    assert later["source_hash"] != qb[0]["source_hash"]
+
+
 def test_build_queue_dedupes_display_keeps_all_ids() -> None:
     # two config_blocked notices for the same agent+summary collapse to one representative
     holds = att.config_blocked_items([{"agent": "beta", "summary": "python not found"}])

--- a/tests/test_attention_cli.py
+++ b/tests/test_attention_cli.py
@@ -274,6 +274,46 @@ def test_config_blocked_defer_then_different_fault_resurfaces_via_cli(tmp_path: 
     assert row and row[0]["state"] == "active"
 
 
+def test_quota_blocked_hold_surfaces_via_collect_attention_items(tmp_path: Path) -> None:
+    # #126: a provider quota/billing refusal must reach the SAME operator-attention
+    # aggregator config_blocked uses, so it is visible without needing a for-agent.
+    s = Store(tmp_path)
+    s.init(["beta", "claude"])
+    s.write_quota_blocked_hold("beta", summary="usage limit hit",
+                              reset_at="2026-08-05T06:10:00Z")
+    items = cli._collect_attention_items(s, for_agent=None, roster=["beta", "claude"])
+    quota_items = [i for i in items if i["source"] == "quota_blocked"]
+    assert len(quota_items) == 1
+    assert quota_items[0]["human_can_unblock_now"] is False
+
+
+def test_quota_blocked_defer_then_new_window_resurfaces_via_cli(tmp_path: Path) -> None:
+    # Mirrors the config_blocked defer/resurface test: a quota-blocked hold is deferred,
+    # then the SAME agent hits a NEW refusal (a later reset window). The content-bound
+    # disposition (gate 1) must not hide the new window - it resurfaces in the queue.
+    s = _team(tmp_path)
+    s.write_quota_blocked_hold("beta", summary="usage limit hit",
+                              reset_at="2026-08-05T06:10:00Z")
+    from agenttalk import attention as A
+    items = cli._collect_attention_items(s, for_agent="claude", roster=["beta", "claude"])
+    item = [i for i in items if i["source"] == "quota_blocked"][0]["item_id"]
+    assert cli.main([*_root(tmp_path), "attention", "defer", "--from", "claude",
+                     "--item", item, "--until", "2099-01-01T00:00:00Z",
+                     "--reason", "self-heals on the reset instant"]) == 0
+
+    disps, _ = A.read_dispositions(s)
+    q = A.build_queue(items, disps, now_iso="2026-06-01T00:00:00Z")
+    assert not [i for i in q["items"] if i["item_id"] == item]  # deferred -> hidden
+
+    # a NEW reset window for the same agent -> new content hash -> resurfaces
+    s.write_quota_blocked_hold("beta", summary="usage limit hit again",
+                              reset_at="2026-08-06T09:00:00Z")
+    items2 = cli._collect_attention_items(s, for_agent="claude", roster=["beta", "claude"])
+    q2 = A.build_queue(items2, disps, now_iso="2026-06-01T00:00:00Z")
+    row = [i for i in q2["items"] if i["item_id"] == item]
+    assert row and row[0]["state"] == "active"
+
+
 def test_resolved_dead_letter_absent_from_attention_queue(tmp_path: Path) -> None:
     # a resolved dead-letter must not resurface in the operator attention queue (CLI).
     from agenttalk.wrapper import recv_api

--- a/tests/test_dead_letter.py
+++ b/tests/test_dead_letter.py
@@ -705,6 +705,42 @@ def test_config_blocked_notice_includes_command_error_and_remediation(tmp_path: 
     assert "dead-lettered" not in notice.body.lower()
 
 
+def test_quota_blocked_notice_is_not_mislabeled_as_a_dead_letter(tmp_path: Path) -> None:
+    # #126 connector P2 on PR #104: a quota park has NO dead-letter entry at all (nothing
+    # was committed, dead-lettered, or disposed) and needs no operator action - the generic
+    # dead-letter-notice branch would otherwise send "repeatedly FAILING... Inspect:
+    # agenttalk dead-letter show" for a message that `dead-letter show` cannot find.
+    s = _store(tmp_path)
+    s.set_operator_facing("lead")
+    p = _send(s, "valid work")
+    notifier = cli._dead_letter_notifier(s, "beta")
+    routed = notifier(
+        {
+            "agent": "beta",
+            "msg_id": p.id,
+            "from": "lead",
+            "kind": "message",
+            "attempts": 0,
+            "failure_class": "quota_blocked",
+            "summary": "provider quota/billing refusal: usage limit hit",
+            "reset_at": "2026-08-05T06:10:00Z",
+        },
+        disposed=False,
+    )
+    assert routed is True
+    notice = s.messages_for("lead")[-1]
+    assert notice.subject == "wrapper quota-blocked"
+    assert "2026-08-05T06:10:00Z" in notice.body
+    assert "usage limit hit" in notice.body
+    assert "No operator action needed" in notice.body
+    # NEVER mislabeled as an actual disposition (the generic branch's own verb for a
+    # real dead-letter) or pointed at a command that would find nothing.
+    assert "DEAD-LETTERED message" not in notice.body
+    assert "dead-letter show" not in notice.body.lower()
+    assert notice.meta.get("dead_letter") != "true"
+    assert notice.meta.get("needs_operator") != "true"
+
+
 def test_29_f2_doctor_loud_on_unrouted_escalation(tmp_path: Path) -> None:
     # F2/codex-P2: an escalated-but-UNROUTED backstop record makes doctor go LOUD ERROR -
     # a known-infra message can't silently loop with no operator signal.

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1686,6 +1686,37 @@ def test_doctor_config_blocked_holds_warns_separately_and_ignores_malformed(tmp_
     assert any(c.name == "config_blocked_holds" for c in doctor.run(tmp_path).checks)
 
 
+def test_doctor_quota_blocked_holds_warns_never_errors_and_shows_reset_instant(
+    tmp_path: Path,
+) -> None:
+    """#126: a provider quota/billing refusal must read `warn`, NEVER `error` - it
+    self-heals on the provider's own reset instant, no operator repair needed."""
+    s = Store(tmp_path)
+    s.init(["worker", "other"])
+    s.write_quota_blocked_hold("worker", summary="usage limit hit",
+                              reset_at="2026-08-05T06:10:00Z")
+    bad = s.quota_blocked_hold_path("other")
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text(json.dumps({"agent": "other", "state": "wrong"}), encoding="utf-8")
+
+    chk = doctor._check_quota_blocked_holds(s)
+    assert chk.status == "warn"
+    assert chk.name == "quota_blocked_holds"
+    assert "worker" in chk.details
+    assert "2026-08-05T06:10:00Z" in chk.details
+    assert "usage limit hit" in chk.details
+    assert "no operator action needed" in chk.fix
+    assert [h["agent"] for h in chk.data["holds"]] == ["worker"]
+    assert any(c.name == "quota_blocked_holds" for c in doctor.run(tmp_path).checks)
+
+
+def test_doctor_quota_blocked_holds_absent_when_no_hold_exists(tmp_path: Path) -> None:
+    s = Store(tmp_path)
+    s.init(["worker"])
+    assert doctor._check_quota_blocked_holds(s) is None
+    assert not any(c.name == "quota_blocked_holds" for c in doctor.run(tmp_path).checks)
+
+
 def test_check_codex_config_warns_on_duplicate_tables(tmp_path: Path, monkeypatch) -> None:
     """`doctor` must WARN (with a repair hint) when a codex config.toml holds duplicate
     [projects] tables — invalid TOML the codex CLI rejects — instead of returning ok as

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -5096,6 +5096,26 @@ def test_api_attention_hides_resolved_dead_letter_and_keeps_unresolved(
     assert f"dead_letter:beta:{unresolved_id}" in dead_letters
 
 
+def test_api_attention_surfaces_quota_blocked_hold(tmp_path: Path) -> None:
+    # #126: a provider quota/billing refusal reaches /api/attention the same way a
+    # config_blocked hold does, with the reset instant visible and no operator remedy.
+    s = _make_store(tmp_path)
+    s.write_quota_blocked_hold("alpha", summary="usage limit hit",
+                              reset_at="2026-08-05T06:10:00Z")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _attention(base)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+    quota_items = [i for i in payload["items"] if i["source"] == "quota_blocked"]
+    assert len(quota_items) == 1
+    assert quota_items[0]["human_can_unblock_now"] is False
+    assert "2026-08-05T06:10:00Z" in quota_items[0]["title"]
+
+
 def test_api_attention_shape_and_gate_hold(tmp_path: Path) -> None:
     """§4a: /api/attention returns the ranked envelope, and a gate HOLD surfaces
     with the frozen wire fields. Envelope-only — no raw body leaks."""

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import errno
 import gc
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 import re
 import sys
@@ -537,6 +538,325 @@ def test_gateway_held_escalates_exactly_once_across_a_long_hold(tmp_path) -> Non
     assert len(escalations) == 1                  # one-shot, not once-per-poll
 
 
+# ------------------------------------- #126: provider quota/billing refusal = durable park
+
+def _epoch(iso: str) -> float:
+    from datetime import datetime
+    return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+
+
+def _quota_blocked_drive(reset_at: str | None = "2026-01-01T00:00:10Z") -> "loop.DriveOutcome":
+    return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_QUOTA_BLOCKED,
+                             summary="provider quota/billing refusal: usage limit",
+                             quota_reset_at=reset_at)
+
+
+def test_quota_blocked_parks_without_consuming_an_attempt_or_dead_lettering(tmp_path) -> None:
+    # #126: unlike gateway_held (cheap to recheck every poll, no child spawned), re-driving a
+    # quota-blocked head means spawning the real CLI again, so it must drive ONCE (discovering
+    # the refusal), then the PRE-DRIVE hold check parks every subsequent poll WITHOUT driving -
+    # never hammering the provider. No attempt is ever persisted (K_poison=K_escalate=1 would
+    # dispose an ordinary failure on the very next poll).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _quota_blocked_drive()
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=5, k_poison=1, k_escalate=1,
+        now_iso=lambda: "2026-01-01T00:00:00Z",   # frozen, well before reset_at
+    )
+    assert turns == 0
+    assert drives["n"] == 1                       # driven ONCE; later polls park without driving
+    assert s.dead_lettered_count("beta") == 0     # NEVER dead-lettered
+    assert s.cursor("beta") == ""                 # head never consumed
+    rec = s.attempt_record("beta", m.id)
+    assert rec in (None, {}) or int(rec.get("attempts_started") or 0) <= 1
+    assert s.read_heartbeat("beta") is not None   # blocked != dead: heartbeat stays fresh
+    hold = s.read_quota_blocked_hold("beta", now_epoch=_epoch("2026-01-01T00:00:00Z"))
+    assert hold is not None
+    assert hold["reset_at"] == "2026-01-01T00:00:10Z"
+
+
+def test_quota_blocked_self_heals_once_the_reset_instant_passes(tmp_path) -> None:
+    # #126: no operator action clears this - the hold SELF-EXPIRES once now passes the
+    # provider's own stated reset instant, and the very next drive succeeds and commits.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        if drives["n"] == 1:
+            return _quota_blocked_drive(reset_at="2026-01-01T00:00:10Z")
+        return loop.DriveOutcome(ok=True)
+
+    # Poll 1: drives, discovers the refusal, parks with a durable hold.
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, k_poison=1, k_escalate=1,
+        now_iso=lambda: "2026-01-01T00:00:00Z",
+    )
+    assert turns == 0 and drives["n"] == 1
+    assert s.read_quota_blocked_hold(
+        "beta", now_epoch=_epoch("2026-01-01T00:00:00Z")) is not None
+
+    # Poll 2: still before the reset instant -> pre-drive check parks, no new drive.
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, k_poison=1, k_escalate=1,
+        now_iso=lambda: "2026-01-01T00:00:05Z",
+    )
+    assert drives["n"] == 1                       # NOT re-driven while still blocked
+
+    # Poll 3: now past the reset instant -> the hold has self-expired -> drives again.
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, k_poison=1, k_escalate=1,
+        now_iso=lambda: "2026-01-01T00:00:15Z",
+    )
+    assert drives["n"] == 2                       # self-healed: re-drove once expired
+    assert turns == 1
+    assert s.cursor("beta") == m.id               # committed
+    assert s.read_quota_blocked_hold(
+        "beta", now_epoch=_epoch("2026-01-01T00:00:15Z")) is None  # cleared (self-expired)
+
+
+def test_quota_blocked_never_disposes_under_tight_ceilings_across_many_polls(tmp_path) -> None:
+    # A hold that never clears must NEVER dead-letter the head, no matter how many polls
+    # elapse - even under tight poison/escalate ceilings that WOULD dispose an ordinary
+    # failure. The pre-drive check means only the FIRST poll actually drives; every later
+    # poll parks for free (no CLI spawn, no ledger write).
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _quota_blocked_drive()             # held forever (same reset_at each time)
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=20, k_poison=1, k_escalate=1,
+        now_iso=lambda: "2026-01-01T00:00:00Z",   # frozen, well before reset_at, for all 20 polls
+    )
+    assert turns == 0
+    assert drives["n"] == 1                       # driven ONCE across all 20 polls
+    assert s.dead_lettered_count("beta") == 0
+
+
+def test_quota_blocked_escalates_exactly_once_across_a_long_hold(tmp_path) -> None:
+    # A silent 20-retry-then-dead-letter loop is the #126 incident; the operator must be
+    # notified ONCE on first entering the blocked state, not stormed every poll.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+
+    def drive(rec):
+        return _quota_blocked_drive()             # held for the whole run
+
+    escalations: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=15, k_poison=0, k_escalate=0,
+        now_iso=lambda: "2026-01-01T00:00:00Z",
+        on_escalate=lambda info: escalations.append(info.get("msg_id")) or True,
+    )
+    assert len(escalations) == 1                  # one-shot, not once-per-poll
+
+
+def test_quota_blocked_hold_survives_a_process_restart_and_gates_the_next_run(tmp_path) -> None:
+    # The hold is a DURABLE file (state/quota-blocked-hold/<agent>.json), not in-memory: a
+    # fresh run_loop invocation (simulating a wrapper restart) must still see it and refuse
+    # to re-drive before the reset instant, and must self-heal after - proving the hold, not
+    # some in-process cache, is what gates re-driving.
+    s = _store(tmp_path)
+    s.write_quota_blocked_hold("beta", summary="provider quota/billing refusal",
+                               reset_at="2026-01-01T00:00:10Z")
+    s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, now_iso=lambda: "2026-01-01T00:00:05Z",
+    )
+    assert turns == 0 and drives["n"] == 0        # pre-existing hold blocks the very first poll
+
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, now_iso=lambda: "2026-01-01T00:00:15Z",
+    )
+    assert turns == 1 and drives["n"] == 1        # self-healed once the reset instant passed
+
+
+# --------------------------------------------------- store: durable quota-blocked hold
+
+def test_quota_blocked_hold_store_roundtrip_and_expiry(tmp_path) -> None:
+    s = _store(tmp_path)
+    assert s.read_quota_blocked_hold("beta") is None      # absent -> None, never raises
+
+    s.write_quota_blocked_hold("beta", summary="usage limit hit",
+                               reset_at="2026-06-01T12:00:00Z")
+    fresh = s.read_quota_blocked_hold("beta", now_epoch=_epoch("2026-06-01T11:59:59Z"))
+    assert fresh == {
+        "agent": "beta", "state": "quota_blocked", "summary": "usage limit hit",
+        "reset_at": "2026-06-01T12:00:00Z", "at": fresh["at"],
+    }
+    # exactly-at and past the reset instant both self-expire (>=, not >)
+    assert s.read_quota_blocked_hold("beta", now_epoch=_epoch("2026-06-01T12:00:00Z")) is None
+    assert s.read_quota_blocked_hold("beta", now_epoch=_epoch("2026-06-01T13:00:00Z")) is None
+
+    s.clear_quota_blocked_hold("beta")
+    assert s.read_quota_blocked_hold("beta", now_epoch=_epoch("2026-06-01T11:59:59Z")) is None
+    s.clear_quota_blocked_hold("beta")            # idempotent, never raises when already absent
+
+
+def test_quota_blocked_hold_without_a_reset_instant_still_holds(tmp_path) -> None:
+    # The reset instant is retained "when present" (#126 ask) - when the provider's text
+    # gave none, the hold is still valid (falls back to bounded backoff, never expires on
+    # its own), and reads it back honestly as reset_at=None rather than fabricating one.
+    s = _store(tmp_path)
+    s.write_quota_blocked_hold("beta", summary="usage limit hit, no stated reset time")
+    hold = s.read_quota_blocked_hold("beta", now_epoch=_epoch("2030-01-01T00:00:00Z"))
+    assert hold is not None
+    assert hold["reset_at"] is None
+
+
+def test_quota_blocked_hold_is_scoped_to_its_own_agent(tmp_path) -> None:
+    s = _store(tmp_path)
+    s.write_quota_blocked_hold("beta", summary="x", reset_at="2030-01-01T00:00:00Z")
+    assert s.read_quota_blocked_hold("alpha") is None     # a different agent sees nothing
+    assert s.read_quota_blocked_hold("beta") is not None
+
+
+# ------------------------------------------- run.py: quota-refusal text/instant parsing
+
+def test_parse_quota_refusal_recognizes_the_real_dead_letter_template() -> None:
+    # The exact real template observed 13 times across 4 agents.
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    got = run._parse_quota_refusal(
+        "You've hit your usage limit. Visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at Aug 5th, 2026 6:10 AM.",
+        now=now,
+    )
+    assert got is not None
+    assert got["reset_at"] == "2026-08-05T06:10:00Z"
+
+
+def test_parse_quota_refusal_handles_the_time_only_variant_and_rolls_to_tomorrow() -> None:
+    now = datetime(2026, 7, 10, 20, 30, tzinfo=timezone.utc)
+    got = run._parse_quota_refusal(
+        "You've hit your usage limit. Visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at 7:55 PM.",
+        now=now,
+    )
+    assert got is not None
+    assert got["reset_at"] == "2026-07-11T19:55:00Z"      # already past today -> tomorrow
+
+
+def test_parse_quota_refusal_same_day_time_only_does_not_roll_forward() -> None:
+    now = datetime(2026, 7, 10, 16, 30, tzinfo=timezone.utc)
+    got = run._parse_quota_refusal(
+        "You've hit your usage limit or try again at 7:55 PM.", now=now)
+    assert got is not None
+    assert got["reset_at"] == "2026-07-10T19:55:00Z"      # still ahead today -> today
+
+
+def test_parse_quota_refusal_none_for_unrelated_infra_text() -> None:
+    # Direction control: a generic infra string must NOT be swept into quota_blocked.
+    assert run._parse_quota_refusal("connection refused by upstream") is None
+    assert run._parse_quota_refusal("HTTP 503 service unavailable") is None
+    assert run._parse_quota_refusal(None) is None
+
+
+def test_parse_quota_refusal_without_a_reset_clause_still_classifies() -> None:
+    # "when present" (#126 ask): a quota refusal with no parseable reset instant is
+    # still recognized - it just retains no reset_at, falling back to bounded backoff.
+    got = run._parse_quota_refusal("You have hit your usage limit for this billing period.")
+    assert got is not None
+    assert got["reset_at"] is None
+
+
+def test_parse_quota_reset_instant_rejects_an_implausibly_far_out_or_past_parse() -> None:
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    # 15 days out is a plausible quota window - accepted.
+    assert run._parse_quota_reset_instant("Jul 25th, 2026 12:00 PM", now=now) is not None
+    # 40/82 days out is far beyond any real quota window - treat as a parse/timezone mistake.
+    assert run._parse_quota_reset_instant("Aug 19th, 2026 12:00 PM", now=now) is None
+    assert run._parse_quota_reset_instant("Sep 30th, 2026 12:00 PM", now=now) is None
+    # A stated instant already in the past (e.g. a timezone mismatch) is discarded, not
+    # trusted as "already clear".
+    assert run._parse_quota_reset_instant("Jul 1st, 2026 12:00 PM", now=now) is None
+
+
+# ------------------------------------------ supervisor: never renders errored/stuck
+
+def test_quota_blocked_wrapper_reads_healthy_idle_to_the_supervisor(tmp_path) -> None:
+    # #126 requirement 4 ("NEVER as errored or stuck"): a wrapper parked on a quota hold
+    # must resolve to HEALTHY_IDLE for the supervisor's own decision - not TURN_FAILED (the
+    # wrapper-runtime record's phase would otherwise sit at terminal/failed for the ENTIRE
+    # hold, unlike a normal failure which retries within one backoff cycle and quickly moves
+    # phase off "terminal"). Drives through the real run.make_drive path (not a hand-built
+    # DriveOutcome) so the runtime_writer.idle() reset is exercised for real.
+    from agenttalk import supervisor as sup
+    from agenttalk import wrapper_runtime as _rt
+    from agenttalk.wrapper.health import WrapperHealthWriter
+
+    s = _store(tmp_path)
+    st = session.SessionState(cli="codex")
+    real_text = (
+        "You've hit your usage limit. Visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at Aug 5th, 2026 6:10 AM."
+    )
+
+    def fake_spawn(argv, stdin):
+        return _failed_turn_lines(real_text)
+
+    runtime_writer = _rt.WrapperRuntimeWriter(
+        s.state_dir, "beta", "test-wrapper-1", wrapper_pid=4242,
+        wrapper_start="2020-01-01T00:00:00.000000Z", clock=lambda: 0.0)
+    health_writer = WrapperHealthWriter(s, "beta", cli="codex", mode="wrapper-loop")
+    drive = run.make_drive(s, "beta", "codex", st, ["codex"], spawn=fake_spawn,
+                           clock=lambda: 0.0, render=False,
+                           runtime_writer=runtime_writer, health_writer=health_writer)
+    rec = {"id": "msg-1", "from": "a", "kind": "message", "body": "hi",
+           "correlation_id": None, "request_id": None, "broadcast_id": None}
+    outcome = drive(rec)
+    assert outcome.failure_class == loop.CLASS_QUOTA_BLOCKED
+
+    runtime = _rt.read_runtime(s.state_dir, "beta", now_epoch=0.0)
+    assert runtime["status"] == _rt.STATUS_VALID
+    assert runtime["record"]["phase"] == _rt.PHASE_IDLE   # NOT stuck at terminal/failed
+
+    s.write_heartbeat("beta")
+    now = 1000.0
+    report = sup.build_report(s, now_epoch=now, state={},
+                              supervisor_config={"agents": {"beta": {"wrapped": True}}})
+    plan = sup.plan_actions(
+        report, {}, {"agents": {"beta": {"wrapped": True, "auto_restart": True}}},
+        now_epoch=now, snapshot=[])
+    # No real process snapshot is injected here (that is #105's CLI-child-binding
+    # machinery, out of #126's scope), so the decision cannot positively confirm
+    # the child - CLI_CHILD_UNKNOWN is the correct, honest answer for THAT reason.
+    # What #126 actually prevents is TURN_FAILED: without the runtime_writer.idle()
+    # reset, the wrapper-runtime record would sit at phase=terminal/outcome=failed
+    # for the ENTIRE hold (unlike a normal failure, which retries within one backoff
+    # cycle and quickly moves phase off "terminal"), and _plan_one turns a fresh-
+    # heartbeat terminal/failed tuple directly into state=TURN_FAILED.
+    decision_state = plan["agents"]["beta"]["state"]
+    assert decision_state != "TURN_FAILED"
+
+
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:
@@ -909,6 +1229,42 @@ def test_make_drive_resume_first_failure_does_not_mark_unavailable(tmp_path) -> 
     assert st.resume_available is True                 # first failure only records the ledger
     assert st.resume_failure_count == 1
     assert st.turns == 0                               # a failed turn does not advance
+
+
+# --------------------------------------------- #126: provider quota/billing refusal
+
+def test_make_drive_classifies_real_provider_quota_refusal_text(tmp_path) -> None:
+    """#126: the EXACT real dead-letter text (13 occurrences across 4 agents, all the
+    same Codex template) must classify as CLASS_QUOTA_BLOCKED with its stated reset
+    instant retained - never ambiguous_or_unknown (the incident: 20 retries burned
+    over 65 minutes, then valid work dead-lettered). Uses the real provider text, not
+    a hand-built record - a fix tested against a synthetic shape that happens to have
+    the field proves nothing (#60 lesson)."""
+    s = _store(tmp_path)
+    st = session.SessionState(cli="codex")
+    real_text = (
+        "You've hit your usage limit. Visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at Aug 5th, 2026 6:10 AM."
+    )
+
+    def fake_spawn(argv, stdin):
+        return _failed_turn_lines(real_text)
+
+    drive = run.make_drive(s, "beta", "codex", st, ["codex"], spawn=fake_spawn,
+                           clock=lambda: 0.0, render=False)
+    rec = {"id": "msg-1", "from": "a", "kind": "message", "body": "hi",
+           "correlation_id": None, "request_id": None, "broadcast_id": None}
+
+    outcome = drive(rec)
+
+    assert outcome.ok is False
+    assert outcome.failure_class == loop.CLASS_QUOTA_BLOCKED
+    assert outcome.quota_reset_at == "2026-08-05T06:10:00Z"
+    assert "usage limit" in outcome.summary.lower()
+    health = s.read_health("beta")
+    assert health.get("state") == "rate_limited_or_outage"  # never errored_ambiguous
+    assert health.get("reason_code") == "quota_blocked"
 
 
 def test_make_drive_resume_structured_infra_failures_do_not_consume_b4_ceiling(

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -714,6 +714,32 @@ def test_quota_blocked_hold_survives_a_process_restart_and_gates_the_next_run(tm
     assert turns == 1 and drives["n"] == 1        # self-healed once the reset instant passed
 
 
+def test_quota_blocked_hold_restores_health_after_a_simulated_restart(tmp_path) -> None:
+    # #126 connector P2: run_loop's own startup unconditionally resets health to
+    # idle_waiting (on_health_idle) BEFORE the pre-drive park ever runs. Since a quota
+    # park deliberately does NOT re-drive (unlike gateway_held, whose re-drive-every-
+    # poll design lets a fresh failed drive() re-write health for free), nothing else
+    # would correct that idle_waiting for the rest of the hold - the worker would
+    # report cheerful idle health despite doctor/attention seeing the quota marker.
+    from agenttalk.wrapper.health import WrapperHealthWriter
+
+    s = _store(tmp_path)
+    s.write_quota_blocked_hold("beta", summary="provider quota/billing refusal",
+                               reset_at="2026-01-01T00:00:10Z")
+    s.send(sender="alpha", recipient="beta", body="task")
+    health_writer = WrapperHealthWriter(s, "beta", cli="codex", mode="wrapper-loop")
+
+    loop.run_loop(
+        s, "beta", lambda rec: loop.DriveOutcome(ok=True),
+        clock=lambda: 0.0, sleep=lambda d: None, max_polls=1,
+        now_iso=lambda: "2026-01-01T00:00:05Z",   # still before the reset instant
+        on_health_idle=health_writer.idle, on_health_parked=health_writer.parked,
+    )
+    health = s.read_health("beta")
+    assert health.get("state") == "rate_limited_or_outage"  # NOT idle_waiting
+    assert health.get("reason_code") == "quota_blocked"
+
+
 # --------------------------------------------------- store: durable quota-blocked hold
 
 def test_quota_blocked_hold_store_roundtrip_and_expiry(tmp_path) -> None:
@@ -736,15 +762,24 @@ def test_quota_blocked_hold_store_roundtrip_and_expiry(tmp_path) -> None:
     s.clear_quota_blocked_hold("beta")            # idempotent, never raises when already absent
 
 
-def test_quota_blocked_hold_without_a_reset_instant_still_holds(tmp_path) -> None:
+def test_quota_blocked_hold_without_a_reset_instant_still_holds_briefly(tmp_path) -> None:
     # The reset instant is retained "when present" (#126 ask) - when the provider's text
-    # gave none, the hold is still valid (falls back to bounded backoff, never expires on
-    # its own), and reads it back honestly as reset_at=None rather than fabricating one.
+    # gave none, the hold is still valid immediately after being written (reads it back
+    # honestly as reset_at=None rather than fabricating one) - it just falls back to a
+    # BOUNDED re-probe window rather than holding forever (connector P1 on PR #104: an
+    # unknown-reset hold with no expiry mechanism at all permanently wedges the mailbox).
+    from agenttalk.store import Store as _StoreCls
+    import time as _time
+
     s = _store(tmp_path)
     s.write_quota_blocked_hold("beta", summary="usage limit hit, no stated reset time")
-    hold = s.read_quota_blocked_hold("beta", now_epoch=_epoch("2030-01-01T00:00:00Z"))
+    now = _time.time()
+    hold = s.read_quota_blocked_hold("beta", now_epoch=now + 60.0)
     assert hold is not None
     assert hold["reset_at"] is None
+    # ...but it MUST eventually re-probe rather than wedge forever.
+    reprobe = _StoreCls.QUOTA_UNKNOWN_RESET_REPROBE_SECONDS
+    assert s.read_quota_blocked_hold("beta", now_epoch=now + reprobe + 1.0) is None
 
 
 def test_quota_blocked_hold_is_scoped_to_its_own_agent(tmp_path) -> None:
@@ -844,9 +879,11 @@ def test_quota_blocked_wrapper_reads_healthy_idle_to_the_supervisor(tmp_path) ->
         s.state_dir, "beta", "test-wrapper-1", wrapper_pid=4242,
         wrapper_start="2020-01-01T00:00:00.000000Z", clock=lambda: 0.0)
     health_writer = WrapperHealthWriter(s, "beta", cli="codex", mode="wrapper-loop")
+    frozen_now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
     drive = run.make_drive(s, "beta", "codex", st, ["codex"], spawn=fake_spawn,
                            clock=lambda: 0.0, render=False,
-                           runtime_writer=runtime_writer, health_writer=health_writer)
+                           runtime_writer=runtime_writer, health_writer=health_writer,
+                           now_wall=lambda: frozen_now)
     rec = {"id": "msg-1", "from": "a", "kind": "message", "body": "hi",
            "correlation_id": None, "request_id": None, "broadcast_id": None}
     outcome = drive(rec)
@@ -1269,8 +1306,12 @@ def test_make_drive_classifies_real_provider_quota_refusal_text(tmp_path) -> Non
     def fake_spawn(argv, stdin):
         return _failed_turn_lines(real_text)
 
+    # A frozen "now" well before the fixture's stated reset instant - without this,
+    # `_parse_quota_refusal` defaults to the REAL wall clock, and this date-bombs the
+    # instant real time passes 2026-08-05T06:10Z (connector P1 catch on PR #104).
+    frozen_now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
     drive = run.make_drive(s, "beta", "codex", st, ["codex"], spawn=fake_spawn,
-                           clock=lambda: 0.0, render=False)
+                           clock=lambda: 0.0, render=False, now_wall=lambda: frozen_now)
     rec = {"id": "msg-1", "from": "a", "kind": "message", "body": "hi",
            "correlation_id": None, "request_id": None, "broadcast_id": None}
 

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -413,6 +413,24 @@ def test_loop_idle_stamps_heartbeat(tmp_path) -> None:
     assert s.read_heartbeat("beta") is not None   # idle kept the heartbeat fresh
 
 
+def test_loop_survives_a_non_iso_now_iso_placeholder(tmp_path) -> None:
+    # PR #104 CI regression: `now_iso` is used elsewhere in this loop purely as an
+    # OPAQUE stamp (never parsed back) - test_dead_letter.py's own default injects a
+    # bare "t" placeholder, not a real ISO string. The #126 pre-drive quota check
+    # parsed it unconditionally and crashed every dev-gate leg (0/13, deterministic
+    # across every OS/Python version) despite this exact scenario being green in
+    # every file this task's own targeted runs touched - the break was in a file none
+    # of them imported at module scope. Must fall back to the real wall clock instead
+    # of raising.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+    turns = loop.run_loop(
+        s, "beta", lambda rec: True, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, now_iso=lambda: "t",
+    )
+    assert turns == 1
+
+
 # ------------------------------------------- #58: config-blocked park visibility + re-probe
 
 def _config_blocked_drive():


### PR DESCRIPTION
## Summary
- The wrapper classified Codex's usage-limit refusal ("You've hit your usage limit ... try again at <time>") as `ambiguous_or_unknown`, retried the same 16.7 KB message 20 times over 65 minutes against a wall that could not clear, then dead-lettered valid work. The agent surfaced as `health=errored_ambiguous` / `supervisor=STUCK_OR_DEAD/stuck_recover` - a pure billing condition rendered as a crashed agent. Historical scan: 13 of 105 dead-letter entries across 4 agents cite a usage limit - a channel class, not an incident.
- Producer-checked the premise first: traced the exact classification path (`wrapper/run.py:_classify_drive_failure` -> `_looks_like_infra` matching "usage limit"/"try again" -> `CLASS_AMBIGUOUS`), confirmed against the real dead-letter record cited in the task and 12 historical siblings (all the identical Codex template).
- New `CLASS_QUOTA_BLOCKED`: parses and retains the stated reset instant (both "Aug 5th, 2026 6:10 AM" and time-only "7:55 PM" variants, with a plausibility bound against a parse/timezone mistake), never consumes a retry attempt or dead-letters (mirrors the existing `CLASS_GATEWAY_HELD` mechanism), and a durable per-agent hold self-expires once the reset instant passes - no operator action needed, and re-driving is gated on that hold instead of hammering the provider every poll.
- `runtime_writer.idle()` resets the wrapper-runtime phase after a quota park - without it, a long hold reads to the supervisor's decision as a stuck `TURN_FAILED` turn (the wrapper-runtime record would otherwise sit at terminal/failed for the whole hold, unlike a normal failure which retries within one backoff cycle).
- Surfaced on the same operator surfaces `config_blocked` already uses: the attention queue (`attention.py`, `cli.py`, `web.py`), doctor (`doctor.py`), all `warn`-level, never `error` - with its own low-severity "QUOTA BLOCKED" bucket on the web console distinct from a GATE HOLD (there is no operator repair here, only the provider's own clock).

## Test plan
- [x] End-to-end classification test using the EXACT real dead-letter text (not a hand-built record) through `run.make_drive`'s real spawn path
- [x] Loop-level tests: no attempt consumed, never dead-letters even under tight ceilings, drives only once then parks without re-driving, self-heals once the reset instant passes, hold survives a simulated process restart, escalates exactly once
- [x] Parser unit tests: real template, time-only rollover (same-day and next-day), negative control on unrelated infra text, no-reset-clause still classifies, implausible-parse rejection
- [x] Store round-trip + expiry unit tests (fresh/expired/absent/malformed/wrong-agent)
- [x] Direction control: temporarily reverted the `runtime_writer.idle()` fix and confirmed the supervisor-decision regression test fails with the wrong phase
- [x] attention.py/doctor.py/cli.py/web.py surfacing tests, including a genuine catch: web.py's `/api/attention` has its own internal source→display map that silently drops any unmapped source - caught by an actual HTTP-level test, not assumed from the cli.py-level test passing
- [x] `pytest tests/test_wrapper_loop.py tests/test_attention.py tests/test_attention_cli.py` = 216 passed
- [x] `pytest tests/test_doctor.py tests/test_wrapper_health.py` = 102 passed
- [x] `pytest tests/test_web.py` = 179 passed
- [x] `pytest tests/test_cli.py` = 216 passed
- [x] `pytest tests/test_supervisor.py` = 361 passed, 2 skipped
- [x] `ruff check` on all 13 changed files - clean
- [ ] Did not run the full local dev-gate/build/wheel/security suite (targeted-tests-only per standing rule) - authoritative CI gates this

🤖 Generated with [Claude Code](https://claude.com/claude-code)