### PR TITLE
fix(supervisor): surface startup kill-switch holds + close the claim race (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,13 @@ design. The item that did ship is the one measured to cost the most in the field
   execution, watchdog exclusion, and mandatory SHA-bound terminal evidence,
   including timeout and kill results, remain the separate #121 implementation.
 
+- **A kill switch present before supervisor startup is now durably visible.**
+  The generated PowerShell supervisor records a strict, level-triggered runtime
+  observation before preserving exit code 3, without claiming the executor
+  instance or writing process state. Mid-poll switch transitions use the same
+  checked operation. Human and JSON `status` project the record independently
+  of the supervisor event-ring limit.
+
 - **Coverage evidence now preserves the zero-runtime-dependency boundary without taking
   custody of report files.** Attestation accepts only a recognized coverage.py/pytest-cov
   terminal summary from stdout; it no longer parses root JSON or XML reports. A scan

--- a/docs/USER-MANUAL.md
+++ b/docs/USER-MANUAL.md
@@ -779,7 +779,12 @@ New-Item .agenttalk\supervisor.kill -ItemType File
 ```
 
 While the kill switch exists, read-only commands still work, but mutating
-supervisor automation is disabled. Remove the file to re-enable automation.
+supervisor automation is disabled. The generated supervisor records the hold
+without acquiring executor authority; inspect it with `agenttalk status` or
+`agenttalk status --json`. After an agenttalk upgrade, stop and wait for the
+supervisor, remove the switch, run `agenttalk supervise --refresh-scripts`,
+re-arm the switch if needed, and then start the supervisor. Remove the file to
+re-enable automation.
 
 ## 9. Work lanes and isolated worktrees
 

--- a/docs/supervisor-hosting.md
+++ b/docs/supervisor-hosting.md
@@ -94,7 +94,24 @@ usable. The supervisor refuses kills, relaunches, seeding, launch-request
 claim/archive, marker clearing, bus notify, and supervisor-state reconciliation
 writes. The sole operator-write exception is the attended process-tree
 ownership reset below; it requires the kill switch as a safety precondition.
-Remove the file to re-enable automation.
+The other operational-state write exception is a checked, field-owned runtime
+observation in `.agenttalk\state\supervisor-runtime-observation.json`. It
+records that the generated supervisor observed the switch at startup or during
+a poll without claiming the executor instance or loading process state.
+Existing cleanup and repair operations remain available where their command
+contract permits them.
+
+`agenttalk status` prints an explicit hold line, and `agenttalk status --json`
+projects the same record under `supervisor_runtime.kill_switch`. A switch found
+at startup remains exit code 3 so Scheduled Task restart-on-failure continues
+to retry the blocked supervisor. To install this generated-script behavior
+after an upgrade, stop and wait for the supervisor, remove `supervisor.kill`,
+run `agenttalk supervise --refresh-scripts`, re-create the switch if the hold
+must continue, and then start the supervisor.
+
+The observation is level-triggered. If the file is removed and recreated
+entirely between supervisor observations, those two active intervals are
+indistinguishable. Remove the file to re-enable automation.
 
 ### Recover an owned-process-tree HOLD
 
@@ -138,7 +155,6 @@ runtime generation still follows normal fail-closed adoption.
    (`--refresh-scripts` refuses while the kill switch is present.) Queue
    `agenttalk request-restart --for <agent>`, then resume the supervisor. The
    new wrapper generation must earn a fresh complete tree.
-
 ## Deadman
 
 `agenttalk deadman --threshold-seconds 900 --json` checks actionable mail age

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -748,6 +748,19 @@ def _read_supervisor_snapshot(store: Store, path_value: str | None = None) -> li
     return raw if isinstance(raw, list) else None
 
 
+def _runtime_kill_switch_warnings(runtime_status: object) -> list[str]:
+    if not isinstance(runtime_status, dict):
+        return []
+    kill_switch = runtime_status.get("kill_switch")
+    if not isinstance(kill_switch, dict):
+        return []
+    return [
+        warning
+        for warning in kill_switch.get("warnings") or []
+        if isinstance(warning, str)
+    ]
+
+
 def _status_supervisor_summaries(store: Store, now_epoch: float,
                                  sup_cfg: dict) -> tuple[
                                      dict[str, dict], list[str], dict
@@ -766,7 +779,10 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
     except Exception as exc:
         return (
             {},
-            [f"supervisor_assessment_unavailable:{type(exc).__name__}"],
+            [
+                f"supervisor_assessment_unavailable:{type(exc).__name__}",
+                *_runtime_kill_switch_warnings(runtime_status),
+            ],
             runtime_status,
         )
     observed_runtime = obs.get("supervisor_runtime")
@@ -796,11 +812,7 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
     for warning in ring.get("warnings") or []:
         if isinstance(warning, str):
             warnings.append(warning)
-    kill_switch = runtime_status.get("kill_switch")
-    if isinstance(kill_switch, dict):
-        for warning in kill_switch.get("warnings") or []:
-            if isinstance(warning, str):
-                warnings.append(warning)
+    warnings.extend(_runtime_kill_switch_warnings(runtime_status))
     return rows, warnings, runtime_status
 
 

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -62,6 +62,7 @@ from agenttalk import supervisor as sup
 from agenttalk import powershell_host as psh
 from agenttalk import supervisor_lifecycle as supervisor_lifecycle
 from agenttalk import wrapper_runtime as runtime_obs
+from agenttalk import supervisor_runtime as supervisor_runtime
 
 # Hard ceiling on cumulative deadline extension from `composing` pings,
 # regardless of how many arrive. Prevents a misbehaving (or stuck) peer
@@ -542,8 +543,11 @@ def _gather_status(store: Store) -> dict:
     sup_agents = (
         sup_cfg.get("agents") if isinstance(sup_cfg.get("agents"), dict) else {}
     )
-    supervisor_rows, supervisor_warnings = _status_supervisor_summaries(
-        store, now.timestamp(), sup_cfg)
+    supervisor_rows, supervisor_warnings, supervisor_runtime_status = (
+        _status_supervisor_summaries(
+            store, now.timestamp(), sup_cfg
+        )
+    )
     agents = []
     for a in cfg.get("agents", []):
         hb = store.read_heartbeat(a)
@@ -653,6 +657,8 @@ def _gather_status(store: Store) -> dict:
         "stale_threshold_seconds": STALE_THRESHOLD_SECONDS,
         "warnings": warnings,
     }
+    if supervisor_runtime.runtime_status_relevant(supervisor_runtime_status):
+        payload["supervisor_runtime"] = supervisor_runtime_status
     if os.name == "nt" and (
         (store.dir / psh.SELECTION_FILENAME).exists()
         or (store.dir / "supervisor.ps1").exists()
@@ -743,7 +749,10 @@ def _read_supervisor_snapshot(store: Store, path_value: str | None = None) -> li
 
 
 def _status_supervisor_summaries(store: Store, now_epoch: float,
-                                 sup_cfg: dict) -> tuple[dict[str, dict], list[str]]:
+                                 sup_cfg: dict) -> tuple[
+                                     dict[str, dict], list[str], dict
+                                 ]:
+    runtime_status = supervisor_runtime.build_runtime_status(store)
     try:
         obs = sup.build_supervisor_observation(
             store,
@@ -755,7 +764,14 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
             lead_liveness_stale_after_seconds=STALE_THRESHOLD_SECONDS,
         )
     except Exception as exc:
-        return {}, [f"supervisor_assessment_unavailable:{type(exc).__name__}"]
+        return (
+            {},
+            [f"supervisor_assessment_unavailable:{type(exc).__name__}"],
+            runtime_status,
+        )
+    observed_runtime = obs.get("supervisor_runtime")
+    if isinstance(observed_runtime, dict):
+        runtime_status = observed_runtime
     rows: dict[str, dict] = {}
     for item in obs.get("agents") or []:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
@@ -780,7 +796,48 @@ def _status_supervisor_summaries(store: Store, now_epoch: float,
     for warning in ring.get("warnings") or []:
         if isinstance(warning, str):
             warnings.append(warning)
-    return rows, warnings
+    kill_switch = runtime_status.get("kill_switch")
+    if isinstance(kill_switch, dict):
+        for warning in kill_switch.get("warnings") or []:
+            if isinstance(warning, str):
+                warnings.append(warning)
+    return rows, warnings, runtime_status
+
+
+def _render_supervisor_kill_switch_status(runtime_status: object) -> str | None:
+    if not isinstance(runtime_status, dict):
+        return None
+    kill_switch = runtime_status.get("kill_switch")
+    if not isinstance(kill_switch, dict) or kill_switch.get("active") is not True:
+        return None
+    if kill_switch.get("observed") is not True:
+        return (
+            "supervisor: HOLD - supervisor.kill active; "
+            "no supervisor observation recorded"
+        )
+    observations = kill_switch.get("observations")
+    if not isinstance(observations, dict):
+        return "supervisor: HOLD - supervisor.kill active; observation unavailable"
+    candidates = []
+    for phase, observation in observations.items():
+        if not isinstance(phase, str) or not isinstance(observation, dict):
+            continue
+        epoch = observation.get("observed_at_epoch")
+        at = observation.get("observed_at")
+        if (
+            isinstance(epoch, (int, float))
+            and not isinstance(epoch, bool)
+            and isinstance(at, str)
+        ):
+            candidates.append((float(epoch), phase, at, observation))
+    if not candidates:
+        return "supervisor: HOLD - supervisor.kill active; observation unavailable"
+    _epoch, phase, observed_at, observation = max(candidates)
+    suffix = "; startup exits 3" if observation.get("exit_code") == 3 else ""
+    return (
+        "supervisor: HOLD - supervisor.kill active; "
+        f"{phase.replace('_', '-')} observed {observed_at}{suffix}"
+    )
 
 
 def _closed_rids(store: Store, agent: str) -> set[str]:
@@ -1222,6 +1279,11 @@ def cmd_status(args: argparse.Namespace) -> int:
     print(f"session_id: {payload['session_id']}")
     print(f"agents:     {', '.join(a['name'] for a in payload['agents'])}")
     print(f"messages:   {payload['message_count']}")
+    supervisor_runtime_line = _render_supervisor_kill_switch_status(
+        payload.get("supervisor_runtime")
+    )
+    if supervisor_runtime_line:
+        print(supervisor_runtime_line)
     if "powershell_host" in payload:
         host = payload["powershell_host"]
         print(
@@ -1322,6 +1384,9 @@ def cmd_supervisor(args: argparse.Namespace) -> int:
                 "warnings": [f"supervisor_read_unavailable:{type(exc).__name__}"],
             },
         }
+        runtime_status = supervisor_runtime.build_runtime_status(store)
+        if supervisor_runtime.runtime_status_relevant(runtime_status):
+            payload["supervisor_runtime"] = runtime_status
     if args.json:
         try:
             rendered = json.dumps(payload, indent=2, allow_nan=False)
@@ -1336,6 +1401,11 @@ def cmd_supervisor(args: argparse.Namespace) -> int:
         return 0
     print(f"root:       {payload['root']}")
     print(f"supervisor: events cap={payload.get('event_ring', {}).get('cap')}")
+    supervisor_runtime_line = _render_supervisor_kill_switch_status(
+        payload.get("supervisor_runtime")
+    )
+    if supervisor_runtime_line:
+        print(supervisor_runtime_line)
     for item in payload.get("agents") or []:
         if not isinstance(item, dict):
             continue
@@ -11737,6 +11807,8 @@ def cmd_supervise(args: argparse.Namespace) -> int:
     emits the read-only liveness JSON; --plan emits the action plan (the shared
     decision table); --clear-restart clears a restart marker by request_id."""
     store = _get_store(args)
+    # `--observe-kill-switch` is intentionally absent: it is the one checked,
+    # field-owned observation writer allowed while the emergency brake is set.
     supervisor_mutations = (
         "archive_launch_request",
         "claim_instance",
@@ -11841,6 +11913,37 @@ def cmd_supervise(args: argparse.Namespace) -> int:
             sys.stderr.write(f"agenttalk supervise --repair-instance-marker: {e}\n")
             return 3
         print("no instance marker present" if path is None else f"quarantined: {path}")
+        return 0
+    if args.observe_kill_switch:
+        if not args.observation_phase:
+            sys.stderr.write(
+                "agenttalk supervise --observe-kill-switch: need "
+                "--observation-phase <startup|mid_poll>\n"
+            )
+            return 2
+        try:
+            payload = supervisor_runtime.observe_powershell_kill_switch(
+                store,
+                phase=args.observation_phase,
+                observer_pid=args.pid if args.pid is not None else os.getpid(),
+                observer_pid_start=args.pid_start,
+                now_epoch=args.now,
+                validate_artifacts=lambda: sup.validate_artifact_bundle(
+                    store, boundary="supervisor"
+                ),
+            )
+        except (
+            OSError,
+            ValueError,
+            sup.ArtifactValidationError,
+            supervisor_lifecycle.SupervisorLifecycleError,
+            supervisor_runtime.SupervisorRuntimeObservationError,
+        ) as e:
+            sys.stderr.write(
+                f"agenttalk supervise --observe-kill-switch: {e}\n"
+            )
+            return 3
+        print(json.dumps(payload, separators=(",", ":"), allow_nan=False))
         return 0
     if args.validate_current_pwsh:
         try:
@@ -14444,6 +14547,8 @@ def build_parser() -> argparse.ArgumentParser:
                            "<--dir>/.claude/settings.json (the Claude unattended seed).")
     gsup.add_argument("--claim-instance", dest="claim_instance", action="store_true",
                       help="(script use) Claim the singleton supervisor instance lock.")
+    gsup.add_argument("--observe-kill-switch", dest="observe_kill_switch",
+                      action="store_true", help=argparse.SUPPRESS)
     gsup.add_argument("--validate-current-pwsh", dest="validate_current_pwsh",
                       action="store_true", help=argparse.SUPPRESS)
     gsup.add_argument("--prepare-task-install", dest="prepare_task_install",
@@ -14474,6 +14579,9 @@ def build_parser() -> argparse.ArgumentParser:
     psup.add_argument("--pid-start", dest="pid_start", default=None,
                       help="(--record-launch) the launcher process start-time "
                            "(anti-pid-reuse guard).")
+    psup.add_argument("--observation-phase", dest="observation_phase",
+                      choices=sorted(supervisor_runtime.KILL_SWITCH_PHASES),
+                      default=None, help=argparse.SUPPRESS)
     psup.add_argument("--pwsh",
                       help="Absolute pwsh.exe path (terminal explicit selection; no fallback).")
     psup.add_argument("--artifact-boundary", dest="artifact_boundary",

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -44,6 +44,7 @@ from agenttalk import lanes as lane_mod
 from agenttalk.store import Store, _process_alive, validate_agent_name
 from agenttalk import powershell_host as psh
 from agenttalk import supervisor_lifecycle as lifecycle
+from agenttalk import supervisor_runtime as runtime_control
 from agenttalk import wrapper_runtime as runtime_obs
 from agenttalk import wrapper_logs as wrapper_log
 
@@ -1813,7 +1814,7 @@ def build_supervisor_observation(store: Store, *, now_epoch: float,
         agents.append(supervisor_agent_assessment(
             name, rpt, plan_agents.get(name), operator_facing=report.get("operator_facing"),
             lead_liveness_stale_after_seconds=lead_liveness_stale_after_seconds))
-    return {
+    observation = {
         "schema_version": 1,
         "root": str(store.root),
         "now_epoch": float(now_epoch),
@@ -1828,6 +1829,10 @@ def build_supervisor_observation(store: Store, *, now_epoch: float,
         "report": _redacted_observation_report(report),
         "plan": _redacted_observation_plan(plan),
     }
+    runtime_status = runtime_control.build_runtime_status(store)
+    if runtime_control.runtime_status_relevant(runtime_status):
+        observation["supervisor_runtime"] = runtime_status
+    return observation
 
 # Per-CLI session-argument templates, as LISTS of literal tokens (so the
 # generated PowerShell uses an array-of-literals ArgumentList - single-quoted
@@ -9640,8 +9645,31 @@ function Supervisor-IdentityArgs {
   if ($SupervisorStart) { $argv += @('--pid-start', $SupervisorStart) }
   return $argv
 }
+function Sync-KillSwitchObservation([string]$phase) {
+  $observeArgs = @('--root', $Root, 'supervise', '--observe-kill-switch',
+                   '--observation-phase', $phase) + (Supervisor-IdentityArgs)
+  $observeText = & $AgenttalkCmd @observeArgs
+  if ($LASTEXITCODE -ne 0) {
+    if (-not $Quiet) {
+      Write-Warning "supervisor: could not persist kill-switch observation"
+    }
+    return $null
+  }
+  try { return ($observeText | ConvertFrom-Json) } catch {
+    if (-not $Quiet) {
+      Write-Warning "supervisor: kill-switch observation response was invalid"
+    }
+    return $null
+  }
+}
 $InstanceToken = $null
-if (Test-Path $KillSwitchPath) { exit 3 }
+$startupObservation = Sync-KillSwitchObservation 'startup'
+if ($null -eq $startupObservation) { exit 3 }
+$script:KillSwitchObservationActive = [bool]$startupObservation.active
+if ($script:KillSwitchObservationActive) {
+  # Exit 3 is a blocked failure, not success: Scheduled Task hosting retries it.
+  exit 3
+}
 if ($DryRun) {
   $validateArgs = @('--root', $Root, 'supervise', '--validate-current-pwsh',
                     '--artifact-boundary', 'supervisor') + (Supervisor-IdentityArgs)
@@ -9650,7 +9678,16 @@ if ($DryRun) {
 } else {
   $claimArgs = @('--root', $Root, 'supervise', '--claim-instance') + (Supervisor-IdentityArgs)
   $claimText = & $AgenttalkCmd @claimArgs
-  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  if ($LASTEXITCODE -ne 0) {
+    $claimExit = $LASTEXITCODE
+    # Close the post-observation race: claim refuses a switch that appeared
+    # after startup sync, so publish that level before preserving exit 3.
+    if (Test-Path $KillSwitchPath) {
+      $startupObservation = Sync-KillSwitchObservation 'startup'
+      exit 3
+    }
+    exit $claimExit
+  }
   $InstanceToken = ($claimText | ConvertFrom-Json).token
 }
 
@@ -9690,7 +9727,15 @@ $WrapperLogEnvKeys = @(
   'AGENTTALK_WRAPPER_LOG_NONCE'
 )
 
-function Actions-Enabled { return -not (Test-Path $KillSwitchPath) }
+function Actions-Enabled {
+  $rawActive = Test-Path $KillSwitchPath
+  if ($rawActive -ne $script:KillSwitchObservationActive) {
+    $observation = Sync-KillSwitchObservation 'mid_poll'
+    if ($null -eq $observation) { return $false }
+    $script:KillSwitchObservationActive = [bool]$observation.active
+  }
+  return -not $script:KillSwitchObservationActive
+}
 function Assert-ActionsEnabled([string]$what) {
   if (Actions-Enabled) { return $true }
   if (-not $Quiet) { Write-Host ("supervisor: kill switch active; skipping {0}" -f $what) }

--- a/src/agenttalk/supervisor_lifecycle.py
+++ b/src/agenttalk/supervisor_lifecycle.py
@@ -514,6 +514,77 @@ def validate_current_powershell(
         _close_process_observation(host)
 
 
+@contextlib.contextmanager
+def checked_powershell_supervisor_observer(
+    store: Store,
+    *,
+    pid: int,
+    pid_start: object,
+    validate_artifacts: Callable[[], None],
+) -> Iterator[None]:
+    """Authorize one generated-supervisor observation without claiming it.
+
+    The caller must be the Python process launched directly by the selected
+    PowerShell host, or through the generated ``agenttalk.cmd`` hop.  Locks stay
+    held through the caller's field-owned write so selection, process identity,
+    and artifact validation cannot change between authorization and publish.
+    """
+    with store._supervisor_lifecycle_lock():
+        validate_artifacts()
+        with store._powershell_selection_lock():
+            first = _read_valid_selection_locked(store)
+            host = _open_process_observation(pid)
+            ancestry: tuple[ProcessObservation, ...] = ()
+            try:
+                if not start_tokens_match(host.creation_token, pid_start):
+                    raise SupervisorLifecycleError(
+                        "PowerShell pid/start locator was reused or ambiguous"
+                    )
+                if not _host_matches_selection(host, first):
+                    raise SupervisorLifecycleError(
+                        "observing PowerShell process does not match the "
+                        "current host selection"
+                    )
+                ancestry = _validate_ancestry(host)
+                for observation in ancestry:
+                    _require_process_active(observation)
+                _require_process_active(host)
+                second = _read_valid_selection_locked(store)
+                if (
+                    second["selection_revision"] != first["selection_revision"]
+                    or second["selection_fingerprint"]
+                    != first["selection_fingerprint"]
+                    or not _host_matches_selection(host, second)
+                ):
+                    raise SupervisorLifecycleError(
+                        "PowerShell host selection changed during "
+                        "supervisor observation"
+                    )
+                with store._config_lock():
+                    for observation in ancestry:
+                        _require_process_active(observation)
+                    _require_process_active(host)
+                    final = _read_valid_selection_locked(store)
+                    if (
+                        final["selection_revision"]
+                        != second["selection_revision"]
+                        or final["selection_fingerprint"]
+                        != second["selection_fingerprint"]
+                        or not _host_matches_selection(host, final)
+                    ):
+                        raise SupervisorLifecycleError(
+                            "PowerShell host selection changed before "
+                            "supervisor observation write"
+                        )
+                    _revalidate_process_image(host, final)
+                    _require_process_active(host)
+                    yield
+            finally:
+                for observation in ancestry:
+                    _close_process_observation(observation)
+                _close_process_observation(host)
+
+
 def _probe_observed_current_host(host: ProcessObservation) -> psh.ProbeResult:
     resolution = psh.resolve_candidate(current_path=host.path)
     if resolution.result is None:

--- a/src/agenttalk/supervisor_lifecycle.py
+++ b/src/agenttalk/supervisor_lifecycle.py
@@ -13,11 +13,13 @@ import ctypes
 import json
 import os
 import re
+import sys
+import sysconfig
 import tempfile
 from ctypes import wintypes
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Callable, Iterator, Mapping
 
 from agenttalk import powershell_host as psh
@@ -433,25 +435,179 @@ def start_tokens_match(observed: str, locator: object) -> bool:
     return abs((left - right).total_seconds()) <= 0.01
 
 
+def _system_cmd_path() -> str:
+    """Return the native system-directory command interpreter."""
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_system_directory = kernel32.GetSystemDirectoryW
+    get_system_directory.argtypes = [wintypes.LPWSTR, wintypes.UINT]
+    get_system_directory.restype = wintypes.UINT
+    capacity = 32768
+    buf = ctypes.create_unicode_buffer(capacity)
+    length = int(get_system_directory(buf, capacity))
+    if length <= 0 or length >= capacity:
+        raise SupervisorLifecycleError("cannot resolve the Windows system directory")
+    return str(Path(buf.value) / "cmd.exe")
+
+
+def _require_observed_image(
+    observation: ProcessObservation,
+    expected_path: str,
+    *,
+    subject: str,
+) -> None:
+    try:
+        expected = psh.native_file_identity(expected_path)
+    except (OSError, ValueError, psh.PowerShellHostError) as exc:
+        raise SupervisorLifecycleError(f"cannot identify {subject}: {exc}") from exc
+    if not psh.same_identity(observation.identity, expected):
+        raise SupervisorLifecycleError(f"{subject} image identity does not match")
+
+
+def _runtime_scripts_path() -> Path:
+    try:
+        scripts = sysconfig.get_path("scripts")
+    except (KeyError, OSError, ValueError) as exc:
+        raise SupervisorLifecycleError(
+            f"cannot resolve the active Python scripts directory: {exc}"
+        ) from exc
+    if not isinstance(scripts, str) or not scripts:
+        raise SupervisorLifecycleError(
+            "cannot resolve the active Python scripts directory"
+        )
+    return Path(scripts)
+
+
+def _classify_intermediate(
+    observation: ProcessObservation,
+    *,
+    current: ProcessObservation,
+) -> str:
+    leaf = PureWindowsPath(observation.path).name.casefold()
+    if leaf == "cmd.exe":
+        _require_observed_image(
+            observation,
+            _system_cmd_path(),
+            subject="command-interpreter ancestor",
+        )
+        return "cmd"
+    if leaf == "agenttalk.exe":
+        expected = _runtime_scripts_path() / "agenttalk.exe"
+        argv0 = sys.argv[0] if sys.argv else ""
+        expected_argv0 = {
+            psh.normalized_path_key(expected),
+            # distlib's generated console entry point strips its ``.exe``
+            # suffix before importing the target function.
+            psh.normalized_path_key(expected.with_suffix("")),
+        }
+        if (
+            not argv0
+            or psh.normalized_path_key(argv0) not in expected_argv0
+            or psh.normalized_path_key(observation.path)
+            != psh.normalized_path_key(expected)
+        ):
+            raise SupervisorLifecycleError(
+                "console-script ancestor is not the active agenttalk entry point"
+            )
+        _require_observed_image(
+            observation,
+            str(expected),
+            subject="agenttalk console-script ancestor",
+        )
+        return "console"
+    if leaf in {"python.exe", "pythonw.exe"}:
+        base_executable = getattr(sys, "_base_executable", None)
+        executable = sys.executable
+        if (
+            sys.prefix == sys.base_prefix
+            or not isinstance(base_executable, str)
+            or not base_executable
+            or psh.normalized_path_key(executable)
+            == psh.normalized_path_key(base_executable)
+            or psh.normalized_path_key(observation.path)
+            != psh.normalized_path_key(executable)
+            or psh.normalized_path_key(Path(executable).parent)
+            != psh.normalized_path_key(_runtime_scripts_path())
+        ):
+            raise SupervisorLifecycleError(
+                "Python ancestor is not the active virtual-environment launcher"
+            )
+        _require_observed_image(
+            observation,
+            executable,
+            subject="virtual-environment Python launcher",
+        )
+        _require_observed_image(
+            current,
+            base_executable,
+            subject="running base Python",
+        )
+        return "venv"
+    raise SupervisorLifecycleError(
+        "generated supervisor caller has an unidentified launcher ancestor"
+    )
+
+
+_ALLOWED_CALLER_ANCESTRIES = frozenset(
+    {
+        (),
+        ("cmd",),
+        ("console",),
+        ("venv",),
+        ("cmd", "console"),
+        ("cmd", "venv"),
+        ("console", "venv"),
+        ("cmd", "console", "venv"),
+    }
+)
+
+
 def _validate_ancestry(host: ProcessObservation) -> tuple[ProcessObservation, ...]:
     parents = _process_parent_map()
     current = _open_process_observation(os.getpid(), parents=parents)
     opened: list[ProcessObservation] = [current]
     try:
-        if current.parent_pid == host.pid:
-            if host.creation_ticks > current.creation_ticks:
-                raise SupervisorLifecycleError("PowerShell ancestor started after Python")
-            return tuple(opened)
-        if current.parent_pid <= 0:
-            raise SupervisorLifecycleError("manual --claim-instance has no PowerShell ancestor")
-        cmd = _open_process_observation(current.parent_pid, parents=parents)
-        opened.append(cmd)
-        if Path(cmd.path).name.casefold() != "cmd.exe" or cmd.parent_pid != host.pid:
+        cursor = current
+        seen = {host.pid, current.pid}
+        while cursor.parent_pid != host.pid:
+            if cursor.parent_pid <= 0:
+                raise SupervisorLifecycleError(
+                    "generated supervisor caller has no PowerShell ancestor"
+                )
+            if len(opened) > 3:
+                raise SupervisorLifecycleError(
+                    "generated supervisor caller has too many launcher ancestors"
+                )
+            if cursor.parent_pid in seen:
+                raise SupervisorLifecycleError(
+                    "generated supervisor caller ancestry contains a process cycle"
+                )
+            seen.add(cursor.parent_pid)
+            cursor = _open_process_observation(cursor.parent_pid, parents=parents)
+            opened.append(cursor)
+
+        intermediates = tuple(reversed(opened[1:]))
+        roles = tuple(
+            _classify_intermediate(observation, current=current)
+            for observation in intermediates
+        )
+        if roles not in _ALLOWED_CALLER_ANCESTRIES:
             raise SupervisorLifecycleError(
-                "manual --claim-instance is unsupported without a direct or cmd-hop PowerShell ancestor"
+                "generated supervisor caller launcher order is unsupported"
             )
-        if not (host.creation_ticks <= cmd.creation_ticks <= current.creation_ticks):
-            raise SupervisorLifecycleError("PowerShell/cmd/Python ancestry start times are inconsistent")
+        ordered = (host, *intermediates, current)
+        if any(
+            parent.creation_ticks > child.creation_ticks
+            for parent, child in zip(ordered, ordered[1:], strict=False)
+        ):
+            raise SupervisorLifecycleError(
+                "PowerShell supervisor caller ancestry start times are inconsistent"
+            )
+        if "venv" not in roles:
+            _require_observed_image(
+                current,
+                sys.executable,
+                subject="running Python",
+            )
         return tuple(opened)
     except Exception:
         for observation in opened:
@@ -524,10 +680,11 @@ def checked_powershell_supervisor_observer(
 ) -> Iterator[None]:
     """Authorize one generated-supervisor observation without claiming it.
 
-    The caller must be the Python process launched directly by the selected
-    PowerShell host, or through the generated ``agenttalk.cmd`` hop.  Locks stay
-    held through the caller's field-owned write so selection, process identity,
-    and artifact validation cannot change between authorization and publish.
+    The caller must be the active Python process reached from the selected
+    PowerShell host through one bounded, positively identified generated-shim
+    or installed-entry-point chain.  Locks stay held through the caller's
+    field-owned write so selection, process identity, and artifact validation
+    cannot change between authorization and publish.
     """
     with store._supervisor_lifecycle_lock():
         validate_artifacts()

--- a/src/agenttalk/supervisor_lifecycle.py
+++ b/src/agenttalk/supervisor_lifecycle.py
@@ -982,6 +982,14 @@ def claim_powershell_supervisor(
                         )
                     _revalidate_process_image(host, final)
                     _require_process_active(host)
+                    # Linearize the emergency brake as late as possible in the
+                    # checked claim, after the outer CLI's fast precheck.
+                    kill_switch = store.supervisor_kill_switch()
+                    if kill_switch is not False:
+                        state = "present" if kill_switch else "unreadable"
+                        raise SupervisorLifecycleError(
+                            f"supervisor.kill is {state}; refusing supervisor claim"
+                        )
                     return store._claim_supervisor_instance_locked(
                         pid=pid,
                         pid_start=pid_start,

--- a/src/agenttalk/supervisor_lifecycle.py
+++ b/src/agenttalk/supervisor_lifecycle.py
@@ -362,7 +362,10 @@ def _open_process_observation(pid: int, *, parents: Mapping[int, int] | None = N
         code = wintypes.DWORD()
         if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)) or code.value != 259:
             raise SupervisorLifecycleError(f"process {pid} is not active")
-        identity, image_handle = psh.open_stable_native_file_identity(buf.value)
+        identity, image_handle = _open_stable_process_image_identity(
+            buf.value,
+            int(handle),
+        )
         parent_map = parents if parents is not None else _process_parent_map()
         ticks = _filetime_ticks(creation)
         return ProcessObservation(
@@ -449,6 +452,175 @@ def _system_cmd_path() -> str:
     return str(Path(buf.value) / "cmd.exe")
 
 
+def _process_machines(process_handle: int) -> tuple[int, int]:
+    """Return the emulated and native PE machines for one live process."""
+    if not process_handle:
+        raise SupervisorLifecycleError("cannot identify process architecture")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    try:
+        is_wow64_process2 = kernel32.IsWow64Process2
+    except AttributeError:
+        try:
+            is_wow64_process = kernel32.IsWow64Process
+        except AttributeError as exc:
+            raise SupervisorLifecycleError(
+                "cannot resolve the Windows process-architecture API"
+            ) from exc
+        is_wow64_process.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.BOOL),
+        ]
+        is_wow64_process.restype = wintypes.BOOL
+        emulated = wintypes.BOOL()
+        if not is_wow64_process(
+            wintypes.HANDLE(process_handle),
+            ctypes.byref(emulated),
+        ):
+            raise SupervisorLifecycleError(
+                "cannot identify process architecture "
+                f"(winerror {ctypes.get_last_error()})"
+            ) from None
+        # IsWow64Process predates multi-architecture WOW64.  On those systems
+        # its true case is the x86 guest machine.
+        return (0x014C if emulated.value else 0), 0
+    is_wow64_process2.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.WORD),
+        ctypes.POINTER(wintypes.WORD),
+    ]
+    is_wow64_process2.restype = wintypes.BOOL
+    process_machine = wintypes.WORD()
+    native_machine = wintypes.WORD()
+    if not is_wow64_process2(
+        wintypes.HANDLE(process_handle),
+        ctypes.byref(process_machine),
+        ctypes.byref(native_machine),
+    ):
+        raise SupervisorLifecycleError(
+            "cannot identify process architecture "
+            f"(winerror {ctypes.get_last_error()})"
+        )
+    return int(process_machine.value), int(native_machine.value)
+
+
+def _wow64_system_directory(machine: int) -> str:
+    """Return the OS-owned system directory for one emulated PE machine."""
+    library = None
+    function = None
+    for dll_name in (
+        "api-ms-win-core-wow64-l1-1-1.dll",
+        "kernelbase.dll",
+        "kernel32.dll",
+    ):
+        try:
+            candidate = ctypes.WinDLL(dll_name, use_last_error=True)
+            resolved = candidate.GetSystemWow64Directory2W
+        except (AttributeError, OSError):
+            continue
+        library = candidate
+        function = resolved
+        break
+    capacity = 32767
+    if library is not None and function is not None:
+        function.argtypes = [wintypes.LPWSTR, wintypes.UINT, wintypes.WORD]
+        function.restype = wintypes.UINT
+        buf = ctypes.create_unicode_buffer(capacity)
+        length = int(function(buf, capacity, machine))
+        if 0 < length < capacity:
+            return buf.value
+    if machine != 0x014C:
+        raise SupervisorLifecycleError(
+            "cannot resolve the Windows emulated system directory"
+        )
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    try:
+        legacy = kernel32.GetSystemWow64DirectoryW
+    except AttributeError as exc:
+        raise SupervisorLifecycleError(
+            "cannot resolve the Windows emulated-system-directory API"
+        ) from exc
+    legacy.argtypes = [wintypes.LPWSTR, wintypes.UINT]
+    legacy.restype = wintypes.UINT
+    buf = ctypes.create_unicode_buffer(capacity)
+    length = int(legacy(buf, capacity))
+    if length <= 0 or length >= capacity:
+        raise SupervisorLifecycleError(
+            "cannot resolve the Windows emulated system directory"
+        )
+    return buf.value
+
+
+def _windows_directory() -> str:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_windows_directory = kernel32.GetWindowsDirectoryW
+    get_windows_directory.argtypes = [wintypes.LPWSTR, wintypes.UINT]
+    get_windows_directory.restype = wintypes.UINT
+    capacity = 32767
+    buf = ctypes.create_unicode_buffer(capacity)
+    length = int(get_windows_directory(buf, capacity))
+    if length <= 0 or length >= capacity:
+        raise SupervisorLifecycleError("cannot resolve the Windows directory")
+    return buf.value
+
+
+def _current_process_handle() -> int:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_current_process = kernel32.GetCurrentProcess
+    get_current_process.argtypes = []
+    get_current_process.restype = wintypes.HANDLE
+    return int(get_current_process())
+
+
+def _process_image_path_for_reopen(image_path: str, process_handle: int) -> str:
+    """Map a native System32 image through Sysnative when Python is WOW64."""
+    process_machine, _ = _process_machines(process_handle)
+    current_machine, _ = _process_machines(_current_process_handle())
+    if process_machine or not current_machine:
+        return image_path
+    windows = PureWindowsPath(_windows_directory())
+    system = windows / "System32"
+    image = PureWindowsPath(image_path)
+    system_parts = tuple(part.casefold() for part in system.parts)
+    image_parts = tuple(part.casefold() for part in image.parts)
+    if image_parts[:len(system_parts)] != system_parts:
+        return image_path
+    relative = image.parts[len(system_parts):]
+    if not relative:
+        raise SupervisorLifecycleError("process image path is not a file")
+    return str(windows / "Sysnative" / PureWindowsPath(*relative))
+
+
+def _open_stable_process_image_identity(
+    image_path: str,
+    process_handle: int,
+) -> tuple[psh.NativeFileIdentity, int]:
+    return psh.open_stable_native_file_identity(
+        _process_image_path_for_reopen(image_path, process_handle)
+    )
+
+
+def _system_cmd_path_for_observation(observation: ProcessObservation) -> str:
+    """Resolve ``cmd.exe`` for the observed process architecture.
+
+    Synthetic observations used by pure tests have no live process handle and
+    retain the same-architecture resolver.  Every production observation has a
+    held handle, so WOW64 ancestry is resolved from that process rather than
+    from the Python process performing validation.
+    """
+    if not observation.handle:
+        return _system_cmd_path()
+    process_machine, _ = _process_machines(observation.handle)
+    if process_machine:
+        return str(Path(_wow64_system_directory(process_machine)) / "cmd.exe")
+
+    current_machine, _ = _process_machines(_current_process_handle())
+    if current_machine:
+        # Sysnative is Microsoft's process-relative alias for bypassing WOW64
+        # redirection and opening the native System32 image.
+        return str(Path(_windows_directory()) / "Sysnative" / "cmd.exe")
+    return _system_cmd_path()
+
+
 def _require_observed_image(
     observation: ProcessObservation,
     expected_path: str,
@@ -486,7 +658,7 @@ def _classify_intermediate(
     if leaf == "cmd.exe":
         _require_observed_image(
             observation,
-            _system_cmd_path(),
+            _system_cmd_path_for_observation(observation),
             subject="command-interpreter ancestor",
         )
         return "cmd"

--- a/src/agenttalk/supervisor_runtime.py
+++ b/src/agenttalk/supervisor_runtime.py
@@ -66,13 +66,33 @@ def _require_epoch(value: object, field: str) -> float:
         ) from exc
     if not math.isfinite(epoch):
         raise SupervisorRuntimeObservationError(f"{field} must be a finite epoch")
+    try:
+        datetime.fromtimestamp(epoch, timezone.utc)
+    except (OSError, OverflowError, ValueError) as exc:
+        raise SupervisorRuntimeObservationError(
+            f"{field} must be a finite epoch representable in UTC"
+        ) from exc
     return epoch
 
 
-def _require_timestamp(value: object, field: str) -> str:
+def _require_timestamp(value: object, field: str, *, epoch: float) -> str:
     if not isinstance(value, str) or not value or len(value) > 64:
         raise SupervisorRuntimeObservationError(f"{field} must be a bounded timestamp")
-    return value
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+        expected = datetime.fromtimestamp(epoch, timezone.utc)
+    except (OSError, OverflowError, ValueError) as exc:
+        raise SupervisorRuntimeObservationError(
+            f"{field} must match its epoch"
+        ) from exc
+    if (
+        parsed.tzinfo is None
+        or parsed.utcoffset() is None
+        or parsed != expected
+    ):
+        raise SupervisorRuntimeObservationError(f"{field} must match its epoch")
+    return expected.isoformat().replace("+00:00", "Z")
 
 
 def _validate_phase_observation(phase: str, value: object) -> dict:
@@ -85,12 +105,14 @@ def _validate_phase_observation(phase: str, value: object) -> dict:
         raise SupervisorRuntimeObservationError(
             f"kill_switch.observations.{phase} has missing or extra fields"
         )
-    observed_at = _require_timestamp(
-        value.get("observed_at"), f"kill_switch.observations.{phase}.observed_at"
-    )
     observed_at_epoch = _require_epoch(
         value.get("observed_at_epoch"),
         f"kill_switch.observations.{phase}.observed_at_epoch",
+    )
+    observed_at = _require_timestamp(
+        value.get("observed_at"),
+        f"kill_switch.observations.{phase}.observed_at",
+        epoch=observed_at_epoch,
     )
     observer_pid = value.get("observer_pid")
     if (
@@ -156,12 +178,14 @@ def _validate_record(store: Store, value: object) -> dict:
         activation_id
     ):
         raise SupervisorRuntimeObservationError("kill_switch.activation_id is invalid")
-    first_observed_at = _require_timestamp(
-        kill_switch.get("first_observed_at"), "kill_switch.first_observed_at"
-    )
     first_observed_at_epoch = _require_epoch(
         kill_switch.get("first_observed_at_epoch"),
         "kill_switch.first_observed_at_epoch",
+    )
+    first_observed_at = _require_timestamp(
+        kill_switch.get("first_observed_at"),
+        "kill_switch.first_observed_at",
+        epoch=first_observed_at_epoch,
     )
     observations = kill_switch.get("observations")
     if (
@@ -176,6 +200,14 @@ def _validate_record(store: Store, value: object) -> dict:
         phase: _validate_phase_observation(phase, observation)
         for phase, observation in observations.items()
     }
+    if not any(
+        observation["observed_at"] == first_observed_at
+        and observation["observed_at_epoch"] == first_observed_at_epoch
+        for observation in clean_observations.values()
+    ):
+        raise SupervisorRuntimeObservationError(
+            "kill_switch.first_observed_at must match a phase observation"
+        )
     clean_kill_switch = {
         "active": active,
         "activation_id": activation_id,
@@ -184,12 +216,15 @@ def _validate_record(store: Store, value: object) -> dict:
         "observations": clean_observations,
     }
     if active is False:
-        clean_kill_switch["resolved_at"] = _require_timestamp(
-            kill_switch.get("resolved_at"), "kill_switch.resolved_at"
-        )
-        clean_kill_switch["resolved_at_epoch"] = _require_epoch(
+        resolved_at_epoch = _require_epoch(
             kill_switch.get("resolved_at_epoch"), "kill_switch.resolved_at_epoch"
         )
+        clean_kill_switch["resolved_at"] = _require_timestamp(
+            kill_switch.get("resolved_at"),
+            "kill_switch.resolved_at",
+            epoch=resolved_at_epoch,
+        )
+        clean_kill_switch["resolved_at_epoch"] = resolved_at_epoch
     return {
         "schema_version": RUNTIME_OBSERVATION_SCHEMA,
         "kind": _RUNTIME_KIND,
@@ -302,9 +337,8 @@ def observe_powershell_kill_switch(
         not isinstance(observer_pid_start, str) or len(observer_pid_start) > 256
     ):
         raise ValueError("observer_pid_start must be a bounded string or null")
-    observed_epoch = _require_epoch(
-        time.time() if now_epoch is None else now_epoch,
-        "now_epoch",
+    provided_epoch = (
+        None if now_epoch is None else _require_epoch(now_epoch, "now_epoch")
     )
 
     with supervisor_lifecycle.checked_powershell_supervisor_observer(
@@ -319,6 +353,11 @@ def observe_powershell_kill_switch(
             raise SupervisorRuntimeObservationError(
                 "supervisor.kill state is unreadable"
             )
+        observed_epoch = (
+            _require_epoch(time.time(), "now_epoch")
+            if provided_epoch is None
+            else provided_epoch
+        )
         try:
             record = _read_strict(store)
         except SupervisorRuntimeObservationError:

--- a/src/agenttalk/supervisor_runtime.py
+++ b/src/agenttalk/supervisor_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import math
+import os
 import re
 import time
 import uuid
@@ -45,6 +46,10 @@ _PHASE_FIELDS = frozenset({
 
 class SupervisorRuntimeObservationError(RuntimeError):
     """A checked supervisor runtime observation could not be trusted or written."""
+
+
+class _RuntimeObservationUnreadableError(SupervisorRuntimeObservationError):
+    """The observation could not be inspected, so it must not be quarantined."""
 
 
 def runtime_observation_path(store: Store) -> Path:
@@ -262,7 +267,7 @@ def _read_strict(store: Store) -> dict | None:
     except FileNotFoundError:
         return None
     except OSError as exc:
-        raise SupervisorRuntimeObservationError(
+        raise _RuntimeObservationUnreadableError(
             f"runtime observation is unreadable: {type(exc).__name__}"
         ) from exc
     if len(raw) > RUNTIME_OBSERVATION_MAX_BYTES:
@@ -335,6 +340,25 @@ def _new_active_record(
     }
 
 
+def _preserve_invalid_observation(store: Store) -> None:
+    source = runtime_observation_path(store)
+    suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    preserved = source.with_name(
+        f"{source.name}.quarantine-{suffix}-{uuid.uuid4().hex}"
+    )
+    if os.path.lexists(preserved):
+        raise SupervisorRuntimeObservationError(
+            "invalid runtime observation quarantine already exists"
+        )
+    try:
+        os.replace(source, preserved)
+    except OSError as exc:
+        raise SupervisorRuntimeObservationError(
+            "invalid runtime observation could not be preserved: "
+            f"{type(exc).__name__}"
+        ) from exc
+
+
 def observe_powershell_kill_switch(
     store: Store,
     *,
@@ -385,12 +409,17 @@ def observe_powershell_kill_switch(
         )
         try:
             record = _read_strict(store)
-        except SupervisorRuntimeObservationError:
+        except SupervisorRuntimeObservationError as exc:
             # This sidecar is evidence, never authority.  Preserve malformed or
-            # future-schema bytes for diagnosis, but do not let them keep a
-            # supervisor disabled after the raw emergency switch is absent.
+            # future-schema bytes in place while inactive so status keeps the
+            # diagnostic visible.  Once the raw switch activates, move those
+            # exact bytes aside before publishing fresh trusted evidence.  An
+            # unreadable record may be transient and was never inspected, so it
+            # remains fail-closed rather than being mislabeled as corrupt.
             if active:
-                raise
+                if isinstance(exc, _RuntimeObservationUnreadableError):
+                    raise
+                _preserve_invalid_observation(store)
             record = None
         if active:
             if record is None or record["kill_switch"]["active"] is False:

--- a/src/agenttalk/supervisor_runtime.py
+++ b/src/agenttalk/supervisor_runtime.py
@@ -56,13 +56,17 @@ def _utc_text(epoch: float) -> str:
 
 
 def _require_epoch(value: object, field: str) -> float:
-    if (
-        not isinstance(value, (int, float))
-        or isinstance(value, bool)
-        or not math.isfinite(float(value))
-    ):
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
         raise SupervisorRuntimeObservationError(f"{field} must be a finite epoch")
-    return float(value)
+    try:
+        epoch = float(value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise SupervisorRuntimeObservationError(
+            f"{field} must be a finite epoch"
+        ) from exc
+    if not math.isfinite(epoch):
+        raise SupervisorRuntimeObservationError(f"{field} must be a finite epoch")
+    return epoch
 
 
 def _require_timestamp(value: object, field: str) -> str:
@@ -208,7 +212,7 @@ def _read_strict(store: Store) -> dict | None:
         raise SupervisorRuntimeObservationError("runtime observation exceeds its size cap")
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeError, RecursionError, ValueError) as exc:
         raise SupervisorRuntimeObservationError(
             f"runtime observation is malformed: {type(exc).__name__}"
         ) from exc

--- a/src/agenttalk/supervisor_runtime.py
+++ b/src/agenttalk/supervisor_runtime.py
@@ -1,0 +1,410 @@
+"""Strict, field-owned observations about the external supervisor runtime."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from agenttalk._atomic import write_text as _atomic_write_text
+from agenttalk import supervisor_lifecycle
+from agenttalk.store import Store
+
+
+RUNTIME_OBSERVATION_SCHEMA = 1
+RUNTIME_OBSERVATION_FILENAME = "supervisor-runtime-observation.json"
+RUNTIME_OBSERVATION_MAX_BYTES = 16_384
+KILL_SWITCH_PHASES = frozenset({"startup", "mid_poll"})
+
+_RUNTIME_KIND = "supervisor_runtime_observation"
+_ACTIVATION_ID_RE = re.compile(r"[0-9a-f]{32}")
+_TOP_LEVEL_FIELDS = frozenset({"schema_version", "kind", "project_id", "kill_switch"})
+_KILL_SWITCH_FIELDS = frozenset({
+    "active",
+    "activation_id",
+    "first_observed_at",
+    "first_observed_at_epoch",
+    "observations",
+    "resolved_at",
+    "resolved_at_epoch",
+})
+_PHASE_FIELDS = frozenset({
+    "observed_at",
+    "observed_at_epoch",
+    "observer_pid",
+    "observer_pid_start",
+    "exit_code",
+})
+
+
+class SupervisorRuntimeObservationError(RuntimeError):
+    """A checked supervisor runtime observation could not be trusted or written."""
+
+
+def runtime_observation_path(store: Store) -> Path:
+    return store.state_dir / RUNTIME_OBSERVATION_FILENAME
+
+
+def _utc_text(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _require_epoch(value: object, field: str) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+    ):
+        raise SupervisorRuntimeObservationError(f"{field} must be a finite epoch")
+    return float(value)
+
+
+def _require_timestamp(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 64:
+        raise SupervisorRuntimeObservationError(f"{field} must be a bounded timestamp")
+    return value
+
+
+def _validate_phase_observation(phase: str, value: object) -> dict:
+    if not isinstance(value, dict) or not set(value).issubset(_PHASE_FIELDS):
+        raise SupervisorRuntimeObservationError(
+            f"kill_switch.observations.{phase} has an invalid shape"
+        )
+    required = _PHASE_FIELDS if phase == "startup" else _PHASE_FIELDS - {"exit_code"}
+    if set(value) != required:
+        raise SupervisorRuntimeObservationError(
+            f"kill_switch.observations.{phase} has missing or extra fields"
+        )
+    observed_at = _require_timestamp(
+        value.get("observed_at"), f"kill_switch.observations.{phase}.observed_at"
+    )
+    observed_at_epoch = _require_epoch(
+        value.get("observed_at_epoch"),
+        f"kill_switch.observations.{phase}.observed_at_epoch",
+    )
+    observer_pid = value.get("observer_pid")
+    if (
+        not isinstance(observer_pid, int)
+        or isinstance(observer_pid, bool)
+        or observer_pid <= 0
+    ):
+        raise SupervisorRuntimeObservationError(
+            f"kill_switch.observations.{phase}.observer_pid must be positive"
+        )
+    observer_pid_start = value.get("observer_pid_start")
+    if observer_pid_start is not None and (
+        not isinstance(observer_pid_start, str) or len(observer_pid_start) > 256
+    ):
+        raise SupervisorRuntimeObservationError(
+            f"kill_switch.observations.{phase}.observer_pid_start is invalid"
+        )
+    clean = {
+        "observed_at": observed_at,
+        "observed_at_epoch": observed_at_epoch,
+        "observer_pid": observer_pid,
+        "observer_pid_start": observer_pid_start,
+    }
+    if phase == "startup":
+        if value.get("exit_code") != 3:
+            raise SupervisorRuntimeObservationError(
+                "kill_switch.observations.startup.exit_code must be 3"
+            )
+        clean["exit_code"] = 3
+    return clean
+
+
+def _validate_record(store: Store, value: object) -> dict:
+    if not isinstance(value, dict) or set(value) != _TOP_LEVEL_FIELDS:
+        raise SupervisorRuntimeObservationError(
+            "runtime observation has missing or unknown top-level fields"
+        )
+    if value.get("schema_version") != RUNTIME_OBSERVATION_SCHEMA:
+        raise SupervisorRuntimeObservationError("runtime observation schema is unsupported")
+    if value.get("kind") != _RUNTIME_KIND:
+        raise SupervisorRuntimeObservationError("runtime observation kind is invalid")
+    if value.get("project_id") != store.project_id():
+        raise SupervisorRuntimeObservationError(
+            "runtime observation belongs to a different project"
+        )
+    kill_switch = value.get("kill_switch")
+    if not isinstance(kill_switch, dict) or not set(kill_switch).issubset(
+        _KILL_SWITCH_FIELDS
+    ):
+        raise SupervisorRuntimeObservationError(
+            "runtime observation kill_switch field is invalid"
+        )
+    required = _KILL_SWITCH_FIELDS - {"resolved_at", "resolved_at_epoch"}
+    active = kill_switch.get("active")
+    if active is False:
+        required = _KILL_SWITCH_FIELDS
+    if not isinstance(active, bool) or set(kill_switch) != required:
+        raise SupervisorRuntimeObservationError(
+            "runtime observation kill_switch fields do not match its active state"
+        )
+    activation_id = kill_switch.get("activation_id")
+    if not isinstance(activation_id, str) or not _ACTIVATION_ID_RE.fullmatch(
+        activation_id
+    ):
+        raise SupervisorRuntimeObservationError("kill_switch.activation_id is invalid")
+    first_observed_at = _require_timestamp(
+        kill_switch.get("first_observed_at"), "kill_switch.first_observed_at"
+    )
+    first_observed_at_epoch = _require_epoch(
+        kill_switch.get("first_observed_at_epoch"),
+        "kill_switch.first_observed_at_epoch",
+    )
+    observations = kill_switch.get("observations")
+    if (
+        not isinstance(observations, dict)
+        or not observations
+        or not set(observations).issubset(KILL_SWITCH_PHASES)
+    ):
+        raise SupervisorRuntimeObservationError(
+            "kill_switch.observations must contain known phases"
+        )
+    clean_observations = {
+        phase: _validate_phase_observation(phase, observation)
+        for phase, observation in observations.items()
+    }
+    clean_kill_switch = {
+        "active": active,
+        "activation_id": activation_id,
+        "first_observed_at": first_observed_at,
+        "first_observed_at_epoch": first_observed_at_epoch,
+        "observations": clean_observations,
+    }
+    if active is False:
+        clean_kill_switch["resolved_at"] = _require_timestamp(
+            kill_switch.get("resolved_at"), "kill_switch.resolved_at"
+        )
+        clean_kill_switch["resolved_at_epoch"] = _require_epoch(
+            kill_switch.get("resolved_at_epoch"), "kill_switch.resolved_at_epoch"
+        )
+    return {
+        "schema_version": RUNTIME_OBSERVATION_SCHEMA,
+        "kind": _RUNTIME_KIND,
+        "project_id": store.project_id(),
+        "kill_switch": clean_kill_switch,
+    }
+
+
+def _read_strict(store: Store) -> dict | None:
+    path = runtime_observation_path(store)
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise SupervisorRuntimeObservationError(
+            f"runtime observation is unreadable: {type(exc).__name__}"
+        ) from exc
+    if size > RUNTIME_OBSERVATION_MAX_BYTES:
+        raise SupervisorRuntimeObservationError("runtime observation exceeds its size cap")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SupervisorRuntimeObservationError(
+            f"runtime observation is malformed: {type(exc).__name__}"
+        ) from exc
+    return _validate_record(store, value)
+
+
+def read_runtime_observation(
+    store: Store,
+) -> tuple[dict | None, list[str]]:
+    """Read the latest strict record without turning corruption into evidence."""
+    try:
+        return _read_strict(store), []
+    except SupervisorRuntimeObservationError as exc:
+        return None, [f"supervisor_runtime_observation_invalid:{exc}"]
+
+
+def _phase_observation(
+    phase: str,
+    *,
+    observer_pid: int,
+    observer_pid_start: str | None,
+    now_epoch: float,
+) -> dict:
+    value = {
+        "observed_at": _utc_text(now_epoch),
+        "observed_at_epoch": now_epoch,
+        "observer_pid": observer_pid,
+        "observer_pid_start": observer_pid_start,
+    }
+    if phase == "startup":
+        value["exit_code"] = 3
+    return value
+
+
+def _new_active_record(
+    store: Store,
+    *,
+    phase: str,
+    observer_pid: int,
+    observer_pid_start: str | None,
+    now_epoch: float,
+) -> dict:
+    observed = _phase_observation(
+        phase,
+        observer_pid=observer_pid,
+        observer_pid_start=observer_pid_start,
+        now_epoch=now_epoch,
+    )
+    return {
+        "schema_version": RUNTIME_OBSERVATION_SCHEMA,
+        "kind": _RUNTIME_KIND,
+        "project_id": store.project_id(),
+        "kill_switch": {
+            "active": True,
+            "activation_id": uuid.uuid4().hex,
+            "first_observed_at": observed["observed_at"],
+            "first_observed_at_epoch": observed["observed_at_epoch"],
+            "observations": {phase: observed},
+        },
+    }
+
+
+def observe_powershell_kill_switch(
+    store: Store,
+    *,
+    phase: str,
+    observer_pid: int,
+    observer_pid_start: object,
+    now_epoch: float | None,
+    validate_artifacts: Callable[[], None],
+) -> dict:
+    """Atomically fold one observed kill-switch level without executor authority.
+
+    The durable operation authenticates the generated PowerShell ancestry and
+    owns ``lifecycle -> selection -> config`` while rechecking the raw switch.
+    It never reads or claims the executor marker/token.
+    """
+    if phase not in KILL_SWITCH_PHASES:
+        raise ValueError(f"unsupported kill-switch observation phase: {phase!r}")
+    if (
+        not isinstance(observer_pid, int)
+        or isinstance(observer_pid, bool)
+        or observer_pid <= 0
+    ):
+        raise ValueError("observer_pid must be a positive integer")
+    if observer_pid_start is not None and (
+        not isinstance(observer_pid_start, str) or len(observer_pid_start) > 256
+    ):
+        raise ValueError("observer_pid_start must be a bounded string or null")
+    observed_epoch = _require_epoch(
+        time.time() if now_epoch is None else now_epoch,
+        "now_epoch",
+    )
+
+    with supervisor_lifecycle.checked_powershell_supervisor_observer(
+        store,
+        pid=observer_pid,
+        pid_start=observer_pid_start,
+        validate_artifacts=validate_artifacts,
+    ):
+        changed = False
+        active = store.supervisor_kill_switch()
+        if active is None:
+            raise SupervisorRuntimeObservationError(
+                "supervisor.kill state is unreadable"
+            )
+        try:
+            record = _read_strict(store)
+        except SupervisorRuntimeObservationError:
+            # This sidecar is evidence, never authority.  Preserve malformed or
+            # future-schema bytes for diagnosis, but do not let them keep a
+            # supervisor disabled after the raw emergency switch is absent.
+            if active:
+                raise
+            record = None
+        if active:
+            if record is None or record["kill_switch"]["active"] is False:
+                record = _new_active_record(
+                    store,
+                    phase=phase,
+                    observer_pid=observer_pid,
+                    observer_pid_start=observer_pid_start,
+                    now_epoch=observed_epoch,
+                )
+                changed = True
+            elif phase not in record["kill_switch"]["observations"]:
+                record = copy.deepcopy(record)
+                record["kill_switch"]["observations"][phase] = _phase_observation(
+                    phase,
+                    observer_pid=observer_pid,
+                    observer_pid_start=observer_pid_start,
+                    now_epoch=observed_epoch,
+                )
+                changed = True
+        elif record is not None and record["kill_switch"]["active"] is True:
+            record = copy.deepcopy(record)
+            record["kill_switch"]["active"] = False
+            record["kill_switch"]["resolved_at"] = _utc_text(observed_epoch)
+            record["kill_switch"]["resolved_at_epoch"] = observed_epoch
+            changed = True
+        if changed:
+            _atomic_write_text(
+                runtime_observation_path(store),
+                json.dumps(
+                    _validate_record(store, record),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    allow_nan=False,
+                )
+                + "\n",
+            )
+    return {
+        "active": bool(active),
+        "changed": changed,
+        "observation": copy.deepcopy(record),
+    }
+
+
+def build_runtime_status(store: Store) -> dict:
+    """Build the human/JSON status projection independently of event history."""
+    active = store.supervisor_kill_switch()
+    record, warnings = read_runtime_observation(store)
+    result: dict[str, object] = {
+        "active": active,
+        "observed": False,
+        "path": str(runtime_observation_path(store)),
+    }
+    if active is None:
+        warnings.insert(0, "supervisor_kill_switch_unreadable")
+    if record is not None:
+        kill_switch = record["kill_switch"]
+        result.update({
+            "activation_id": kill_switch["activation_id"],
+            "first_observed_at": kill_switch["first_observed_at"],
+            "first_observed_at_epoch": kill_switch["first_observed_at_epoch"],
+            "observations": copy.deepcopy(kill_switch["observations"]),
+            "record_active": kill_switch["active"],
+        })
+        if "resolved_at" in kill_switch:
+            result["resolved_at"] = kill_switch["resolved_at"]
+            result["resolved_at_epoch"] = kill_switch["resolved_at_epoch"]
+        result["observed"] = active is True and kill_switch["active"] is True
+    if warnings:
+        result["warnings"] = warnings
+    return {"kill_switch": result}
+
+
+def runtime_status_relevant(value: object) -> bool:
+    """Whether an additive status projection carries non-baseline evidence."""
+    if not isinstance(value, dict):
+        return False
+    kill_switch = value.get("kill_switch")
+    if not isinstance(kill_switch, dict):
+        return False
+    return (
+        kill_switch.get("active") is not False
+        or "activation_id" in kill_switch
+        or bool(kill_switch.get("warnings"))
+    )

--- a/src/agenttalk/supervisor_runtime.py
+++ b/src/agenttalk/supervisor_runtime.py
@@ -145,6 +145,19 @@ def _validate_phase_observation(phase: str, value: object) -> dict:
     return clean
 
 
+def _reject_duplicate_object_keys(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise SupervisorRuntimeObservationError(
+                "runtime observation contains a duplicate JSON object key"
+            )
+        value[key] = item
+    return value
+
+
 def _validate_record(store: Store, value: object) -> dict:
     if not isinstance(value, dict) or set(value) != _TOP_LEVEL_FIELDS:
         raise SupervisorRuntimeObservationError(
@@ -200,13 +213,21 @@ def _validate_record(store: Store, value: object) -> dict:
         phase: _validate_phase_observation(phase, observation)
         for phase, observation in observations.items()
     }
-    if not any(
-        observation["observed_at"] == first_observed_at
-        and observation["observed_at_epoch"] == first_observed_at_epoch
-        for observation in clean_observations.values()
+    # The generated supervisor exits immediately when startup first sees an
+    # active switch.  Therefore both phases can coexist only when mid_poll
+    # observed the activation and a later restart added startup.  This causal
+    # phase order remains valid across wall-clock rollback; minimum(epoch) does
+    # not.
+    activation_source_phase = (
+        "mid_poll" if "mid_poll" in clean_observations else "startup"
+    )
+    activation_source = clean_observations[activation_source_phase]
+    if not (
+        activation_source["observed_at"] == first_observed_at
+        and activation_source["observed_at_epoch"] == first_observed_at_epoch
     ):
         raise SupervisorRuntimeObservationError(
-            "kill_switch.first_observed_at must match a phase observation"
+            "kill_switch.first_observed_at must match its activation-source phase"
         )
     clean_kill_switch = {
         "active": active,
@@ -236,17 +257,21 @@ def _validate_record(store: Store, value: object) -> dict:
 def _read_strict(store: Store) -> dict | None:
     path = runtime_observation_path(store)
     try:
-        size = path.stat().st_size
+        with path.open("rb") as stream:
+            raw = stream.read(RUNTIME_OBSERVATION_MAX_BYTES + 1)
     except FileNotFoundError:
         return None
     except OSError as exc:
         raise SupervisorRuntimeObservationError(
             f"runtime observation is unreadable: {type(exc).__name__}"
         ) from exc
-    if size > RUNTIME_OBSERVATION_MAX_BYTES:
+    if len(raw) > RUNTIME_OBSERVATION_MAX_BYTES:
         raise SupervisorRuntimeObservationError("runtime observation exceeds its size cap")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_object_keys,
+        )
     except (OSError, UnicodeError, RecursionError, ValueError) as exc:
         raise SupervisorRuntimeObservationError(
             f"runtime observation is malformed: {type(exc).__name__}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,6 +505,29 @@ def test_status_supervisor_assessment_fail_safe(
     assert "supervisor_assessment_unavailable:ValueError" in payload["warnings"]
 
 
+def test_status_human_preserves_runtime_warning_when_assessment_fails(
+    store_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    store = Store(store_root)
+    (store.state_dir / "supervisor-runtime-observation.json").write_text(
+        "{broken",
+        encoding="utf-8",
+    )
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("bad supervisor report")
+
+    monkeypatch.setattr(cli.sup, "build_supervisor_observation", boom)
+
+    assert _run(["status"], store_root) == 0
+
+    rendered = capsys.readouterr().out
+    assert "WARN:       supervisor_assessment_unavailable:ValueError" in rendered
+    assert "WARN:       supervisor_runtime_observation_invalid:" in rendered
+
+
 def test_supervisor_cli_read_fail_safe(
     store_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_powershell_test_portability.py
+++ b/tests/test_powershell_test_portability.py
@@ -24,7 +24,15 @@ EXPECTED_WINDOWS_ONLY = {
         "test_task_install_commit_refuses_concurrent_selection_change",
         "test_task_install_prepare_refuses_different_existing_binding",
         "test_task_uninstall_clears_binding_before_new_name_prepare",
-        "test_validate_ancestry_accepts_direct_and_cmd_hop",
+        "test_validate_ancestry_accepts_base_install_console_script",
+        "test_validate_ancestry_accepts_identified_generated_launch_classes",
+        "test_validate_ancestry_refuses_copied_cmd_and_start_inversion",
+        "test_validate_ancestry_refuses_launcher_identity_read_failure",
+        "test_validate_ancestry_refuses_missing_venv_redirector",
+        "test_validate_ancestry_refuses_replaced_console_script_image",
+        "test_validate_ancestry_refuses_unattributed_console_and_python_launchers",
+        "test_validate_ancestry_refuses_unbounded_or_reordered_launchers",
+        "test_validate_ancestry_refuses_venv_launcher_identity_mismatch",
     },
 }
 

--- a/tests/test_powershell_test_portability.py
+++ b/tests/test_powershell_test_portability.py
@@ -21,11 +21,16 @@ EXPECTED_WINDOWS_ONLY = {
     "test_supervisor_lifecycle.py": {
         "test_explicit_selection_repairs_invalid_record_under_writer_locks",
         "test_lifecycle_barrier_blocks_claim_select_and_refresh_without_mutation",
+        "test_process_image_identity_reopens_native_system_image_through_sysnative",
+        "test_process_machine_query_falls_back_to_legacy_wow64_api",
+        "test_system_cmd_resolver_uses_observed_guest_architecture",
+        "test_system_cmd_resolver_uses_sysnative_for_native_ancestor_from_wow64",
         "test_task_install_commit_refuses_concurrent_selection_change",
         "test_task_install_prepare_refuses_different_existing_binding",
         "test_task_uninstall_clears_binding_before_new_name_prepare",
         "test_validate_ancestry_accepts_base_install_console_script",
         "test_validate_ancestry_accepts_identified_generated_launch_classes",
+        "test_validate_ancestry_accepts_verified_wow64_cmd_for_cross_arch_host",
         "test_validate_ancestry_refuses_copied_cmd_and_start_inversion",
         "test_validate_ancestry_refuses_launcher_identity_read_failure",
         "test_validate_ancestry_refuses_missing_venv_redirector",
@@ -33,6 +38,7 @@ EXPECTED_WINDOWS_ONLY = {
         "test_validate_ancestry_refuses_unattributed_console_and_python_launchers",
         "test_validate_ancestry_refuses_unbounded_or_reordered_launchers",
         "test_validate_ancestry_refuses_venv_launcher_identity_mismatch",
+        "test_wow64_directory_query_falls_back_to_legacy_api",
     },
 }
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -516,6 +516,80 @@ def test_invalid_observation_cannot_hold_supervisor_after_switch_is_absent(
     assert status["kill_switch"]["warnings"]
 
 
+def test_status_warns_on_oversized_runtime_epoch(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    path = runtime_control.runtime_observation_path(s)
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record["kill_switch"]["observations"]["startup"]["observed_at_epoch"] = 10**400
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    assert _run(["status", "--json"], tmp_path) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    projected = payload["supervisor_runtime"]["kill_switch"]
+    assert projected["observed"] is False
+    assert any(
+        "observed_at_epoch must be a finite epoch" in warning
+        for warning in projected["warnings"]
+    )
+
+
+def test_status_warns_on_runtime_integer_beyond_json_conversion_limit(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    s = _team(tmp_path)
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"epoch":' + ("1" * 5000) + "}", encoding="utf-8")
+
+    assert _run(["status", "--json"], tmp_path) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    warnings = payload["supervisor_runtime"]["kill_switch"]["warnings"]
+    assert any(
+        "runtime observation is malformed: ValueError" in warning
+        for warning in warnings
+    )
+
+
+def test_runtime_reader_warns_when_json_nesting_exceeds_decoder_limit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}", encoding="utf-8")
+
+    def reject_nesting(raw: str) -> object:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(runtime_control.json, "loads", reject_nesting)
+
+    record, warnings = runtime_control.read_runtime_observation(s)
+
+    assert record is None
+    assert any(
+        "runtime observation is malformed: RecursionError" in warning
+        for warning in warnings
+    )
+
+
 # ---- snapshot-model fixtures (the 8-state classifier reads a process snapshot) ----
 BRAIN_PID, LAUNCHER_PID, WAIT_PID = 200, 199, 400
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -517,6 +517,180 @@ def test_invalid_observation_cannot_hold_supervisor_after_switch_is_absent(
     assert status["kill_switch"]["warnings"]
 
 
+@pytest.mark.parametrize(
+    "invalid_record",
+    [
+        b"{broken",
+        json.dumps({
+            "schema_version": runtime_control.RUNTIME_OBSERVATION_SCHEMA + 1,
+        }).encode("utf-8"),
+    ],
+    ids=["malformed", "future-schema"],
+)
+def test_invalid_inactive_observation_is_preserved_and_activation_recovers(
+    tmp_path: Path,
+    monkeypatch,
+    invalid_record: bytes,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(invalid_record)
+
+    inactive = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="mid_poll",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    assert inactive == {"active": False, "changed": False, "observation": None}
+    assert path.read_bytes() == invalid_record
+
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    activated = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="mid_poll",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW + 1,
+        validate_artifacts=lambda: None,
+    )
+
+    observed, warnings = runtime_control.read_runtime_observation(s)
+    assert warnings == []
+    assert observed == activated["observation"]
+    assert observed is not None
+    assert observed["kill_switch"]["active"] is True
+    preserved = list(path.parent.glob(f"{path.name}.quarantine-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_bytes() == invalid_record
+
+
+def test_invalid_active_observation_preservation_failure_keeps_original(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    invalid_record = b"{broken"
+    path.write_bytes(invalid_record)
+
+    def fail_preservation(source: object, destination: object) -> None:
+        del source, destination
+        raise PermissionError("preservation denied")
+
+    monkeypatch.setattr(runtime_control.os, "replace", fail_preservation)
+
+    with pytest.raises(
+        runtime_control.SupervisorRuntimeObservationError,
+        match="could not be preserved: PermissionError",
+    ):
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=NOW,
+            validate_artifacts=lambda: None,
+        )
+
+    assert path.read_bytes() == invalid_record
+    assert list(path.parent.glob(f"{path.name}.quarantine-*")) == []
+
+
+def test_active_unreadable_observation_stays_fail_closed_without_quarantine(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    preservation_attempted = False
+
+    def unreadable(store: Store) -> dict | None:
+        del store
+        raise runtime_control._RuntimeObservationUnreadableError("sharing violation")
+
+    def preserve(store: Store) -> None:
+        nonlocal preservation_attempted
+        del store
+        preservation_attempted = True
+
+    monkeypatch.setattr(runtime_control, "_read_strict", unreadable)
+    monkeypatch.setattr(runtime_control, "_preserve_invalid_observation", preserve)
+
+    with pytest.raises(
+        runtime_control.SupervisorRuntimeObservationError,
+        match="sharing violation",
+    ):
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=NOW,
+            validate_artifacts=lambda: None,
+        )
+
+    assert preservation_attempted is False
+
+
+def test_invalid_active_observation_write_failure_retries_from_preserved_copy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    invalid_record = b"{broken"
+    path.write_bytes(invalid_record)
+    real_write = runtime_control._atomic_write_text
+
+    def fail_write(destination: Path, text: str) -> None:
+        del destination, text
+        raise OSError("disk full")
+
+    monkeypatch.setattr(runtime_control, "_atomic_write_text", fail_write)
+    with pytest.raises(OSError, match="disk full"):
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=NOW,
+            validate_artifacts=lambda: None,
+        )
+
+    assert not path.exists()
+    preserved = list(path.parent.glob(f"{path.name}.quarantine-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_bytes() == invalid_record
+
+    monkeypatch.setattr(runtime_control, "_atomic_write_text", real_write)
+    recovered = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW + 1,
+        validate_artifacts=lambda: None,
+    )
+
+    assert recovered["changed"] is True
+    observed, warnings = runtime_control.read_runtime_observation(s)
+    assert warnings == []
+    assert observed == recovered["observation"]
+    assert preserved[0].read_bytes() == invalid_record
+
+
 def test_status_warns_on_oversized_runtime_epoch(
     tmp_path: Path,
     capsys,

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -18,6 +18,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import sysconfig
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -4142,13 +4143,42 @@ def _select_test_powershell_with_slow_probe(root: Path, shell: str) -> None:
 
 
 def _checkout_runtime_env(base: dict[str, str] | None = None) -> dict[str, str]:
-    """Make generated-shim subprocesses execute the checkout under test."""
+    """Keep generated subprocesses on the same candidate as the test process."""
     env = dict(os.environ if base is None else base)
-    source = str(Path(__file__).resolve().parents[1] / "src")
-    existing = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = source + (os.pathsep + existing if existing else "")
+    source = (Path(__file__).resolve().parents[1] / "src").resolve()
+    candidate = Path(sup.__file__).resolve()
+    pythonpath_keys = [
+        key for key in env if key.casefold() == "pythonpath"
+    ]
+    existing = next((env[key] for key in pythonpath_keys), None)
+    for key in pythonpath_keys:
+        del env[key]
+    if candidate.is_relative_to(source):
+        env["PYTHONPATH"] = str(source) + (
+            os.pathsep + existing if existing else ""
+        )
     env["AGENTTALK_PYTHON"] = sys.executable
     return env
+
+
+def test_checkout_runtime_env_preserves_imported_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = (Path(__file__).resolve().parents[1] / "src").resolve()
+    monkeypatch.setattr(sup, "__file__", str(source / "agenttalk" / "supervisor.py"))
+    source_env = _checkout_runtime_env({"PythonPath": "existing"})
+    assert source_env["PYTHONPATH"].split(os.pathsep) == [
+        str(source),
+        "existing",
+    ]
+
+    installed = tmp_path / "site-packages" / "agenttalk" / "supervisor.py"
+    monkeypatch.setattr(sup, "__file__", str(installed))
+    wheel_env = _checkout_runtime_env(
+        {"PYTHONPATH": str(source), "PythonPath": "also-source"}
+    )
+    assert not any(key.casefold() == "pythonpath" for key in wheel_env)
 
 
 def _live_supervisor_config(*agents: str) -> dict:
@@ -5342,6 +5372,20 @@ def test_generated_ps1_runs_bus_calls_without_console_script_on_path(tmp_path: P
     reduced["PATH"] = os.pathsep.join([
         os.path.join(windir, "System32"), windir,
         os.path.join(windir, "System32", "WindowsPowerShell", "v1.0")])
+    provenance = subprocess.run(
+        [
+            reduced["AGENTTALK_PYTHON"],
+            "-c",
+            "import agenttalk.supervisor as m; print(m.__file__)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=reduced,
+        cwd=str(tmp_path),
+    )
+    assert provenance.returncode == 0, provenance.stderr
+    assert Path(provenance.stdout.strip()).resolve() == Path(sup.__file__).resolve()
     res = subprocess.run(
         [shell, "-NoProfile", "-File", str(ps1), "-Once", "-DryRun"],
         capture_output=True, text=True, timeout=120, env=reduced, cwd=str(tmp_path))
@@ -5350,6 +5394,152 @@ def test_generated_ps1_runs_bus_calls_without_console_script_on_path(tmp_path: P
     assert "is not recognized" not in combined and "CommandNotFound" not in combined, combined
     # the DryRun plan line for the dead worker actually printed (the bus call ran)
     assert "worker:" in res.stdout, f"no plan emitted; stdout={res.stdout!r} stderr={res.stderr!r}"
+
+
+def test_generated_ps1_records_startup_kill_switch_through_wheel_shim(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """The wheel's venv redirector is part of the checked generated-shim path."""
+    shell = _pick_powershell()
+    if not shell:
+        return
+    store = _team(tmp_path)
+    (store.dir / "supervisor.json").write_text(
+        json.dumps(_CONFIG),
+        encoding="utf-8",
+    )
+    assert _run(["supervise", "--init"], tmp_path) == 0
+    _select_test_powershell(tmp_path, shell)
+    capsys.readouterr()
+    (store.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            shell,
+            "-NoProfile",
+            "-File",
+            str(store.dir / "supervisor.ps1"),
+            "-Once",
+            "-DryRun",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=_checkout_runtime_env(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert store.read_supervisor_instance() is None
+    observation = json.loads(
+        runtime_control.runtime_observation_path(store).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert observation["kill_switch"]["active"] is True
+    assert "startup" in observation["kill_switch"]["observations"]
+
+    assert _run(["status", "--json"], tmp_path) == 0
+    projected = json.loads(capsys.readouterr().out)["supervisor_runtime"][
+        "kill_switch"
+    ]
+    assert projected["active"] is True
+    assert projected["observed"] is True
+    assert "startup" in projected["observations"]
+
+
+def test_generated_ps1_claims_and_releases_through_wheel_shim(
+    tmp_path: Path,
+) -> None:
+    """The same bounded ancestry authorizes the executor claim path."""
+    shell = _pick_powershell()
+    if not shell:
+        return
+    store = _team(tmp_path)
+    store.set_role("lead", "lead")
+    config = {
+        **_CONFIG,
+        "agents": {"lead": {"auto_restart": True, "cli": "claude"}},
+    }
+    (store.dir / "supervisor.json").write_text(
+        json.dumps(config),
+        encoding="utf-8",
+    )
+    assert _run(["supervise", "--init"], tmp_path) == 0
+    _select_test_powershell(tmp_path, shell)
+
+    result = subprocess.run(
+        [
+            shell,
+            "-NoProfile",
+            "-File",
+            str(store.dir / "supervisor.ps1"),
+            "-Once",
+            "-Quiet",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=_checkout_runtime_env(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert store.read_supervisor_instance() is None
+    assert (store.dir / "supervisor-state.json").exists()
+
+
+def test_checked_observer_accepts_identified_console_script_ancestry(
+    tmp_path: Path,
+) -> None:
+    shell = _pick_powershell()
+    if not shell:
+        return
+    console = Path(sysconfig.get_path("scripts")) / "agenttalk.exe"
+    if not console.is_file():
+        pytest.skip("the active Python has no installed agenttalk console script")
+    store = _team(tmp_path)
+    (store.dir / "supervisor.json").write_text(
+        json.dumps(_CONFIG),
+        encoding="utf-8",
+    )
+    assert _run(["supervise", "--init"], tmp_path) == 0
+    _select_test_powershell(tmp_path, shell)
+    (store.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    harness = tmp_path / "console-observer.ps1"
+    harness.write_text(
+        "\n".join(
+            [
+                "$start = ([datetimeoffset](Get-Process -Id $PID).StartTime).ToString('o')",
+                (
+                    f"& {_pslit(str(console))} --root {_pslit(str(tmp_path))} "
+                    "supervise --observe-kill-switch "
+                    "--observation-phase startup --pid $PID --pid-start $start"
+                ),
+                "exit $LASTEXITCODE",
+            ]
+        ),
+        encoding="utf-8-sig",
+    )
+
+    result = subprocess.run(
+        [shell, "-NoProfile", "-File", str(harness)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=_checkout_runtime_env(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["active"] is True
+    observation = json.loads(
+        runtime_control.runtime_observation_path(store).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert "startup" in observation["kill_switch"]["observations"]
 
 
 def test_proc_start_falls_back_to_get_process_when_cim_denied(tmp_path: Path) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -8,6 +8,7 @@ fixtures. The generated PS/bash scripts are thin executors (documented-manual).
 from __future__ import annotations
 
 import hashlib
+import contextlib
 import io
 import json
 import os
@@ -17,7 +18,9 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,7 +31,10 @@ from agenttalk import (
     cli,
     ephemeral as eph,
     health as hm,
+    powershell_host as psh,
     supervisor as sup,
+    supervisor_lifecycle as lifecycle,
+    supervisor_runtime as runtime_control,
     wrapper_runtime as wrt,
 )
 from agenttalk.store import Store, _process_alive
@@ -203,6 +209,311 @@ def test_supervise_claim_instance_refuses_kill_switch_and_release_allows_cleanup
         "--pid-start", "start", "--instance-token", rec["token"],
     ], tmp_path) == 0
     assert s.read_supervisor_instance() is None
+
+
+def _allow_checked_kill_switch_observer(monkeypatch) -> None:
+    @contextlib.contextmanager
+    def allowed(
+        store,
+        *,
+        pid,
+        pid_start,
+        validate_artifacts,
+    ):
+        with store._supervisor_lifecycle_lock():
+            validate_artifacts()
+            with store._config_lock():
+                yield
+
+    monkeypatch.setattr(
+        lifecycle,
+        "checked_powershell_supervisor_observer",
+        allowed,
+    )
+
+
+def test_supervise_observe_kill_switch_records_checked_active_transition(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    monkeypatch.setattr(sup, "validate_artifact_bundle", lambda *args, **kwargs: None)
+
+    rc = _run([
+        "supervise",
+        "--observe-kill-switch",
+        "--observation-phase", "startup",
+        "--pid", "123",
+        "--pid-start", "start",
+        "--now", str(NOW),
+    ], tmp_path)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["active"] is True
+    assert payload["changed"] is True
+    record = json.loads(
+        (s.state_dir / "supervisor-runtime-observation.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    startup = record["kill_switch"]["observations"]["startup"]
+    assert startup == {
+        "exit_code": 3,
+        "observed_at": _iso(NOW),
+        "observed_at_epoch": NOW,
+        "observer_pid": 123,
+        "observer_pid_start": "start",
+    }
+    assert s.read_supervisor_instance() is None
+
+
+def test_kill_switch_observation_is_idempotent_and_reactivates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    kill_switch_path = s.dir / "supervisor.kill"
+    kill_switch_path.write_text("stop", encoding="utf-8")
+
+    def observe(phase: str, now: float) -> dict:
+        return runtime_control.observe_powershell_kill_switch(
+            s,
+            phase=phase,
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=now,
+            validate_artifacts=lambda: None,
+        )
+
+    first = observe("startup", NOW)
+    first_bytes = runtime_control.runtime_observation_path(s).read_bytes()
+    duplicate = observe("startup", NOW + 1)
+    assert duplicate["changed"] is False
+    assert runtime_control.runtime_observation_path(s).read_bytes() == first_bytes
+
+    kill_switch_path.unlink()
+    resolved = observe("mid_poll", NOW + 2)
+    assert resolved["active"] is False
+    assert resolved["changed"] is True
+
+    kill_switch_path.write_text("stop-again", encoding="utf-8")
+    reactivated = observe("mid_poll", NOW + 3)
+    assert reactivated["changed"] is True
+    assert (
+        reactivated["observation"]["kill_switch"]["activation_id"]
+        != first["observation"]["kill_switch"]["activation_id"]
+    )
+    assert set(
+        reactivated["observation"]["kill_switch"]["observations"]
+    ) == {"mid_poll"}
+
+
+def test_kill_switch_observation_does_not_invent_an_active_level(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+
+    result = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+
+    assert result == {"active": False, "changed": False, "observation": None}
+    assert not runtime_control.runtime_observation_path(s).exists()
+
+
+def test_concurrent_kill_switch_observers_publish_one_transition(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    barrier = threading.Barrier(2)
+
+    def observe(observer_pid: int) -> dict:
+        barrier.wait(timeout=10)
+        return runtime_control.observe_powershell_kill_switch(
+            Store(tmp_path),
+            phase="startup",
+            observer_pid=observer_pid,
+            observer_pid_start=f"start-{observer_pid}",
+            now_epoch=NOW,
+            validate_artifacts=lambda: None,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(observe, [123, 456]))
+
+    assert sorted(result["changed"] for result in results) == [False, True]
+    assert len({
+        result["observation"]["kill_switch"]["activation_id"]
+        for result in results
+    }) == 1
+
+
+def test_status_projects_kill_switch_observation_without_event_history(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    result = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    assert not sup.supervisor_events_path(s).exists()
+
+    assert _run(["status", "--json"], tmp_path) == 0
+    structured = json.loads(capsys.readouterr().out)
+    projected = structured["supervisor_runtime"]["kill_switch"]
+    assert projected["active"] is True
+    assert projected["observed"] is True
+    assert (
+        projected["activation_id"]
+        == result["observation"]["kill_switch"]["activation_id"]
+    )
+
+    assert _run(["status"], tmp_path) == 0
+    rendered = capsys.readouterr().out
+    assert "supervisor.kill active" in rendered
+    assert "startup observed" in rendered
+    assert _iso(NOW) in rendered
+
+
+def test_pristine_status_omits_additive_supervisor_runtime_key(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _team(tmp_path)
+
+    assert _run(["status", "--json"], tmp_path) == 0
+
+    assert "supervisor_runtime" not in json.loads(capsys.readouterr().out)
+
+
+def test_kill_switch_observer_validation_failure_writes_nothing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+
+    @contextlib.contextmanager
+    def denied(*args, **kwargs):
+        raise lifecycle.SupervisorLifecycleError("unrelated PowerShell caller")
+        yield
+
+    monkeypatch.setattr(
+        lifecycle,
+        "checked_powershell_supervisor_observer",
+        denied,
+    )
+
+    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unrelated"):
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=NOW,
+            validate_artifacts=lambda: None,
+        )
+    assert not runtime_control.runtime_observation_path(s).exists()
+
+
+def test_kill_switch_level_is_rechecked_inside_checked_operation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    kill_switch_path = s.dir / "supervisor.kill"
+    assert not kill_switch_path.exists()
+
+    @contextlib.contextmanager
+    def checked(
+        store,
+        *,
+        pid,
+        pid_start,
+        validate_artifacts,
+    ):
+        validate_artifacts()
+        yield
+
+    monkeypatch.setattr(
+        lifecycle,
+        "checked_powershell_supervisor_observer",
+        checked,
+    )
+
+    result = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: kill_switch_path.write_text(
+            "appeared-during-validation",
+            encoding="utf-8",
+        ),
+    )
+
+    assert result["active"] is True
+    assert result["changed"] is True
+    assert runtime_control.runtime_observation_path(s).exists()
+
+
+@pytest.mark.parametrize(
+    "invalid_record",
+    [
+        "{broken",
+        json.dumps({"schema_version": runtime_control.RUNTIME_OBSERVATION_SCHEMA + 1}),
+    ],
+)
+def test_invalid_observation_cannot_hold_supervisor_after_switch_is_absent(
+    tmp_path: Path,
+    monkeypatch,
+    invalid_record: str,
+) -> None:
+    s = _team(tmp_path)
+    _allow_checked_kill_switch_observer(monkeypatch)
+    path = runtime_control.runtime_observation_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(invalid_record, encoding="utf-8")
+
+    result = runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="mid_poll",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+
+    assert result == {"active": False, "changed": False, "observation": None}
+    assert path.read_text(encoding="utf-8") == invalid_record
+    status = runtime_control.build_runtime_status(s)
+    assert status["kill_switch"]["active"] is False
+    assert status["kill_switch"]["warnings"]
+
 
 # ---- snapshot-model fixtures (the 8-state classifier reads a process snapshot) ----
 BRAIN_PID, LAUNCHER_PID, WAIT_PID = 200, 199, 400
@@ -713,6 +1024,9 @@ def test_supervisor_report_surfaces_kill_switch_and_mutations_refuse(
 def test_ps_template_kill_switch_guards_mutating_boundaries() -> None:
     ps = sup.PS_TEMPLATE
     assert "$KillSwitchPath" in ps
+    assert "function Sync-KillSwitchObservation" in ps
+    assert ps.index("'--observe-kill-switch'") < ps.index("'--claim-instance'")
+    assert "Scheduled Task hosting retries it" in ps
     assert "function Actions-Enabled" in ps
     assert "function Assert-ActionsEnabled" in ps
     assert "function Save-State($state)" in ps
@@ -1264,6 +1578,7 @@ def test_supervisor_cli_json_decision_matches_plan_actions(tmp_path: Path, capsy
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
+    assert "supervisor_runtime" not in payload
     expected = payload["plan"]["agents"]["worker"]
     worker = next(a for a in payload["agents"] if a["name"] == "worker")
     assert worker["decision"]["action"] == expected["action"]
@@ -3810,6 +4125,22 @@ def _select_test_powershell(root: Path, shell: str) -> None:
     assert _run(["supervise", "--select-pwsh", "--pwsh", shell], root) == 0
 
 
+def _select_test_powershell_with_slow_probe(root: Path, shell: str) -> None:
+    """Set up the selected-host contract without the production 5s probe budget.
+
+    The shared Windows host can take longer than that under parallel review
+    load.  Host selection is not the boundary under test in #114.
+    """
+    store = Store(root)
+    result = psh.probe_candidate(
+        shell,
+        source="explicit",
+        timeout=30,
+    )
+    record = psh.make_selection_record(result, project_id=store.project_id())
+    lifecycle._atomic_write_selection(lifecycle.selection_path(store), record)
+
+
 def _checkout_runtime_env(base: dict[str, str] | None = None) -> dict[str, str]:
     """Make generated-shim subprocesses execute the checkout under test."""
     env = dict(os.environ if base is None else base)
@@ -3907,6 +4238,8 @@ def _replace_text_when_unlocked(path: Path, text: str, *, timeout: float = 5) ->
 def _start_live_generated_supervisor(
     tmp_path: Path,
     shell: str,
+    *,
+    slow_host_probe: bool = False,
 ) -> tuple[Store, subprocess.Popen, object, Path]:
     store = _team(tmp_path)
     store.set_role("lead", "lead")
@@ -3915,7 +4248,10 @@ def _start_live_generated_supervisor(
         encoding="utf-8",
     )
     assert _run(["supervise", "--init"], tmp_path) == 0
-    _select_test_powershell(tmp_path, shell)
+    if slow_host_probe:
+        _select_test_powershell_with_slow_probe(tmp_path, shell)
+    else:
+        _select_test_powershell(tmp_path, shell)
     log_path = tmp_path / "live-supervisor.log"
     log_handle = log_path.open("w", encoding="utf-8")
     proc = subprocess.Popen(
@@ -3927,6 +4263,132 @@ def _start_live_generated_supervisor(
         env=_checkout_runtime_env(),
     )
     return store, proc, log_handle, log_path
+
+
+def _read_kill_switch_observation(store: Store) -> dict | None:
+    path = store.state_dir / "supervisor-runtime-observation.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.source_layout
+@pytest.mark.parametrize("activation_order", ["before_start", "mid_poll"])
+def test_generated_supervisor_kill_switch_observation_reaches_status(
+    tmp_path: Path,
+    capsys,
+    activation_order: str,
+) -> None:
+    shell = _pick_powershell()
+    if not shell:
+        pytest.skip("PowerShell is unavailable")
+    proc: subprocess.Popen | None = None
+    log_handle = None
+    if activation_order == "before_start":
+        store = _team(tmp_path)
+        store.set_role("lead", "lead")
+        (store.dir / "supervisor.json").write_text(
+            json.dumps(_live_supervisor_config("lead")),
+            encoding="utf-8",
+        )
+        assert _run(["supervise", "--init"], tmp_path) == 0
+        _select_test_powershell_with_slow_probe(tmp_path, shell)
+        capsys.readouterr()
+        (store.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+        result = subprocess.run(
+            [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-File",
+                str(store.dir / "supervisor.ps1"),
+                "-Once",
+                "-Quiet",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=tmp_path,
+            env=_checkout_runtime_env(),
+        )
+        assert result.returncode == 3, result.stdout + result.stderr
+        assert not store.supervisor_instance_path().exists()
+        assert not (store.dir / "supervisor-state.json").exists()
+        expected_phase = "startup"
+    else:
+        store, proc, log_handle, log_path = _start_live_generated_supervisor(
+            tmp_path,
+            shell,
+            slow_host_probe=True,
+        )
+        capsys.readouterr()
+        _wait_for_live_supervisor(
+            proc,
+            log_path,
+            lambda: store.supervisor_instance_path().exists()
+            and _state_has_agent(store.dir / "supervisor-state.json", "lead"),
+        )
+        (store.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+        expected_phase = "mid_poll"
+    try:
+        observation_path = store.state_dir / "supervisor-runtime-observation.json"
+        if proc is not None:
+            _wait_for_live_supervisor(
+                proc,
+                log_path,
+                lambda: (
+                    (observation := _read_kill_switch_observation(store)) is not None
+                    and expected_phase
+                    in observation.get("kill_switch", {}).get("observations", {})
+                ),
+            )
+            assert proc.poll() is None
+            assert store.supervisor_instance_path().exists()
+            store.add_agent("held-agent", role="worker")
+            _replace_text_when_unlocked(
+                store.dir / "supervisor.json",
+                json.dumps(_live_supervisor_config("lead", "held-agent")),
+            )
+            _wait_for_live_supervisor(
+                proc,
+                log_path,
+                lambda: _log_contains(
+                    log_path,
+                    "kill switch active; skipping agent held-agent",
+                ),
+            )
+            assert not _state_has_agent(
+                store.dir / "supervisor-state.json",
+                "held-agent",
+            )
+
+        observation = _read_kill_switch_observation(store)
+        assert observation is not None
+        kill_switch = observation["kill_switch"]
+        assert kill_switch["active"] is True
+        phase_observation = kill_switch["observations"][expected_phase]
+        observed_at = phase_observation["observed_at"]
+        assert observation_path.exists()
+
+        assert _run(["status", "--json"], tmp_path) == 0
+        structured = json.loads(capsys.readouterr().out)
+        projected = structured["supervisor_runtime"]["kill_switch"]
+        assert projected["active"] is True
+        assert projected["observed"] is True
+        assert projected["activation_id"] == kill_switch["activation_id"]
+        assert projected["observations"][expected_phase]["observed_at"] == observed_at
+
+        assert _run(["status"], tmp_path) == 0
+        rendered = capsys.readouterr().out
+        assert "supervisor.kill active" in rendered
+        assert expected_phase.replace("_", "-") in rendered
+        assert observed_at in rendered
+    finally:
+        if proc is not None:
+            _stop_live_supervisor(proc)
+        if log_handle is not None:
+            log_handle.close()
 
 
 @pytest.mark.source_layout

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -642,6 +642,75 @@ def test_status_rejects_first_observed_pair_not_backed_by_phase(
     assert "supervisor_runtime_observation_invalid:" in capsys.readouterr().out
 
 
+def test_runtime_reader_rejects_later_phase_as_first_observation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="mid_poll",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW + 1,
+        validate_artifacts=lambda: None,
+    )
+    path = runtime_control.runtime_observation_path(s)
+    record = json.loads(path.read_text(encoding="utf-8"))
+    later = record["kill_switch"]["observations"]["startup"]
+    record["kill_switch"]["first_observed_at"] = later["observed_at"]
+    record["kill_switch"]["first_observed_at_epoch"] = later[
+        "observed_at_epoch"
+    ]
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    observed, warnings = runtime_control.read_runtime_observation(s)
+
+    assert observed is None
+    assert any("activation-source phase" in warning for warning in warnings)
+
+
+def test_runtime_first_observation_uses_phase_order_across_clock_rollback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="mid_poll",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW + 1,
+        validate_artifacts=lambda: None,
+    )
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+
+    observed, warnings = runtime_control.read_runtime_observation(s)
+
+    assert warnings == []
+    assert observed is not None
+    assert observed["kill_switch"]["first_observed_at_epoch"] == NOW + 1
+
+
 def test_default_observation_clock_is_sampled_after_lifecycle_lock_wait(
     tmp_path: Path,
     monkeypatch,
@@ -744,7 +813,7 @@ def test_runtime_reader_warns_when_json_nesting_exceeds_decoder_limit(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{}", encoding="utf-8")
 
-    def reject_nesting(raw: str) -> object:
+    def reject_nesting(raw: str, **kwargs) -> object:
         raise RecursionError("maximum recursion depth exceeded")
 
     monkeypatch.setattr(runtime_control.json, "loads", reject_nesting)
@@ -756,6 +825,73 @@ def test_runtime_reader_warns_when_json_nesting_exceeds_decoder_limit(
         "runtime observation is malformed: RecursionError" in warning
         for warning in warnings
     )
+
+
+def test_runtime_reader_bounds_bytes_from_same_open_after_stale_size_check(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    path = runtime_control.runtime_observation_path(s)
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + (" " * (runtime_control.RUNTIME_OBSERVATION_MAX_BYTES + 1)),
+        encoding="utf-8",
+    )
+    real_stat = Path.stat
+
+    class StaleSmallStat:
+        st_size = 1
+
+    def stale_stat(self: Path, *args, **kwargs):
+        if self == path:
+            return StaleSmallStat()
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stale_stat)
+
+    observed, warnings = runtime_control.read_runtime_observation(s)
+
+    assert observed is None
+    assert any("exceeds its size cap" in warning for warning in warnings)
+
+
+def test_runtime_reader_rejects_duplicate_json_object_keys(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    path = runtime_control.runtime_observation_path(s)
+    raw = path.read_text(encoding="utf-8")
+    path.write_text(
+        raw.replace('"active": true', '"active": false, "active": true', 1),
+        encoding="utf-8",
+    )
+
+    observed, warnings = runtime_control.read_runtime_observation(s)
+
+    assert observed is None
+    assert any("duplicate JSON object key" in warning for warning in warnings)
 
 
 # ---- snapshot-model fixtures (the 8-state classifier reads a process snapshot) ----

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -33,6 +33,7 @@ from agenttalk import (
     ephemeral as eph,
     health as hm,
     powershell_host as psh,
+    store as store_module,
     supervisor as sup,
     supervisor_lifecycle as lifecycle,
     supervisor_runtime as runtime_control,
@@ -546,6 +547,173 @@ def test_status_warns_on_oversized_runtime_epoch(
         "observed_at_epoch must be a finite epoch" in warning
         for warning in projected["warnings"]
     )
+
+
+@pytest.mark.parametrize(
+    ("field_path", "replacement", "resolved"),
+    [
+        (
+            ("kill_switch", "observations", "startup", "observed_at"),
+            "garbage",
+            False,
+        ),
+        (
+            ("kill_switch", "first_observed_at"),
+            _iso(NOW + 1),
+            False,
+        ),
+        (
+            ("kill_switch", "resolved_at"),
+            _iso(NOW + 2),
+            True,
+        ),
+    ],
+    ids=["unparseable-phase", "mismatched-first", "mismatched-resolution"],
+)
+def test_status_rejects_runtime_timestamp_that_does_not_match_epoch(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+    field_path: tuple[str, ...],
+    replacement: str,
+    resolved: bool,
+) -> None:
+    s = _team(tmp_path)
+    kill_switch = s.dir / "supervisor.kill"
+    kill_switch.write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    if resolved:
+        kill_switch.unlink()
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="mid_poll",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=NOW + 1,
+            validate_artifacts=lambda: None,
+        )
+    path = runtime_control.runtime_observation_path(s)
+    record = json.loads(path.read_text(encoding="utf-8"))
+    target = record
+    for field in field_path[:-1]:
+        target = target[field]
+    target[field_path[-1]] = replacement
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    assert _run(["status"], tmp_path) == 0
+
+    rendered = capsys.readouterr().out
+    assert "supervisor_runtime_observation_invalid:" in rendered
+    assert "startup observed garbage" not in rendered
+
+
+def test_status_rejects_first_observed_pair_not_backed_by_phase(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+    runtime_control.observe_powershell_kill_switch(
+        s,
+        phase="startup",
+        observer_pid=123,
+        observer_pid_start="start",
+        now_epoch=NOW,
+        validate_artifacts=lambda: None,
+    )
+    path = runtime_control.runtime_observation_path(s)
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record["kill_switch"]["first_observed_at"] = _iso(NOW + 1)
+    record["kill_switch"]["first_observed_at_epoch"] = NOW + 1
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    assert _run(["status"], tmp_path) == 0
+
+    assert "supervisor_runtime_observation_invalid:" in capsys.readouterr().out
+
+
+def test_default_observation_clock_is_sampled_after_lifecycle_lock_wait(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    kill_switch = s.dir / "supervisor.kill"
+    _allow_checked_kill_switch_observer(monkeypatch)
+    real_lock = s._supervisor_lifecycle_lock
+    attempted = threading.Event()
+    real_store_time = store_module.time
+
+    class ObservedLockWaitTime:
+        monotonic = staticmethod(real_store_time.monotonic)
+        time = staticmethod(real_store_time.time)
+
+        @staticmethod
+        def sleep(seconds: float) -> None:
+            attempted.set()
+            real_store_time.sleep(seconds)
+
+    class SwitchAwareClock:
+        @staticmethod
+        def time() -> float:
+            return NOW + 1 if kill_switch.exists() else NOW
+
+    monkeypatch.setattr(runtime_control, "time", SwitchAwareClock)
+
+    def observe() -> dict:
+        return runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=None,
+            validate_artifacts=lambda: None,
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        with real_lock():
+            monkeypatch.setattr(store_module, "time", ObservedLockWaitTime)
+            future = pool.submit(observe)
+            assert attempted.wait(timeout=10)
+            kill_switch.write_text("appeared-during-lock-wait", encoding="utf-8")
+        result = future.result(timeout=10)
+
+    record = result["observation"]["kill_switch"]
+    assert record["first_observed_at_epoch"] == NOW + 1
+    assert record["observations"]["startup"]["observed_at_epoch"] == NOW + 1
+
+
+def test_kill_switch_observer_rejects_datetime_unrepresentable_epoch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    s = _team(tmp_path)
+    (s.dir / "supervisor.kill").write_text("stop", encoding="utf-8")
+    _allow_checked_kill_switch_observer(monkeypatch)
+
+    with pytest.raises(
+        runtime_control.SupervisorRuntimeObservationError,
+        match="representable in UTC",
+    ):
+        runtime_control.observe_powershell_kill_switch(
+            s,
+            phase="startup",
+            observer_pid=123,
+            observer_pid_start="start",
+            now_epoch=1e300,
+            validate_artifacts=lambda: None,
+        )
+
+    assert not runtime_control.runtime_observation_path(s).exists()
 
 
 def test_status_warns_on_runtime_integer_beyond_json_conversion_limit(

--- a/tests/test_supervisor_lifecycle.py
+++ b/tests/test_supervisor_lifecycle.py
@@ -312,6 +312,119 @@ def test_claim_refuses_unrelated_pid_without_marker(
     assert not store.supervisor_instance_path().exists()
 
 
+def test_observer_refuses_unrelated_powershell_pid_without_claiming(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    selected = _selected(store)
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    current_pid = os.getpid()
+    current = _observation(
+        current_pid,
+        parent=200,
+        path=r"C:\Python\python.exe",
+        ticks=300,
+    )
+    unrelated = _observation(
+        200,
+        parent=999,
+        path=r"C:\Tools\runner.exe",
+        ticks=200,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_read_valid_selection_locked",
+        lambda store: selected,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_parent_map",
+        lambda: {current_pid: 200, 200: 999},
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_open_process_observation",
+        lambda pid, parents=None: (
+            host
+            if pid == host.pid
+            else current
+            if pid == current_pid
+            else unrelated
+        ),
+    )
+
+    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unsupported"):
+        with lifecycle.checked_powershell_supervisor_observer(
+            store,
+            pid=host.pid,
+            pid_start=host.creation_token,
+            validate_artifacts=lambda: None,
+        ):
+            pytest.fail("unrelated caller reached the observation write")
+    assert not store.supervisor_instance_path().exists()
+
+
+def test_observer_holds_lifecycle_selection_config_through_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    events: list[str] = []
+
+    def lock(name: str):
+        @contextlib.contextmanager
+        def held():
+            events.append("enter:" + name)
+            try:
+                yield
+            finally:
+                events.append("exit:" + name)
+
+        return held()
+
+    monkeypatch.setattr(store, "_supervisor_lifecycle_lock", lambda: lock("lifecycle"))
+    monkeypatch.setattr(store, "_powershell_selection_lock", lambda: lock("selection"))
+    monkeypatch.setattr(store, "_config_lock", lambda: lock("config"))
+    selected = _selected(store)
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    current = _observation(
+        os.getpid(),
+        parent=100,
+        path=r"C:\Python\python.exe",
+        ticks=200,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_read_valid_selection_locked",
+        lambda store: selected,
+    )
+    monkeypatch.setattr(lifecycle, "_open_process_observation", lambda pid: host)
+    monkeypatch.setattr(lifecycle, "_validate_ancestry", lambda observed: (current,))
+    monkeypatch.setattr(lifecycle, "_require_process_active", lambda observed: None)
+    monkeypatch.setattr(psh, "native_file_identity", lambda path: host.identity)
+
+    with lifecycle.checked_powershell_supervisor_observer(
+        store,
+        pid=host.pid,
+        pid_start=host.creation_token,
+        validate_artifacts=lambda: events.append("artifacts"),
+    ):
+        events.append("write")
+
+    assert events == [
+        "enter:lifecycle",
+        "artifacts",
+        "enter:selection",
+        "enter:config",
+        "write",
+        "exit:config",
+        "exit:selection",
+        "exit:lifecycle",
+    ]
+    assert not store.supervisor_instance_path().exists()
+
+
 def test_generated_claim_reports_corrupt_marker_recovery_before_write(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_supervisor_lifecycle.py
+++ b/tests/test_supervisor_lifecycle.py
@@ -749,6 +749,43 @@ def test_claim_rechecks_selection_before_marker_write(
     assert not store.supervisor_instance_path().exists()
 
 
+def test_claim_rechecks_kill_switch_before_marker_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    selected = _selected(store)
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    current = _observation(
+        os.getpid(), parent=100, path=r"C:\Python\python.exe", ticks=200,
+    )
+    kill_switch = store.dir / "supervisor.kill"
+    monkeypatch.setattr(
+        lifecycle, "_read_valid_selection_locked", lambda store: selected,
+    )
+    monkeypatch.setattr(lifecycle, "_open_process_observation", lambda pid: host)
+    monkeypatch.setattr(lifecycle, "_validate_ancestry", lambda observed: (current,))
+    monkeypatch.setattr(lifecycle, "_require_process_active", lambda observed: None)
+    monkeypatch.setattr(psh, "native_file_identity", lambda path: host.identity)
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match=r"supervisor\.kill is present",
+    ):
+        lifecycle.claim_powershell_supervisor(
+            store,
+            pid=host.pid,
+            pid_start=host.creation_token,
+            validate_artifacts=lambda: kill_switch.write_text(
+                "appeared-after-precheck",
+                encoding="utf-8",
+            ),
+        )
+
+    assert kill_switch.exists()
+    assert not store.supervisor_instance_path().exists()
+
+
 def test_claim_revalidates_image_identity_after_config_lock_entry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_supervisor_lifecycle.py
+++ b/tests/test_supervisor_lifecycle.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import json
 import os
 import sys
 import sysconfig
+from ctypes import wintypes
 from pathlib import Path
 
 import pytest
@@ -273,6 +275,210 @@ def test_validate_ancestry_accepts_identified_generated_launch_classes(
         for index in reversed(range(len(intermediate_paths)))
     )
     assert lifecycle._validate_ancestry(host) == expected, name
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_accepts_verified_wow64_cmd_for_cross_arch_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(
+        100,
+        parent=1,
+        path=r"C:\Program Files (x86)\PowerShell\7\pwsh.exe",
+        ticks=100,
+    )
+    native_cmd = r"C:\Windows\System32\cmd.exe"
+    wow64_cmd = r"C:\Windows\SysWOW64\cmd.exe"
+    base_python = r"C:\Python\python.exe"
+    identities = {
+        native_cmd: _identity(native_cmd, "70"),
+        wow64_cmd: _identity(wow64_cmd, "71"),
+        base_python: _identity(base_python, "72"),
+    }
+    current, (cmd,) = _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((wow64_cmd, identities[wow64_cmd], 200),),
+        current_path=base_python,
+        current_identity=identities[base_python],
+    )
+    monkeypatch.setattr(sys, "executable", base_python)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(lifecycle, "_system_cmd_path", lambda: native_cmd)
+    monkeypatch.setattr(
+        lifecycle,
+        "_system_cmd_path_for_observation",
+        lambda observation: wow64_cmd,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: identities[str(path)],
+    )
+
+    assert lifecycle._validate_ancestry(host) == (current, cmd)
+
+
+@WINDOWS_ONLY
+def test_system_cmd_resolver_uses_observed_guest_architecture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cmd = _observation(
+        200,
+        parent=100,
+        path=r"C:\Windows\SysWOW64\cmd.exe",
+        ticks=200,
+    )
+    cmd.handle = 700
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_machines",
+        lambda handle: (0x014C, 0x8664),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_wow64_system_directory",
+        lambda machine: r"C:\Windows\SysWOW64" if machine == 0x014C else "",
+    )
+
+    assert lifecycle._system_cmd_path_for_observation(cmd) == (
+        r"C:\Windows\SysWOW64\cmd.exe"
+    )
+
+
+@WINDOWS_ONLY
+def test_system_cmd_resolver_uses_sysnative_for_native_ancestor_from_wow64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cmd = _observation(
+        200,
+        parent=100,
+        path=r"C:\Windows\System32\cmd.exe",
+        ticks=200,
+    )
+    cmd.handle = 700
+    monkeypatch.setattr(lifecycle, "_current_process_handle", lambda: 800)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_machines",
+        lambda handle: (0, 0x8664) if handle == 700 else (0x014C, 0x8664),
+    )
+    monkeypatch.setattr(lifecycle, "_windows_directory", lambda: r"C:\Windows")
+
+    assert lifecycle._system_cmd_path_for_observation(cmd) == (
+        r"C:\Windows\Sysnative\cmd.exe"
+    )
+
+
+@WINDOWS_ONLY
+def test_process_image_identity_reopens_native_system_image_through_sysnative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    native_cmd = r"C:\Windows\System32\cmd.exe"
+    native_identity = _identity(native_cmd, "73")
+    opened: list[str] = []
+    monkeypatch.setattr(lifecycle, "_current_process_handle", lambda: 800)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_machines",
+        lambda handle: (0, 0x8664) if handle == 700 else (0x014C, 0x8664),
+    )
+    monkeypatch.setattr(lifecycle, "_windows_directory", lambda: r"C:\Windows")
+
+    def open_identity(path: str):
+        opened.append(str(path))
+        return native_identity, 900
+
+    monkeypatch.setattr(psh, "open_stable_native_file_identity", open_identity)
+
+    identity, handle = lifecycle._open_stable_process_image_identity(
+        native_cmd,
+        700,
+    )
+
+    assert opened == [r"C:\Windows\Sysnative\cmd.exe"]
+    assert identity is native_identity
+    assert handle == 900
+
+
+@WINDOWS_ONLY
+def test_process_machine_query_falls_back_to_legacy_wow64_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LegacyIsWow64Process:
+        argtypes = None
+        restype = None
+
+        def __call__(self, handle, emulated) -> int:
+            assert int(handle.value) == 700
+            ctypes.cast(
+                emulated,
+                ctypes.POINTER(wintypes.BOOL),
+            ).contents.value = 1
+            return 1
+
+    class LegacyKernel32:
+        IsWow64Process = LegacyIsWow64Process()
+
+        def __getattr__(self, name: str):
+            raise AttributeError(name)
+
+    monkeypatch.setattr(
+        lifecycle.ctypes,
+        "WinDLL",
+        lambda name, use_last_error=True: LegacyKernel32(),
+    )
+
+    assert lifecycle._process_machines(700) == (0x014C, 0)
+
+
+@WINDOWS_ONLY
+@pytest.mark.parametrize("v2_mode", ["missing", "failure"])
+def test_wow64_directory_query_falls_back_to_legacy_api(
+    monkeypatch: pytest.MonkeyPatch,
+    v2_mode: str,
+) -> None:
+    class FailedDirectory2:
+        argtypes = None
+        restype = None
+
+        def __call__(self, buffer, capacity, machine) -> int:
+            assert machine == 0x014C
+            return 0
+
+    class LegacyDirectory:
+        argtypes = None
+        restype = None
+        called = 0
+
+        def __call__(self, buffer, capacity) -> int:
+            self.called += 1
+            buffer.value = r"C:\Windows\SysWOW64"
+            return len(buffer.value)
+
+    legacy = LegacyDirectory()
+
+    class LegacyKernel32:
+        GetSystemWow64DirectoryW = legacy
+
+        def __getattr__(self, name: str):
+            if name == "GetSystemWow64Directory2W" and v2_mode == "failure":
+                return FailedDirectory2()
+            raise AttributeError(name)
+
+    monkeypatch.setattr(
+        lifecycle.ctypes,
+        "WinDLL",
+        lambda name, use_last_error=True: LegacyKernel32(),
+    )
+
+    assert lifecycle._wow64_system_directory(0x014C) == (
+        r"C:\Windows\SysWOW64"
+    )
+    assert legacy.called == 1
 
 
 @WINDOWS_ONLY

--- a/tests/test_supervisor_lifecycle.py
+++ b/tests/test_supervisor_lifecycle.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import os
 import sys
+import sysconfig
 from pathlib import Path
 
 import pytest
@@ -87,6 +88,58 @@ def _observation(
     )
 
 
+def _patch_observed_chain(
+    monkeypatch: pytest.MonkeyPatch,
+    host: lifecycle.ProcessObservation,
+    *,
+    intermediate: tuple[tuple[str, psh.NativeFileIdentity, int], ...],
+    current_path: str,
+    current_identity: psh.NativeFileIdentity,
+    current_ticks: int = 500,
+) -> tuple[
+    lifecycle.ProcessObservation,
+    tuple[lifecycle.ProcessObservation, ...],
+]:
+    current_pid = os.getpid()
+    observations: dict[int, lifecycle.ProcessObservation] = {}
+    parent_pid = host.pid
+    ordered: list[lifecycle.ProcessObservation] = []
+    for index, (path, identity, ticks) in enumerate(intermediate):
+        pid = 200 + index
+        item = _observation(
+            pid,
+            parent=parent_pid,
+            path=path,
+            ticks=ticks,
+            identity=identity,
+        )
+        observations[pid] = item
+        ordered.append(item)
+        parent_pid = pid
+    current = _observation(
+        current_pid,
+        parent=parent_pid,
+        path=current_path,
+        ticks=current_ticks,
+        identity=current_identity,
+    )
+    observations[current_pid] = current
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_parent_map",
+        lambda: {
+            pid: observation.parent_pid
+            for pid, observation in observations.items()
+        },
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_open_process_observation",
+        lambda pid, parents=None: observations[pid],
+    )
+    return current, tuple(ordered)
+
+
 def test_dotnet_seven_digit_creation_locator_matches_kernel_token() -> None:
     assert lifecycle.start_tokens_match(
         "2026-07-15T13:05:52.062092Z",
@@ -95,27 +148,553 @@ def test_dotnet_seven_digit_creation_locator_matches_kernel_token() -> None:
 
 
 @WINDOWS_ONLY
-def test_validate_ancestry_accepts_direct_and_cmd_hop(
+@pytest.mark.parametrize(
+    ("name", "intermediate_paths"),
+    [
+        ("direct-pwsh", ()),
+        ("cmd-hop", (r"C:\Windows\System32\cmd.exe",)),
+        ("venv-launcher", (r"C:\venv\Scripts\python.exe",)),
+        (
+            "generated-bin-shim",
+            (
+                r"C:\Windows\System32\cmd.exe",
+                r"C:\venv\Scripts\python.exe",
+            ),
+        ),
+        (
+            "wheel-console-script",
+            (
+                r"C:\venv\Scripts\agenttalk.exe",
+                r"C:\venv\Scripts\python.exe",
+            ),
+        ),
+        (
+            "cmd-wheel-console-script",
+            (
+                r"C:\Windows\System32\cmd.exe",
+                r"C:\venv\Scripts\agenttalk.exe",
+                r"C:\venv\Scripts\python.exe",
+            ),
+        ),
+    ],
+)
+def test_validate_ancestry_accepts_identified_generated_launch_classes(
     monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    intermediate_paths: tuple[str, ...],
 ) -> None:
     host = _observation(100, parent=1, path=PWSH, ticks=100)
     current_pid = os.getpid()
-    direct = _observation(current_pid, parent=100, path=r"C:\Python\python.exe", ticks=300)
-    monkeypatch.setattr(lifecycle, "_process_parent_map", lambda: {current_pid: 100})
-    monkeypatch.setattr(lifecycle, "_open_process_observation", lambda pid, parents=None: direct)
-    assert lifecycle._validate_ancestry(host) == (direct,)
-
-    cmd = _observation(200, parent=100, path=r"C:\Windows\System32\cmd.exe", ticks=200)
-    current = _observation(current_pid, parent=200, path=r"C:\Python\python.exe", ticks=300)
+    base_python = r"C:\Python\python.exe"
+    identities = {
+        path: _identity(path, f"{index + 1:02x}")
+        for index, path in enumerate(
+            (
+                r"C:\Windows\System32\cmd.exe",
+                r"C:\venv\Scripts\agenttalk.exe",
+                r"C:\venv\Scripts\python.exe",
+                base_python,
+            )
+        )
+    }
+    observations: dict[int, lifecycle.ProcessObservation] = {}
+    parent_pid = host.pid
+    for index, path in enumerate(intermediate_paths):
+        pid = 200 + index
+        observations[pid] = _observation(
+            pid,
+            parent=parent_pid,
+            path=path,
+            ticks=200 + index,
+            identity=identities[path],
+        )
+        parent_pid = pid
+    current = _observation(
+        current_pid,
+        parent=parent_pid,
+        path=base_python,
+        ticks=300,
+        identity=identities[base_python],
+    )
+    observations[current_pid] = current
+    parent_map = {
+        pid: observation.parent_pid
+        for pid, observation in observations.items()
+    }
+    monkeypatch.setattr(lifecycle, "_process_parent_map", lambda: parent_map)
     monkeypatch.setattr(
-        lifecycle, "_process_parent_map", lambda: {current_pid: 200, 200: 100},
+        lifecycle,
+        "_open_process_observation",
+        lambda pid, parents=None: observations[pid],
+    )
+    uses_venv = r"C:\venv\Scripts\python.exe" in intermediate_paths
+    monkeypatch.setattr(
+        sys,
+        "executable",
+        r"C:\venv\Scripts\python.exe" if uses_venv else base_python,
+    )
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\venv" if uses_venv else r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            (
+                r"C:\venv\Scripts\agenttalk"
+                if r"C:\venv\Scripts\agenttalk.exe" in intermediate_paths
+                else r"C:\venv\Lib\site-packages\agenttalk\__main__.py"
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: (
+            (r"C:\venv\Scripts" if uses_venv else r"C:\Python\Scripts")
+            if name == "scripts"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_system_cmd_path",
+        lambda: r"C:\Windows\System32\cmd.exe",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: identities[str(path)],
+    )
+
+    expected = (current,) + tuple(
+        observations[200 + index]
+        for index in reversed(range(len(intermediate_paths)))
+    )
+    assert lifecycle._validate_ancestry(host) == expected, name
+
+
+@WINDOWS_ONLY
+@pytest.mark.parametrize("with_cmd", [False, True])
+def test_validate_ancestry_accepts_base_install_console_script(
+    monkeypatch: pytest.MonkeyPatch,
+    with_cmd: bool,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    current_pid = os.getpid()
+    cmd_path = r"C:\Windows\System32\cmd.exe"
+    console_path = r"C:\Python\Scripts\agenttalk.exe"
+    base_python = r"C:\Python\python.exe"
+    cmd = _observation(
+        200,
+        parent=host.pid,
+        path=cmd_path,
+        ticks=200,
+        identity=_identity(cmd_path, "0f"),
+    )
+    console = _observation(
+        201,
+        parent=cmd.pid if with_cmd else host.pid,
+        path=console_path,
+        ticks=210,
+        identity=_identity(console_path, "10"),
+    )
+    current = _observation(
+        current_pid,
+        parent=console.pid,
+        path=base_python,
+        ticks=300,
+        identity=_identity(base_python, "11"),
+    )
+    observations = {current_pid: current, console.pid: console}
+    if with_cmd:
+        observations[cmd.pid] = cmd
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_parent_map",
+        lambda: {pid: item.parent_pid for pid, item in observations.items()},
     )
     monkeypatch.setattr(
         lifecycle,
         "_open_process_observation",
-        lambda pid, parents=None: current if pid == current_pid else cmd,
+        lambda pid, parents=None: observations[pid],
     )
-    assert lifecycle._validate_ancestry(host) == (current, cmd)
+    monkeypatch.setattr(sys, "executable", base_python)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "argv", [r"C:\Python\Scripts\agenttalk"])
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: r"C:\Python\Scripts" if name == "scripts" else None,
+    )
+    monkeypatch.setattr(lifecycle, "_system_cmd_path", lambda: cmd_path)
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: (
+            cmd.identity
+            if str(path) == cmd_path
+            else console.identity
+            if str(path) == console_path
+            else current.identity
+        ),
+    )
+
+    expected = (current, console, cmd) if with_cmd else (current, console)
+    assert lifecycle._validate_ancestry(host) == expected
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_venv_launcher_identity_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    launcher_path = r"C:\venv\Scripts\python.exe"
+    base_python = r"C:\Python\python.exe"
+    launcher_identity = _identity(launcher_path, "20")
+    base_identity = _identity(base_python, "21")
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((launcher_path, launcher_identity, 200),),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    monkeypatch.setattr(sys, "executable", launcher_path)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\venv")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: r"C:\venv\Scripts" if name == "scripts" else None,
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: (
+            _identity(launcher_path, "different")
+            if str(path) == launcher_path
+            else base_identity
+        ),
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="virtual-environment Python launcher image identity",
+    ):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_missing_venv_redirector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    launcher_path = r"C:\venv\Scripts\python.exe"
+    base_python = r"C:\Python\python.exe"
+    base_identity = _identity(base_python, "30")
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=(),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    monkeypatch.setattr(sys, "executable", launcher_path)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\venv")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: _identity(str(path), "31"),
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="running Python image identity",
+    ):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_unattributed_console_and_python_launchers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    base_python = r"C:\Python\python.exe"
+    base_identity = _identity(base_python, "32")
+    console_path = r"C:\Python\Scripts\agenttalk.exe"
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((console_path, _identity(console_path, "33"), 200),),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    monkeypatch.setattr(sys, "executable", base_python)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "argv", [r"C:\Tools\not-agenttalk.py"])
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: r"C:\Python\Scripts" if name == "scripts" else None,
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="not the active agenttalk entry point",
+    ):
+        lifecycle._validate_ancestry(host)
+
+    arbitrary_python = r"C:\Tools\python.exe"
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=(
+            (arbitrary_python, _identity(arbitrary_python, "34"), 200),
+        ),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="not the active virtual-environment launcher",
+    ):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_replaced_console_script_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    console_path = r"C:\Python\Scripts\agenttalk.exe"
+    base_python = r"C:\Python\python.exe"
+    console_identity = _identity(console_path, "35")
+    base_identity = _identity(base_python, "36")
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((console_path, console_identity, 200),),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    monkeypatch.setattr(sys, "executable", base_python)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "argv", [r"C:\Python\Scripts\agenttalk"])
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: r"C:\Python\Scripts" if name == "scripts" else None,
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: (
+            _identity(console_path, "replaced")
+            if str(path) == console_path
+            else base_identity
+        ),
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="agenttalk console-script ancestor image identity",
+    ):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+@pytest.mark.parametrize(
+    ("name", "intermediate_paths", "match"),
+    [
+        (
+            "reordered",
+            (
+                r"C:\venv\Scripts\python.exe",
+                r"C:\Windows\System32\cmd.exe",
+            ),
+            "launcher order",
+        ),
+        (
+            "duplicate",
+            (
+                r"C:\Windows\System32\cmd.exe",
+                r"C:\Windows\System32\cmd.exe",
+            ),
+            "launcher order",
+        ),
+        (
+            "over-depth",
+            (
+                r"C:\Windows\System32\cmd.exe",
+                r"C:\venv\Scripts\agenttalk.exe",
+                r"C:\venv\Scripts\python.exe",
+                r"C:\Windows\System32\cmd.exe",
+            ),
+            "too many",
+        ),
+    ],
+)
+def test_validate_ancestry_refuses_unbounded_or_reordered_launchers(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    intermediate_paths: tuple[str, ...],
+    match: str,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    base_python = r"C:\Python\python.exe"
+    identities = {
+        path: _identity(path, f"{index + 40:02x}")
+        for index, path in enumerate(set(intermediate_paths) | {base_python})
+    }
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=tuple(
+            (path, identities[path], 200 + index)
+            for index, path in enumerate(intermediate_paths)
+        ),
+        current_path=base_python,
+        current_identity=identities[base_python],
+    )
+    uses_venv = r"C:\venv\Scripts\python.exe" in intermediate_paths
+    monkeypatch.setattr(
+        sys,
+        "executable",
+        r"C:\venv\Scripts\python.exe" if uses_venv else base_python,
+    )
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\venv" if uses_venv else r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            (
+                r"C:\venv\Scripts\agenttalk"
+                if r"C:\venv\Scripts\agenttalk.exe" in intermediate_paths
+                else r"C:\agenttalk\__main__.py"
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: r"C:\venv\Scripts" if name == "scripts" else None,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_system_cmd_path",
+        lambda: r"C:\Windows\System32\cmd.exe",
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: identities[str(path)],
+    )
+
+    with pytest.raises(lifecycle.SupervisorLifecycleError, match=match):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_copied_cmd_and_start_inversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    copied_cmd = r"C:\Tools\cmd.exe"
+    base_python = r"C:\Python\python.exe"
+    copied_identity = _identity(copied_cmd, "50")
+    base_identity = _identity(base_python, "51")
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((copied_cmd, copied_identity, 90),),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    monkeypatch.setattr(sys, "executable", base_python)
+    monkeypatch.setattr(sys, "_base_executable", base_python)
+    monkeypatch.setattr(sys, "prefix", r"C:\Python")
+    monkeypatch.setattr(sys, "base_prefix", r"C:\Python")
+    monkeypatch.setattr(
+        lifecycle,
+        "_system_cmd_path",
+        lambda: r"C:\Windows\System32\cmd.exe",
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: (
+            _identity(r"C:\Windows\System32\cmd.exe", "52")
+            if str(path) == r"C:\Windows\System32\cmd.exe"
+            else base_identity
+        ),
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="command-interpreter ancestor image identity",
+    ):
+        lifecycle._validate_ancestry(host)
+
+    system_cmd = _identity(r"C:\Windows\System32\cmd.exe", "52")
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((r"C:\Windows\System32\cmd.exe", system_cmd, 90),),
+        current_path=base_python,
+        current_identity=base_identity,
+    )
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="start times are inconsistent",
+    ):
+        lifecycle._validate_ancestry(host)
+
+
+@WINDOWS_ONLY
+def test_validate_ancestry_refuses_launcher_identity_read_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    cmd_path = r"C:\Windows\System32\cmd.exe"
+    base_python = r"C:\Python\python.exe"
+    _patch_observed_chain(
+        monkeypatch,
+        host,
+        intermediate=((cmd_path, _identity(cmd_path, "60"), 200),),
+        current_path=base_python,
+        current_identity=_identity(base_python, "61"),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_system_cmd_path",
+        lambda: cmd_path,
+    )
+    monkeypatch.setattr(
+        psh,
+        "native_file_identity",
+        lambda path: (_ for _ in ()).throw(
+            psh.PowerShellHostError("access denied")
+        ),
+    )
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="cannot identify command-interpreter ancestor",
+    ):
+        lifecycle._validate_ancestry(host)
 
 
 def test_validate_ancestry_refuses_unrelated_manual_claim(
@@ -124,16 +703,23 @@ def test_validate_ancestry_refuses_unrelated_manual_claim(
     host = _observation(100, parent=1, path=PWSH, ticks=100)
     current_pid = os.getpid()
     current = _observation(current_pid, parent=200, path=r"C:\Python\python.exe", ticks=300)
-    unrelated = _observation(200, parent=999, path=r"C:\Tools\runner.exe", ticks=200)
+    unrelated = _observation(
+        200,
+        parent=host.pid,
+        path=r"C:\Tools\runner.exe",
+        ticks=200,
+    )
     monkeypatch.setattr(
-        lifecycle, "_process_parent_map", lambda: {current_pid: 200, 200: 999},
+        lifecycle,
+        "_process_parent_map",
+        lambda: {current_pid: 200, 200: host.pid},
     )
     monkeypatch.setattr(
         lifecycle,
         "_open_process_observation",
         lambda pid, parents=None: current if pid == current_pid else unrelated,
     )
-    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unsupported"):
+    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unidentified"):
         lifecycle._validate_ancestry(host)
 
 
@@ -328,7 +914,7 @@ def test_observer_refuses_unrelated_powershell_pid_without_claiming(
     )
     unrelated = _observation(
         200,
-        parent=999,
+        parent=host.pid,
         path=r"C:\Tools\runner.exe",
         ticks=200,
     )
@@ -340,7 +926,7 @@ def test_observer_refuses_unrelated_powershell_pid_without_claiming(
     monkeypatch.setattr(
         lifecycle,
         "_process_parent_map",
-        lambda: {current_pid: 200, 200: 999},
+        lambda: {current_pid: 200, 200: host.pid},
     )
     monkeypatch.setattr(
         lifecycle,
@@ -354,7 +940,7 @@ def test_observer_refuses_unrelated_powershell_pid_without_claiming(
         ),
     )
 
-    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unsupported"):
+    with pytest.raises(lifecycle.SupervisorLifecycleError, match="unidentified"):
         with lifecycle.checked_powershell_supervisor_observer(
             store,
             pid=host.pid,
@@ -362,6 +948,59 @@ def test_observer_refuses_unrelated_powershell_pid_without_claiming(
             validate_artifacts=lambda: None,
         ):
             pytest.fail("unrelated caller reached the observation write")
+    assert not store.supervisor_instance_path().exists()
+
+
+def test_observer_refuses_exited_identified_launcher_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    selected = _selected(store)
+    host = _observation(100, parent=1, path=PWSH, ticks=100)
+    launcher = _observation(
+        200,
+        parent=host.pid,
+        path=r"C:\venv\Scripts\python.exe",
+        ticks=200,
+    )
+    current = _observation(
+        os.getpid(),
+        parent=launcher.pid,
+        path=r"C:\Python\python.exe",
+        ticks=300,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_read_valid_selection_locked",
+        lambda store: selected,
+    )
+    monkeypatch.setattr(lifecycle, "_open_process_observation", lambda pid: host)
+    monkeypatch.setattr(
+        lifecycle,
+        "_validate_ancestry",
+        lambda observed: (current, launcher),
+    )
+
+    def require_active(observed: lifecycle.ProcessObservation) -> None:
+        if observed is launcher:
+            raise lifecycle.SupervisorLifecycleError(
+                "process 200 exited during validation"
+            )
+
+    monkeypatch.setattr(lifecycle, "_require_process_active", require_active)
+
+    with pytest.raises(
+        lifecycle.SupervisorLifecycleError,
+        match="exited during validation",
+    ):
+        with lifecycle.checked_powershell_supervisor_observer(
+            store,
+            pid=host.pid,
+            pid_start=host.creation_token,
+            validate_artifacts=lambda: None,
+        ):
+            pytest.fail("an exited launcher reached the observation write")
     assert not store.supervisor_instance_path().exists()
 
 


### PR DESCRIPTION
Supersedes PR #97. Rebased onto master `a51639d` and remediates the two NEW-ON-HEAD connector P2s that PR #97 carried at 15/15 green — both confirmed against the code by `codex-agenttalk-developer-3`, neither catchable by the prior matrix.

## The two defects

**1. Startup claim race** (`supervisor.py`). The CLI precheck was unlocked and the lifecycle/config-locked claim never re-read `supervisor.kill`. If the switch appeared inside the precheck-to-claim window, the claim succeeded and the process **kept executor authority** instead of publishing the startup observation and exiting 3 for Scheduled Task retry — defeating the entire purpose of #114. The claim now fails closed on a final in-lock read immediately before marker creation.

**2. Corrupt-epoch crash** (`supervisor_runtime.py`). `float(10**400)` escaped as `OverflowError` rather than `SupervisorRuntimeObservationError`, so `agenttalk status` / `status --json` **crashed** while reading evidence that should have been treated as invalid. JSON integer-conversion limits and excessive nesting could escape the same way. Numeric conversion and strict JSON reading now translate those to the domain error, preserving warning-only operator surfaces.

## Direction controls — the tests fail on the unfixed code

The four affected source/test files were **byte-identical** between `279bc72` and the rebased pre-fix commit `fdd30f3`. Before the production changes, both new controls failed:

- claim test: `DID NOT RAISE`
- status: crashed with a bare `OverflowError`

The claim control creates the switch from `validate_artifacts`, i.e. inside the reported window, and asserts no marker is written.

## Why prior green CI missed both

It ran these test files, but had **no injected claim-window interleaving** and **no oversized/deep corrupt-evidence input**. The new controls make the ordinary matrix capable of catching both classes.

## Preserved work

`git range-diff` confirms the original #114 ancestry commit is equivalent through the rebase (`fc8e681 ≡ fdd30f3`).

## Local evidence (targeted, per the standing rule)

- `tests/test_supervisor_lifecycle.py tests/test_supervisor.py`: 420 passed, 2 skipped
- Ruff on all four changed files: passed
- `git diff --check`: passed
- Full gate/suite/wheel/security: **intentionally not run** — authoritative CI is the gate

v0.80.0 item; unblocks #115, which is mechanically stacked on this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
