### PR TITLE
fix(ci): ignore two public schema-type fingerprints (#67)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,6 @@
 8d0dbb7010538d6e21b85074fd6c67b7bb12e06f:tests/test_supervisor.py:generic-api-key:775
 276a049e21285f59fc841db8acafeb6433650636:tests/test_wrapper_health.py:generic-api-key:213
 722bb9dd33ef926f9c39cf9bbae56abe19d5381f:tests/test_wrapper_health.py:generic-api-key:213
+# Public schema type used by ChildEstablishmentGuardV1.key; not a credential.
+0ae2e8858614efd2f1294e1cd2eb7a98e2564e37:docs/DESIGN-87A-supervisor-classifier-authority.md:generic-api-key:377
+0ae2e8858614efd2f1294e1cd2eb7a98e2564e37:docs/DESIGN-87A-supervisor-classifier-authority.md:generic-api-key:383


### PR DESCRIPTION
## Root cause

The release gate runs gitleaks with `--log-opts=--all` after `actions/checkout` fetches every remote branch at depth 0. An unrelated design branch added two `generic-api-key` false positives after the last green master checkout, so later PRs scanned them even though neither finding is in master or either PR history.

Both findings are in commit `0ae2e8858614efd2f1294e1cd2eb7a98e2564e37`, `docs/DESIGN-87A-supervisor-classifier-authority.md`, lines 377 and 383. They are the same public PascalCase schema type used after `key:` in two algebraic variants, not credentials. No matched value is reproduced here.

## Fix

Add exactly the two immutable `commit:path:rule:line` fingerprints to `.gitleaksignore`, with an explanatory comment. No regex, path, rule, or commit-wide allowlist is added.

## Targeted evidence

- Official gitleaks 8.30.1 Windows x64 asset checksum verified against its release manifest.
- Exact gate argv before change: 1,020 commits scanned, two findings, exit 1.
- Exact gate argv after change: 1,020 commits scanned, no leaks, exit 0.
- Master, PR 103 head, PR 101 head, and both pull-request merge refs each scan clean independently.
- Offending commit and its design branch each reproduce exactly two findings.
- `git diff --check` passed.
- Fresh read-only security review: no blocking findings.

No full dev-gate or test suite was run in-turn.