### PR TITLE
Parallelize dev-gate pytest with two workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ design. The item that did ship is the one measured to cost the most in the field
 
 ### Changed
 
+- **The source and built-wheel pytest gate legs now run concurrently without reducing coverage.**
+  Both modes execute the full `tests` path with two pytest-xdist workers and `--dist loadfile`.
+  The gate provisions pytest-xdist as bootstrap-only tooling and installs it in the isolated
+  wheel-test environment; the shipped package still has no runtime dependencies.
+
 - **The lead skill now requires reading the code host's AUTOMATED review findings as a gate
   step, in both the Claude and Codex editions.** Automated reviewers typically post findings
   as INLINE comments on changed lines rather than in the review body, so a lead who reads

--- a/dev-gate-requirements.txt
+++ b/dev-gate-requirements.txt
@@ -1,5 +1,6 @@
 # Bootstrap-only tooling. The committed dev-gate.json owns every voting argv.
 pytest>=8.0
+pytest-xdist>=3.8.0
 build>=1.2
 hatchling>=1.31.0
 ruff>=0.6

--- a/dev-gate.json
+++ b/dev-gate.json
@@ -67,9 +67,16 @@
         "tests"
       ],
       "args": [
-        "-q"
+        "-q",
+        "-p",
+        "xdist.plugin",
+        "-n",
+        "2",
+        "--dist",
+        "loadfile"
       ],
       "test_requirement": "pytest>=8.0",
+      "xdist_requirement": "pytest-xdist>=3.8.0",
       "timeout_seconds": 2700
     },
     "ruff": {

--- a/docs/DEV-GATE.md
+++ b/docs/DEV-GATE.md
@@ -67,7 +67,9 @@ does not own check selection or argv.
 
 Every local run checks:
 
-- full pytest in source mode and built-wheel mode on Python 3.10 and 3.14;
+- full pytest in source mode and built-wheel mode on Python 3.10 and 3.14. Each run loads
+  `xdist.plugin` explicitly and uses two workers with `--dist loadfile`; file grouping preserves
+  within-file ordering while worker-specific pytest temp roots isolate concurrent files;
 - one sdist and one wheel built without build isolation;
 - sdist exclusion sentinels and required shipped files;
 - dependency-resolving wheel installation in fresh `system_site_packages=False` runtime and test environments,

--- a/src/agenttalk/dev_gate.py
+++ b/src/agenttalk/dev_gate.py
@@ -265,6 +265,7 @@ def validate_manifest(data: Any) -> dict[str, Any]:
         "required_wheel_resources",
         "dependency_index",
         "test_requirement",
+        "xdist_requirement",
     }
     for check_id, expected_kind in REQUIRED_CONFIGURED_CHECKS.items():
         spec = _require_object(checks.get(check_id), f"checks.{check_id}")
@@ -278,7 +279,12 @@ def validate_manifest(data: Any) -> dict[str, Any]:
             raise GateBlock("manifest_schema_invalid", f"checks.{check_id}.timeout_seconds must be positive")
 
     required_contract = {
-        "pytest": {"paths": ["tests"], "args": ["-q"], "test_requirement": "pytest>=8.0"},
+        "pytest": {
+            "paths": ["tests"],
+            "args": ["-q", "-p", "xdist.plugin", "-n", "2", "--dist", "loadfile"],
+            "test_requirement": "pytest>=8.0",
+            "xdist_requirement": "pytest-xdist>=3.8.0",
+        },
         "ruff": {"paths": ["src", "tests"]},
         "bandit": {"paths": ["src"], "exclude": ["src/agenttalk/skills"]},
         "gitleaks": {"config": ".gitleaks.toml", "require_full_history": True},
@@ -2689,6 +2695,7 @@ def _prepare_wheel_test_environment(
     for label, requirement in (
         ("candidate", str(wheel)),
         ("pytest", manifest["checks"]["pytest"]["test_requirement"]),
+        ("pytest-xdist", manifest["checks"]["pytest"]["xdist_requirement"]),
     ):
         outcome = run_command(
             check_id=f"wheel-test-install-{label}-{_python_suffix(creator.requested)}",

--- a/tests/test_dev_gate.py
+++ b/tests/test_dev_gate.py
@@ -435,6 +435,11 @@ def test_manifest_declares_real_ci_matrix_separately_from_local_interpreters() -
         lambda data: data["checks"].pop("semgrep"),
         lambda data: data.update({"ci_native_exceptions": []}),
         lambda data: data["checks"]["pytest"].update({"paths": ["tests/test_dev_gate.py"]}),
+        lambda data: data["checks"]["pytest"].update({"args": ["-q"]}),
+        lambda data: data["checks"]["pytest"].pop("xdist_requirement"),
+        lambda data: data["checks"]["pytest"].update(
+            {"xdist_requirement": "pytest-xdist"}
+        ),
         lambda data: data["checks"]["ruff"].update({"paths": []}),
         lambda data: data["checks"]["bandit"].update({"exclude": ["src"]}),
         lambda data: data["checks"]["gitleaks"].update({"require_full_history": False}),
@@ -587,6 +592,85 @@ def test_passing_check_command_must_match_committed_plan() -> None:
 
     with pytest.raises(dev_gate.GateBlock, match="command"):
         dev_gate.validate_run_artifact(artifact, manifest)
+
+
+@pytest.mark.parametrize("parallel_arg", ["xdist.plugin", "2", "loadfile"])
+def test_passing_pytest_evidence_requires_parallel_command(parallel_arg: str) -> None:
+    manifest = dev_gate.validate_manifest(_manifest())
+    artifact = _leg_artifact(manifest, "windows/3.10")
+    pytest_record = next(
+        check for check in artifact["checks"] if check["id"].startswith("pytest-")
+    )
+    pytest_record["argv"].remove(parallel_arg)
+
+    with pytest.raises(dev_gate.GateBlock, match="command"):
+        dev_gate.validate_run_artifact(artifact, manifest)
+
+
+def test_wheel_test_environment_installs_xdist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    creator = dev_gate.InterpreterInfo(
+        requested="3.14",
+        path=Path(sys.executable),
+        implementation="CPython",
+        version=platform.python_version(),
+    )
+    test_interpreter = dev_gate.InterpreterInfo(
+        requested="3.14",
+        path=tmp_path / "test-venv" / "python",
+        implementation="CPython",
+        version=platform.python_version(),
+    )
+    calls: list[dict] = []
+
+    monkeypatch.setattr(
+        dev_gate,
+        "_create_isolated_venv",
+        lambda **_kwargs: (test_interpreter, {"role": "test"}),
+    )
+
+    def passing_command(**kwargs):
+        calls.append(kwargs)
+        return dev_gate.CommandOutcome(
+            argv=tuple(kwargs["argv"]),
+            returncode=0,
+            duration_ms=1,
+            status="pass",
+            reason_code=None,
+            diagnostic="",
+            log_path=tmp_path / "command.log",
+        )
+
+    monkeypatch.setattr(dev_gate, "run_command", passing_command)
+    wheel = tmp_path / "agenttalk.whl"
+
+    interpreter, proof = dev_gate._prepare_wheel_test_environment(
+        creator=creator,
+        wheel=wheel,
+        root=tmp_path / "test-venv",
+        source_root=tmp_path,
+        env={},
+        manifest=_manifest(),
+        logs_dir=tmp_path / "logs",
+    )
+
+    assert interpreter is test_interpreter
+    assert proof == {"role": "test"}
+    assert [call["check_id"] for call in calls] == [
+        "wheel-test-install-candidate-py314",
+        "wheel-test-install-pytest-py314",
+        "wheel-test-install-pytest-xdist-py314",
+        "wheel-test-pip-check-py314",
+    ]
+    assert [call["argv"][-1] for call in calls[:-1]] == [
+        str(wheel),
+        "pytest>=8.0",
+        "pytest-xdist>=3.8.0",
+    ]
+    assert calls[-1]["argv"] == dev_gate.isolated_tool_argv(
+        test_interpreter.path, "pip", "check"
+    )
 
 
 def test_import_provenance_rejects_parent_traversal() -> None:

--- a/tests/test_dev_gate_docs.py
+++ b/tests/test_dev_gate_docs.py
@@ -48,6 +48,30 @@ def test_dev_gate_reference_tracks_the_committed_authority_split() -> None:
     assert "`linux/3.12`" in reference
 
 
+def test_dev_gate_reference_tracks_parallel_pytest_without_runtime_dependency() -> None:
+    manifest = json.loads(Path("dev-gate.json").read_text(encoding="utf-8"))
+    pytest_spec = manifest["checks"]["pytest"]
+    reference = Path("docs/DEV-GATE.md").read_text(encoding="utf-8")
+    gate_requirements = Path("dev-gate-requirements.txt").read_text(encoding="utf-8")
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert pytest_spec["paths"] == ["tests"]
+    assert pytest_spec["args"] == [
+        "-q",
+        "-p",
+        "xdist.plugin",
+        "-n",
+        "2",
+        "--dist",
+        "loadfile",
+    ]
+    assert pytest_spec["xdist_requirement"] == "pytest-xdist>=3.8.0"
+    assert "pytest-xdist>=3.8.0" in gate_requirements.splitlines()
+    assert "two workers" in reference
+    assert "`--dist loadfile`" in reference
+    assert "dependencies = []" in pyproject
+
+
 def test_dev_gate_reference_and_manifest_are_shipped_in_the_sdist() -> None:
     pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
 

--- a/tests/test_ovh_gateway_front.py
+++ b/tests/test_ovh_gateway_front.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import errno
 import http.client
 import io
 import json
@@ -56,6 +57,10 @@ def _listen_port() -> int:
         return int(server.server_address[1])
     finally:
         server.server_close()
+
+
+def _address_in_use(exc: OSError) -> bool:
+    return exc.errno == errno.EADDRINUSE or getattr(exc, "winerror", None) == 10048
 
 
 class FakeUpstream:
@@ -210,15 +215,6 @@ class RunningFront:
             request_id="q-front-fixture",
             issuer_token=TEST_CHILD_CAP_ISSUER,
         )
-        public_port = _listen_port()
-        self.config = FrontConfig(
-            public_token="front-secret",
-            internal_token="internal-secret",
-            public_port=public_port,
-            internal_port=upstream.port,
-            request_timeout_seconds=5,
-        )
-
         def fake_upstream_connection(*args, **kwargs) -> http.client.HTTPConnection:
             # GatewayFront still has to request its configured timeout. The
             # hermetic fake transport is governed by the cumulative test budget.
@@ -230,12 +226,25 @@ class RunningFront:
                 **kwargs,
             )
 
-        self.front = GatewayFront(
-            self.config,
-            self.ledger,
-            connection_factory=fake_upstream_connection,
-        )
-        self.server = self.front.make_server()
+        for attempt in range(5):
+            self.config = FrontConfig(
+                public_token="front-secret",
+                internal_token="internal-secret",
+                public_port=_listen_port(),
+                internal_port=upstream.port,
+                request_timeout_seconds=5,
+            )
+            self.front = GatewayFront(
+                self.config,
+                self.ledger,
+                connection_factory=fake_upstream_connection,
+            )
+            try:
+                self.server = self.front.make_server()
+                break
+            except OSError as exc:
+                if not _address_in_use(exc) or attempt == 4:
+                    raise
         track_server(self.server, self.activity)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
@@ -490,6 +499,32 @@ def test_stream_usage_accepts_complete_sse_and_json() -> None:
         b'data: {"type":"message_stop"}\n'
     )
     assert parser.finish() == (MODEL_ALIAS, 5, 2)
+
+
+def test_running_front_retries_ephemeral_bind_collision(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_listen_port = _listen_port
+    allocations = 0
+    occupied = ThreadingHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    occupied_port = int(occupied.server_address[1])
+
+    def allocate_port() -> int:
+        nonlocal allocations
+        allocations += 1
+        if allocations == 1:
+            return occupied_port
+        return original_listen_port()
+
+    monkeypatch.setitem(globals(), "_listen_port", allocate_port)
+    try:
+        with FakeUpstream() as upstream:
+            with RunningFront(tmp_path, upstream) as running:
+                assert running.config.public_port != occupied_port
+    finally:
+        occupied.server_close()
+
+    assert allocations == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -182,7 +182,9 @@ def test_concurrent_exact_task_installer_converges_without_overwrite(tmp_path) -
     assert task_xml_matches(commands.tasks[identity.task_name], identity)
 
 
-def test_exclusive_bind_probe_refuses_occupied_listener() -> None:
+def test_exclusive_bind_probe_refuses_occupied_listener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.bind(("127.0.0.1", 0))
     port = int(listener.getsockname()[1])
@@ -191,7 +193,27 @@ def test_exclusive_bind_probe_refuses_occupied_listener() -> None:
             exclusive_bind_probe("127.0.0.1", port)
     finally:
         listener.close()
+
+    observed: list[tuple[str, int]] = []
+
+    class ReleasedPortSocket:
+        def setsockopt(self, *_args: object) -> None:
+            return
+
+        def bind(self, address: tuple[str, int]) -> None:
+            observed.append(address)
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(
+        service.socket,
+        "socket",
+        lambda *_args: ReleasedPortSocket(),
+    )
     exclusive_bind_probe("127.0.0.1", port)
+
+    assert observed == [("127.0.0.1", port)]
 
 
 def test_one_time_install_writes_nonsecret_config_and_tokens_outside_project(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- run every source and built-wheel pytest leg with two fixed pytest-xdist workers and `--dist loadfile`
- load `xdist.plugin` explicitly because the gate disables plugin autoload
- keep pytest-xdist in `dev-gate-requirements.txt` and install it into the isolated wheel-test venv; `pyproject.toml` remains `dependencies = []`
- harden the gateway front fixture against real ephemeral-port bind collisions and retain the released named-port probe without a TOCTOU rebind
- ratchet the manifest, evidence command, wheel provisioning, docs, and unchanged full `tests` path

## Why two workers

On the pinned Windows workload (`test_ovh_gateway_front.py`, `test_lanes.py`, `test_checkpoint.py`, `test_dev_gate.py`), serial runs were 302.01s and 314.36s (308.19s median), with 313 passed / 6 skipped. Four workers passed once in 241.71s, then produced 37 failures after Windows Git process launches began failing with `0xC0000142`; that configuration was rejected.

Two workers passed twice: 313 passed / 6 skipped in 231.43s before the regression additions, then 321 passed / 6 skipped in 230.36s after them. The final run is 25.3% faster than the serial median while executing eight additional regression cases. Serial collection and the final parallel outcome both account for exactly 327 tests.

## Validation

- focused gate/docs/workflow/port regressions: 31 passed
- review-remediation port regressions: 2 passed
- final parallel workload: 321 passed, 6 skipped in 230.36s
- targeted Ruff over changed Python files: passed
- two read-only review lenses: approved after remediation

The full dev gate was intentionally not run inside the wrapped turn. Authoritative multi-OS/source/wheel CI is pending.

## Named residual

`test_ovh_litellm_conformance.py` still uses released numeric ports when its explicit local LiteLLM opt-in is enabled. The voting gate scrubs that opt-in, so all three cases remain intentionally skipped and no voting coverage changed; manual opt-in execution remains serial-only pending a LiteLLM socket-activation seam.