### PR TITLE
fix(#150): a confirmed-absent wrapper must be launchable under a sticky invalid owned-process-tree

### DIFF
--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -4754,6 +4754,18 @@ def _attribution(
             continue
         row = idx.get(entry["pid"])
         if isinstance(row, dict) and _start_of(row) == entry["start"]:
+            # Deliberately UNCHANGED (see
+            # test_process_ownership_provenanced_prior_exact_fields_
+            # request_and_ttl): a validly-matching prior is not itself
+            # ambiguous, so its own last_fresh_attribution_epoch is left
+            # to age normally toward _PROVENANCE_TTL_SECONDS - the TTL
+            # bounds how long an identity may be passively carried forward
+            # without a fresh, independently-earned re-derivation, and an
+            # unambiguous match is exactly the case that DOES have another
+            # path to re-earn one (own_wrapper/own_wait/live_chain_
+            # descendant/legacy_rederived). Round 13 only touches the
+            # EXCLUDED branch below, where no such alternative path exists
+            # while the ambiguity persists - see that branch's own comment.
             managed_by_pid[entry["pid"]] = entry
         elif entry["pid"] in excluded_pids:
             # Task #150 round 8 connector finding: idx.get(pid) is None
@@ -4762,9 +4774,33 @@ def _attribution(
             # managed_by_pid here is what actually persists the loss: the
             # NEXT poll's valid_priors would no longer carry this
             # identity at all, even once the ambiguity clears. Keep it
-            # unchanged as ambiguous HOLD evidence rather than silently
-            # forgetting a still-tracked descendant.
-            managed_by_pid[entry["pid"]] = entry
+            # as ambiguous HOLD evidence rather than silently forgetting a
+            # still-tracked descendant.
+            #
+            # Task #150 round 13 connector finding: keeping the entry
+            # UNCHANGED left its own last_fresh_attribution_epoch frozen at
+            # whenever it was last unambiguous - _prior_valid's TTL check
+            # then expires it after _PROVENANCE_TTL_SECONDS of continuous
+            # ambiguity, even though the pid is present in conflicting rows
+            # on EVERY one of those polls. Unlike the matching branch
+            # above, an excluded identity has NO alternative path to earn
+            # a fresh stamp while the ambiguity persists - own_wrapper/
+            # own_wait/live_chain_descendant/legacy_rederived all require
+            # a real idx row, which this pid does not have by construction.
+            # A TTL is the right instrument for evidence nobody has
+            # rechecked; it is the wrong instrument for an identity
+            # rechecked every poll that just cannot be disambiguated - a
+            # live observation of an unresolved condition, not aging
+            # evidence. Expiring it converts "we still cannot tell" into
+            # "there was never anything here", dropping the seed the very
+            # UNACCOUNTED_LIVE_DESCENDANT HOLD depends on to discover its
+            # own child. Refresh the epoch on every poll the ambiguity is
+            # still directly observed, so the entry cannot lapse while the
+            # condition producing it is still present.
+            managed_by_pid[entry["pid"]] = {
+                **entry,
+                "last_fresh_attribution_epoch": now_epoch,
+            }
 
     for legacy in legacy_priors:
         pid = legacy.get("pid")

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2073,6 +2073,36 @@ def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
     return idx
 
 
+def _snap_all_edges(snapshot: list[dict] | None) -> dict[int, list[int]]:
+    """Permissive parent -> children edges, straight from every row's own
+    pid/parent_pid - including a pid _snap_index excluded for identity
+    ambiguity (a duplicate or malformed row).
+
+    Task #150 round 4 connector finding 1: _snap_index's exclusion popped
+    the excluded pid's row out of idx BEFORE _children_map(idx) was built,
+    which destroyed the only edge connecting it to its own parent - so
+    neither the main walk nor the discovery-closure invariant could ever
+    reach it, or reach anything further below it, to reject it. A
+    candidate the walk cannot trust to ADMIT is still a candidate it must
+    ACCOUNT for. This map is never used for admission or identity lookups
+    (idx/_children_map(idx) still own that, unchanged) - only to seed what
+    the discovery-closure invariant reconciles against, where routing
+    through an untrusted edge is exactly the point.
+    """
+    kids: dict[int, list[int]] = {}
+    for row in snapshot or []:
+        if not isinstance(row, dict):
+            continue
+        pid = row.get("pid")
+        parent_pid = row.get("parent_pid")
+        if not isinstance(pid, int) or isinstance(pid, bool):
+            continue
+        if not isinstance(parent_pid, int) or isinstance(parent_pid, bool):
+            continue
+        kids.setdefault(parent_pid, []).append(pid)
+    return kids
+
+
 def _snapshot_pid_integrity_error(snapshot: list[dict]) -> str | None:
     """Validate the PID/parent graph before any last-row-wins indexing.
 
@@ -3097,6 +3127,11 @@ def _owned_process_tree(
     add_node(wrapper_row, role="wrapper", depth=0, live=True)
     wrapper_pid = wrapper_row.get("pid")
     recycled_parent_pids: set[int] = set()
+    # Task #150 round 4 connector finding 2: the replacement's own row, kept
+    # alongside the pid, so the discovery-closure invariant can draw the
+    # same old-side/new-side line evaluate_launch_barrier already draws
+    # instead of excluding every child of a recycled root.
+    recycled_parent_rows: dict[int, dict] = {}
 
     # Rehydrate exact live identities from the previous complete tree. A live
     # descendant whose intermediate parent exited remains owned only because
@@ -3128,6 +3163,7 @@ def _owned_process_tree(
                     and _has_exact_start_identity(row)
                 ):
                     recycled_parent_pids.add(entry["pid"])
+                    recycled_parent_rows[entry["pid"]] = row
                     continue
                 if not isinstance(row, dict) or not _start_tokens_match(
                     _start_of(row),
@@ -3195,6 +3231,8 @@ def _owned_process_tree(
         )
         if current_launcher_identity == "different":
             recycled_parent_pids.add(launcher_pid)
+            if isinstance(current_launcher, dict):
+                recycled_parent_rows[launcher_pid] = current_launcher
         launcher_live = bool(
             isinstance(current_launcher, dict)
             and current_launcher.get("parent_pid") == wrapper_pid
@@ -3366,11 +3404,11 @@ def _owned_process_tree(
     # simply exited) of a known root - the wrapper, the declared launcher,
     # the discovered brain, and every PRIOR entry, whether or not
     # prior_authority ended up trusted - reachable via the CURRENT
-    # snapshot's raw parent-child edges, regardless of whether admission
-    # logic actually walked into it. children.get(pid, ...) still returns a
-    # live child whose OWN row names pid as parent even when pid itself is
-    # absent or was never visited, so an orphaned intermediate's live child
-    # - or a rejected launcher's live child - is still IN this closure. Any
+    # snapshot's raw parent-child edges (discovery_edges below), regardless
+    # of whether admission logic actually walked into it. A live child whose
+    # OWN row names pid as parent is found even when pid itself is absent
+    # or was never visited, so an orphaned intermediate's live child - or a
+    # rejected launcher's live child - is still IN this closure. Any
     # such descendant that never made it into "owned" is unaccounted -
     # either a case already flagged above (harmless double count;
     # rejected_count is a gate, not an exact tally) or exactly the silent-
@@ -3389,28 +3427,57 @@ def _owned_process_tree(
         _prior_pid = _prior_entry.get("pid") if isinstance(_prior_entry, dict) else None
         if isinstance(_prior_pid, int) and not isinstance(_prior_pid, bool):
             discovery_roots.add(_prior_pid)
-    # A root already PROVEN to be a different, recycled process (exact
-    # identity mismatch, not merely absent) is not a candidate this agent
-    # has any claim to - its current children are a REPLACEMENT process's
-    # own descendants, not ours, and the existing recycled_parent_pids
-    # check a few lines above already treats them as foreign on purpose
-    # (test: test_owned_process_tree_recycled_launcher_ignores_foreign_
-    # children / ..._recycled_virtual_parent_ignores_replacement_child).
-    # Expanding into a recycled root's children here would flag someone
-    # else's process tree as our own unaccounted loss.
+    # Task #150 round 4 connector finding 1: children.get(...) above is
+    # _children_map(idx) - built from the DEDUPED idx, so a pid _snap_index
+    # excluded for identity ambiguity (a duplicate or malformed row) has no
+    # row left in idx to contribute its own edge to that map. Its parent
+    # never learns it exists, and neither does anything below it - the
+    # exact silent loss this invariant exists to close, just moved one
+    # level earlier than round 3 checked. discovery_edges is built straight
+    # from the raw snapshot instead, so an excluded pid's edge to its OWN
+    # parent survives for discovery/rejection purposes (never for
+    # admission - idx/children, used everywhere above this block, are
+    # unchanged and still the strict, trusted source).
+    discovery_edges = _snap_all_edges(snapshot)
+    # Task #150 round 4 connector finding 2 (round 3's own exclusion was too
+    # blanket): a root already PROVEN to be a different, recycled process
+    # does not make EVERY current child foreign - evaluate_launch_barrier
+    # already draws the old-side/new-side line for exactly this situation
+    # (a child whose exact start strictly predates the replacement belongs
+    # to the process this agent actually owned; only a child at or after
+    # the replacement's own exact start belongs to the replacement).
+    # Missing/incomparable exact evidence stays conservative - treated as
+    # ours - matching the barrier's own default. Applying that same test
+    # here, rather than excluding wholesale, is what the two tests that
+    # forced the round-3 exclusion actually needed: they construct a
+    # replacement whose OWN current children postdate it, which this still
+    # excludes correctly.
     discovered_descendants: set[int] = set()
-    frontier = [
-        pid
-        for root in discovery_roots
-        if root not in recycled_parent_pids
-        for pid in children.get(root, [])
-    ]
+    frontier: list[int] = []
+    for root in discovery_roots:
+        if root not in recycled_parent_pids:
+            frontier.extend(discovery_edges.get(root, []))
+            continue
+        replacement_key = _exact_start_order_key(recycled_parent_rows.get(root))
+        for pid in discovery_edges.get(root, []):
+            child_key = _exact_start_order_key(idx.get(pid))
+            if (
+                replacement_key is not None
+                and child_key is not None
+                and child_key[0] == replacement_key[0]
+                and child_key[1] >= replacement_key[1]
+            ):
+                # At or after the replacement's own exact start: the
+                # replacement's own descendant, not a candidate we ever
+                # owned.
+                continue
+            frontier.append(pid)
     while frontier:
         candidate_pid = frontier.pop()
         if candidate_pid in discovered_descendants:
             continue
         discovered_descendants.add(candidate_pid)
-        frontier.extend(children.get(candidate_pid, []))
+        frontier.extend(discovery_edges.get(candidate_pid, []))
     for _ in sorted(discovered_descendants - set(owned)):
         mark_rejected("unaccounted_discovery")
 
@@ -11400,6 +11467,14 @@ $pollNum = 0
             $p.barrier_state.owned_process_tree.truncated = $false
             $p.barrier_state.owned_process_tree.omitted_count = 0
             $p.barrier_state.owned_process_tree.observed_count = [int]$p.barrier_state.owned_process_tree.recorded_count
+            # Task #150 round 4 connector finding 3: this barrier observed
+            # survivors by its OWN accounting, not the Python walk's - it
+            # must not leave a stale rejected_count (0, from whenever this
+            # tree was last complete) presenting as "the walk found nothing
+            # unaccounted". Removing the property entirely reads as unknown
+            # downstream, never zero - the same shape the v2-migration fix
+            # already relies on for a field a record simply never had.
+            $p.barrier_state.owned_process_tree.PSObject.Properties.Remove('rejected_count')
           }
           if ($p.barrier_state) { Set-AgentState $state $name $p.barrier_state } else { Set-AgentState $state $name $p.next_state }
           if (-not (Save-StateForPoll $state)) {
@@ -11616,6 +11691,10 @@ $pollNum = 0
             $p.next_entry.owned_process_tree.truncated = $false
             $p.next_entry.owned_process_tree.omitted_count = 0
             $p.next_entry.owned_process_tree.observed_count = [int]$p.next_entry.owned_process_tree.recorded_count
+            # Task #150 round 4 connector finding 3: see the matching
+            # comment on the relaunch/stuck_recover barrier above - same
+            # second-producer shape, same fix.
+            $p.next_entry.owned_process_tree.PSObject.Properties.Remove('rejected_count')
           }
           $p.next_entry | Add-Member -NotePropertyName process_tree_hold_reason `
             -NotePropertyValue ("process_tree_invalid_post_kill_{0}" -f $why) -Force

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2131,6 +2131,27 @@ def _snap_all_edges(snapshot: list[dict] | None) -> dict[int, list[int]]:
     the discovery-closure invariant reconciles against, where routing
     through an untrusted edge is exactly the point.
     """
+    # Task #150 round 9 connector finding (documented residual, not fixed):
+    # a row whose own PID field is malformed - as opposed to round 5's
+    # malformed PARENT_PID - contributes no edge either direction, since
+    # there is no valid pid to key it by. For a row bearing a PRIOR-ENTRY
+    # pid this is already safe: the trusted-rehydration block above never
+    # looks at this row at all - it reconstructs the intermediate's
+    # identity straight from the prior record's own start/filetime and
+    # re-verifies any live child against that same prior chain, bypassing
+    # the malformed current row entirely (confirmed by direct execution,
+    # not merely reasoned). For a row that has NEVER been a prior entry -
+    # no independently-trusted pid to reconcile it against - there is no
+    # snapshot-only signal distinguishing "this malformed-pid row is a
+    # lost candidate of ours" from "this malformed-pid row belongs to an
+    # unrelated process elsewhere on the host": every other fix in this
+    # family works by looking a row up BY its own intact pid field
+    # (idx.get(known_pid)), and that is exactly the field missing here.
+    # Treating every malformed-pid row as ours would revive the exact
+    # host-wide-poisoning failure mode round 5 already ruled out for the
+    # analogous malformed-parent_pid case. Genuinely unbounded for a
+    # first-time-seen intermediate; accepted as a residual rather than
+    # patched speculatively.
     kids: dict[int, list[int]] = {}
     for row in snapshot or []:
         if not isinstance(row, dict):
@@ -3104,9 +3125,29 @@ def _owned_process_tree(
     # exactly what makes the "invalid but re-derivable" case in
     # _unverified_owned_process_tree safe.
     rejected_count = 0
+    # Task #150 round 9 connector finding: rejected_count's own "harmless
+    # double count, this is a gate not a tally" justification (round 3)
+    # stopped being true the moment round 3 (and round 5) added an
+    # operator-facing message that reports the number - a value's
+    # tolerance for imprecision is a property of its CONSUMERS, not of
+    # the value, and a new, more precise consumer retroactively
+    # invalidates an old "close enough" judgement. A live child behind an
+    # unproven virtual-parent bridge (or any other candidate rejected
+    # once during the main walk) is also absent from `owned`, so the
+    # discovery-closure loop below finds it AGAIN and would double-count
+    # it. Dedupe by pid wherever a call site has one: the same candidate
+    # is only ever one exclusion, however many different checks noticed
+    # it. Calls with no single identifiable candidate (a whole-snapshot
+    # fact, or the mandatory-closure size cap) pass no pid and are never
+    # deduped against each other.
+    rejected_pids: set[int] = set()
 
-    def mark_rejected(reason: str) -> None:
+    def mark_rejected(reason: str, pid: int | None = None) -> None:
         nonlocal invalid_reason, rejected_count
+        if isinstance(pid, int) and not isinstance(pid, bool):
+            if pid in rejected_pids:
+                return
+            rejected_pids.add(pid)
         rejected_count += 1
         invalid_reason = invalid_reason or reason
 
@@ -3136,7 +3177,10 @@ def _owned_process_tree(
             or not start
             or start_key is None
         ):
-            mark_rejected("invalid_process_row")
+            mark_rejected(
+                "invalid_process_row",
+                pid if isinstance(pid, int) and not isinstance(pid, bool) else None,
+            )
             return False
         if not _has_exact_start_identity(row):
             # Windows' CIM timestamp is rounded. It can identify graph edges,
@@ -3156,7 +3200,7 @@ def _owned_process_tree(
             # both sides agree: an entry this imprecise never contributes to
             # a rejected_count of 0, so it can never reach a status the
             # validator would then refuse.
-            mark_rejected("exact_start_filetime_unavailable")
+            mark_rejected("exact_start_filetime_unavailable", pid)
         existing = owned.get(pid)
         if existing is not None:
             if (
@@ -3164,7 +3208,7 @@ def _owned_process_tree(
                 or _filetime_of(existing["row"]) != start_filetime
                 or existing["row"].get("parent_pid") != parent_pid
             ):
-                mark_rejected("pid_identity_collision")
+                mark_rejected("pid_identity_collision", pid)
                 return False
             existing["depth"] = min(int(existing["depth"]), depth)
             if role_rank[role] > role_rank[existing["role"]]:
@@ -3196,14 +3240,20 @@ def _owned_process_tree(
     # already earned. Missing ancestors are retained as non-killable bridges.
     if prior_authority is not None and prior_entries:
         prior_root = prior_entries[0]
+        prior_root_pid = prior_root.get("pid")
         if (
-            prior_root.get("pid") != wrapper_pid
+            prior_root_pid != wrapper_pid
             or not _start_tokens_match(
                 prior_root.get("start"),
                 _start_of(wrapper_row),
             )
         ):
-            mark_rejected("prior_wrapper_mismatch")
+            mark_rejected(
+                "prior_wrapper_mismatch",
+                prior_root_pid
+                if isinstance(prior_root_pid, int) and not isinstance(prior_root_pid, bool)
+                else None,
+            )
             prior_authority = None
         else:
             live_prior: set[int] = set()
@@ -3228,13 +3278,13 @@ def _owned_process_tree(
                 ):
                     continue
                 if row.get("parent_pid") != entry["parent_pid"]:
-                    mark_rejected("prior_parent_drift")
+                    mark_rejected("prior_parent_drift", entry["pid"])
                     continue
                 if not _filetime_identity_matches(
                     row,
                     entry.get("start_filetime"),
                 ):
-                    mark_rejected("prior_filetime_drift")
+                    mark_rejected("prior_filetime_drift", entry["pid"])
                     continue
                 live_prior.add(entry["pid"])
             needed = set(live_prior)
@@ -3320,7 +3370,7 @@ def _owned_process_tree(
                 )
                 and current_launcher.get("parent_pid") != wrapper_pid
             ):
-                mark_rejected("launcher_parent_mismatch")
+                mark_rejected("launcher_parent_mismatch", launcher_pid)
             launcher_row = {
                 "pid": launcher_pid,
                 "parent_pid": wrapper_pid,
@@ -3343,13 +3393,13 @@ def _owned_process_tree(
                     # authority.
                     launcher_row = None
                 elif current_launcher is not None:
-                    mark_rejected("exact_start_filetime_unavailable")
+                    mark_rejected("exact_start_filetime_unavailable", launcher_pid)
                     launcher_row = None
                 elif children.get(launcher_pid):
                     # Windows retains PPID edges after a parent exits. Without
                     # an exact lifetime/prior certificate those children are
                     # ambiguous.
-                    mark_rejected("unproven_virtual_parent_descendant")
+                    mark_rejected("unproven_virtual_parent_descendant", launcher_pid)
                     launcher_row = None
                 else:
                     # A childless, absent launcher cannot be killed and its
@@ -3357,11 +3407,11 @@ def _owned_process_tree(
                     # ownership authority.
                     launcher_row = None
         if launcher_pid == wrapper_pid:
-            mark_rejected("launcher_equals_wrapper")
+            mark_rejected("launcher_equals_wrapper", launcher_pid)
         elif launcher_row is not None:
             edge_reason = _strict_owned_child_edge(wrapper_row, launcher_row)
             if edge_reason is not None:
-                mark_rejected(edge_reason)
+                mark_rejected(edge_reason, launcher_pid)
             add_node(
                 launcher_row,
                 role="cli_launcher",
@@ -3380,7 +3430,7 @@ def _owned_process_tree(
         for child_pid in sorted(children.get(parent_pid, [])):
             child = idx.get(child_pid)
             if not isinstance(child, dict):
-                mark_rejected("missing_child_row")
+                mark_rejected("missing_child_row", child_pid)
                 continue
             if not parent["live"]:
                 prior_parent = prior_by_pid.get(parent_pid)
@@ -3423,11 +3473,11 @@ def _owned_process_tree(
                     # or by the exited launcher's exact lifetime bounds.
                     continue
                 if not certified_launcher_child and not prior_owned_child:
-                    mark_rejected("unproven_virtual_parent_descendant")
+                    mark_rejected("unproven_virtual_parent_descendant", child_pid)
                     continue
             edge_reason = _strict_owned_child_edge(parent_row, child)
             if edge_reason is not None:
-                mark_rejected(edge_reason)
+                mark_rejected(edge_reason, child_pid)
                 continue
             role = (
                 "cli_brain"
@@ -3446,7 +3496,10 @@ def _owned_process_tree(
     if isinstance(brain_row, dict):
         brain_pid = brain_row.get("pid")
         if brain_pid not in owned:
-            mark_rejected("brain_outside_owned_tree")
+            mark_rejected(
+                "brain_outside_owned_tree",
+                brain_pid if isinstance(brain_pid, int) and not isinstance(brain_pid, bool) else None,
+            )
         elif owned[brain_pid]["role"] == "tool_descendant":
             owned[brain_pid]["role"] = "cli_brain"
 
@@ -3467,10 +3520,15 @@ def _owned_process_tree(
     # or was never visited, so an orphaned intermediate's live child - or a
     # rejected launcher's live child - is still IN this closure. Any
     # such descendant that never made it into "owned" is unaccounted -
-    # either a case already flagged above (harmless double count;
-    # rejected_count is a gate, not an exact tally) or exactly the silent-
-    # loss class hand enumeration cannot bound. Either way it becomes a
-    # rejection here, mechanically, rather than by finding a fourth site.
+    # either a case already flagged above by pid (mark_rejected's own
+    # dedup means re-flagging the same pid here is a no-op, not a double
+    # count - round 9 connector finding retracted round 3's "harmless,
+    # rejected_count is a gate not a tally" call: that was true before
+    # round 3 itself added an operator-facing message reporting the
+    # number, and stopped being true the moment it did) or exactly the
+    # silent-loss class hand enumeration cannot bound. Either way it
+    # becomes a rejection here, mechanically, rather than by finding a
+    # fourth site.
     discovery_roots: set[int] = set()
     if isinstance(wrapper_pid, int) and not isinstance(wrapper_pid, bool):
         discovery_roots.add(wrapper_pid)
@@ -3495,8 +3553,9 @@ def _owned_process_tree(
     # a since-corrupted intermediate the prior once recorded would
     # otherwise sit at rejected_count 0 forever. This check is independent
     # of that trust gate on purpose - it does NOT retire the rehydration
-    # block's own check (a double-count there is harmless; rejected_count
-    # is a gate, not an exact tally).
+    # block's own check. Both pass the same entry pid to mark_rejected, so
+    # a poll where BOTH fire for the same identity is deduped by pid
+    # rather than double-counted (round 9 connector finding).
     for _prior_entry in prior_entries:
         _prior_pid = _prior_entry.get("pid") if isinstance(_prior_entry, dict) else None
         if not isinstance(_prior_pid, int) or isinstance(_prior_pid, bool):
@@ -3515,11 +3574,11 @@ def _owned_process_tree(
             # examines a pid that isn't already a recorded identity of
             # ours.
             if _prior_pid in excluded_pids:
-                mark_rejected("prior_entry_row_unindexable")
+                mark_rejected("prior_entry_row_unindexable", _prior_pid)
             continue
         _prior_parent_pid = _prior_row.get("parent_pid")
         if not isinstance(_prior_parent_pid, int) or isinstance(_prior_parent_pid, bool):
-            mark_rejected("prior_entry_parent_pid_malformed")
+            mark_rejected("prior_entry_parent_pid_malformed", _prior_pid)
     # Task #150 round 4 connector finding 1: children.get(...) above is
     # _children_map(idx) - built from the DEDUPED idx, so a pid _snap_index
     # excluded for identity ambiguity (a duplicate or malformed row) has no
@@ -3571,8 +3630,8 @@ def _owned_process_tree(
             continue
         discovered_descendants.add(candidate_pid)
         frontier.extend(discovery_edges.get(candidate_pid, []))
-    for _ in sorted(discovered_descendants - set(owned)):
-        mark_rejected("unaccounted_discovery")
+    for _unaccounted_pid in sorted(discovered_descendants - set(owned)):
+        mark_rejected("unaccounted_discovery", _unaccounted_pid)
 
     observed_count = len(owned)
     mandatory: set[int] = set()
@@ -7003,9 +7062,30 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         # all. The flag's own text only mentions omitted identities; a
         # nonzero rejected_count needs the same warning stated explicitly,
         # not folded silently into "every process this record could name".
+        # Round 9 (connector finding, the third instance of the same wrong
+        # direction): the first two rounds each closed the ONE precondition
+        # that had actually bitten - an entryless placeholder's missing
+        # nonce (round 2), a rejected candidate the command's identity list
+        # can't see (round 3) - by patching that specific case, which is
+        # why there was a third: a configured-agent reset ALSO requires
+        # (cli.py, --reset-process-tree-ownership) the CURRENT wrapper
+        # runtime record to read STATUS_VALID, entirely independent of the
+        # tree's own entries/rejected_count. A tree can hold non-empty
+        # entries while the runtime record is exactly what made it invalid
+        # in the first place (process_tree_invalid_runtime_absent/invalid/
+        # record_missing/record_invalid) - the remedy named the command for
+        # precisely that case. One predicate now gates naming the command
+        # at all: this poll's own liveness read of the SAME runtime record
+        # the command re-reads at reset time. It can still go stale between
+        # this poll and when the operator acts - unavoidable from where the
+        # message is produced - but it is never wrong about what THIS poll
+        # already knows, which is what "must never guess" means here.
+        runtime_currently_valid = (
+            liveness.get("runtime_status") == runtime_obs.STATUS_VALID
+        )
         has_entries = bool(owned_tree.get("entries"))
         rejected_count = owned_tree.get("rejected_count")
-        if has_entries:
+        if has_entries and runtime_currently_valid:
             # Round 4 (connector finding 2, the same wrong direction a third
             # time): a legacy v2 record predates rejected_count entirely -
             # missing, not zero, is what keeps it out of absence-promotion
@@ -7044,6 +7124,18 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
                 "required --acknowledge-* flags); do NOT kill the wrapper "
                 "expecting an automatic relaunch - that is only safe once "
                 "this record already reflects the wrapper as absent"
+            )
+        elif has_entries:
+            remedy = (
+                "recovery: this record has named identities, but the "
+                "current wrapper runtime record is not valid "
+                f"({liveness.get('runtime_status')}) and --reset-process-"
+                "tree-ownership requires exactly that record to read valid "
+                "before it will act - it will refuse; this needs operator "
+                "investigation of "
+                f"{owned_tree.get('reason_code')} (a valid runtime record "
+                "recovering on its own is what would let a scripted reset "
+                "apply here, not a --acknowledge-* flag)"
             )
         else:
             remedy = (

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2746,14 +2746,37 @@ def _unverified_owned_process_tree(
 ) -> dict | None:
     """Fail closed when current proof cannot safely reuse a prior tree.
 
-    A complete prior remains the durable absence certificate when a current
-    snapshot proves every recorded pid/start identity absent. Any prior identity
-    still present, or an unavailable snapshot, converts it to sticky invalid
-    HOLD evidence. Existing truncated/invalid records are already sticky.
+    A complete or absent prior remains the durable absence certificate when a
+    current snapshot proves every recorded pid/start identity absent or
+    replaced. Task #150 connector finding: an INVALID prior is not
+    categorically excluded from that same re-derivation - only when its own
+    entries are a COMPLETE description of what was found (omitted_count == 0,
+    at least one entry recorded). Whatever made the tree invalid in the first
+    place (in the production incident, a single UNRELATED row elsewhere in
+    that poll's whole-host snapshot failing _snapshot_pid_integrity_error, not
+    anything about this agent's own identities) says nothing about whether
+    those SPECIFIC recorded identities are still alive - the same evidentiary
+    bar the complete/absent case already trusts. A TRUNCATED prior's entries
+    are incomplete by definition (omitted_count > 0) and never qualifies:
+    proving the recorded subset gone says nothing about whatever the size cap
+    dropped. A prior with no entries at all (schema-drift/generation-adoption
+    placeholders built by _invalid_owned_process_tree_record, never a real
+    tree walk) has nothing to disprove against and never qualifies either.
+    Any prior identity still present, or an unavailable/poisoned CURRENT
+    snapshot, remains sticky HOLD evidence exactly as before.
     """
     if prior is None:
         return None
-    if prior.get("status") not in {"complete", "absent"}:
+    entries = prior.get("entries")
+    entries_are_complete = (
+        isinstance(entries, list)
+        and bool(entries)
+        and prior.get("omitted_count") == 0
+    )
+    eligible_for_rederivation = prior.get("status") in {"complete", "absent"} or (
+        prior.get("status") == "invalid" and entries_are_complete
+    )
+    if not eligible_for_rederivation:
         held = copy.deepcopy(prior)
         if (
             held.get("status") == "invalid"
@@ -2776,10 +2799,12 @@ def _unverified_owned_process_tree(
                 expected_start=entry.get("start"),
                 expected_filetime=entry.get("start_filetime"),
             )
-            for entry in prior.get("entries", [])
+            for entry in entries or []
             if isinstance(entry, dict)
         ]
-        if all(state in {"absent", "different"} for state in identity_states):
+        if identity_states and all(
+            state in {"absent", "different"} for state in identity_states
+        ):
             absent = copy.deepcopy(prior)
             absent["status"] = "absent"
             absent["reason_code"] = "process_tree_absent"
@@ -2865,10 +2890,21 @@ def _owned_process_tree(
     # pid -> {row, role, depth, live}; exited, previously earned identities may
     # remain as virtual ancestry bridges, but are never emitted as kill targets.
     owned: dict[int, dict] = {}
+    # Task #150 connector finding: a WHOLE-SNAPSHOT integrity failure (one
+    # unrelated row anywhere on the host - a system process CIM could not
+    # resolve a parent for, say - fails _snapshot_pid_integrity_error for
+    # EVERY agent polled this cycle) and a per-row admission failure inside
+    # add_node's own check below used to both surface as the exact same
+    # "process_tree_invalid_invalid_process_row" text, even though one is
+    # "something elsewhere on this host is malformed" and the other is
+    # "one of THIS agent's own tracked rows is malformed" - different
+    # operator situations with different remedies. The "snapshot_" prefix
+    # matches _unverified_owned_process_tree's own existing convention for
+    # the identical distinction, so this is a naming fix, not a new one.
     invalid_reason = (
         "prior_record_invalid"
         if prior_record_invalid
-        else snapshot_error
+        else (f"snapshot_{snapshot_error}" if snapshot_error is not None else None)
     )
     role_rank = {
         "tool_descendant": 0,
@@ -6488,20 +6524,35 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         notify = now_epoch - last_warn >= suspect_interval
         if notify:
             nxt["last_warn_epoch"] = now_epoch
+        # Task #150: name the remedy. A held state that does not tell the
+        # operator how to leave it is a defect on its own - especially since
+        # the obvious guess (kill the wrapper, expecting the supervisor to
+        # see it absent and relaunch) makes this WORSE, not better: a
+        # wrapper this is still holding for is exempt from this HOLD the
+        # moment it is independently confirmed absent (see
+        # _unverified_owned_process_tree); a wrapper that is still present,
+        # or whose absence this record cannot yet prove on its own, needs
+        # the attended reset named below.
+        remedy = (
+            "recovery: if every process this record names is confirmed gone, "
+            "run `agenttalk supervise --reset-process-tree-ownership` (see "
+            "--help for the required --acknowledge-* flags); do NOT kill the "
+            "wrapper expecting an automatic relaunch - that is only safe once "
+            "this record already reflects the wrapper as absent"
+        )
         if tree_status == "truncated":
             tree_state = "PROCESS_TREE_TRUNCATED"
             tree_reason = (
                 f"owned process tree observed {observed} identities over cap "
                 f"{limit}; HOLDING automatic teardown because a partial kill "
-                "could strand descendants; operator attention required"
+                f"could strand descendants; {remedy}"
             )
         else:
             tree_state = "PROCESS_TREE_INVALID"
             tree_reason = (
                 "owned process tree failed strict parent/start validation "
                 f"({owned_tree.get('reason_code')}); HOLDING automatic teardown "
-                "because a partial kill could strand descendants; operator "
-                "attention required"
+                f"because a partial kill could strand descendants; {remedy}"
             )
         return _result(
             WARN_ONLY,

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -4522,7 +4522,6 @@ def _attribution(
     targets_by_pid: dict[int, dict] = {}
     seed_pids: set[int] = set()
     seed_launcher_sources: dict[int, dict] = {}
-    seed_synthetic_rows: dict[int, dict] = {}
     unaccounted_excluded_children: set[int] = set()
     launcher_pid = st.get("launcher_pid")
     launcher_start = st.get("launcher_start")
@@ -4607,22 +4606,16 @@ def _attribution(
             # target here.
             if isinstance(entry_pid, int) and entry_pid in excluded_pids:
                 row = {"pid": entry_pid, "start_time": entry.get("start")}
-                # Task #150 round 10 connector finding: this same excluded
-                # seed can go on to be a BFS parent below (seed_descendants),
-                # and idx.get(parent_pid) will fail there for the identical
-                # reason it failed here. _strict_child_edge only ever reads
-                # parent["pid"] and _start_of(parent) - the same two fields
-                # this synthetic row already carries and that Stop-Tree
-                # already trusts to order this pid's own kill - so it is
-                # sufficient to stand in as the BFS parent too. Without this,
-                # an opaque, never-recorded child living under an excluded
-                # tracked pid (e.g. a duplicate-row ambiguity) is never even
-                # looked up, let alone targeted: the tracked pid gets killed
-                # and the child survives it, unseen by evaluate_launch_barrier
-                # (which has no tree evidence to block on for this path
-                # either) - a replacement launches alongside a live child of
-                # the pid it just replaced.
-                seed_synthetic_rows[entry_pid] = row
+                # Task #150 round 10 connector finding (later corrected by
+                # round 12, see the BFS loop below): this synthetic row is
+                # ONLY safe as a KILL TARGET here - Stop-Tree re-verifies
+                # the live process's actual start time against it before
+                # acting, so a recycled pid (a genuinely different process
+                # now holding it) is protected against by Stop-Tree's own
+                # real-time check. It is NOT safe to reuse as a
+                # _strict_child_edge PARENT for further BFS discovery:
+                # nothing re-verifies that time-ordering claim before it
+                # feeds an INDEPENDENT kill decision about a DIFFERENT pid.
             else:
                 continue
         if entry["pid"] in targets_by_pid:
@@ -4652,17 +4645,31 @@ def _attribution(
         visited_seed.add(parent_pid)
         parent = idx.get(parent_pid)
         if not isinstance(parent, dict):
-            # An excluded seed (see seed_synthetic_rows above) has no row
-            # in idx by construction, not because it is absent - fall back
-            # to the same synthetic identity already trusted to kill it.
-            # Every other pid that ever reaches this queue was admitted via
-            # a real idx row (the child-admission check below requires
-            # isinstance(child, dict) before queue.append), so a seed with
-            # neither a real row nor a synthetic one is unreachable here;
-            # this continue is a defensive backstop, not a live branch.
-            parent = seed_synthetic_rows.get(parent_pid)
-            if not isinstance(parent, dict):
-                continue
+            # Task #150 round 12 connector finding: round 10 fell back to
+            # the excluded seed's own synthetic row (pid/start from the
+            # PRIOR record) as the _strict_child_edge PARENT here - but
+            # that identity is only ever re-verified by STOP-TREE, at KILL
+            # time, for THIS pid's own kill (see the comment above where
+            # the synthetic row is built). Nothing re-verifies it before
+            # it feeds a FURTHER, independent kill decision about a
+            # DIFFERENT pid. If this pid has been RECYCLED (a genuinely
+            # different, unrelated process now holds it), the synthetic
+            # row's stale start time is almost always EARLIER than any of
+            # the replacement's own children - the ordering check that
+            # exists to REJECT an unrelated descendant would instead PASS
+            # every one of them, misattributing a recycled process's own
+            # children as ours. Do not descend through an excluded parent
+            # at all: every current child reported under it - real row or
+            # itself excluded - is unaccounted, not merely unreached.
+            for child_pid in all_edges.get(parent_pid, []):
+                if (
+                    child_pid in targets_by_pid
+                    or child_pid in unaccounted_excluded_children
+                ):
+                    continue
+                unaccounted_excluded_children.add(child_pid)
+                _bump(diagnostics, "excluded_live_descendant_unaccounted")
+            continue
         for child_pid in kids.get(parent_pid, []):
             if child_pid in targets_by_pid:
                 continue
@@ -4683,10 +4690,10 @@ def _attribution(
         # is built only from idx.items() - a child excluded this poll
         # (duplicate/ambiguous rows) never contributed a row to idx at all,
         # so it never contributes an edge here either, regardless of the
-        # parent. This is a DIFFERENT gap than the one above: an excluded
-        # PARENT still has a trusted prior identity to fall back on
-        # (seed_synthetic_rows); a brand-new, never-before-tracked
-        # EXCLUDED CHILD has no such independent anchor - the ambiguous
+        # parent. This is a DIFFERENT gap than the one above (which
+        # applies when the PARENT itself is excluded): here the parent is
+        # a REAL, trusted row, but a brand-new, never-before-tracked
+        # EXCLUDED CHILD has no independent anchor - the ambiguous
         # current-poll rows are the only information that exists about it,
         # which is the same "no snapshot-only signal to disambiguate a
         # first-time-seen identity" residual already documented in
@@ -7296,6 +7303,34 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
             state=tree_state,
             notify=notify,
             reason=tree_reason,
+        )
+
+    # Task #150 round 12 connector finding: excluded_live_descendant_
+    # unaccounted (see _attribution's BFS loop) was computed and then never
+    # read by anything - the manual-restart-request path below still
+    # killed only the trusted, accounted-for root and relaunched, exactly
+    # the outcome the diagnostic exists to prevent. A check that runs and
+    # is never acted on is not a check. HOLD here, at the SAME precedence
+    # the wrapped tree_status check above already has over even an
+    # authorized restart marker: a partial kill can strand an unaccounted
+    # descendant exactly as a partial wrapped tree can.
+    if not wrapped and int(diagnostics.get("excluded_live_descendant_unaccounted") or 0) > 0:
+        notify = now_epoch - last_warn >= suspect_interval
+        if notify:
+            nxt["last_warn_epoch"] = now_epoch
+        return _result(
+            WARN_ONLY,
+            state="UNACCOUNTED_LIVE_DESCENDANT",
+            notify=notify,
+            reason=(
+                "a live descendant of a tracked process could not be "
+                "verified this poll (its own identity is ambiguous - "
+                "duplicate/conflicting rows this poll) and cannot safely "
+                "be targeted or ruled out; HOLDING automatic teardown/"
+                "relaunch because killing only the accounted-for parent "
+                "could strand it - this should clear on its own once the "
+                "ambiguity resolves on a later, clean poll"
+            ),
         )
 
     # 0) Manual restart-request marker (highest priority).

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -564,6 +564,7 @@ _DIAGNOSTIC_COUNTERS = (
     "launcher_nonce_duplicate",
     "launcher_nonce_after_subcommand_or_tail",
     "launcher_wrap_parse_failed",
+    "excluded_live_descendant_unaccounted",
 )
 
 
@@ -3055,6 +3056,20 @@ def _unverified_owned_process_tree(
         else reason_code
     )
     held["refreshed_at"] = _event_now(now_epoch)
+    # Task #150 round 11 connector finding: this relabels a PRIOR poll's
+    # entries as THIS poll's invalid record without ever walking the
+    # current process graph - the same "a producer that doesn't walk must
+    # not claim to have walked" rule round 4 already applied to the
+    # PowerShell post-kill barrier, which strips this same field at its own
+    # mutation sites for the identical reason. rejected_count == 0 was true
+    # of the walk that produced `prior`; it says nothing about THIS poll,
+    # which performed no walk at all. Left uncorrected, a LATER poll's
+    # entries_are_complete check reads that stale zero as proof this
+    # invalid record is complete, re-admitting it for absence-promotion on
+    # an accounting question nobody actually asked this poll. Missing reads
+    # as unknown - already ineligible for re-derivation - which is the
+    # correct meaning: we genuinely do not know.
+    held.pop("rejected_count", None)
     return held
 
 
@@ -4503,10 +4518,12 @@ def _attribution(
     # see the two fixes below. excluded_pids is no longer discarded.
     idx, excluded_pids = _snap_index_and_excluded(snapshot)
     kids = _children_map(idx)
+    all_edges = _snap_all_edges(snapshot)
     targets_by_pid: dict[int, dict] = {}
     seed_pids: set[int] = set()
     seed_launcher_sources: dict[int, dict] = {}
     seed_synthetic_rows: dict[int, dict] = {}
+    unaccounted_excluded_children: set[int] = set()
     launcher_pid = st.get("launcher_pid")
     launcher_start = st.get("launcher_start")
     launcher_row = idx.get(launcher_pid) if isinstance(launcher_pid, int) else None
@@ -4662,6 +4679,32 @@ def _attribution(
             if child_launcher_source is not None:
                 seed_launcher_sources[child_pid] = child_launcher_source
             queue.append(child_pid)
+        # Task #150 round 11 connector finding: kids (_children_map(idx))
+        # is built only from idx.items() - a child excluded this poll
+        # (duplicate/ambiguous rows) never contributed a row to idx at all,
+        # so it never contributes an edge here either, regardless of the
+        # parent. This is a DIFFERENT gap than the one above: an excluded
+        # PARENT still has a trusted prior identity to fall back on
+        # (seed_synthetic_rows); a brand-new, never-before-tracked
+        # EXCLUDED CHILD has no such independent anchor - the ambiguous
+        # current-poll rows are the only information that exists about it,
+        # which is the same "no snapshot-only signal to disambiguate a
+        # first-time-seen identity" residual already documented in
+        # _snap_all_edges for a malformed pid. Inventing a synthetic child
+        # row from one of the ambiguous rows would extend trust exactly
+        # where round 1's original incident began. Cannot safely target or
+        # persist it - but it must not vanish silently either: the
+        # permissive all_edges map still sees it, so surface it as a known
+        # gap rather than a total loss.
+        for child_pid in all_edges.get(parent_pid, []):
+            if (
+                child_pid not in excluded_pids
+                or child_pid in targets_by_pid
+                or child_pid in unaccounted_excluded_children
+            ):
+                continue
+            unaccounted_excluded_children.add(child_pid)
+            _bump(diagnostics, "excluded_live_descendant_unaccounted")
 
     fresh_pids = set(targets_by_pid)
     managed_by_pid: dict[int, dict] = {}

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -3427,6 +3427,29 @@ def _owned_process_tree(
         _prior_pid = _prior_entry.get("pid") if isinstance(_prior_entry, dict) else None
         if isinstance(_prior_pid, int) and not isinstance(_prior_pid, bool):
             discovery_roots.add(_prior_pid)
+    # Task #150 round 5 connector finding 1: a PRIOR entry's own current
+    # row can have a malformed parent_pid - _snap_all_edges below correctly
+    # cannot place it (no valid edge to build), but "cannot place" must not
+    # collapse to "not ours". The trusted-rehydration block above already
+    # calls mark_rejected("prior_parent_drift") for exactly this shape, but
+    # ONLY when prior_authority is trusted (status == "complete") - an
+    # untrusted-but-readable prior (the same generation-adoption-pending
+    # exemption round 3's finding 5 needed) skips that block entirely, so
+    # a since-corrupted intermediate the prior once recorded would
+    # otherwise sit at rejected_count 0 forever. This check is independent
+    # of that trust gate on purpose - it does NOT retire the rehydration
+    # block's own check (a double-count there is harmless; rejected_count
+    # is a gate, not an exact tally).
+    for _prior_entry in prior_entries:
+        _prior_pid = _prior_entry.get("pid") if isinstance(_prior_entry, dict) else None
+        if not isinstance(_prior_pid, int) or isinstance(_prior_pid, bool):
+            continue
+        _prior_row = idx.get(_prior_pid)
+        if not isinstance(_prior_row, dict):
+            continue
+        _prior_parent_pid = _prior_row.get("parent_pid")
+        if not isinstance(_prior_parent_pid, int) or isinstance(_prior_parent_pid, bool):
+            mark_rejected("prior_entry_parent_pid_malformed")
     # Task #150 round 4 connector finding 1: children.get(...) above is
     # _children_map(idx) - built from the DEDUPED idx, so a pid _snap_index
     # excluded for identity ambiguity (a duplicate or malformed row) has no
@@ -6812,15 +6835,34 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         has_entries = bool(owned_tree.get("entries"))
         rejected_count = owned_tree.get("rejected_count")
         if has_entries:
-            rejected_clause = (
-                f" This record also excluded {rejected_count} candidate(s) "
-                "the walk could not admit (rejected_count) - the reset "
-                "command's own identity list does not include them, so "
-                "confirming those specifically gone is on you, not the "
-                "command."
-                if isinstance(rejected_count, int) and rejected_count > 0
-                else ""
-            )
+            # Round 4 (connector finding 2, the same wrong direction a third
+            # time): a legacy v2 record predates rejected_count entirely -
+            # missing, not zero, is what keeps it out of absence-promotion
+            # (see the v2-migration fix), but that same "unknown" must warn
+            # here too. Warning only for a known positive integer told the
+            # operator a v2 record excluded nothing, when the truth is the
+            # walk that produced it never even counted - absent must warn
+            # like unknown, not like zero.
+            if isinstance(rejected_count, int) and rejected_count > 0:
+                rejected_clause = (
+                    f" This record also excluded {rejected_count} "
+                    "candidate(s) the walk could not admit (rejected_count) "
+                    "- the reset command's own identity list does not "
+                    "include them, so confirming those specifically gone is "
+                    "on you, not the command."
+                )
+            elif rejected_count is None:
+                rejected_clause = (
+                    " This record predates rejected_count (an older "
+                    "schema) so whether the walk that produced it excluded "
+                    "any candidate is UNKNOWN, not zero - the reset "
+                    "command's own identity list cannot cover an excluded "
+                    "candidate either way, so treat this the same as a "
+                    "nonzero count: confirming anything beyond the named "
+                    "entries gone is on you, not the command."
+                )
+            else:
+                rejected_clause = ""
             remedy = (
                 "recovery: if every process this record could name is "
                 "confirmed gone - including any omitted by a truncated "

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2060,9 +2060,41 @@ def _snap_index_and_excluded(
     # are different facts to a caller checking a PRIOR entry's current row
     # - a prior identity whose row was excluded here (present, ambiguous)
     # must be rejected, not silently treated the same as one that simply
-    # exited (absent, normal). The excluded set is the one piece of that
-    # distinction only this function has; _snap_index stays the thin,
-    # unchanged accessor every other caller already uses.
+    # exited (absent, normal).
+    #
+    # Task #150 round 7 connector finding: a thin `_snap_index` wrapper
+    # that silently discarded the excluded set was the trap - eight call
+    # sites read "PID not in the index" as a single fact, and only round
+    # 6's own fix (the prior-entry check here) had been taught the new,
+    # correct three-way distinction. Surveyed the other seven, each with a
+    # keep-or-fix reason at its own call site:
+    #   - proven to matter, confirmed by a failing/passing test:
+    #     _ephemeral_process_alive (the named finding this round).
+    #   - proven NOT to matter: the promotion check in
+    #     _unverified_owned_process_tree and evaluate_launch_barrier are
+    #     each gated by _snapshot_pid_integrity_error finding the SAME
+    #     underlying condition first (a duplicated pid is a strict subset
+    #     of what that whole-snapshot check already catches), so the
+    #     excluded set is provably empty by the time either site's own
+    #     fix would run - proven by construction, not merely reasoned; a
+    #     test built to discriminate this passed identically either way.
+    #   - genuinely indifferent by design: _attribution's launcher
+    #     confirmation only ever suppresses kill-targeting for an
+    #     ambiguous identity, this file's own stated default elsewhere.
+    #   - fixed defensively, reachability NOT proven either way:
+    #     _unverified_owned_process_may_exist and the wrapper-liveness
+    #     check in _wrapped_liveness, and brain liveness in _liveness for
+    #     the legacy, non-wrapped path. Every end-to-end scenario tried
+    #     already reached the same safe outcome through a DIFFERENT,
+    #     pre-existing mechanism first, so no test could be made to
+    #     discriminate these three branches' own effect - kept because
+    #     the rule is correct and they are not proven dead the way the
+    #     two above are.
+    # With every consumer surveyed and fixed, justified, or disclosed as
+    # unproven, the wrapper that made the excluded set optional to check
+    # has no remaining callers and is retired - a future caller now has no
+    # way to get an index without also being handed the one set that this
+    # conflation kept breaking on.
     idx: dict[int, dict] = {}
     seen: set[int] = set()
     excluded: set[int] = set()
@@ -2081,10 +2113,6 @@ def _snap_index_and_excluded(
         seen.add(pid)
         idx[pid] = row
     return idx, excluded
-
-
-def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
-    return _snap_index_and_excluded(snapshot)[0]
 
 
 def _snap_all_edges(snapshot: list[dict] | None) -> dict[int, list[int]]:
@@ -2937,7 +2965,22 @@ def _unverified_owned_process_tree(
         else None
     )
     if snapshot is not None and snapshot_error is None:
-        idx = _snap_index(snapshot)
+        # Task #150 round 7 connector survey: idx.get(pid) is None both for
+        # a genuinely absent pid AND one _snap_index would exclude this
+        # poll (a duplicate/ambiguous row) - but this whole block is only
+        # ever reached when snapshot_error is None, and _snap_index's
+        # exclusion criterion (a valid pid repeated) is a strict subset of
+        # what _snapshot_pid_integrity_error's own "duplicate_pid"/
+        # "invalid_process_row" already detects over the SAME snapshot -
+        # snapshot_error is None here implies the excluded set would be
+        # empty too. Verified by construction (not merely reasoned): a
+        # direction-controlled test built to exercise this exact path with
+        # a duplicated entry pid passed unmodified with and without a
+        # from-scratch idx.get-based rewrite, proving the gate above
+        # already makes this site safe. Genuinely indifferent - left as
+        # _snap_index_and_excluded only so no caller anywhere still reaches
+        # the retired bare accessor.
+        idx, _excluded_pids = _snap_index_and_excluded(snapshot)
         identity_states = [
             _recorded_process_identity_state(
                 idx.get(entry.get("pid")),
@@ -4360,7 +4403,19 @@ def _attribution(
             "discovered_brain": False,
         }
 
-    idx = _snap_index(snapshot)
+    # Task #150 round 7 connector finding survey: an excluded launcher pid
+    # reads as absent here exactly like everywhere else _snap_index is
+    # consumed, but the ONLY effect is _is_confirmed_launcher returning
+    # False - this agent's launcher is left out of kill_targets/seed_pids
+    # for THIS poll. Failing to confirm an ambiguous identity for kill-
+    # targeting is already this file's stated default (an ambiguous
+    # identity "grants no kill authority" - see _owned_process_tree's own
+    # recycled-parent handling); it never asserts the agent is dead, and
+    # nothing downstream of _attribution's return treats an unconfirmed
+    # launcher as death. Genuinely indifferent - kept on _snap_index_and_
+    # excluded only so the bare, silently-lossy _snap_index wrapper can be
+    # retired now that every consumer has been surveyed.
+    idx, _excluded_pids = _snap_index_and_excluded(snapshot)
     kids = _children_map(idx)
     targets_by_pid: dict[int, dict] = {}
     seed_pids: set[int] = set()
@@ -4687,7 +4742,18 @@ def evaluate_launch_barrier(
             "survivor_count": 0,
             "survivors": [],
         }
-    idx = _snap_index(snapshot)
+    # Task #150 round 7 connector survey: this function early-returns
+    # blocked=True above the moment _snapshot_pid_integrity_error finds
+    # anything wrong ANYWHERE in the snapshot, and _snap_index's own
+    # exclusion criterion (a valid pid repeated) is a strict subset of
+    # what that whole-snapshot check already catches over the SAME
+    # snapshot - reaching this line already proves the excluded set is
+    # empty. Verified by construction, not merely reasoned: a duplicated
+    # entry pid never reaches the loop below at all: it is blocked earlier
+    # with reason "snapshot_duplicate_pid" before idx is ever built.
+    # Genuinely indifferent here - kept on _snap_index_and_excluded only
+    # so no caller anywhere still reaches the retired bare accessor.
+    idx, _excluded_pids = _snap_index_and_excluded(snapshot)
     tree_judged_state_launcher = False
     if isinstance(tree, dict):
         tree_entries = tree.get("entries", [])
@@ -5211,7 +5277,7 @@ def _liveness(snapshot: list[dict] | None, st: dict, cfg_agent: dict,
                 "kill_targets": attr.get("targets") or [],
                 "diagnostics": attr.get("diagnostics") or _diag(),
                 "discovered_brain": False}
-    idx = _snap_index(snapshot)
+    idx, excluded_pids = _snap_index_and_excluded(snapshot)
     allow_launcher_self = bool(lcfg.get("allow_launcher_self", False))
     launcher_pid = st.get("launcher_pid")
     brain_pid = st.get("brain_pid")
@@ -5222,8 +5288,25 @@ def _liveness(snapshot: list[dict] | None, st: dict, cfg_agent: dict,
     # bad launcher pin.
     bad_launcher_pin = (not allow_launcher_self and brain_pid is not None
                         and brain_pid == launcher_pid)
-    brain_alive = (not bad_launcher_pin
-                   and _pid_alive_guarded(idx, brain_pid, brain_start))
+    # Task #150 round 7 connector survey: idx.get(brain_pid) misses both a
+    # genuinely dead brain AND one _snap_index excluded this poll (a
+    # duplicate/ambiguous row) - _pid_alive_guarded cannot tell them apart.
+    # Correctness fix, kept defensively: in every scenario tried, the
+    # legacy agent's own action/state (STUCK_RECOVER vs suspect_warn) and
+    # kill_targets were identical with and without this branch - heartbeat
+    # staleness plus the activity-hook config, not brain_alive itself,
+    # appear to drive that decision here. No end-to-end test could be made
+    # to discriminate this branch's own effect. Conservatively alive is
+    # never the destructive direction, so left in rather than reverted.
+    brain_excluded = (
+        isinstance(brain_pid, int)
+        and not isinstance(brain_pid, bool)
+        and brain_pid in excluded_pids
+    )
+    brain_alive = bool(
+        not bad_launcher_pin
+        and (brain_excluded or _pid_alive_guarded(idx, brain_pid, brain_start))
+    )
     discovered = False
     if not brain_alive:
         cand = _discover_brain(idx, agent, launcher_pid,
@@ -5410,8 +5493,26 @@ def _wrapped_liveness(
         if snapshot is None:
             return bool(identities)
         roots = {pid for pid, _start in identities}
+        idx, excluded_pids = _snap_index_and_excluded(snapshot)
         for pid, start in identities:
-            row = _snap_index(snapshot).get(pid)
+            # Task #150 round 7 connector survey: a duplicated/ambiguous
+            # row for one of these identities is present-but-excluded, not
+            # absent - it IS ownership-shaped live evidence, exactly what
+            # this function exists to detect conservatively for HOLD.
+            # Correctness fix, kept defensively: every scenario tried (a
+            # stored prior tree present; no prior tree at all, matching
+            # generation) already reaches this same conservative outcome
+            # through a DIFFERENT, pre-existing mechanism first
+            # (adopted_tree_missing, or _unverified_owned_process_tree's
+            # own snapshot_error gate) - no end-to-end test could be made
+            # to discriminate this branch's effect, unlike the ephemeral
+            # fix. Left in because it is not proven unreachable either
+            # (unlike the two sites this round reverted after that proof),
+            # and the rule itself is uncontroversially correct wherever
+            # else this file checks it.
+            if pid in excluded_pids:
+                return True
+            row = idx.get(pid)
             if isinstance(row, dict) and _start_tokens_match(_start_of(row), start):
                 return True
         # A launcher may already have exited and left a reparenting race. A
@@ -5600,7 +5701,7 @@ def _wrapped_liveness(
             "snapshot_unavailable",
             hold_reason="process_tree_invalid_snapshot_unavailable",
         )
-    idx = _snap_index(snapshot)
+    idx, excluded_pids = _snap_index_and_excluded(snapshot)
     wrapper_pid = record.get("wrapper_pid")
     wrapper_start = record.get("wrapper_start")
     if (
@@ -5613,6 +5714,24 @@ def _wrapped_liveness(
         )
     wrapper_row = idx.get(wrapper_pid)
     if wrapper_row is None:
+        if isinstance(wrapper_pid, int) and wrapper_pid in excluded_pids:
+            # Task #150 round 7 connector survey: excluded (present this
+            # poll as a duplicate/ambiguous row) is not "dead" - setting
+            # wrapper_state="dead" here would, in isolation, be able to
+            # feed STUCK_OR_DEAD once the heartbeat also goes stale.
+            # Correctness fix, kept defensively: every scenario tried
+            # (a stored prior tree present; no prior tree at all with
+            # _unverified_owned_process_may_exist's own fix already
+            # applied) reaches this same conservative outcome earlier,
+            # through _plan_one's own tree_status intercept, before
+            # wrapper_state is ever consulted - no end-to-end test could
+            # be made to discriminate this branch's own effect. Left in
+            # because it is not proven unreachable, and matches the
+            # ambiguous-identity handling immediately below it.
+            return _current_proof_failed(
+                "wrapper_identity_ambiguous",
+                hold_reason="process_tree_invalid_wrapper_identity_ambiguous",
+            )
         base["wrapper_state"] = "dead"
         return _current_proof_failed(
             "wrapper_absent",
@@ -7556,8 +7675,20 @@ def _ephemeral_owned_process_view(
 def _ephemeral_process_alive(snapshot: list[dict] | None, entry: dict) -> bool | None:
     if snapshot is None:
         return None
-    return _pid_alive_guarded(_snap_index(snapshot), entry.get("launcher_pid"),
-                              entry.get("launcher_start"))
+    idx, excluded_pids = _snap_index_and_excluded(snapshot)
+    launcher_pid = entry.get("launcher_pid")
+    # Task #150 round 7 connector finding: a duplicated (or otherwise
+    # ambiguous) row for this launcher pid is EXCLUDED from idx, which is
+    # indistinguishable from "not running" to a plain idx.get(pid) miss -
+    # the same conflation round 6 fixed for a prior entry, arriving in a
+    # different consumer of _snap_index. The caller's own held_terminal
+    # is unrewritable once persisted, so a False here from a transient
+    # snapshot glitch permanently archives a healthy review as failed.
+    # None (unknown) is safe: the caller only treats `alive is False` as
+    # a terminal failure signal, never `alive is None`.
+    if isinstance(launcher_pid, int) and not isinstance(launcher_pid, bool) and launcher_pid in excluded_pids:
+        return None
+    return _pid_alive_guarded(idx, launcher_pid, entry.get("launcher_start"))
 
 
 def _ephemeral_next_without(state: dict, request_id: str) -> dict:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -143,7 +143,7 @@ _COORDINATION_BARRIER_FIELDS = frozenset({
     "last_observed_epoch",
     "consecutive_blocked_polls",
 })
-_OWNED_PROCESS_TREE_SCHEMA = 2
+_OWNED_PROCESS_TREE_SCHEMA = 3
 _OWNED_PROCESS_TREE_MODEL = "owned_process_tree_v2"
 _OWNED_PROCESS_TREE_LIMIT = 64
 _LEGACY_PROCESS_EVIDENCE_SCHEMA = 1
@@ -168,6 +168,19 @@ _OWNED_PROCESS_TREE_STATUSES = frozenset({
 _SAFE_WRAPPER_GENERATION_RE = re.compile(
     r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z"
 )
+# Task #150 connector finding (blocker): observed_count/omitted_count only
+# ever counted ADMITTED nodes vs the size-cap truncation of already-admitted
+# nodes - they say nothing about a candidate branch the walk SAW and
+# explicitly excluded for any other reason (an unproven virtual-parent
+# descendant, a failed strict edge, a missing child row, ...). rejected_count
+# is that missing signal: incremented at every site in _owned_process_tree
+# where a specific candidate is excluded rather than admitted, independently
+# of whatever reason_code text ends up chosen (first-write-wins there would
+# otherwise mask a later rejection once an earlier one - even a whole-
+# snapshot one - had already set it). Only rejected_count == 0 (together
+# with omitted_count == 0 and at least one entry) means this record is a
+# complete, trustworthy description of everything the walk found - the bar
+# _unverified_owned_process_tree's re-derivation now actually checks.
 _OWNED_PROCESS_TREE_FIELDS = frozenset({
     "schema_version",
     "attribution_model",
@@ -179,6 +192,7 @@ _OWNED_PROCESS_TREE_FIELDS = frozenset({
     "observed_count",
     "recorded_count",
     "omitted_count",
+    "rejected_count",
     "truncated",
     "refreshed_at",
     "wrapper_generation",
@@ -2402,12 +2416,12 @@ def _valid_owned_process_tree(
     ):
         return None
     counts: list[int] = []
-    for field in ("observed_count", "recorded_count", "omitted_count"):
+    for field in ("observed_count", "recorded_count", "omitted_count", "rejected_count"):
         count = value.get(field)
         if not isinstance(count, int) or isinstance(count, bool) or count < 0:
             return None
         counts.append(count)
-    observed_count, recorded_count, omitted_count = counts
+    observed_count, recorded_count, omitted_count, _rejected_count = counts
     entries = value.get("entries")
     if (
         not isinstance(entries, list)
@@ -2530,6 +2544,7 @@ def _invalid_owned_process_tree_record(
         "observed_count": 0,
         "recorded_count": 0,
         "omitted_count": 0,
+        "rejected_count": 0,
         "truncated": False,
         "refreshed_at": _event_now(now_epoch),
         "wrapper_generation": wrapper_generation,
@@ -2750,14 +2765,23 @@ def _unverified_owned_process_tree(
     current snapshot proves every recorded pid/start identity absent or
     replaced. Task #150 connector finding: an INVALID prior is not
     categorically excluded from that same re-derivation - only when its own
-    entries are a COMPLETE description of what was found (omitted_count == 0,
-    at least one entry recorded). Whatever made the tree invalid in the first
-    place (in the production incident, a single UNRELATED row elsewhere in
-    that poll's whole-host snapshot failing _snapshot_pid_integrity_error, not
-    anything about this agent's own identities) says nothing about whether
-    those SPECIFIC recorded identities are still alive - the same evidentiary
-    bar the complete/absent case already trusts. A TRUNCATED prior's entries
-    are incomplete by definition (omitted_count > 0) and never qualifies:
+    entries are a COMPLETE description of what was found. Whatever made the
+    tree invalid in the first place (in the production incident, a single
+    UNRELATED row elsewhere in that poll's whole-host snapshot failing
+    _snapshot_pid_integrity_error, not anything about this agent's own
+    identities) says nothing about whether those SPECIFIC recorded identities
+    are still alive - the same evidentiary bar the complete/absent case
+    already trusts.
+
+    Round 2 (connector blocker): omitted_count alone is NOT that bar - it
+    only counts the size-cap gap between admitted nodes and recorded entries,
+    never a candidate branch the walk SAW and explicitly excluded for any
+    other reason (an unproven virtual-parent descendant with a live child,
+    say). rejected_count (see _OWNED_PROCESS_TREE_FIELDS) is the field that
+    actually means "nothing the walk considered was left unaccounted for" -
+    both it and omitted_count must be zero, with at least one entry recorded,
+    for an invalid prior to qualify. A TRUNCATED prior's entries are
+    incomplete by definition (omitted_count > 0) and never qualifies:
     proving the recorded subset gone says nothing about whatever the size cap
     dropped. A prior with no entries at all (schema-drift/generation-adoption
     placeholders built by _invalid_owned_process_tree_record, never a real
@@ -2772,6 +2796,7 @@ def _unverified_owned_process_tree(
         isinstance(entries, list)
         and bool(entries)
         and prior.get("omitted_count") == 0
+        and prior.get("rejected_count") == 0
     )
     eligible_for_rederivation = prior.get("status") in {"complete", "absent"} or (
         prior.get("status") == "invalid" and entries_are_complete
@@ -2906,6 +2931,22 @@ def _owned_process_tree(
         if prior_record_invalid
         else (f"snapshot_{snapshot_error}" if snapshot_error is not None else None)
     )
+    # Task #150 connector finding (blocker): see _OWNED_PROCESS_TREE_FIELDS'
+    # own comment. mark_rejected is the ONE place a specific candidate branch
+    # gets excluded from this tree - every such site below calls it instead
+    # of setting invalid_reason directly, so rejected_count can never miss
+    # one by construction, the same way add_node is the one place a node
+    # gets admitted. A whole-snapshot/prior-record issue (the two branches
+    # above, seeded before this point) never calls it - that distinction is
+    # exactly what makes the "invalid but re-derivable" case in
+    # _unverified_owned_process_tree safe.
+    rejected_count = 0
+
+    def mark_rejected(reason: str) -> None:
+        nonlocal invalid_reason, rejected_count
+        rejected_count += 1
+        invalid_reason = invalid_reason or reason
+
     role_rank = {
         "tool_descendant": 0,
         "detached_gate_runner": 1,
@@ -2932,7 +2973,7 @@ def _owned_process_tree(
             or not start
             or start_key is None
         ):
-            invalid_reason = invalid_reason or "invalid_process_row"
+            mark_rejected("invalid_process_row")
             return False
         if not _has_exact_start_identity(row):
             # Windows' CIM timestamp is rounded. It can identify graph edges,
@@ -2950,7 +2991,7 @@ def _owned_process_tree(
                 or _filetime_of(existing["row"]) != start_filetime
                 or existing["row"].get("parent_pid") != parent_pid
             ):
-                invalid_reason = invalid_reason or "pid_identity_collision"
+                mark_rejected("pid_identity_collision")
                 return False
             existing["depth"] = min(int(existing["depth"]), depth)
             if role_rank[role] > role_rank[existing["role"]]:
@@ -2984,7 +3025,7 @@ def _owned_process_tree(
                 _start_of(wrapper_row),
             )
         ):
-            invalid_reason = invalid_reason or "prior_wrapper_mismatch"
+            mark_rejected("prior_wrapper_mismatch")
             prior_authority = None
         else:
             live_prior: set[int] = set()
@@ -3008,13 +3049,13 @@ def _owned_process_tree(
                 ):
                     continue
                 if row.get("parent_pid") != entry["parent_pid"]:
-                    invalid_reason = invalid_reason or "prior_parent_drift"
+                    mark_rejected("prior_parent_drift")
                     continue
                 if not _filetime_identity_matches(
                     row,
                     entry.get("start_filetime"),
                 ):
-                    invalid_reason = invalid_reason or "prior_filetime_drift"
+                    mark_rejected("prior_filetime_drift")
                     continue
                 live_prior.add(entry["pid"])
             needed = set(live_prior)
@@ -3098,7 +3139,7 @@ def _owned_process_tree(
                 )
                 and current_launcher.get("parent_pid") != wrapper_pid
             ):
-                invalid_reason = invalid_reason or "launcher_parent_mismatch"
+                mark_rejected("launcher_parent_mismatch")
             launcher_row = {
                 "pid": launcher_pid,
                 "parent_pid": wrapper_pid,
@@ -3121,17 +3162,13 @@ def _owned_process_tree(
                     # authority.
                     launcher_row = None
                 elif current_launcher is not None:
-                    invalid_reason = (
-                        invalid_reason or "exact_start_filetime_unavailable"
-                    )
+                    mark_rejected("exact_start_filetime_unavailable")
                     launcher_row = None
                 elif children.get(launcher_pid):
                     # Windows retains PPID edges after a parent exits. Without
                     # an exact lifetime/prior certificate those children are
                     # ambiguous.
-                    invalid_reason = (
-                        invalid_reason or "unproven_virtual_parent_descendant"
-                    )
+                    mark_rejected("unproven_virtual_parent_descendant")
                     launcher_row = None
                 else:
                     # A childless, absent launcher cannot be killed and its
@@ -3139,11 +3176,11 @@ def _owned_process_tree(
                     # ownership authority.
                     launcher_row = None
         if launcher_pid == wrapper_pid:
-            invalid_reason = invalid_reason or "launcher_equals_wrapper"
+            mark_rejected("launcher_equals_wrapper")
         elif launcher_row is not None:
             edge_reason = _strict_owned_child_edge(wrapper_row, launcher_row)
             if edge_reason is not None:
-                invalid_reason = invalid_reason or edge_reason
+                mark_rejected(edge_reason)
             add_node(
                 launcher_row,
                 role="cli_launcher",
@@ -3162,7 +3199,7 @@ def _owned_process_tree(
         for child_pid in sorted(children.get(parent_pid, [])):
             child = idx.get(child_pid)
             if not isinstance(child, dict):
-                invalid_reason = invalid_reason or "missing_child_row"
+                mark_rejected("missing_child_row")
                 continue
             if not parent["live"]:
                 prior_parent = prior_by_pid.get(parent_pid)
@@ -3205,14 +3242,11 @@ def _owned_process_tree(
                     # or by the exited launcher's exact lifetime bounds.
                     continue
                 if not certified_launcher_child and not prior_owned_child:
-                    invalid_reason = (
-                        invalid_reason
-                        or "unproven_virtual_parent_descendant"
-                    )
+                    mark_rejected("unproven_virtual_parent_descendant")
                     continue
             edge_reason = _strict_owned_child_edge(parent_row, child)
             if edge_reason is not None:
-                invalid_reason = invalid_reason or edge_reason
+                mark_rejected(edge_reason)
                 continue
             role = (
                 "cli_brain"
@@ -3231,7 +3265,7 @@ def _owned_process_tree(
     if isinstance(brain_row, dict):
         brain_pid = brain_row.get("pid")
         if brain_pid not in owned:
-            invalid_reason = invalid_reason or "brain_outside_owned_tree"
+            mark_rejected("brain_outside_owned_tree")
         elif owned[brain_pid]["role"] == "tool_descendant":
             owned[brain_pid]["role"] = "cli_brain"
 
@@ -3257,7 +3291,7 @@ def _owned_process_tree(
     )
     if len(selected) > _OWNED_PROCESS_TREE_LIMIT:
         # A mandatory identity plus its ancestor closure must never be sliced.
-        invalid_reason = invalid_reason or "mandatory_tree_exceeds_limit"
+        mark_rejected("mandatory_tree_exceeds_limit")
         selected = set(parent_first[:_OWNED_PROCESS_TREE_LIMIT])
     else:
         for pid in parent_first:
@@ -3317,6 +3351,7 @@ def _owned_process_tree(
         "observed_count": observed_count,
         "recorded_count": len(entries),
         "omitted_count": omitted_count,
+        "rejected_count": rejected_count,
         "truncated": bool(omitted_count),
         "refreshed_at": refreshed_at,
         "wrapper_generation": wrapper_generation,
@@ -5148,13 +5183,16 @@ def _wrapped_liveness(
             now_epoch=now_epoch,
             reason_code=hold_reason,
         )
-        if (
-            isinstance(prior_for_check, dict)
-            and prior_for_check.get("status") in {"complete", "absent"}
-            and isinstance(tree, dict)
-            and tree.get("status") == "absent"
-            and snapshot is not None
-        ):
+        # Task #150 connector finding 4: this used to re-check
+        # prior_for_check.get("status") against {"complete", "absent"} -
+        # duplicating _unverified_owned_process_tree's OWN eligibility gate
+        # with a copy that drifted the moment that gate widened to admit an
+        # invalid-but-complete prior too. tree.get("status") == "absent" is
+        # already the complete, self-contained signal: it is the ONLY value
+        # _unverified_owned_process_tree ever returns for "absent", and it
+        # already re-checked eligibility internally - a second, independent
+        # copy of that check here can only go stale, not add safety.
+        if isinstance(tree, dict) and tree.get("status") == "absent" and snapshot is not None:
             base["owned_process_tree_refreshed"] = True
         adopted_tree_missing = bool(
             prior_for_check is None
@@ -6532,14 +6570,45 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         # moment it is independently confirmed absent (see
         # _unverified_owned_process_tree); a wrapper that is still present,
         # or whose absence this record cannot yet prove on its own, needs
-        # the attended reset named below.
-        remedy = (
-            "recovery: if every process this record names is confirmed gone, "
-            "run `agenttalk supervise --reset-process-tree-ownership` (see "
-            "--help for the required --acknowledge-* flags); do NOT kill the "
-            "wrapper expecting an automatic relaunch - that is only safe once "
-            "this record already reflects the wrapper as absent"
-        )
+        # the attended reset.
+        #
+        # Round 2 (connector findings 2 and 3): the FIRST version of this
+        # remedy named --reset-process-tree-ownership unconditionally and
+        # was wrong twice over. (a) --acknowledge-owned-processes-stopped's
+        # own contract already covers "any identities omitted by a
+        # truncated record" - the message must not narrow that to only the
+        # NAMED ones. (b) --reset-process-tree-ownership requires the tree
+        # evidence to carry a real wrapper_generation/launch_nonce that
+        # agrees with a CURRENT, valid runtime record - true for a tree
+        # _owned_process_tree itself walked (non-empty entries), but an
+        # entryless placeholder (_invalid_owned_process_tree_record - schema
+        # drift, a revoked runtime, legacy migration evidence) usually has
+        # no such nonce to agree with, so the command fails for precisely
+        # the case that names it. Naming a remedy that cannot work is worse
+        # than naming none, so the entryless case gets an honest "no
+        # verified one-line fix" message instead of a command that would
+        # frustrate the operator a second time.
+        has_entries = bool(owned_tree.get("entries"))
+        if has_entries:
+            remedy = (
+                "recovery: if every process this record could name is "
+                "confirmed gone - including any omitted by a truncated "
+                "record, which is exactly what --acknowledge-owned-"
+                "processes-stopped attests to - run `agenttalk supervise "
+                "--reset-process-tree-ownership` (see --help for the "
+                "required --acknowledge-* flags); do NOT kill the wrapper "
+                "expecting an automatic relaunch - that is only safe once "
+                "this record already reflects the wrapper as absent"
+            )
+        else:
+            remedy = (
+                "recovery: this record has no observed process identities "
+                "to reset against, so --reset-process-tree-ownership will "
+                "refuse it; a new wrapper generation replaces this record "
+                "automatically once adopted - if it does not clear on its "
+                "own, this needs operator investigation of "
+                f"{owned_tree.get('reason_code')}, not a scripted remedy"
+            )
         if tree_status == "truncated":
             tree_state = "PROCESS_TREE_TRUNCATED"
             tree_reason = (

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -143,7 +143,7 @@ _COORDINATION_BARRIER_FIELDS = frozenset({
     "last_observed_epoch",
     "consecutive_blocked_polls",
 })
-_OWNED_PROCESS_TREE_SCHEMA = 3
+_OWNED_PROCESS_TREE_SCHEMA = 2
 _OWNED_PROCESS_TREE_MODEL = "owned_process_tree_v2"
 _OWNED_PROCESS_TREE_LIMIT = 64
 _LEGACY_PROCESS_EVIDENCE_SCHEMA = 1
@@ -181,6 +181,23 @@ _SAFE_WRAPPER_GENERATION_RE = re.compile(
 # with omitted_count == 0 and at least one entry) means this record is a
 # complete, trustworthy description of everything the walk found - the bar
 # _unverified_owned_process_tree's re-derivation now actually checks.
+#
+# Round 3 connector finding (blocker, on the finding above): a bare
+# schema_version bump made every pre-existing v2 record fail validation
+# SOLELY on the new field's absence, and a live wrapper then rebuilds that
+# now-"invalid" prior into process_tree_invalid_prior_record_invalid on
+# EVERY poll from then on via the very seed this PR added - reintroducing
+# the sticky fleet-wide HOLD this PR exists to remove, at the moment of
+# upgrade, for agents that were never anything but healthy. A v2 record
+# is READABLE; what it lacks is one fact, not its validity. rejected_count
+# is therefore OPTIONAL in the persisted field set: a record missing it is
+# still valid authority (kept as before-this-PR, unrestricted by rejection
+# accounting), but _unverified_owned_process_tree treats a missing count as
+# UNKNOWN, not zero - unknown must never grant the new eligibility a v2
+# record never earned. schema_version is deliberately NOT bumped: the
+# field's own optionality is the migration, so there is nothing for a
+# version bump to gate that isn't already handled without one.
+_OWNED_PROCESS_TREE_OPTIONAL_FIELDS = frozenset({"rejected_count"})
 _OWNED_PROCESS_TREE_FIELDS = frozenset({
     "schema_version",
     "attribution_model",
@@ -2025,13 +2042,34 @@ def _launch_detail(st: dict, cfg_agent: dict, perm_mode: str = "bypassPermission
 # process by a guessed name (codex discipline note 3).
 
 def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
+    # Task #150 connector finding 1: last-write-wins on a duplicate pid
+    # silently picks ONE of two rows - if the winner happens to be a
+    # malformed/unrelated row while the loser was a genuinely live child,
+    # every later idx.get(that_pid) call sees the wrong identity with no
+    # signal anything was lost, and _snapshot_pid_integrity_error's own
+    # "duplicate_pid" detection (a separate, whole-snapshot-level check)
+    # never told THIS specific lookup that its answer is unreliable.
+    # Excluding a duplicated pid entirely - rather than guessing which row
+    # to keep - makes it "not found" for every caller, which is exactly
+    # the shape the existing missing_child_row/add_node rejection sites
+    # already handle correctly; no caller needs new logic to benefit.
     idx: dict[int, dict] = {}
+    seen: set[int] = set()
+    excluded: set[int] = set()
     for row in snapshot or []:
         if not isinstance(row, dict):
             continue
         pid = row.get("pid")
-        if isinstance(pid, int):
-            idx[pid] = row
+        if not isinstance(pid, int) or isinstance(pid, bool):
+            continue
+        if pid in excluded:
+            continue
+        if pid in seen:
+            excluded.add(pid)
+            idx.pop(pid, None)
+            continue
+        seen.add(pid)
+        idx[pid] = row
     return idx
 
 
@@ -2369,7 +2407,16 @@ def _valid_owned_process_tree(
     duplicate identities, and a changed wrapper generation/nonce all invalidate
     carry-forward rather than silently widening authority.
     """
-    if not isinstance(value, dict) or frozenset(value) != _OWNED_PROCESS_TREE_FIELDS:
+    if not isinstance(value, dict):
+        return None
+    value_keys = frozenset(value)
+    # A v2 record (predates rejected_count) is missing exactly one optional
+    # key - still a complete, valid schema for everything it DOES claim; see
+    # _OWNED_PROCESS_TREE_OPTIONAL_FIELDS' own comment for why that must not
+    # collapse to schema-invalid.
+    if value_keys != _OWNED_PROCESS_TREE_FIELDS and value_keys != (
+        _OWNED_PROCESS_TREE_FIELDS - _OWNED_PROCESS_TREE_OPTIONAL_FIELDS
+    ):
         return None
     status = value.get("status")
     record_generation = value.get("wrapper_generation")
@@ -2416,12 +2463,41 @@ def _valid_owned_process_tree(
     ):
         return None
     counts: list[int] = []
-    for field in ("observed_count", "recorded_count", "omitted_count", "rejected_count"):
+    for field in ("observed_count", "recorded_count", "omitted_count"):
         count = value.get(field)
         if not isinstance(count, int) or isinstance(count, bool) or count < 0:
             return None
         counts.append(count)
-    observed_count, recorded_count, omitted_count, _rejected_count = counts
+    observed_count, recorded_count, omitted_count = counts
+    # rejected_count is the one OPTIONAL field (see _OWNED_PROCESS_TREE_
+    # OPTIONAL_FIELDS) - absent on a v2 record means UNKNOWN, not zero, so
+    # this stores None rather than defaulting it, and every reader (the
+    # eligibility check, the status/count cross-check below) must treat
+    # None as "cannot be trusted", never as "0 rejections".
+    if "rejected_count" in value:
+        rejected_count = value.get("rejected_count")
+        if (
+            not isinstance(rejected_count, int)
+            or isinstance(rejected_count, bool)
+            or rejected_count < 0
+        ):
+            return None
+    else:
+        rejected_count = None
+    # Round 3 connector finding 4: complete/absent are the two statuses
+    # that grant future launch/teardown authority - a record claiming one
+    # of them while also recording a nonzero rejection is internally
+    # contradictory (a rejection means the walk excluded a candidate it
+    # could not vouch for, which is precisely what "complete" and
+    # "absent" both promise did not happen). A corrupted or partially-
+    # written record must not read as authoritative just because the
+    # count field itself still parses.
+    if (
+        status in {"complete", "absent"}
+        and rejected_count is not None
+        and rejected_count != 0
+    ):
+        return None
     entries = value.get("entries")
     if (
         not isinstance(entries, list)
@@ -2981,9 +3057,19 @@ def _owned_process_tree(
             # Any retained Windows row therefore needs the exact kernel
             # FILETIME; childless absent launchers are omitted before reaching
             # add_node rather than persisted as future ownership authority.
-            invalid_reason = (
-                invalid_reason or "exact_start_filetime_unavailable"
-            )
+            #
+            # Task #150 connector finding 3: this used to flag invalid_reason
+            # but still ADMIT the node - yet _valid_owned_process_tree
+            # independently REFUSES an ISO-style entry missing start_filetime
+            # for status complete/absent. A tree carrying this exact entry
+            # could reach "absent" under round 2's own eligibility check
+            # (rejected_count stayed 0 for this case) and then fail its own
+            # schema validation the moment anything re-read it - admitted
+            # and refused, disagreeing with each other. mark_rejected makes
+            # both sides agree: an entry this imprecise never contributes to
+            # a rejected_count of 0, so it can never reach a status the
+            # validator would then refuse.
+            mark_rejected("exact_start_filetime_unavailable")
         existing = owned.get(pid)
         if existing is not None:
             if (
@@ -3268,6 +3354,65 @@ def _owned_process_tree(
             mark_rejected("brain_outside_owned_tree")
         elif owned[brain_pid]["role"] == "tool_descendant":
             owned[brain_pid]["role"] = "cli_brain"
+
+    # Task #150 connector findings 1, 3, 5 (round 3): three MORE sites lose
+    # a candidate without incrementing rejected_count, found by review after
+    # round 2 hand-enumerated sixteen invalid_reason sites and missed these
+    # - two of which are not invalid_reason sites at all. Hand enumeration
+    # is the wrong instrument for a universal claim; replace it with
+    # construction. Compute every DESCENDANT (not the roots themselves - a
+    # root simply being absent/exited is normal and already handled at its
+    # own site, e.g. a childless absent launcher, or a prior descendant that
+    # simply exited) of a known root - the wrapper, the declared launcher,
+    # the discovered brain, and every PRIOR entry, whether or not
+    # prior_authority ended up trusted - reachable via the CURRENT
+    # snapshot's raw parent-child edges, regardless of whether admission
+    # logic actually walked into it. children.get(pid, ...) still returns a
+    # live child whose OWN row names pid as parent even when pid itself is
+    # absent or was never visited, so an orphaned intermediate's live child
+    # - or a rejected launcher's live child - is still IN this closure. Any
+    # such descendant that never made it into "owned" is unaccounted -
+    # either a case already flagged above (harmless double count;
+    # rejected_count is a gate, not an exact tally) or exactly the silent-
+    # loss class hand enumeration cannot bound. Either way it becomes a
+    # rejection here, mechanically, rather than by finding a fourth site.
+    discovery_roots: set[int] = set()
+    if isinstance(wrapper_pid, int) and not isinstance(wrapper_pid, bool):
+        discovery_roots.add(wrapper_pid)
+    if isinstance(launcher_pid, int) and not isinstance(launcher_pid, bool):
+        discovery_roots.add(launcher_pid)
+    if isinstance(brain_row, dict):
+        _brain_pid = brain_row.get("pid")
+        if isinstance(_brain_pid, int) and not isinstance(_brain_pid, bool):
+            discovery_roots.add(_brain_pid)
+    for _prior_entry in prior_entries:
+        _prior_pid = _prior_entry.get("pid") if isinstance(_prior_entry, dict) else None
+        if isinstance(_prior_pid, int) and not isinstance(_prior_pid, bool):
+            discovery_roots.add(_prior_pid)
+    # A root already PROVEN to be a different, recycled process (exact
+    # identity mismatch, not merely absent) is not a candidate this agent
+    # has any claim to - its current children are a REPLACEMENT process's
+    # own descendants, not ours, and the existing recycled_parent_pids
+    # check a few lines above already treats them as foreign on purpose
+    # (test: test_owned_process_tree_recycled_launcher_ignores_foreign_
+    # children / ..._recycled_virtual_parent_ignores_replacement_child).
+    # Expanding into a recycled root's children here would flag someone
+    # else's process tree as our own unaccounted loss.
+    discovered_descendants: set[int] = set()
+    frontier = [
+        pid
+        for root in discovery_roots
+        if root not in recycled_parent_pids
+        for pid in children.get(root, [])
+    ]
+    while frontier:
+        candidate_pid = frontier.pop()
+        if candidate_pid in discovered_descendants:
+            continue
+        discovered_descendants.add(candidate_pid)
+        frontier.extend(children.get(candidate_pid, []))
+    for _ in sorted(discovered_descendants - set(owned)):
+        mark_rejected("unaccounted_discovery")
 
     observed_count = len(owned)
     mandatory: set[int] = set()
@@ -6588,13 +6733,33 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         # than naming none, so the entryless case gets an honest "no
         # verified one-line fix" message instead of a command that would
         # frustrate the operator a second time.
+        #
+        # Round 3 (connector finding 6, the same wrong direction again): a
+        # REJECTED candidate is precisely what this record's own entries
+        # never named either, same as a truncated record's omitted ones -
+        # but the reset command's own identity list is built from entries
+        # alone, so it has no way to know about a rejected candidate at
+        # all. The flag's own text only mentions omitted identities; a
+        # nonzero rejected_count needs the same warning stated explicitly,
+        # not folded silently into "every process this record could name".
         has_entries = bool(owned_tree.get("entries"))
+        rejected_count = owned_tree.get("rejected_count")
         if has_entries:
+            rejected_clause = (
+                f" This record also excluded {rejected_count} candidate(s) "
+                "the walk could not admit (rejected_count) - the reset "
+                "command's own identity list does not include them, so "
+                "confirming those specifically gone is on you, not the "
+                "command."
+                if isinstance(rejected_count, int) and rejected_count > 0
+                else ""
+            )
             remedy = (
                 "recovery: if every process this record could name is "
                 "confirmed gone - including any omitted by a truncated "
                 "record, which is exactly what --acknowledge-owned-"
-                "processes-stopped attests to - run `agenttalk supervise "
+                "processes-stopped attests to -"
+                f"{rejected_clause} run `agenttalk supervise "
                 "--reset-process-tree-ownership` (see --help for the "
                 "required --acknowledge-* flags); do NOT kill the wrapper "
                 "expecting an automatic relaunch - that is only safe once "

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2334,6 +2334,34 @@ def _start_tokens_match(observed, expected) -> bool:
     return abs(observed_epoch - expected_epoch) <= 0.001
 
 
+def _wrapper_identity_matches_state(record: dict, st: dict) -> bool:
+    """True iff a wrapper runtime record's own identity agrees with the
+    launcher pid/start a supervisor state dict has stored for it.
+
+    Task #150 round 10 connector finding: this is the actual conjunct
+    process_tree_ownership_reset_evidence requires (a fresh record read at
+    reset time, against the state passed to that call) before it will admit
+    a reset - a DIFFERENT conjunct from runtime_status/STATUS_VALID, which
+    only proves the record parses. _wrapped_liveness's own
+    wrapper_state_mismatch HOLD branch and the remedy message that names
+    --reset-process-tree-ownership must both trust the SAME check the
+    command itself runs, not independently re-derive it: one drifts free of
+    the others otherwise, exactly what happened when the message only
+    checked runtime_status.
+    """
+    wrapper_pid = record.get("wrapper_pid")
+    wrapper_start = record.get("wrapper_start")
+    return (
+        isinstance(wrapper_pid, int)
+        and not isinstance(wrapper_pid, bool)
+        and wrapper_pid > 0
+        and isinstance(wrapper_start, str)
+        and bool(wrapper_start)
+        and st.get("launcher_pid") == wrapper_pid
+        and _start_tokens_match(st.get("launcher_start"), wrapper_start)
+    )
+
+
 def _start_order_key(value: object) -> tuple[str, int | float] | None:
     """Comparable process-start key for known snapshot/token schemes."""
     if not isinstance(value, str) or not value.strip() or len(value) > 256:
@@ -4478,6 +4506,7 @@ def _attribution(
     targets_by_pid: dict[int, dict] = {}
     seed_pids: set[int] = set()
     seed_launcher_sources: dict[int, dict] = {}
+    seed_synthetic_rows: dict[int, dict] = {}
     launcher_pid = st.get("launcher_pid")
     launcher_start = st.get("launcher_start")
     launcher_row = idx.get(launcher_pid) if isinstance(launcher_pid, int) else None
@@ -4561,6 +4590,22 @@ def _attribution(
             # target here.
             if isinstance(entry_pid, int) and entry_pid in excluded_pids:
                 row = {"pid": entry_pid, "start_time": entry.get("start")}
+                # Task #150 round 10 connector finding: this same excluded
+                # seed can go on to be a BFS parent below (seed_descendants),
+                # and idx.get(parent_pid) will fail there for the identical
+                # reason it failed here. _strict_child_edge only ever reads
+                # parent["pid"] and _start_of(parent) - the same two fields
+                # this synthetic row already carries and that Stop-Tree
+                # already trusts to order this pid's own kill - so it is
+                # sufficient to stand in as the BFS parent too. Without this,
+                # an opaque, never-recorded child living under an excluded
+                # tracked pid (e.g. a duplicate-row ambiguity) is never even
+                # looked up, let alone targeted: the tracked pid gets killed
+                # and the child survives it, unseen by evaluate_launch_barrier
+                # (which has no tree evidence to block on for this path
+                # either) - a replacement launches alongside a live child of
+                # the pid it just replaced.
+                seed_synthetic_rows[entry_pid] = row
             else:
                 continue
         if entry["pid"] in targets_by_pid:
@@ -4590,7 +4635,17 @@ def _attribution(
         visited_seed.add(parent_pid)
         parent = idx.get(parent_pid)
         if not isinstance(parent, dict):
-            continue
+            # An excluded seed (see seed_synthetic_rows above) has no row
+            # in idx by construction, not because it is absent - fall back
+            # to the same synthetic identity already trusted to kill it.
+            # Every other pid that ever reaches this queue was admitted via
+            # a real idx row (the child-admission check below requires
+            # isinstance(child, dict) before queue.append), so a seed with
+            # neither a real row nor a synthetic one is unreachable here;
+            # this continue is a defensive backstop, not a live branch.
+            parent = seed_synthetic_rows.get(parent_pid)
+            if not isinstance(parent, dict):
+                continue
         for child_pid in kids.get(parent_pid, []):
             if child_pid in targets_by_pid:
                 continue
@@ -5788,10 +5843,7 @@ def _wrapped_liveness(
     idx, excluded_pids = _snap_index_and_excluded(snapshot)
     wrapper_pid = record.get("wrapper_pid")
     wrapper_start = record.get("wrapper_start")
-    if (
-        wrapper_pid != st.get("launcher_pid")
-        or not _start_tokens_match(wrapper_start, st.get("launcher_start"))
-    ):
+    if not _wrapper_identity_matches_state(record, st):
         return _current_proof_failed(
             "wrapper_state_mismatch",
             hold_reason="process_tree_invalid_wrapper_state_mismatch",
@@ -7080,8 +7132,28 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
         # this poll and when the operator acts - unavoidable from where the
         # message is produced - but it is never wrong about what THIS poll
         # already knows, which is what "must never guess" means here.
+        #
+        # Round 10 (connector finding, a fourth instance of the same wrong
+        # direction, this time in the predicate's own precision rather than
+        # a missing precondition): STATUS_VALID only proves the runtime
+        # record parses - a wrapper runtime record can be STATUS_VALID while
+        # its OWN wrapper_pid/wrapper_start disagrees with this state's
+        # stored launcher_pid/launcher_start, which is exactly what sends
+        # _wrapped_liveness down wrapper_state_mismatch
+        # (process_tree_invalid_wrapper_state_mismatch) with a nonempty
+        # inherited tree. process_tree_ownership_reset_evidence rejects that
+        # case on wrapper identity agreement, a DIFFERENT conjunct than
+        # runtime_status - so "one predicate" needed to mean the actual
+        # admission predicate, not one signal that happens to correlate with
+        # it. _wrapper_identity_matches_state is now the single function
+        # both process_tree_ownership_reset_evidence and this check call -
+        # not a second hand-written comparison that could drift from the
+        # first the way runtime_status alone already did once.
+        runtime_record = liveness.get("runtime_record")
         runtime_currently_valid = (
             liveness.get("runtime_status") == runtime_obs.STATUS_VALID
+            and isinstance(runtime_record, dict)
+            and _wrapper_identity_matches_state(runtime_record, st)
         )
         has_entries = bool(owned_tree.get("entries"))
         rejected_count = owned_tree.get("rejected_count")
@@ -7125,7 +7197,7 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
                 "expecting an automatic relaunch - that is only safe once "
                 "this record already reflects the wrapper as absent"
             )
-        elif has_entries:
+        elif has_entries and liveness.get("runtime_status") != runtime_obs.STATUS_VALID:
             remedy = (
                 "recovery: this record has named identities, but the "
                 "current wrapper runtime record is not valid "
@@ -7136,6 +7208,22 @@ def _plan_one(name: str, rpt: dict, st: dict, config: dict, cfg_agent: dict,
                 f"{owned_tree.get('reason_code')} (a valid runtime record "
                 "recovering on its own is what would let a scripted reset "
                 "apply here, not a --acknowledge-* flag)"
+            )
+        elif has_entries:
+            # Round 10: runtime_status is valid but wrapper_identity_matches_state
+            # is not - the record parses, yet its own wrapper pid/start
+            # disagrees with what this state has stored, which is a
+            # separate refusal reason the command checks independently.
+            remedy = (
+                "recovery: this record has named identities and the "
+                "current wrapper runtime record reads valid, but its own "
+                "wrapper identity (pid/start) does not agree with this "
+                "state's stored launcher identity, and --reset-process-"
+                "tree-ownership refuses on exactly that disagreement - it "
+                "will refuse; this needs operator investigation of "
+                f"{owned_tree.get('reason_code')} (the two identities need "
+                "to agree again - on their own, or via an attended reset - "
+                "before a scripted reset can apply here)"
             )
         else:
             remedy = (
@@ -8150,13 +8238,7 @@ def process_tree_ownership_reset_evidence(
     wrapper_start = runtime.get("wrapper_start")
     if (
         runtime.get("wrapper_generation") != wrapper_generation
-        or not isinstance(wrapper_pid, int)
-        or isinstance(wrapper_pid, bool)
-        or wrapper_pid <= 0
-        or not isinstance(wrapper_start, str)
-        or not wrapper_start
-        or entry.get("launcher_pid") != wrapper_pid
-        or not _start_tokens_match(entry.get("launcher_start"), wrapper_start)
+        or not _wrapper_identity_matches_state(runtime, entry)
     ):
         raise ValueError(
             "supervisor state and strict wrapper runtime record do not agree "

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -4403,19 +4403,18 @@ def _attribution(
             "discovered_brain": False,
         }
 
-    # Task #150 round 7 connector finding survey: an excluded launcher pid
-    # reads as absent here exactly like everywhere else _snap_index is
-    # consumed, but the ONLY effect is _is_confirmed_launcher returning
-    # False - this agent's launcher is left out of kill_targets/seed_pids
-    # for THIS poll. Failing to confirm an ambiguous identity for kill-
-    # targeting is already this file's stated default (an ambiguous
-    # identity "grants no kill authority" - see _owned_process_tree's own
-    # recycled-parent handling); it never asserts the agent is dead, and
-    # nothing downstream of _attribution's return treats an unconfirmed
-    # launcher as death. Genuinely indifferent - kept on _snap_index_and_
-    # excluded only so the bare, silently-lossy _snap_index wrapper can be
-    # retired now that every consumer has been surveyed.
-    idx, _excluded_pids = _snap_index_and_excluded(snapshot)
+    # Task #150 round 7 connector finding survey (revised round 8): an
+    # excluded LAUNCHER pid reads as absent here exactly like everywhere
+    # else _snap_index is consumed, but the only effect on the launcher
+    # itself is _is_confirmed_launcher returning False - failing to
+    # confirm an ambiguous identity for kill-targeting is already this
+    # file's stated default. That classification was correct for the
+    # launcher specifically but was wrongly generalized to the whole
+    # function: round 8 found the SAME idx.get miss, applied to a
+    # PRIOR-TRACKED descendant a few lines below instead of the launcher,
+    # silently drops both its kill target and its persisted provenance -
+    # see the two fixes below. excluded_pids is no longer discarded.
+    idx, excluded_pids = _snap_index_and_excluded(snapshot)
     kids = _children_map(idx)
     targets_by_pid: dict[int, dict] = {}
     seed_pids: set[int] = set()
@@ -4486,9 +4485,25 @@ def _attribution(
     for entry in valid_priors:
         if entry.get("pid") == launcher_pid:
             continue
-        row = idx.get(entry.get("pid"))
+        entry_pid = entry.get("pid")
+        row = idx.get(entry_pid)
         if not isinstance(row, dict) or _start_of(row) != entry.get("start"):
-            continue
+            # Task #150 round 8 connector finding: idx.get(pid) is None
+            # both for a genuinely absent prior identity AND one
+            # _snap_index excluded this poll (a duplicate/ambiguous row) -
+            # dropping BOTH here the same way loses a live, still-tracked
+            # descendant's kill target on a poll that goes on to kill the
+            # launcher and relaunch, leaving that descendant alive
+            # alongside the replacement. An excluded pid is present, not
+            # gone - trust the prior record's own pid/start (the only
+            # identity this attribution model ever carried for it) as a
+            # synthetic row; Stop-Tree's own start-time guard is what
+            # actually decides whether to kill it, same as any other
+            # target here.
+            if isinstance(entry_pid, int) and entry_pid in excluded_pids:
+                row = {"pid": entry_pid, "start_time": entry.get("start")}
+            else:
+                continue
         if entry["pid"] in targets_by_pid:
             continue
         reason = str(entry.get("source") or "provenanced_prior")
@@ -4575,6 +4590,16 @@ def _attribution(
             continue
         row = idx.get(entry["pid"])
         if isinstance(row, dict) and _start_of(row) == entry["start"]:
+            managed_by_pid[entry["pid"]] = entry
+        elif entry["pid"] in excluded_pids:
+            # Task #150 round 8 connector finding: idx.get(pid) is None
+            # both for a genuinely absent prior identity AND one
+            # _snap_index excluded this poll - dropping this entry from
+            # managed_by_pid here is what actually persists the loss: the
+            # NEXT poll's valid_priors would no longer carry this
+            # identity at all, even once the ambiguity clears. Keep it
+            # unchanged as ambiguous HOLD evidence rather than silently
+            # forgetting a still-tracked descendant.
             managed_by_pid[entry["pid"]] = entry
 
     for legacy in legacy_priors:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2041,7 +2041,9 @@ def _launch_detail(st: dict, cfg_agent: dict, perm_mode: str = "bypassPermission
 # (access-limited): we then degrade to name+ancestry only and NEVER match/kill a
 # process by a guessed name (codex discipline note 3).
 
-def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
+def _snap_index_and_excluded(
+    snapshot: list[dict] | None,
+) -> tuple[dict[int, dict], set[int]]:
     # Task #150 connector finding 1: last-write-wins on a duplicate pid
     # silently picks ONE of two rows - if the winner happens to be a
     # malformed/unrelated row while the loser was a genuinely live child,
@@ -2053,6 +2055,14 @@ def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
     # to keep - makes it "not found" for every caller, which is exactly
     # the shape the existing missing_child_row/add_node rejection sites
     # already handle correctly; no caller needs new logic to benefit.
+    #
+    # Task #150 round 6 connector finding: "not found" and "never existed"
+    # are different facts to a caller checking a PRIOR entry's current row
+    # - a prior identity whose row was excluded here (present, ambiguous)
+    # must be rejected, not silently treated the same as one that simply
+    # exited (absent, normal). The excluded set is the one piece of that
+    # distinction only this function has; _snap_index stays the thin,
+    # unchanged accessor every other caller already uses.
     idx: dict[int, dict] = {}
     seen: set[int] = set()
     excluded: set[int] = set()
@@ -2070,7 +2080,11 @@ def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
             continue
         seen.add(pid)
         idx[pid] = row
-    return idx
+    return idx, excluded
+
+
+def _snap_index(snapshot: list[dict] | None) -> dict[int, dict]:
+    return _snap_index_and_excluded(snapshot)[0]
 
 
 def _snap_all_edges(snapshot: list[dict] | None) -> dict[int, list[int]]:
@@ -3015,7 +3029,7 @@ def _owned_process_tree(
     )
 
     snapshot_error = _snapshot_pid_integrity_error(snapshot)
-    idx = _snap_index(snapshot)
+    idx, excluded_pids = _snap_index_and_excluded(snapshot)
     children = _children_map(idx)
 
     # pid -> {row, role, depth, live}; exited, previously earned identities may
@@ -3446,6 +3460,19 @@ def _owned_process_tree(
             continue
         _prior_row = idx.get(_prior_pid)
         if not isinstance(_prior_row, dict):
+            # Task #150 round 6 connector finding: "not indexable" and
+            # "never existed" are different facts for a PREVIOUSLY OWNED
+            # identity. _snap_index excludes a pid entirely when its rows
+            # disagree (a duplicate, or a row whose own parent no longer
+            # connects it) - that pid is PRESENT this poll, just ambiguous,
+            # not gone. A genuinely absent prior descendant (no row at all,
+            # never in excluded_pids either) simply exited, which is normal
+            # and already safe. Bounded strictly to prior_entries - this
+            # cannot poison an unrelated agent's count, since it never
+            # examines a pid that isn't already a recorded identity of
+            # ours.
+            if _prior_pid in excluded_pids:
+                mark_rejected("prior_entry_row_unindexable")
             continue
         _prior_parent_pid = _prior_row.get("parent_pid")
         if not isinstance(_prior_parent_pid, int) or isinstance(_prior_parent_pid, bool):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14023,6 +14023,62 @@ def test_process_ownership_opaque_child_of_excluded_seed_still_killed_with_launc
     assert {11, 12} <= kill_target_pids  # opaque child killed in the SAME operation as the excluded seed
 
 
+def test_process_ownership_excluded_opaque_child_is_unaccounted_not_lost() -> None:
+    """Task #150 round 11 finding 2: _children_map(idx) is built only from
+    idx.items() - a newly discovered child excluded this poll (duplicate/
+    ambiguous rows) never contributed a row to idx, so it never
+    contributes an edge either, regardless of its parent's own trust
+    state. A valid, non-excluded seed_descendants root's opaque child is
+    therefore invisible to the BFS discovery entirely, not merely skipped
+    after being found - a structurally different gap than round 10's
+    finding 1 (an excluded PARENT still has a trusted prior identity to
+    fall back on; a first-time-seen EXCLUDED CHILD has no independent
+    anchor at all, the same "no snapshot-only signal to disambiguate a
+    first-time-seen identity" residual _snap_all_edges already documents
+    for a malformed pid). Asserts the operator-visible outcome: the child
+    is never invented as an untrustworthy kill target (which of the
+    ambiguous rows is real cannot be verified), but it is also never
+    silently lost - diagnostics surfaces it as an accounted-for gap
+    rather than a total loss."""
+    prior = {
+        "attribution_model": "process_ownership_v1",
+        "root_key": sup._root_key(TEST_ROOT),
+        "agent": "worker",
+        "request_id": None,
+        "pid": 11,
+        "start": _ps_iso(200000),
+        "source": "launch_child_provenance",
+        "captured_at_epoch": NOW - 10,
+        "last_fresh_attribution_epoch": NOW - 10,
+        "seed_descendants": True,
+        "source_launcher_pid": 10,
+        "source_launcher_start": _ps_iso(100000),
+        "source_launcher_nonce": SUPERVISOR_NONCE,
+    }
+    opaque_child = _proc(12, 11, "node.exe", "node worker.js", _ps_iso(250000))
+    snap = [
+        _proc(10, 1, "codex.exe", "codex exec", _ps_iso(100000)),
+        _proc(11, 1, "codex.exe", "codex exec --json", _ps_iso(200000)),
+        opaque_child,
+        dict(opaque_child),
+    ]
+    p = sup.plan_actions(
+        _ownership_report(),
+        _ownership_state(
+            launcher_pid=10,
+            launcher_start=_ps_iso(100000),
+            managed_pids=[json.loads(json.dumps(prior))],
+        ),
+        _OWNERSHIP_ATTR_CONFIG,
+        now_epoch=NOW,
+        snapshot=snap,
+    )["agents"]["worker"]
+    kill_target_pids = {t["pid"] for t in p["kill_targets"]}
+    assert 11 in kill_target_pids  # the trusted root is still targeted
+    assert 12 not in kill_target_pids  # never invent trust from ambiguous rows
+    assert p["diagnostics"]["excluded_live_descendant_unaccounted"] == 1
+
+
 def test_process_ownership_stale_launcher_prior_does_not_rescue_row_without_nonce() -> None:
     prior = {
         "attribution_model": "process_ownership_v1",
@@ -14856,6 +14912,34 @@ def test_unverified_owned_process_tree_invalid_with_no_entries_never_promotes() 
         placeholder, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
     )
     assert result["status"] == "invalid"
+
+
+def test_unverified_owned_process_tree_invalid_conversion_does_not_inherit_rejected_count() -> None:
+    """Task #150 round 11 finding 1: converting a previously COMPLETE tree
+    to invalid (because THIS poll's runtime record is invalid or
+    mismatched, not because of anything about the entries themselves)
+    performs no walk of its own - the resulting record must not carry the
+    original walk's rejected_count forward as if it were this poll's own
+    answer. Left uncorrected, a LATER poll's entries_are_complete check
+    would read that stale zero as proof this invalid record is complete,
+    re-admitting it for absence-promotion on an accounting question
+    nobody actually asked this poll. Missing reads as unknown - already
+    ineligible for re-derivation - which is the correct meaning: this
+    poll genuinely does not know. Same "a producer that doesn't walk must
+    not claim to have walked" rule round 4 already applied to the
+    PowerShell post-kill barrier's own mutation sites."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-round11-rejected-count-carry",
+    )["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+    assert tree.get("rejected_count") == 0
+
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        tree, _wrap_snap(), now_epoch=NOW + 1,
+        reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "invalid"
+    assert "rejected_count" not in result
 
 
 def test_unverified_owned_process_tree_invalid_stays_held_when_entry_still_alive() -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -13825,6 +13825,74 @@ def test_process_ownership_provenanced_prior_exact_fields_request_and_ttl() -> N
     assert p_missing["diagnostics"]["prior_ttl_expired"] == 1
 
 
+def test_process_ownership_duplicated_prior_descendant_still_killed_with_launcher() -> None:
+    """Task #150 round 8 connector finding: the SAME idx.get(pid)-is-None
+    conflation round 7 fixed for the ephemeral path also reaches the
+    legacy (non-wrapped) attribution model, arriving in TWO valid_priors
+    loops instead of one - dropping both the kill target AND the
+    persisted provenance for a tracked descendant whose row is merely
+    duplicated this poll, not gone. The observable failure this produces
+    is exactly the duplicate-wrapper hazard the whole PR exists to
+    prevent: a recovery kills the launcher, the glitch clears before the
+    next snapshot, and the untargeted descendant is left alive alongside
+    a freshly launched replacement. This asserts the outcome an operator
+    would see - the descendant IS a kill target, killed in the SAME
+    operation as the launcher, and its provenance survives the glitched
+    poll - not _attribution's own internal classification."""
+    prior = {
+        "attribution_model": "process_ownership_v1",
+        "root_key": sup._root_key(TEST_ROOT),
+        "agent": "worker",
+        "request_id": None,
+        "pid": 11,
+        "start": _ps_iso(200000),
+        "source": "launch_child_provenance",
+        "captured_at_epoch": NOW - 10,
+        "last_fresh_attribution_epoch": NOW - 10,
+        "seed_descendants": False,
+        "source_launcher_pid": 10,
+        "source_launcher_start": _ps_iso(100000),
+        "source_launcher_nonce": SUPERVISOR_NONCE,
+    }
+    duplicated_descendant = _proc(11, 1, "codex.exe", "codex exec --json", _ps_iso(200000))
+    snap = [
+        _proc(10, 1, "codex.exe", "codex exec", _ps_iso(100000)),
+        duplicated_descendant,
+        dict(duplicated_descendant),
+    ]
+    p = sup.plan_actions(
+        _ownership_report(),
+        _ownership_state(
+            launcher_pid=10,
+            launcher_start=_ps_iso(100000),
+            managed_pids=[json.loads(json.dumps(prior))],
+        ),
+        _OWNERSHIP_ATTR_CONFIG,
+        now_epoch=NOW,
+        snapshot=snap,
+    )["agents"]["worker"]
+    kill_target_pids = {t["pid"] for t in p["kill_targets"]}
+    assert 11 in kill_target_pids  # the ambiguous descendant, killed alongside the launcher
+
+    # Separately: a ROUTINE poll (fresh heartbeat, no restart decision) must
+    # not lose this descendant's provenance either - a manual-restart poll
+    # legitimately starts managed_pids fresh on relaunch, so it cannot
+    # isolate the persistence half of this fix on its own.
+    p_routine = sup.plan_actions(
+        _ownership_report(stale=False),
+        _ownership_state(
+            launcher_pid=10,
+            launcher_start=_ps_iso(100000),
+            managed_pids=[json.loads(json.dumps(prior))],
+        ),
+        _OWNERSHIP_ATTR_CONFIG,
+        now_epoch=NOW,
+        snapshot=snap,
+    )["agents"]["worker"]
+    managed_pids_after = {m["pid"] for m in p_routine["next_state"]["managed_pids"]}
+    assert 11 in managed_pids_after  # provenance survives the glitched poll
+
+
 def test_process_ownership_stale_launcher_prior_does_not_rescue_row_without_nonce() -> None:
     prior = {
         "attribution_model": "process_ownership_v1",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14090,6 +14090,77 @@ def test_process_ownership_excluded_opaque_child_is_unaccounted_not_lost() -> No
     assert p["diagnostics"]["excluded_live_descendant_unaccounted"] == 1
 
 
+def test_process_ownership_ambiguous_seed_hold_survives_the_provenance_ttl() -> None:
+    """Task #150 round 13 connector finding: keeping an excluded prior
+    entry UNCHANGED across polls (round 8's fix) left its own
+    last_fresh_attribution_epoch frozen at whenever it was last
+    unambiguous - _prior_valid's TTL check then expires it after
+    _PROVENANCE_TTL_SECONDS of CONTINUOUS ambiguity, even though the pid
+    is present in conflicting rows on every single one of those polls. A
+    TTL is the right instrument for evidence nobody has rechecked; this
+    pid IS rechecked every poll, it just cannot be disambiguated - a live
+    observation of an unresolved condition, not aging evidence. Expiring
+    it drops the seed the UNACCOUNTED_LIVE_DESCENDANT HOLD (round 12)
+    depends on to discover its own child at all, so a pending authorized
+    restart relaunches without targeting either process.
+
+    Simulates three consecutive polls with the identical ambiguity present
+    throughout (same duplicate-rowed seed, same opaque child), spaced
+    2000 seconds apart - each individual gap is under the one-hour TTL,
+    but the CUMULATIVE gap from the first poll to the third (4000s)
+    exceeds it. Asserts the operator-visible outcome on the THIRD poll:
+    the HOLD still fires - not a changed epoch value."""
+    prior = {
+        "attribution_model": "process_ownership_v1",
+        "root_key": sup._root_key(TEST_ROOT),
+        "agent": "worker",
+        "request_id": None,
+        "pid": 11,
+        "start": _ps_iso(200000),
+        "source": "launch_child_provenance",
+        "captured_at_epoch": NOW - 10,
+        "last_fresh_attribution_epoch": NOW - 10,
+        "seed_descendants": True,
+        "source_launcher_pid": 10,
+        "source_launcher_start": _ps_iso(100000),
+        "source_launcher_nonce": SUPERVISOR_NONCE,
+    }
+    duplicated_seed = _proc(11, 1, "codex.exe", "codex exec --json", _ps_iso(200000))
+    opaque_child = _proc(12, 11, "node.exe", "node worker.js", _ps_iso(250000))
+    snap = [
+        _proc(10, 1, "codex.exe", "codex exec", _ps_iso(100000)),
+        duplicated_seed,
+        dict(duplicated_seed),
+        opaque_child,
+    ]
+    assert sup._PROVENANCE_TTL_SECONDS == 3600.0  # noqa: SLF001
+
+    state = _ownership_state(
+        launcher_pid=10,
+        launcher_start=_ps_iso(100000),
+        managed_pids=[json.loads(json.dumps(prior))],
+    )
+    poll_epochs = [NOW, NOW + 2000, NOW + 4000]
+    p = None
+    for epoch in poll_epochs:
+        p = sup.plan_actions(
+            _ownership_report(),
+            state,
+            _OWNERSHIP_ATTR_CONFIG,
+            now_epoch=epoch,
+            snapshot=snap,
+        )["agents"]["worker"]
+        state = {"agents": {"worker": {**state["agents"]["worker"], **p["next_state"]}}}
+
+    assert poll_epochs[-1] - poll_epochs[0] > sup._PROVENANCE_TTL_SECONDS  # noqa: SLF001
+    assert p["action"] == sup.WARN_ONLY
+    assert p["state"] == "UNACCOUNTED_LIVE_DESCENDANT"
+    assert p["kill_targets"] == []
+    assert p["diagnostics"]["excluded_live_descendant_unaccounted"] == 1
+    managed_after = {m["pid"]: m for m in p["next_state"]["managed_pids"]}
+    assert managed_after[11]["last_fresh_attribution_epoch"] == poll_epochs[-1]
+
+
 def test_process_ownership_stale_launcher_prior_does_not_rescue_row_without_nonce() -> None:
     prior = {
         "attribution_model": "process_ownership_v1",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -13971,20 +13971,23 @@ def test_process_ownership_duplicated_prior_descendant_still_killed_with_launche
 
 
 def test_process_ownership_opaque_child_of_excluded_seed_still_killed_with_launcher() -> None:
-    """Task #150 round 10 finding 1: round 8's synthetic-row fix (above)
-    made an excluded tracked pid a kill target again, but the BFS
-    descendant-walk a few lines later still looked it up via idx.get and
-    skipped it as a BFS parent for the identical reason - so a live,
-    never-recorded child of that excluded pid (opaque: not itself a prior
-    entry, not an agenttalk wrap/wait invocation, discoverable only by
-    walking down from pid 11) was never even queried, let alone targeted.
-    The connector's scenario: tracked pid 11 has duplicate rows this poll
-    (excluded) and an untracked child pid 12 underneath it. This asserts
-    the operator-visible outcome the lead named - a surviving opaque
-    child preventing the clear - not a changed internal set: pid 12 must
-    be a kill target in the SAME operation that kills pid 11, so Stop-Tree
-    takes both out together and no replacement launches alongside a still
-    -live child of the pid it just replaced."""
+    """Task #150 round 10 finding 1, corrected by round 12 finding 2:
+    round 10 made an excluded tracked pid's opaque child a kill target in
+    the SAME operation, by reusing the excluded seed's synthetic row
+    (prior pid/start) as the _strict_child_edge PARENT for BFS discovery.
+    That synthetic identity is only ever re-verified by Stop-Tree, at kill
+    time, for the SEED's own kill - nothing re-verifies it before it feeds
+    an independent kill decision about the CHILD. If pid 11 has been
+    RECYCLED (a genuinely different process now holds it), the synthetic
+    row's stale start time is almost always earlier than any of the
+    replacement's own children, so the ordering check meant to REJECT an
+    unrelated descendant would instead pass every one of them - a new
+    hazard round 10's fix itself created. Round 12 stopped descending
+    through an excluded parent at all: pid 12 is neither invented as a
+    kill target nor silently lost - it is unaccounted, which now correctly
+    HOLDS the whole poll (no kill, no relaunch, not even the seed) rather
+    than proceeding on a kill decision made from an unverifiable identity.
+    Asserts the operator-visible outcome: the poll holds."""
     prior = {
         "attribution_model": "process_ownership_v1",
         "root_key": sup._root_key(TEST_ROOT),
@@ -14019,12 +14022,15 @@ def test_process_ownership_opaque_child_of_excluded_seed_still_killed_with_launc
         now_epoch=NOW,
         snapshot=snap,
     )["agents"]["worker"]
-    kill_target_pids = {t["pid"] for t in p["kill_targets"]}
-    assert {11, 12} <= kill_target_pids  # opaque child killed in the SAME operation as the excluded seed
+    assert p["action"] == sup.WARN_ONLY
+    assert p["state"] == "UNACCOUNTED_LIVE_DESCENDANT"
+    assert p["kill_targets"] == []  # not even the excluded seed itself is killed
+    assert p["diagnostics"]["excluded_live_descendant_unaccounted"] == 1
 
 
 def test_process_ownership_excluded_opaque_child_is_unaccounted_not_lost() -> None:
-    """Task #150 round 11 finding 2: _children_map(idx) is built only from
+    """Task #150 round 11 finding 2 (discovery), corrected by round 12
+    finding 1 (the remedy): _children_map(idx) is built only from
     idx.items() - a newly discovered child excluded this poll (duplicate/
     ambiguous rows) never contributed a row to idx, so it never
     contributes an edge either, regardless of its parent's own trust
@@ -14035,11 +14041,16 @@ def test_process_ownership_excluded_opaque_child_is_unaccounted_not_lost() -> No
     fall back on; a first-time-seen EXCLUDED CHILD has no independent
     anchor at all, the same "no snapshot-only signal to disambiguate a
     first-time-seen identity" residual _snap_all_edges already documents
-    for a malformed pid). Asserts the operator-visible outcome: the child
-    is never invented as an untrustworthy kill target (which of the
-    ambiguous rows is real cannot be verified), but it is also never
-    silently lost - diagnostics surfaces it as an accounted-for gap
-    rather than a total loss."""
+    for a malformed pid).
+
+    Round 11 surfaced this via a diagnostic counter alone, which round 12
+    correctly called out as a check that runs and is never acted on: a
+    manual restart request would still have killed only the trusted
+    parent and relaunched, stranding the unaccounted child exactly as
+    before. Asserts the ACTUAL operator-visible outcome now: the poll
+    HOLDS (no kill, no relaunch) rather than proceeding on partial
+    accounting, while still never inventing an untrustworthy kill target
+    for the ambiguous child itself."""
     prior = {
         "attribution_model": "process_ownership_v1",
         "root_key": sup._root_key(TEST_ROOT),
@@ -14073,9 +14084,9 @@ def test_process_ownership_excluded_opaque_child_is_unaccounted_not_lost() -> No
         now_epoch=NOW,
         snapshot=snap,
     )["agents"]["worker"]
-    kill_target_pids = {t["pid"] for t in p["kill_targets"]}
-    assert 11 in kill_target_pids  # the trusted root is still targeted
-    assert 12 not in kill_target_pids  # never invent trust from ambiguous rows
+    assert p["action"] == sup.WARN_ONLY
+    assert p["state"] == "UNACCOUNTED_LIVE_DESCENDANT"
+    assert p["kill_targets"] == []  # HOLD - not even the trusted parent is killed
     assert p["diagnostics"]["excluded_live_descendant_unaccounted"] == 1
 
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -15341,6 +15341,67 @@ def test_owned_process_tree_rejects_prior_entry_with_malformed_parent_pid() -> N
     assert intermediate_pid not in [e["pid"] for e in tree["entries"]]
 
 
+def test_owned_process_tree_rejects_prior_entry_excluded_by_snap_index() -> None:
+    """Task #150 round 6 connector finding: "unindexable" and "invalid
+    parent" are different failure modes, and round 5's fix only covered
+    the second. When a PREVIOUSLY OWNED pid's row is DUPLICATED this
+    poll, _snap_index correctly excludes it entirely (ambiguous, not
+    "not found") - idx.get(that_pid) then returns None, same as a
+    genuinely exited descendant would. Round 5's check only inspects
+    parent_pid on a row it can actually retrieve, so it silently
+    `continue`s past an excluded pid exactly like it would past one that
+    simply exited - even though this one is present, not gone. Bounded
+    strictly to prior_entries (via the pid, not by trusting the excluded
+    row's own content, which does not exist), this cannot poison an
+    unrelated agent's count: it only ever inspects a pid already
+    recorded as one of ours."""
+    intermediate_pid = 500
+    first_snapshot = [
+        *_wrap_snap(),
+        _proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+    ]
+    first = _owned_tree_plan(first_snapshot, request_id="rr-150-excluded-prior-first")
+    complete_tree = first["next_state"]["owned_process_tree"]
+    assert complete_tree["status"] == "complete"
+    assert intermediate_pid in [e["pid"] for e in complete_tree["entries"]]
+
+    untrusted_state = dict(first["next_state"])
+    untrusted_tree = dict(complete_tree)
+    untrusted_tree["status"] = "invalid"
+    untrusted_tree["reason_code"] = "process_tree_invalid_generation_adoption_pending"
+    untrusted_state["owned_process_tree"] = untrusted_tree
+
+    # Second poll: the SAME pid appears twice, both rows now claiming an
+    # UNRELATED parent (matching the round-5 isolation technique) rather
+    # than the launcher - so this pid contributes no edge to EITHER idx
+    # (excluded, ambiguous) OR the permissive discovery_edges map (its
+    # declared parent no longer connects it to the wrapper at all), and
+    # round 4's own discovery-closure fix - which finds a duplicated pid
+    # via a STILL-VALID edge from a root - plays no part. The only path
+    # left is prior_entries seeding it as a root directly.
+    duplicated_row = _proc(intermediate_pid, 1, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000))
+    duplicate_of_same_pid = {**duplicated_row, "start_time": _ps_iso(700001)}
+    second_snapshot = [*_wrap_snap(), duplicated_row, duplicate_of_same_pid]
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-excluded-prior-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": untrusted_state}},
+        now=NOW + 1,
+        snapshot=second_snapshot,
+    )
+    tree = second["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["rejected_count"] >= 1
+    assert intermediate_pid not in [e["pid"] for e in tree["entries"]]
+
+
 def test_reset_remedy_names_rejected_candidates_separately_from_omitted() -> None:
     """Task #150 round 3 connector finding 6, the same wrong direction as
     round 2's own finding 2: a rejected candidate is precisely what this

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -9972,6 +9972,44 @@ def test_wrapped_missing_runtime_is_unknown_with_rollout_remediation() -> None:
     )
 
 
+def test_reset_remedy_does_not_name_command_when_runtime_currently_invalid() -> None:
+    """Task #150 round 9 connector finding, the third instance of the same
+    wrong direction: --reset-process-tree-ownership (cli.py) requires the
+    CURRENT wrapper runtime record to read STATUS_VALID before it will
+    act on a configured agent, entirely independent of the tree's own
+    entries/rejected_count - round 2 and round 3 each closed the ONE
+    precondition that had actually bitten (an entryless placeholder's
+    missing nonce; a rejected candidate outside the identity list) by
+    patching that specific case, leaving this one unclosed. A tree can
+    hold real, non-empty entries (inherited from an earlier complete
+    poll) while the runtime record is exactly what made THIS poll
+    invalid - the remedy must not name a command that will refuse the
+    operator for that reason. Asserts the operator-visible message, not
+    the internal predicate."""
+    earned = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-reset-remedy-runtime-invalid",
+    )["next_state"]["owned_process_tree"]
+    assert earned["status"] == "complete"
+    assert earned["entries"]
+
+    plan = sup.plan_actions(
+        _report(heartbeat_stale=False),
+        {"agents": {"worker": _wrap_ready(owned_process_tree=earned)}},
+        _WRAP_CONFIG,
+        now_epoch=NOW,
+        snapshot=_wrap_snap()[:1],
+    )["agents"]["worker"]
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["entries"]  # has_entries branch, not the entryless one
+    assert tree["reason_code"] == "process_tree_invalid_runtime_absent"
+    # The command may still be NAMED for context (same as the established
+    # entryless-placeholder wording), but must never be RECOMMENDED to run
+    # when this poll already knows it would refuse.
+    assert "run `agenttalk supervise --reset-process-tree-ownership`" not in plan["reason"]
+    assert "runtime record is not valid" in plan["reason"]
+
+
 def test_wrapped_torn_runtime_read_is_unknown_without_partial_fields(
     tmp_path: Path,
 ) -> None:
@@ -15401,6 +15439,167 @@ def test_owned_process_tree_accounts_for_orphaned_intermediates_live_child() -> 
     assert tree["status"] == "invalid"
     assert tree["rejected_count"] >= 1
     assert live_grandchild_pid not in [e["pid"] for e in tree["entries"]]
+
+
+def test_owned_process_tree_does_not_double_count_same_rejected_candidate() -> None:
+    """Task #150 round 9 connector finding: a candidate rejected once
+    during the main walk (here, an unproven virtual-parent descendant
+    below a TRUSTED but now-exited intermediate) is ALSO absent from
+    `owned`, so the discovery-closure loop finds it again and used to
+    call mark_rejected a second time for the identical pid - one lost
+    candidate reported as two. Round 3's own "harmless, rejected_count
+    is a gate not a tally" justification for this was true when written
+    and stopped being true the moment round 3 (and round 5) added an
+    operator-facing message that reports the number as a count - a
+    value's tolerance for imprecision is a property of its consumers,
+    not the value itself. Asserts the operator-visible outcome: the
+    remedy message reports ONE excluded candidate, not two."""
+    intermediate_pid = 500
+    anchor_child_pid = 501
+    new_child_pid = 502
+    first_snapshot = [
+        *_wrap_snap(),
+        _proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        _proc(anchor_child_pid, intermediate_pid, "node.exe", "node anchor.js", _ps_iso(800000)),
+    ]
+    first = _owned_tree_plan(first_snapshot, request_id="rr-150-no-double-count-first")
+    complete_tree = first["next_state"]["owned_process_tree"]
+    assert complete_tree["status"] == "complete"
+    assert {e["pid"] for e in complete_tree["entries"]} >= {intermediate_pid, anchor_child_pid}
+
+    # Second poll: the intermediate itself has exited (no row at all, so
+    # prior_authority's own rehydration must rebuild it as a virtual
+    # bridge via anchor_child_pid, still alive, needing it as an
+    # ancestor). A brand-new live child - never recorded in the prior -
+    # appears below that same virtual bridge: unproven at the main-walk
+    # site (line ~3455) AND separately reachable via discovery_edges
+    # from the same intermediate_pid discovery root.
+    second_snapshot = [
+        *_wrap_snap(),
+        _proc(anchor_child_pid, intermediate_pid, "node.exe", "node anchor.js", _ps_iso(800000)),
+        _proc(new_child_pid, intermediate_pid, "node.exe", "node new.js", _ps_iso(900000)),
+    ]
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-no-double-count-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": first["next_state"]}},
+        now=NOW + 1,
+        snapshot=second_snapshot,
+    )
+    tree = second["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert new_child_pid not in [e["pid"] for e in tree["entries"]]
+    # The internal counter, checked once for context:
+    assert tree["rejected_count"] == 1
+    # The operator-visible outcome the standing test rule asks for: the
+    # remedy message must report ONE excluded candidate, not two.
+    assert "excluded 1 candidate(s)" in second["reason"]
+    assert "excluded 2 candidate(s)" not in second["reason"]
+
+
+def test_owned_process_tree_prior_entry_malformed_pid_still_finds_live_child() -> None:
+    """Task #150 round 9 connector finding 3: a row whose OWN pid field is
+    malformed (as opposed to round 5's malformed parent_pid) contributes
+    no edge either direction, since there is no valid pid to key it by.
+    This test confirms the case the connector says is already safe: for
+    a PRIOR-TRACKED intermediate, the trusted-rehydration block never
+    even looks at this poll's malformed row - it reconstructs the
+    intermediate's identity from the prior record's own start/filetime
+    and re-verifies the live child against that same prior chain,
+    bypassing the malformed current row entirely. Locks in behavior that
+    was already correct by construction (not a new fix) so it cannot
+    silently regress."""
+    intermediate_pid = 500
+    live_child_pid = 501
+    first_snapshot = [
+        *_wrap_snap(),
+        _proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        _proc(live_child_pid, intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    first = _owned_tree_plan(first_snapshot, request_id="rr-150-malformed-pid-prior-first")
+    complete_tree = first["next_state"]["owned_process_tree"]
+    assert complete_tree["status"] == "complete"
+    assert {e["pid"] for e in complete_tree["entries"]} >= {intermediate_pid, live_child_pid}
+
+    # Second poll: same trusted prior, but the intermediate's own row now
+    # has a malformed pid field - the child is unchanged and still alive.
+    malformed_intermediate = {
+        **_proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        "pid": None,
+    }
+    second_snapshot = [
+        *_wrap_snap(),
+        malformed_intermediate,
+        _proc(live_child_pid, intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-malformed-pid-prior-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": first["next_state"]}},
+        now=NOW + 1,
+        snapshot=second_snapshot,
+    )
+    tree = second["next_state"]["owned_process_tree"]
+    # The whole-snapshot integrity check still (correctly) sees a
+    # malformed row and marks the tree invalid this poll - that is
+    # orthogonal to whether the specific tracked identities were lost.
+    assert tree["status"] == "invalid"
+    assert tree["reason_code"] == "process_tree_invalid_snapshot_invalid_process_row"
+    assert {intermediate_pid, live_child_pid} <= {e["pid"] for e in tree["entries"]}
+
+
+def test_owned_process_tree_first_seen_malformed_pid_is_a_documented_residual() -> None:
+    """Task #150 round 9 connector finding 3, the genuinely unbounded half:
+    a first-time-seen intermediate (never a prior entry) whose row has a
+    malformed pid contributes no edge either direction, so nothing ever
+    learns it exists at all - not as a root (no prior_entries pid to seed
+    it), not as anyone's discovered child (the one edge that would have
+    named it depends on ITS OWN row, which is unusable). Its own live
+    child is consequently unreachable too. Every other fix in this
+    family works by looking a row up BY its own intact pid field; that
+    is exactly the field missing here, and there is no snapshot-only
+    signal to distinguish this row from an unrelated malformed row
+    elsewhere on the host. This test documents the residual by
+    execution rather than asserting a fix - see _snap_all_edges's own
+    comment for why treating this as boundable would revive the
+    host-wide-poisoning failure mode round 5 already ruled out."""
+    intermediate_pid = 500
+    live_child_pid = 501
+    malformed_intermediate = {
+        **_proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        "pid": None,
+    }
+    snapshot = [
+        *_wrap_snap(),
+        malformed_intermediate,
+        _proc(live_child_pid, intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-malformed-pid-first-seen")
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["reason_code"] == "process_tree_invalid_snapshot_invalid_process_row"
+    # The documented gap: neither identity is accounted for, and the
+    # whole-snapshot fact that produced "invalid" is not itself a
+    # per-candidate rejection (matching every other whole-snapshot site
+    # in this file), so rejected_count stays 0 despite a real, live,
+    # untracked descendant.
+    assert tree["rejected_count"] == 0
+    assert intermediate_pid not in [e["pid"] for e in tree["entries"]]
+    assert live_child_pid not in [e["pid"] for e in tree["entries"]]
 
 
 def test_owned_process_tree_rejects_prior_entry_with_malformed_parent_pid() -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -10010,6 +10010,45 @@ def test_reset_remedy_does_not_name_command_when_runtime_currently_invalid() -> 
     assert "runtime record is not valid" in plan["reason"]
 
 
+def test_reset_remedy_does_not_name_command_when_wrapper_identity_mismatches_state() -> None:
+    """Task #150 round 10 finding 2: round 9's fix gated the remedy on
+    runtime_status == STATUS_VALID alone - one signal _wrapped_liveness
+    computes, not the reset command's actual admission predicate.
+    --reset-process-tree-ownership (cli.py,
+    process_tree_ownership_reset_evidence) also refuses when a STATUS_VALID
+    runtime record's own wrapper_pid/wrapper_start disagrees with this
+    state's stored launcher_pid/launcher_start - a record can parse fine
+    (STATUS_VALID) while still failing that agreement, which is exactly
+    what sends _wrapped_liveness down wrapper_state_mismatch
+    (process_tree_invalid_wrapper_state_mismatch) with a nonempty inherited
+    tree. The remedy must not recommend a command that refuses for that
+    reason either. Asserts the operator-visible message, not the internal
+    predicate."""
+    earned = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-reset-remedy-wrapper-mismatch",
+    )["next_state"]["owned_process_tree"]
+    assert earned["status"] == "complete"
+    assert earned["entries"]
+
+    mismatched_runtime = _wrapper_runtime_view(
+        wrapper_pid=WRAP_LAUNCHER_PID + 500,
+        wrapper_start=_ps_iso(999000),
+    )
+    plan = sup.plan_actions(
+        _report(heartbeat_stale=False, wrapper_runtime=mismatched_runtime),
+        {"agents": {"worker": _wrap_ready(owned_process_tree=earned)}},
+        _WRAP_CONFIG,
+        now_epoch=NOW,
+        snapshot=_wrap_snap()[:1],
+    )["agents"]["worker"]
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["entries"]  # has_entries branch, not the entryless one
+    assert tree["reason_code"] == "process_tree_invalid_wrapper_state_mismatch"
+    assert "run `agenttalk supervise --reset-process-tree-ownership`" not in plan["reason"]
+    assert "does not agree with this state's stored launcher identity" in plan["reason"]
+
+
 def test_wrapped_torn_runtime_read_is_unknown_without_partial_fields(
     tmp_path: Path,
 ) -> None:
@@ -13929,6 +13968,59 @@ def test_process_ownership_duplicated_prior_descendant_still_killed_with_launche
     )["agents"]["worker"]
     managed_pids_after = {m["pid"] for m in p_routine["next_state"]["managed_pids"]}
     assert 11 in managed_pids_after  # provenance survives the glitched poll
+
+
+def test_process_ownership_opaque_child_of_excluded_seed_still_killed_with_launcher() -> None:
+    """Task #150 round 10 finding 1: round 8's synthetic-row fix (above)
+    made an excluded tracked pid a kill target again, but the BFS
+    descendant-walk a few lines later still looked it up via idx.get and
+    skipped it as a BFS parent for the identical reason - so a live,
+    never-recorded child of that excluded pid (opaque: not itself a prior
+    entry, not an agenttalk wrap/wait invocation, discoverable only by
+    walking down from pid 11) was never even queried, let alone targeted.
+    The connector's scenario: tracked pid 11 has duplicate rows this poll
+    (excluded) and an untracked child pid 12 underneath it. This asserts
+    the operator-visible outcome the lead named - a surviving opaque
+    child preventing the clear - not a changed internal set: pid 12 must
+    be a kill target in the SAME operation that kills pid 11, so Stop-Tree
+    takes both out together and no replacement launches alongside a still
+    -live child of the pid it just replaced."""
+    prior = {
+        "attribution_model": "process_ownership_v1",
+        "root_key": sup._root_key(TEST_ROOT),
+        "agent": "worker",
+        "request_id": None,
+        "pid": 11,
+        "start": _ps_iso(200000),
+        "source": "launch_child_provenance",
+        "captured_at_epoch": NOW - 10,
+        "last_fresh_attribution_epoch": NOW - 10,
+        "seed_descendants": True,
+        "source_launcher_pid": 10,
+        "source_launcher_start": _ps_iso(100000),
+        "source_launcher_nonce": SUPERVISOR_NONCE,
+    }
+    duplicated_descendant = _proc(11, 1, "codex.exe", "codex exec --json", _ps_iso(200000))
+    opaque_child = _proc(12, 11, "node.exe", "node worker.js", _ps_iso(250000))
+    snap = [
+        _proc(10, 1, "codex.exe", "codex exec", _ps_iso(100000)),
+        duplicated_descendant,
+        dict(duplicated_descendant),
+        opaque_child,
+    ]
+    p = sup.plan_actions(
+        _ownership_report(),
+        _ownership_state(
+            launcher_pid=10,
+            launcher_start=_ps_iso(100000),
+            managed_pids=[json.loads(json.dumps(prior))],
+        ),
+        _OWNERSHIP_ATTR_CONFIG,
+        now_epoch=NOW,
+        snapshot=snap,
+    )["agents"]["worker"]
+    kill_target_pids = {t["pid"] for t in p["kill_targets"]}
+    assert {11, 12} <= kill_target_pids  # opaque child killed in the SAME operation as the excluded seed
 
 
 def test_process_ownership_stale_launcher_prior_does_not_rescue_row_without_nonce() -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14888,6 +14888,239 @@ def test_process_tree_truncated_remedy_covers_omitted_identities_too() -> None:
     assert "--acknowledge-owned-processes-stopped" in plan["reason"]
 
 
+def test_v2_record_missing_rejected_count_stays_valid_but_ineligible() -> None:
+    """Task #150 round 3 connector finding 2, the blocker on round 2's own
+    blocker fix: a bare schema_version bump would have made every record
+    persisted before rejected_count existed fail validation SOLELY on the
+    new field's absence - and on the wrapped-liveness path a live,
+    healthy wrapper then rebuilds that now-"invalid" prior into a fresh
+    process_tree_invalid_prior_record_invalid on EVERY poll from then on,
+    reintroducing the sticky fleet-wide HOLD this PR exists to remove, at
+    the moment of upgrade, for agents that were never anything but
+    healthy. rejected_count is therefore OPTIONAL in the persisted schema:
+    a v2-shaped record (missing it entirely) must still validate as
+    authoritative - proving the upgrade itself does not brick a healthy
+    fleet - while remaining ineligible for the NEW absence-promotion
+    eligibility this round grants, because "missing" must mean unknown,
+    never zero."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-v2-migration",
+    )["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+    v2_shaped = dict(tree)
+    del v2_shaped["rejected_count"]
+
+    # (a) still readable/valid authority - the upgrade itself must not
+    # brick a healthy agent's own persisted record.
+    validated = sup._valid_owned_process_tree(  # noqa: SLF001
+        v2_shaped, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    )
+    assert validated is not None
+    assert "rejected_count" not in validated
+
+    # (b) a healthy, ALIVE wrapper polling against this v2-shaped prior
+    # must NOT be forced into PROCESS_TREE_INVALID merely because its own
+    # persisted record predates rejected_count - the exact self-inflicted
+    # regression the bare version bump caused.
+    st = _wrap_ready(runtime_wrapper_generation="wrapper-1")
+    st["owned_process_tree"] = v2_shaped
+    healthy_plan = _plan_wrap(
+        _report(wrapper_runtime=_wrapper_runtime_view(phase="idle", now=NOW)),
+        {"agents": {"worker": st}},
+        snapshot=_wrap_snap(),
+    )
+    assert healthy_plan["state"] != "PROCESS_TREE_INVALID"
+    assert healthy_plan["next_state"]["owned_process_tree"]["status"] == "complete"
+
+    # (c) once invalid for an UNRELATED reason, a v2-shaped prior must not
+    # be promoted to absent just because omitted_count reads 0 - unknown
+    # rejected_count must block eligibility exactly like a real nonzero
+    # count would.
+    poisoned = dict(v2_shaped)
+    poisoned["status"] = "invalid"
+    poisoned["reason_code"] = "process_tree_invalid_snapshot_invalid_process_row"
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        poisoned, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "invalid"
+
+
+def test_validator_refuses_complete_or_absent_with_nonzero_rejected_count() -> None:
+    """Task #150 round 3 connector finding 4: the validator parsed
+    rejected_count but never constrained it against status - a corrupted
+    or partially-updated record claiming complete/absent while also
+    recording a nonzero rejection is internally contradictory (those two
+    statuses both promise nothing was excluded) and must not read as
+    authoritative just because the count field itself still parses."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-validator-constraint",
+    )["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+    corrupted = dict(tree)
+    corrupted["rejected_count"] = 1
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        corrupted, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+
+    absent_tree = dict(corrupted)
+    absent_tree["status"] = "absent"
+    absent_tree["reason_code"] = "process_tree_absent"
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        absent_tree, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+
+    # The control: rejected_count == 0 on complete/absent is exactly what
+    # every real construction site already writes, and must keep validating.
+    clean = dict(tree)
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        clean, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+
+
+def test_snap_index_excludes_rather_than_picks_a_duplicate_pid() -> None:
+    """Task #150 round 3 connector finding 1: last-write-wins on a
+    duplicate pid silently picks ONE of two rows - if a malformed or
+    unrelated row wins over a genuinely live child, every later
+    idx.get(that_pid) call sees the wrong identity with no signal
+    anything was lost. Excluding the duplicated pid entirely makes it
+    "not found" for every caller, which the existing missing_child_row
+    rejection already handles correctly."""
+    good_child = _proc(999, WRAP_LAUNCHER_PID, "node.exe", "node tool.js", _ps_iso(700000))
+    duplicate_bad_row = {**good_child, "parent_pid": None}
+    idx = sup._snap_index([_wrap_snap()[0], good_child, duplicate_bad_row])  # noqa: SLF001
+    assert 999 not in idx
+    assert WRAP_LAUNCHER_PID in idx  # unrelated pids are unaffected
+
+
+def test_owned_process_tree_rejects_walk_when_launcher_missing_exact_filetime() -> None:
+    """Task #150 round 3 connector finding 3: a Windows row lacking exact
+    start_filetime used to be ADMITTED by add_node while
+    _valid_owned_process_tree independently REFUSES that same entry for
+    status complete/absent - the two disagreeing with each other meant a
+    tree carrying this entry could reach "absent" under round 2's own
+    eligibility check and then fail its own schema validation the moment
+    anything re-read it. mark_rejected on this path means such an entry
+    can never contribute to a rejected_count of 0, so it can never reach
+    a status the validator would then refuse."""
+    launcher_no_filetime = {
+        **_proc(WRAP_CHILD_PID, WRAP_LAUNCHER_PID, "codex.exe", "codex exec --json", WRAP_CHILD_START),
+        "start_filetime": None,
+    }
+    snapshot = [_wrap_snap()[0], launcher_no_filetime]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-imprecise-filetime")
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["rejected_count"] >= 1
+    # The entry is still captured (admitted), just never eligible to reach
+    # a status the validator would then refuse.
+    assert WRAP_CHILD_PID in [e["pid"] for e in tree["entries"]]
+
+
+def test_owned_process_tree_accounts_for_orphaned_intermediates_live_child() -> None:
+    """Task #150 round 3 connector finding 5: a rebuild after a corrupt
+    prior cannot reach an orphan below an already-exited intermediate
+    parent, because the rehydration loop that would normally re-admit a
+    prior descendant as a virtual bridge is gated entirely behind a
+    TRUSTED prior_authority (status == "complete"). An invalid prior that
+    is still READABLE (schema-valid, non-empty entries, just not trusted
+    for rehydration - the generation-adoption-pending exemption is the
+    one invalid reason_code this walk still rebuilds against instead of
+    holding on) never runs that rehydration loop at all, so a live
+    descendant whose ONLY evidence is the untrusted prior's own entries
+    goes completely unaccounted: not admitted, not omitted, not rejected
+    - simply invisible. The discovery-closure reconciliation catches this
+    mechanically because it seeds discovery roots from every prior entry
+    regardless of whether prior_authority ended up trusted, then expands
+    through the CURRENT snapshot's raw parent-child edges - which still
+    names the orphan's live child even though admission logic never
+    walks into it."""
+    orphaned_intermediate_pid = 500
+    live_grandchild_pid = 501
+    first_snapshot = [
+        *_wrap_snap(),
+        _proc(orphaned_intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        _proc(live_grandchild_pid, orphaned_intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    first = _owned_tree_plan(first_snapshot, request_id="rr-150-orphan-first")
+    complete_tree = first["next_state"]["owned_process_tree"]
+    assert complete_tree["status"] == "complete"
+    assert {e["pid"] for e in complete_tree["entries"]} >= {
+        orphaned_intermediate_pid,
+        live_grandchild_pid,
+    }
+
+    # Recast the same, otherwise-untouched complete tree as an untrusted-
+    # but-readable prior - the one invalid reason_code this walk rebuilds
+    # against rather than holding on - so prior_authority becomes None
+    # while prior_entries (still carrying the orphan and its child) stays
+    # populated. This is deliberately hand-built rather than reached via
+    # a real generation-adoption poll: the mechanism under test is
+    # whether the WALK correctly ignores an untrusted prior's rehydration
+    # authority while still using its entries for discovery, not whether
+    # this exact status/reason_code/entries combination is reachable
+    # through today's callers.
+    untrusted_state = dict(first["next_state"])
+    untrusted_tree = dict(complete_tree)
+    untrusted_tree["status"] = "invalid"
+    untrusted_tree["reason_code"] = "process_tree_invalid_generation_adoption_pending"
+    untrusted_state["owned_process_tree"] = untrusted_tree
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        untrusted_tree, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+
+    # Second poll: the intermediate has exited (no row at all); its child
+    # remains live, now a true orphan in the CURRENT snapshot - exactly
+    # the shape an untrusted prior's own rehydration can no longer reach.
+    second_snapshot = [
+        *_wrap_snap(),
+        _proc(live_grandchild_pid, orphaned_intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-orphan-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": untrusted_state}},
+        now=NOW + 1,
+        snapshot=second_snapshot,
+    )
+    tree = second["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["rejected_count"] >= 1
+    assert live_grandchild_pid not in [e["pid"] for e in tree["entries"]]
+
+
+def test_reset_remedy_names_rejected_candidates_separately_from_omitted() -> None:
+    """Task #150 round 3 connector finding 6, the same wrong direction as
+    round 2's own finding 2: a rejected candidate is precisely what this
+    record's entries never named at all, same as a truncated record's
+    omitted ones - but the reset command's own identity list is built
+    from entries alone, so it cannot know about a rejected candidate
+    either. The message must say so explicitly rather than folding it
+    silently into "every process this record could name"."""
+    launcher_no_filetime = {
+        **_proc(WRAP_CHILD_PID, WRAP_LAUNCHER_PID, "codex.exe", "codex exec --json", WRAP_CHILD_START),
+        "start_filetime": None,
+    }
+    snapshot = [_wrap_snap()[0], launcher_no_filetime]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-reset-remedy-rejected")
+    assert plan["state"] == "PROCESS_TREE_INVALID"
+    assert plan["next_state"]["owned_process_tree"]["rejected_count"] >= 1
+    assert "rejected_count" in plan["reason"]
+    assert "does not include them" in plan["reason"]
+    assert "--reset-process-tree-ownership" in plan["reason"]
+
+
 def test_launch_barrier_same_agent_wait_survivor_blocks_replacement() -> None:
     snap = [
         _proc(31, 1, "python.exe",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14537,6 +14537,166 @@ def test_owned_process_absence_certificate_requires_definite_identity_result() -
     )
 
 
+# ------------------------------------------------------ Task #150: the HOLD
+# must not pre-empt the LAUNCH path for a confirmed-absent agent.
+
+
+def test_unverified_owned_process_tree_promotes_invalid_to_absent_when_entries_complete_and_gone() -> None:
+    """Task #150 connector finding: an invalid tree is not categorically
+    excluded from absence re-derivation - only an invalid tree whose
+    entries are a COMPLETE description of what was found (omitted_count ==
+    0, at least one entry) qualifies, the same evidentiary bar the
+    complete/absent case already trusts. The production incident: a single
+    UNRELATED row elsewhere in that poll's whole-host snapshot failed
+    _snapshot_pid_integrity_error and marked EVERY currently-polled agent's
+    tree invalid that poll, even though each agent's own entries were
+    untouched and remained a complete, faithful record."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-invalid-promotes",
+    )["next_state"]["owned_process_tree"]
+    poisoned = dict(tree)
+    poisoned["status"] = "invalid"
+    poisoned["reason_code"] = "process_tree_invalid_snapshot_invalid_process_row"
+    assert poisoned["omitted_count"] == 0
+    assert poisoned["entries"]
+
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        poisoned, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "absent"
+    assert result["reason_code"] == "process_tree_absent"
+
+
+def test_unverified_owned_process_tree_truncated_never_promotes_even_when_gone() -> None:
+    """A truncated prior's entries are incomplete by definition
+    (omitted_count > 0) - proving the RECORDED subset gone says nothing
+    about whatever the size cap dropped, so it must never promote to
+    absent, unlike an invalid-but-complete prior."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-truncated-never",
+    )["next_state"]["owned_process_tree"]
+    truncated = dict(tree)
+    truncated["status"] = "truncated"
+    truncated["reason_code"] = "process_tree_truncated"
+    truncated["omitted_count"] = 3
+    truncated["observed_count"] = truncated["recorded_count"] + 3
+
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        truncated, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "truncated"
+
+
+def test_unverified_owned_process_tree_invalid_with_no_entries_never_promotes() -> None:
+    """A schema-drift/generation-adoption placeholder (built by
+    _invalid_owned_process_tree_record, entries always []) never had a real
+    tree walk to begin with - there is nothing to disprove against, so it
+    must stay sticky HOLD evidence even against a fully empty snapshot,
+    guarding the vacuous-truth trap (all(state in ... for state in []) is
+    True)."""
+    placeholder = sup._invalid_owned_process_tree_record(  # noqa: SLF001
+        agent="worker",
+        root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation=None,
+        launch_nonce=None,
+        now_epoch=NOW,
+        reason_code="process_tree_invalid_prior_record_invalid",
+    )
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        placeholder, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "invalid"
+
+
+def test_unverified_owned_process_tree_invalid_stays_held_when_entry_still_alive() -> None:
+    """The safety half: an invalid-but-complete prior must NOT promote to
+    absent when the current snapshot proves an entry is still alive -
+    exactly the same bar the complete/absent case already uses."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-still-alive",
+    )["next_state"]["owned_process_tree"]
+    poisoned = dict(tree)
+    poisoned["status"] = "invalid"
+    poisoned["reason_code"] = "process_tree_invalid_snapshot_invalid_process_row"
+
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        poisoned, _wrap_snap(), now_epoch=NOW + 1,
+        reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "invalid"
+
+
+def test_plan_actions_confirmed_absent_wrapper_recovers_despite_unrelated_snapshot_poisoning() -> None:
+    """Task #150, the production incident reproduced end to end. Poll 1: one
+    UNRELATED process row on the same host (e.g. a system process CIM could
+    not resolve a parent for) fails _snapshot_pid_integrity_error for that
+    WHOLE poll, marking this otherwise-healthy idle wrapped agent's owned
+    tree invalid even though its own row was clean - matching the
+    production report exactly ("276 rows, zero failures... the detail
+    string is actively misleading"). Poll 2, much later: the SAME agent is
+    now confirmed completely absent from an entirely empty snapshot, yet
+    the persisted tree is still that sticky invalid record from poll 1. It
+    must still reach a relaunch decision (STUCK_OR_DEAD / stuck_recover)
+    rather than being held on PROCESS_TREE_INVALID forever - the exact
+    defect: a confirmed-absent agent could not self-heal by any means."""
+    poisoning_row = {
+        "pid": 4, "parent_pid": None, "name": "System",
+        "command_line": None,
+        "start_time": "2026-01-01T00:00:00.0000000+00:00",
+        "start_filetime": None,
+    }
+    wrapper_row = _wrap_snap()[0]
+    poisoned_snapshot = [wrapper_row, poisoning_row]
+
+    state = {"agents": {"worker": _wrap_ready(runtime_wrapper_generation="wrapper-1")}}
+    poll1 = _plan_wrap(
+        _report(wrapper_runtime=_wrapper_runtime_view(phase="idle", now=NOW)),
+        state,
+        snapshot=poisoned_snapshot,
+    )
+    assert poll1["state"] == "PROCESS_TREE_INVALID"
+    assert poll1["next_state"]["owned_process_tree"]["status"] == "invalid"
+    assert poll1["next_state"]["owned_process_tree"]["reason_code"] == (
+        "process_tree_invalid_snapshot_invalid_process_row"
+    )
+    # Task #150 priority 4: the HOLD message must name the remedy, not just
+    # announce that it is holding.
+    assert "--reset-process-tree-ownership" in poll1["reason"]
+    assert "do NOT kill the wrapper" in poll1["reason"]
+
+    state_after_poll1 = {
+        "agents": {
+            "worker": {**state["agents"]["worker"], **poll1["next_state"]},
+        }
+    }
+    later = NOW + 600
+    poll2 = _plan_wrap(
+        _report(
+            heartbeat_stale=True,
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="idle", now=later, updated_age=600,
+            ),
+        ),
+        state_after_poll1,
+        snapshot=[],
+        now=later,
+    )
+
+    assert poll2["state"] == "STUCK_OR_DEAD"
+    assert poll2["action"] == sup.STUCK_RECOVER
+    assert poll2["next_state"]["owned_process_tree"]["status"] == "absent"
+
+    barrier = sup.evaluate_launch_barrier(
+        [],
+        {"agents": {"worker": {**state_after_poll1["agents"]["worker"], **poll2["next_state"]}}},
+        _WRAP_CONFIG,
+        "worker",
+        root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+    )
+    assert barrier["allow_launch"] is True
+    assert barrier["blocked"] is False
+
+
 def test_launch_barrier_same_agent_wait_survivor_blocks_replacement() -> None:
     snap = [
         _proc(31, 1, "python.exe",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1950,19 +1950,19 @@ def test_discover_brain_picks_tui_not_launcher() -> None:
     NEVER the forking launcher (199, which exits after handoff). The
     codex-command-runner.exe (300, also matches the 'codex' substring) is below
     the TUI so it never wins either."""
-    idx = sup._snap_index(_codex_tree())
+    idx = sup._snap_index_and_excluded(_codex_tree())[0]
     b = sup._discover_brain(idx, "codex-test", LAUNCHER_PID, "codex",
                             allow_launcher_self=False)
     assert b["pid"] == BRAIN_PID                      # the TUI, not 199 / not 300
 
 
 def test_discover_brain_tui_wins_even_when_launcher_iterates_first() -> None:
-    idx = sup._snap_index(_codex_tree(order_launcher_first=True))
+    idx = sup._snap_index_and_excluded(_codex_tree(order_launcher_first=True))[0]
     b = sup._discover_brain(idx, "codex-test", LAUNCHER_PID, "codex",
                             allow_launcher_self=False)
     assert b["pid"] == BRAIN_PID
     # and after the launcher has EXITED, the TUI is still found (parent_pid persists)
-    idx2 = sup._snap_index(_codex_tree(launcher=False))
+    idx2 = sup._snap_index_and_excluded(_codex_tree(launcher=False))[0]
     assert sup._discover_brain(idx2, "codex-test", LAUNCHER_PID, "codex",
                                allow_launcher_self=False)["pid"] == BRAIN_PID
 
@@ -1970,7 +1970,7 @@ def test_discover_brain_tui_wins_even_when_launcher_iterates_first() -> None:
 def test_allow_launcher_self_true_picks_launcher() -> None:
     """A non-forking CLI (allow_launcher_self=true) still selects the launcher as
     its own brain (claude.exe) - the codex exclusion must not regress it."""
-    idx = sup._snap_index(_codex_tree())
+    idx = sup._snap_index_and_excluded(_codex_tree())[0]
     b = sup._discover_brain(idx, "codex-test", LAUNCHER_PID, "codex",
                             allow_launcher_self=True)
     assert b["pid"] == LAUNCHER_PID
@@ -8560,7 +8560,7 @@ def test_wrapped_unbound_wait_tree_cannot_certify_current_turn_brain(
             "start_time": _ps_iso(910000),
         },
     ]
-    wait = sup._wait_row_for(sup._snap_index(snapshot), "worker")
+    wait = sup._wait_row_for(sup._snap_index_and_excluded(snapshot)[0], "worker")
     assert (wait is not None) is (wait_agent == "worker")
 
     plan = _plan_wrap(
@@ -13600,6 +13600,58 @@ def test_ephemeral_launch_uses_no_legacy_or_command_line_kill_authority() -> Non
     assert timeout_suppressed["archive"] is False
 
 
+def test_ephemeral_review_survives_duplicate_row_poll_not_archived_failed() -> None:
+    """Task #150 round 7 connector finding: a snapshot containing two rows
+    for an ACTIVE EPHEMERAL REVIEWER's launcher pid (even identical rows)
+    made _snap_index exclude that pid, and _ephemeral_process_alive read
+    the resulting idx.get(pid)-is-None the same as "process exited" -
+    permanently archiving a healthy review as failed, since a persisted
+    held_terminal is deliberately unrewritable by any later report. This
+    tests the OUTCOME an operator would see - the review survives the
+    glitched poll and is still active, not the internal alive-flag value
+    - per the explicit instruction that a test proving _ephemeral_process_
+    alive now returns None is not the same as a test proving the review
+    is not archived."""
+    start = _ps_iso(100000)
+    state = {
+        "ephemeral_reviewers": {
+            "active": {
+                "R1": {
+                    "request_id": "R1",
+                    "agent": "worker",
+                    "phase": eph.STATE_REQUESTED,
+                }
+            }
+        }
+    }
+    sup.record_ephemeral_launch(
+        state,
+        "R1",
+        pid=10,
+        pid_start=start,
+        now_epoch=NOW,
+        timeout_seconds=100000,  # far from expiring on this poll
+        root_key=sup._root_key(TEST_ROOT),
+        launcher_nonce=SUPERVISOR_NONCE,
+        launcher_nonce_injected=True,
+        launcher_nonce_source="agenttalk_global_arg",
+    )
+    report = {
+        "root_key": sup._root_key(TEST_ROOT),
+        "agents": {},
+        "launch_requests": [],
+        "ephemeral_reviewers": {"active": {"R1": {}}},
+    }
+    duplicated_launcher = _proc(10, 1, "codex.exe", "codex exec", start)
+    glitched_snapshot = [duplicated_launcher, dict(duplicated_launcher)]
+    plan = sup.plan_actions(
+        report, state, _WRAP_CONFIG, now_epoch=NOW + 1, snapshot=glitched_snapshot,
+    )
+    result = plan["ephemeral_reviewers"]["R1"]
+    assert result["action"] != eph.ACTION_FAILED
+    assert result["next_entry"].get("held_terminal") is None
+
+
 def test_ephemeral_launch_spec_preserves_declared_module_args_from() -> None:
     """Round 13 connector finding, the third location this field has been
     lost: launch_spec() rebuilt its "launch" sub-dict from only
@@ -14991,7 +15043,7 @@ def test_snap_index_excludes_rather_than_picks_a_duplicate_pid() -> None:
     rejection already handles correctly."""
     good_child = _proc(999, WRAP_LAUNCHER_PID, "node.exe", "node tool.js", _ps_iso(700000))
     duplicate_bad_row = {**good_child, "parent_pid": None}
-    idx = sup._snap_index([_wrap_snap()[0], good_child, duplicate_bad_row])  # noqa: SLF001
+    idx = sup._snap_index_and_excluded([_wrap_snap()[0], good_child, duplicate_bad_row])[0]  # noqa: SLF001
     assert 999 not in idx
     assert WRAP_LAUNCHER_PID in idx  # unrelated pids are unaffected
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -15131,6 +15131,54 @@ def test_post_kill_barrier_hold_cannot_present_a_trustworthy_zero() -> None:
     assert promoted["status"] == "absent"
 
 
+def test_reset_remedy_warns_on_legacy_v2_record_missing_rejected_count() -> None:
+    """Task #150 round 5 connector finding 2: the round-3 remedy clause
+    only fired for a KNOWN positive rejected_count - a legacy v2 record
+    (missing the field entirely, deliberately still valid authority per
+    the v2-migration fix) got NO warning at all, telling the operator to
+    verify only the named/omitted identities when the truth is the walk
+    that produced this record never counted rejections in the first
+    place. Unknown must warn like unknown, not silently read as zero -
+    the same "absent must warn like unknown" correction finding 6 made
+    for the round-2 remedy, now needed again for the same field's
+    missing-vs-zero distinction."""
+    limit = sup._OWNED_PROCESS_TREE_LIMIT
+    snapshot = [_wrap_snap()[0]] + [
+        _proc(400 + i, WRAP_LAUNCHER_PID, "node.exe", "node tool.js", _ps_iso(700000 + i))
+        for i in range(limit)
+    ]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-v2-remedy-first")
+    assert plan["state"] == "PROCESS_TREE_TRUNCATED"
+    truncated_tree = plan["next_state"]["owned_process_tree"]
+    v2_shaped = dict(truncated_tree)
+    del v2_shaped["rejected_count"]
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        v2_shaped, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+
+    second_state = dict(plan["next_state"])
+    second_state["owned_process_tree"] = v2_shaped
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-v2-remedy-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": second_state}},
+        now=NOW + 1,
+        snapshot=snapshot,
+    )
+    assert second["state"] == "PROCESS_TREE_TRUNCATED"
+    assert "rejected_count" not in second["next_state"]["owned_process_tree"]
+    assert "UNKNOWN, not zero" in second["reason"]
+    assert "--acknowledge-owned-processes-stopped" in second["reason"]
+
+
 def test_owned_process_tree_rejects_walk_when_launcher_missing_exact_filetime() -> None:
     """Task #150 round 3 connector finding 3: a Windows row lacking exact
     start_filetime used to be ADMITTED by add_node while
@@ -15233,6 +15281,64 @@ def test_owned_process_tree_accounts_for_orphaned_intermediates_live_child() -> 
     assert tree["status"] == "invalid"
     assert tree["rejected_count"] >= 1
     assert live_grandchild_pid not in [e["pid"] for e in tree["entries"]]
+
+
+def test_owned_process_tree_rejects_prior_entry_with_malformed_parent_pid() -> None:
+    """Task #150 round 5 connector finding 1: _snap_all_edges correctly
+    cannot build an edge for a row with a malformed parent_pid - but
+    "cannot place" must not collapse to "not ours". A PRIOR entry (an
+    owned intermediate the walk once admitted) whose CURRENT row has a
+    malformed parent_pid contributes no edge either way, and since a
+    discovery ROOT is deliberately never itself checked against `owned`
+    (only its descendants are - a root simply exiting is normal), a
+    childless malformed-parent root would sit at rejected_count 0
+    forever if nothing else names it. This test isolates exactly that
+    shape (no grandchild at all, so the existing discovery-closure
+    reconciliation for a live descendant plays no part) under an
+    untrusted-but-readable prior, where the trusted-rehydration block's
+    own prior_parent_drift check does not run either."""
+    intermediate_pid = 500
+    first_snapshot = [
+        *_wrap_snap(),
+        _proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+    ]
+    first = _owned_tree_plan(first_snapshot, request_id="rr-150-malformed-parent-first")
+    complete_tree = first["next_state"]["owned_process_tree"]
+    assert complete_tree["status"] == "complete"
+    assert intermediate_pid in [e["pid"] for e in complete_tree["entries"]]
+
+    untrusted_state = dict(first["next_state"])
+    untrusted_tree = dict(complete_tree)
+    untrusted_tree["status"] = "invalid"
+    untrusted_tree["reason_code"] = "process_tree_invalid_generation_adoption_pending"
+    untrusted_state["owned_process_tree"] = untrusted_tree
+
+    # Second poll: same pid, same start/filetime (still "same" identity,
+    # not a recycled/different one) - only parent_pid is now malformed,
+    # exactly the shape a transient WMI/CIM hiccup on one row produces.
+    malformed_row = {
+        **_proc(intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000)),
+        "parent_pid": None,
+    }
+    second_snapshot = [*_wrap_snap(), malformed_row]
+    second = _plan_wrap(
+        _report(
+            restart_request=_auth_marker("rr-150-malformed-parent-second"),
+            wrapper_runtime=_wrapper_runtime_view(
+                phase="active",
+                launcher_pid=WRAP_CHILD_PID,
+                launcher_start=WRAP_CHILD_START,
+                now=NOW + 1,
+            ),
+        ),
+        {"agents": {"worker": untrusted_state}},
+        now=NOW + 1,
+        snapshot=second_snapshot,
+    )
+    tree = second["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["rejected_count"] >= 1
+    assert intermediate_pid not in [e["pid"] for e in tree["entries"]]
 
 
 def test_reset_remedy_names_rejected_candidates_separately_from_omitted() -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14697,6 +14697,197 @@ def test_plan_actions_confirmed_absent_wrapper_recovers_despite_unrelated_snapsh
     assert barrier["blocked"] is False
 
 
+def test_owned_process_tree_rejected_child_blocks_absence_promotion_blocker() -> None:
+    """Task #150 connector finding 1, the BLOCKER: omitted_count only ever
+    counted the gap between ADMITTED nodes and the size-cap truncation of
+    already-admitted nodes - never a candidate branch the walk SAW and
+    explicitly excluded for an unrelated reason. Reproduces the exact
+    duplicate-wrapper hazard: the CLI launcher has exited (absent from the
+    snapshot), carries no exact lifetime certificate, and left a LIVE
+    child behind. The launcher is excluded as an unproven virtual-parent
+    descendant - so its child is never even reached by the walk - while
+    omitted_count stays 0 (only the wrapper was ever admitted, so there is
+    no size-cap gap to report). Without rejected_count, this record would
+    satisfy the round-1 eligibility bar and promote to absent the moment
+    the wrapper also exits, even though the launcher's child is still
+    alive and would then get orphaned by a replacement wrapper launching
+    alongside it."""
+    exited_launcher_pid = WRAP_CHILD_PID  # the CLI launcher, per _owned_process_tree's terms
+    live_grandchild_pid = 999
+    snapshot = [
+        _wrap_snap()[0],  # the wrapper - alive
+        # exited_launcher_pid itself is deliberately ABSENT from the snapshot.
+        _proc(
+            live_grandchild_pid, exited_launcher_pid, "node.exe", "node tool.js",
+            _ps_iso(700000),
+        ),
+    ]
+    plan = _owned_tree_plan(
+        snapshot,
+        request_id="rr-150-blocker-rejected-child",
+        # No cli_launcher_lifetime override - no exact lifetime certificate,
+        # exactly the finding's precondition.
+    )
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert tree["reason_code"] == (
+        "process_tree_invalid_unproven_virtual_parent_descendant"
+    )
+    assert [entry["pid"] for entry in tree["entries"]] == [WRAP_LAUNCHER_PID]
+    assert tree["omitted_count"] == 0, (
+        "the exact hazard: the size-cap counter alone looks like a complete "
+        "record even though a live child was excluded"
+    )
+    assert tree["rejected_count"] >= 1, (
+        "the fix: a candidate the walk saw and excluded must be counted "
+        "even when omitted_count cannot see it"
+    )
+
+    # The blocker, made concrete: if the wrapper ALSO now disappears, this
+    # record must NOT promote to absent - the live grandchild is still
+    # unaccounted for.
+    result = sup._unverified_owned_process_tree(  # noqa: SLF001
+        tree, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert result["status"] == "invalid", (
+        "a rejected branch must keep this record sticky - promoting it here "
+        "is the duplicate-wrapper hazard arriving through the round-1 fix"
+    )
+
+
+def test_wrapped_liveness_sets_refreshed_flag_when_invalid_promotes_to_absent() -> None:
+    """Task #150 connector finding 4: _current_proof_failed used to set
+    owned_process_tree_refreshed only when the PRIOR status was already
+    {complete, absent} - a stale duplicate of _unverified_owned_process_
+    tree's own eligibility gate that drifted the moment that gate widened
+    to admit an invalid-but-complete prior too. A promoted-invalid record
+    (tree.status becomes "absent") must set this flag exactly like a
+    promoted-complete one does - it is the same call, the same real
+    _wrapped_liveness (shared by configured AND ephemeral agents), driven
+    through the identical poisoned-poll-then-absent-poll sequence as the
+    end-to-end test above, but reading the intermediate liveness dict
+    directly rather than the final plan."""
+    poisoning_row = {
+        "pid": 4, "parent_pid": None, "name": "System",
+        "command_line": None,
+        "start_time": "2026-01-01T00:00:00.0000000+00:00",
+        "start_filetime": None,
+    }
+    st = _wrap_ready(runtime_wrapper_generation="wrapper-1")
+    cfg_agent = _WRAP_CONFIG["agents"]["worker"]
+    liveness1 = sup._wrapped_liveness(  # noqa: SLF001
+        [_wrap_snap()[0], poisoning_row],
+        st, cfg_agent, "worker", NOW,
+        _wrapper_runtime_view(phase="idle", now=NOW),
+        root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+    )
+    assert liveness1["owned_process_tree"]["status"] == "invalid"
+
+    st_after_poll1 = {**st, "owned_process_tree": liveness1["owned_process_tree"]}
+    later = NOW + 600
+    liveness2 = sup._wrapped_liveness(  # noqa: SLF001
+        [],
+        st_after_poll1, cfg_agent, "worker", later,
+        _wrapper_runtime_view(phase="idle", now=later, updated_age=600),
+        root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+    )
+    assert liveness2["owned_process_tree"]["status"] == "absent"
+    assert liveness2["owned_process_tree_refreshed"] is True, (
+        "an ephemeral reviewer reads exactly this flag to decide "
+        "teardown_ready - unset here means held rather than archived, "
+        "indefinitely, under supervise --once"
+    )
+
+
+def test_ephemeral_teardown_ready_when_wrapped_liveness_reports_refreshed_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of finding 4, isolating _ephemeral_owned_process_view's
+    OWN consumption of the flag (unchanged by this fix) via the same
+    fake-_wrapped_liveness pattern the existing module_args_from
+    reconstruction test uses - so a regression in either the producer
+    (_wrapped_liveness, tested above) or this consumer is caught
+    independently."""
+    def _fake_wrapped_liveness(snapshot, entry, cfg_agent, agent, now_epoch,
+                               runtime_view, *, root_key):
+        return {
+            "kill_targets": [],
+            "owned_process_tree": {"status": "absent", "reason_code": "process_tree_absent"},
+            "owned_process_tree_refreshed": True,
+            "child_reason": "test_absent",
+        }
+
+    monkeypatch.setattr(sup, "_wrapped_liveness", _fake_wrapped_liveness)
+    entry = {
+        "request_id": "R1", "agent": "adversary-1", "cli": "codex",
+        "launch": {},
+    }
+    _next_entry, _liveness, teardown_ready = sup._ephemeral_owned_process_view(  # noqa: SLF001
+        [], entry, {}, NOW, root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+    )
+    assert teardown_ready is True
+
+
+def test_process_tree_hold_message_names_no_remedy_for_entryless_placeholder() -> None:
+    """Task #150 connector finding 3: --reset-process-tree-ownership requires
+    the tree evidence to carry a wrapper_generation/launch_nonce that agrees
+    with a CURRENT, valid runtime record - true for a tree
+    _owned_process_tree itself walked, but an entryless placeholder
+    (_invalid_owned_process_tree_record - schema drift, a revoked runtime,
+    legacy migration evidence) has no such nonce to agree with, so the
+    command fails for precisely the case that names it. The HOLD message
+    for an entryless record must say so rather than naming a command that
+    cannot work."""
+    st = _wrap_ready(runtime_wrapper_generation="wrapper-1")
+    # A schema-drifted persisted record - _valid_owned_process_tree returns
+    # None for it. Reaching the EMPTY-entries placeholder specifically
+    # requires a FAILED wrapper-liveness check (here: the wrapper is fully
+    # absent) - a HEALTHY wrapper reaches _owned_process_tree's own fresh
+    # walk instead, which still populates real entries even with the same
+    # malformed prior (a different mechanism, same reason_code text - not
+    # this finding).
+    st["owned_process_tree"] = {"not": "the expected schema at all"}
+    plan = _plan_wrap(
+        _report(
+            heartbeat_stale=True,
+            wrapper_runtime=_wrapper_runtime_view(phase="idle", now=NOW),
+        ),
+        {"agents": {"worker": st}},
+        snapshot=[],
+    )
+    assert plan["state"] == "PROCESS_TREE_INVALID"
+    assert plan["next_state"]["owned_process_tree"]["reason_code"] == (
+        "process_tree_invalid_prior_record_invalid"
+    )
+    assert not plan["next_state"]["owned_process_tree"]["entries"]
+    # It may NAME the command to explain why it will not help, but must
+    # never tell the operator to run it - that is the exact "worse than
+    # naming none" failure mode finding 3 identified.
+    assert "run `agenttalk supervise --reset-process-tree-ownership`" not in plan["reason"]
+    assert "will refuse it" in plan["reason"]
+    assert "not a scripted remedy" in plan["reason"]
+    assert "process_tree_invalid_prior_record_invalid" in plan["reason"]
+
+
+def test_process_tree_truncated_remedy_covers_omitted_identities_too() -> None:
+    """Task #150 connector finding 2: the truncated-tree remedy must not
+    read as "confirm only the NAMED processes are gone" -
+    --acknowledge-owned-processes-stopped's own contract explicitly covers
+    "any identities omitted by a truncated record", and the message must
+    say so rather than narrowing the precondition to what the record
+    happens to name."""
+    limit = sup._OWNED_PROCESS_TREE_LIMIT  # noqa: SLF001
+    snapshot = [_wrap_snap()[0]] + [
+        _proc(400 + i, WRAP_LAUNCHER_PID, "node.exe", "node tool.js", _ps_iso(700000 + i))
+        for i in range(limit)
+    ]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-truncated-remedy")
+    assert plan["state"] == "PROCESS_TREE_TRUNCATED"
+    assert plan["next_state"]["owned_process_tree"]["omitted_count"] > 0
+    assert "omitted by a truncated record" in plan["reason"]
+    assert "--acknowledge-owned-processes-stopped" in plan["reason"]
+
+
 def test_launch_barrier_same_agent_wait_survivor_blocks_replacement() -> None:
     snap = [
         _proc(31, 1, "python.exe",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14996,6 +14996,141 @@ def test_snap_index_excludes_rather_than_picks_a_duplicate_pid() -> None:
     assert WRAP_LAUNCHER_PID in idx  # unrelated pids are unaffected
 
 
+def test_owned_process_tree_duplicate_pid_orphan_still_rejected() -> None:
+    """Task #150 round 4 connector finding 1: _snap_index's own exclusion
+    popped the duplicated pid's row out of idx BEFORE _children_map(idx)
+    was built (round 3's `children`), which destroyed the only edge
+    connecting the duplicated pid to its OWN parent - so neither the main
+    walk nor the discovery-closure invariant could ever reach it, or
+    anything below it. The whole-snapshot "duplicate_pid" fact still set
+    the tree invalid, but rejected_count stayed 0 - a path that lost two
+    real candidates (the duplicated intermediate and its live child)
+    without saying so, the exact silent-loss class this invariant exists
+    to close, just one level earlier than round 3 checked."""
+    intermediate_pid = 500
+    live_child_pid = 501
+    duplicated_intermediate = _proc(
+        intermediate_pid, WRAP_CHILD_PID, "pwsh.exe", "pwsh tool.ps1", _ps_iso(700000),
+    )
+    duplicate_of_same_pid = {
+        **duplicated_intermediate,
+        "start_time": _ps_iso(700001),
+    }
+    snapshot = [
+        *_wrap_snap(),
+        duplicated_intermediate,
+        duplicate_of_same_pid,
+        _proc(live_child_pid, intermediate_pid, "node.exe", "node build.js", _ps_iso(800000)),
+    ]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-duplicate-pid-orphan")
+    tree = plan["next_state"]["owned_process_tree"]
+    assert tree["status"] == "invalid"
+    assert "duplicate_pid" in tree["reason_code"]
+    assert tree["rejected_count"] >= 1
+    assert intermediate_pid not in [e["pid"] for e in tree["entries"]]
+    assert live_child_pid not in [e["pid"] for e in tree["entries"]]
+
+
+def test_owned_process_tree_recycled_root_old_side_child_still_counted() -> None:
+    """Task #150 round 4 connector finding 2: round 3's recycled-root
+    exclusion was too blanket - it treated EVERY current child of a
+    recycled pid as the replacement's foreign descendant, but a child
+    whose exact start strictly PREDATES the replacement belongs to the
+    OLD, genuinely-owned process, not the new one. evaluate_launch_barrier
+    already draws exactly this line (see its recycled_parent_rows/
+    replacement_key handling); the discovery-closure invariant must agree
+    with it rather than drawing its own, wider one.
+
+    Modeled directly on test_owned_process_tree_recycled_launcher_ignores_
+    foreign_children (the test whose "990" fixture forced round 3's
+    blanket exclusion): the replacement's own parent_pid is unrelated
+    (not the wrapper), and no lifetime certificate is configured, so
+    launcher_pid is admitted by NEITHER the declared-launcher path NOR
+    generic BFS - the discovery-closure invariant is the only thing that
+    can reach anything below it at all. That test's own foreign child
+    postdates the replacement and must stay excluded (unchanged here);
+    this test adds a second child that PREDATES the replacement and must
+    now be caught as a real, unaccounted loss instead of silently
+    dropped alongside it."""
+    old_child_pid = 890
+    old_child_start = _ps_iso(700000)  # predates the replacement below
+    replacement_start = _ps_iso(800000)
+    foreign_child_pid = 990
+    foreign_child_start = _ps_iso(900000)  # postdates the replacement
+
+    snapshot = [
+        _wrap_snap()[0],
+        _proc(WRAP_CHILD_PID, 1, "unrelated.exe", "unrelated replacement", replacement_start),
+        _proc(old_child_pid, WRAP_CHILD_PID, "node.exe", "node build.js", old_child_start),
+        _proc(foreign_child_pid, WRAP_CHILD_PID, "node.exe", "node foreign.js", foreign_child_start),
+    ]
+    plan = _owned_tree_plan(snapshot, request_id="rr-150-recycled-old-side")
+    tree = plan["next_state"]["owned_process_tree"]
+    # The old-side child is a real, unaccounted loss (its true parent is
+    # gone, replaced) - the invariant must now catch it.
+    assert tree["status"] == "invalid"
+    assert tree["rejected_count"] >= 1
+    entry_pids = {e["pid"] for e in tree["entries"]}
+    assert old_child_pid not in entry_pids  # rejected, never admitted
+    # The replacement's OWN (foreign) child must still NOT be counted as
+    # ours - unchanged from the existing sibling test's own assertion.
+    assert foreign_child_pid not in entry_pids
+
+
+def test_post_kill_barrier_hold_cannot_present_a_trustworthy_zero() -> None:
+    """Task #150 round 4 connector finding 3: the post-kill and ephemeral
+    teardown barriers (the .ps1 template, around the relaunch/stuck_recover
+    and ephemeral_complete/timeout/failed branches) are a SECOND producer
+    of invalid owned_process_tree records - they mutate a formerly-complete
+    tree's status/reason_code straight in PowerShell, entirely outside
+    _owned_process_tree's own walk, and never ran any accounting of their
+    own. Before this fix they left rejected_count untouched at its old
+    "complete" value (0), so process_tree_invalid_post_kill_* sailed
+    through _unverified_owned_process_tree's eligibility bar even though
+    the barrier's own survivors were never counted anywhere. The fix
+    removes the property entirely rather than writing a number - the same
+    "missing means unknown, not zero" shape the v2-migration fix already
+    established for a field a record simply never had, reused here for a
+    field this record's PRODUCER never computed."""
+    ps1_source = sup.PS_TEMPLATE
+    assert ps1_source.count(
+        "owned_process_tree.PSObject.Properties.Remove('rejected_count')",
+    ) == 2
+
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-post-kill-producer",
+    )["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+
+    # The FIXED shape: the barrier removed rejected_count entirely when it
+    # externally invalidated the tree. Still valid, readable authority -
+    # just not eligible for the walk's own re-derivation.
+    post_kill_fixed = dict(tree)
+    post_kill_fixed["status"] = "invalid"
+    post_kill_fixed["reason_code"] = "process_tree_invalid_post_kill_launch_barrier_unavailable"
+    del post_kill_fixed["rejected_count"]
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        post_kill_fixed, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+    held = sup._unverified_owned_process_tree(  # noqa: SLF001
+        post_kill_fixed, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert held["status"] == "invalid"
+
+    # The PRE-FIX shape, for contrast: rejected_count left at its stale
+    # "complete" value of 0 - this is exactly the hazard finding 3 named,
+    # and it genuinely does promote, proving the fix closes a real gap
+    # rather than a hypothetical one.
+    post_kill_stale = dict(tree)
+    post_kill_stale["status"] = "invalid"
+    post_kill_stale["reason_code"] = "process_tree_invalid_post_kill_launch_barrier_unavailable"
+    promoted = sup._unverified_owned_process_tree(  # noqa: SLF001
+        post_kill_stale, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert promoted["status"] == "absent"
+
+
 def test_owned_process_tree_rejects_walk_when_launcher_missing_exact_filetime() -> None:
     """Task #150 round 3 connector finding 3: a Windows row lacking exact
     start_filetime used to be ADMITTED by add_node while


### PR DESCRIPTION
## Root cause, in one sentence

A one-second glitch permanently disabled fleet-wide auto-recovery: a single transient bad row in one poll's whole-host process snapshot (most likely a process exiting mid-enumeration so CIM never resolved a parent for it) failed the snapshot integrity check for that ONE poll, marking every currently-polled agent's `owned_process_tree` invalid at once - and that invalid status was then STICKY forever, because nothing ever re-checked it against a later, clean snapshot. The transient trigger is almost incidental; the defect is that an invalid record could never be re-derived, so a wrapper later confirmed completely absent still couldn't reach a relaunch decision. This PR fixes the stickiness, not the trigger.

## Summary (round 1)
- Reproduces the production incident end to end: one UNRELATED row anywhere in a poll's whole-host snapshot (e.g. a system process with a null/negative parent_pid) fails `_snapshot_pid_integrity_error` for that whole poll and marks EVERY currently-polled agent's `owned_process_tree` invalid that cycle - even though each agent's own row is clean.
- That invalid status used to be permanently sticky: `_unverified_owned_process_tree` never re-derived absence for a non-`{complete,absent}` prior, so a wrapper later confirmed **completely absent** from an empty snapshot still never reached a relaunch decision.
- Verified this closes BOTH gates that read the persisted status (`_plan_one`'s own short-circuit and `evaluate_launch_barrier`'s post-kill barrier), without touching Stop-Tree (#146 owns that path).

## Round 2: connector found a blocker in round 1's own eligibility guard

- **Blocker**: `omitted_count == 0` (round 1's eligibility bar) only ever counted the gap between admitted nodes and size-cap truncation - never a candidate branch the walk SAW and explicitly excluded for another reason (an exited CLI launcher with no exact lifetime that left a live child behind). Reproduced and confirmed the exploit against the actual round-1 code before fixing: this promoted straight to `absent` even with a live, orphaned child still unaccounted for - the duplicate-wrapper hazard, arriving through round 1's own fix.
- Closed by adding one new persisted field, `rejected_count` (schema bumped 2->3), incremented at every site in `_owned_process_tree`'s walk that excludes a specific candidate rather than admitting it - enumerated and classified site by site. Eligibility is now `omitted_count == 0 AND rejected_count == 0 AND at least one entry`.
- Round 1's own remedy message had two more problems: it told operators to confirm only the NAMED processes were gone (missing what `--acknowledge-owned-processes-stopped` already covers for truncated records), and it named `--reset-process-tree-ownership` for a case (an entryless placeholder) where that command's own generation/nonce check will always refuse it. Both corrected - the entryless case now says plainly that no scripted remedy is verified to work, rather than naming one that doesn't.
- `_current_proof_failed`'s `owned_process_tree_refreshed` flag had a stale hand-copied duplicate of the eligibility check that never got updated when round 1 widened it - ephemeral reviewers held (never archived) on a promoted-invalid tree. Fixed by removing the duplicate and trusting the callee's own return value.

## Round 3: the round-2 schema bump was itself a defect, plus one more class closed by construction

- **Blocker, retraction of round 2's own fix**: bumping `schema_version` 2->3 to force re-validation of legacy records reintroduced, fleet-wide at upgrade, the exact sticky HOLD this PR exists to remove - a v2 record's field-set mismatch alone (not the version number) made `_valid_owned_process_tree` reject it outright, so even a healthy wrapper's fresh walk got seeded with `prior_record_invalid` on the first poll after upgrade and stuck from the second poll onward. Reverted `schema_version` to 2. `rejected_count` is now an OPTIONAL field: a v2-shaped record (missing it) is still valid, readable authority - missing means UNKNOWN, never coerced to zero, so it stays ineligible for absence-promotion without needing to be invalid. This IS the migration; there's nothing left for a version bump to gate.
- The validator parsed `rejected_count` but never constrained it against `status` - added the missing constraint (complete/absent with a nonzero `rejected_count` now fails validation).
- Three more sites lost a candidate without incrementing `rejected_count` (a duplicate pid silently picked in `_snap_index`; a Windows row missing exact `start_filetime` admitted by the walk but separately refused by the validator; a rebuild after an untrusted-but-readable prior unable to reach an orphaned intermediate's live child). Per the explicit review instruction, replaced hand-enumeration with a mechanical invariant instead of patching a fourth site: **discovered must equal admitted plus rejected**, checked once at the end of the walk. `discovery_roots` (wrapper, launcher, brain, every prior entry regardless of trust) expand through the CURRENT snapshot's raw parent-child edges; any descendant absent from `owned` becomes a rejection.
- The reset remedy said "every process this record could name" - wrong in the same direction as round 2's own finding 2. A rejected candidate is exactly what this record's entries never named either, so the reset command's own identity list can't cover it. Added an explicit clause naming this when `rejected_count > 0`.
- Two existing tests failed mid-implementation and were fixed by excluding `recycled_parent_pids` roots from the discovery-closure expansion: a confirmed-recycled (replacement) process's current children are someone else's tree, not an unaccounted loss of ours.

## Round 4: two self-inflicted-by-round-3 gaps, plus a second producer of invalid records

- The `_snap_index` dedup (round 3's own finding-1 fix) popped an excluded pid's row out of `idx` before `_children_map(idx)` was built, destroying the only edge connecting it to its own parent - so neither the main walk nor round 3's discovery-closure invariant could ever reach it, or anything below it. Added a permissive parent->children map built straight from the raw snapshot, used only by the discovery-closure block to seed/expand its frontier; `idx`/`_children_map(idx)` (admission, identity lookups) are unchanged.
- Round 3's recycled-root exclusion in the discovery-closure was too blanket - it treated every current child of a recycled pid as foreign, when `evaluate_launch_barrier` already draws an old-side/new-side line for exactly this situation (a child whose exact start strictly predates the replacement belongs to the process this agent actually owned). Applied that same comparison instead of excluding wholesale; the two existing tests that forced the round-3 exclusion still pass unchanged.
- The one that mattered: the post-kill launch barrier and ephemeral teardown barrier (the `.ps1` template) are a SECOND producer of invalid `owned_process_tree` records - they mutate a formerly-complete tree's status/reason_code directly in PowerShell, entirely outside `_owned_process_tree`'s own walk, and never ran any accounting of their own. They left `rejected_count` at its stale "complete" value (0), so `process_tree_invalid_post_kill_*` sailed through the eligibility bar even though the barrier's own survivors were never counted. Fixed by removing the property entirely at both mutation sites - the same "missing means unknown, not zero" shape the v2-migration fix already established, reused for a field this record's producer never computed. No Python-side change needed; the existing missing-key handling already treats this correctly.
- Did not plumb the barrier's survivor observations through as real rejections (an open option, not ordered this round) - flagged as a real schema/CLI extension to `evaluate_launch_barrier`'s output, not required to close this blocker.

## Round 5: one more malformed-row gap closed, one closed only partially with the sizing question raised rather than answered speculatively

- A PRIOR entry's own current row can have a malformed `parent_pid` this poll (a transient WMI/CIM hiccup). `_snap_all_edges` correctly cannot build an edge for it, but "cannot place" was silently collapsing to "not ours": a discovery ROOT is deliberately never itself checked against `owned` (only its descendants are, since a root simply exiting is normal), so a childless malformed-parent root sat at `rejected_count 0` forever unless something else happened to name it. Fixed the bounded case: every prior entry's current row is now checked for `parent_pid` validity unconditionally, independent of whether `prior_authority` ended up trusted (the existing trusted-rehydration block's own `prior_parent_drift` check already covered the trusted case).
- Did **not** implement the fully general "every valid-PID row on the host is a candidate" reframing as literally proposed - a row's placement is entirely determined by its own `parent_pid` field, and when that's malformed with no other valid edge connecting it to a root (never a prior entry, never the declared launcher), there is no snapshot-only signal distinguishing "malformed row near our tree" from "malformed row elsewhere on a busy host." Treating every such row as ours would reintroduce round 1's original bug in a new, eligibility-blocking form for any host where such a row persists across many polls. Flagged the tension and asked for direction rather than building the general version speculatively.
- The round-3 remedy clause only fired for a KNOWN positive `rejected_count`. A legacy v2 record (missing the field entirely, deliberately still valid authority per the v2-migration fix) got NO warning at all - the operator was told to verify only the named/omitted identities when the walk that produced the record never counted rejections in the first place. Added a second branch: `rejected_count is None` now warns that whether anything was excluded is UNKNOWN, not zero, and must be treated the same as a nonzero count.

## Round 6: the residual from round 5, closed - it turned out to be bounded after all

- Round 5's fix only inspected `parent_pid` on a prior entry's row when `idx.get(pid)` actually returned one. When that pid's row is DUPLICATED this poll, `_snap_index` correctly excludes it entirely (ambiguous, not absent) - `idx.get(pid)` then returns `None`, indistinguishable from a genuinely exited descendant, and round 5's check silently skipped past it. The connector's own framing settled the bounding question raised in the round-5 reply: this is a PREVIOUSLY OWNED identity - a prior entry - so there is no ambiguity about whether it's ours; we recorded it. That signal (which the fully-general reframing declined in round 5 was missing) does not exist for an unrelated row elsewhere on the host, so this fix cannot reintroduce round 1's incident.
- Split `_snap_index` into a thin wrapper over a new `_snap_index_and_excluded`, which also returns the set of pids it excluded - distinct from a pid simply never present (absent, normal, already safe). `_snap_index`'s own signature and behavior are unchanged for its other 8 call sites. `_owned_process_tree` now rejects a prior entry whose current row is `None` AND in the excluded set; one that's simply absent (not excluded) is unchanged.
- First test attempt reused round 4's own duplicate-pid shape (parent_pid pointing at the launcher) - round 4's discovery-closure already catches that via the permissive edge map regardless of the pid's own exclusion, so the test passed on the PRE-FIX commit too. Caught it before committing (same discipline as the round-4 recycled-root false-green) and rebuilt with an unrelated parent_pid so only `prior_entries` seeding it as a root can reach it.

## Round 7: the named finding, plus a full survey of every other `_snap_index` consumer

- **The finding**: a snapshot containing two rows for an ACTIVE EPHEMERAL REVIEWER's launcher pid (even identical rows) made `_snap_index` exclude it, and `_ephemeral_process_alive` read the resulting `idx.get(pid)`-is-`None` the same as "process exited" - permanently misclassifying a healthy review as failed, since a persisted `held_terminal` is deliberately unrewritable by any later report. Fixed: `_ephemeral_process_alive` now returns `None` (unknown) rather than `False` for an excluded pid; the caller already only treats `alive is False` as a terminal-failure signal. Test proves the operator-visible outcome (the review survives the glitched poll, `held_terminal` stays unset), not the internal flag value.
- This was a regression from round 6's own `_snap_index`/`_snap_index_and_excluded` split: it taught exactly one caller (the prior-entry check) the new distinction, and the thin `_snap_index(snapshot)` wrapper let the other seven call sites keep reading a miss as a single fact. Surveyed all seven, each with a keep-or-fix reason recorded at its own call site:
  - Proven NOT to matter, by construction: the promotion check in `_unverified_owned_process_tree` and `evaluate_launch_barrier` are each gated by `_snapshot_pid_integrity_error` finding the same underlying condition first (a duplicated pid is a strict subset of what that whole-snapshot check already catches) - the excluded set is provably empty by the time either site's own fix would run. Found this by testing, not just reading: a first attempt at each site's fix passed identically with and without the change, exposing dead code before it was kept.
  - Classified `_attribution`'s launcher confirmation as genuinely indifferent by design - **round 8 found this wrong; see below.**
  - Fixed defensively, reachability not proven either way: `_unverified_owned_process_may_exist`, the wrapper-liveness check in `_wrapped_liveness`, and brain liveness in `_liveness` for the legacy, non-wrapped path. Every end-to-end scenario tried already reached the same safe outcome through a different, pre-existing mechanism first, so no test could discriminate these three branches' own effect - disclosed as such rather than shipped with a non-discriminating test standing in for real coverage.
- With every consumer surveyed and fixed, justified, or disclosed as unproven, the thin `_snap_index` wrapper has zero remaining callers and is retired - a future caller has no way to get an index without also being handed the one set this conflation kept breaking on.

## Round 8: the round-7 `_attribution` classification was wrong - classified by local behavior, not by what downstream consumes

- Round 7 read `_attribution`'s own code correctly (an excluded launcher pid only suppresses launcher confirmation) but generalized that reading to the whole function. Two more consumers of the SAME index a few lines below - both iterating `valid_priors`, the legacy attribution model's persisted `managed_pids` - apply the identical `idx.get(pid)`-is-`None` miss to a PRIOR-TRACKED DESCENDANT instead of the launcher: the kill-targeting loop drops the descendant's kill target when its row is merely duplicated (not absent) this poll, and the provenance loop drops it from `managed_by_pid` the same way, so the NEXT poll's `valid_priors` no longer carries it at all even once the ambiguity clears.
- The observable consequence: a manual or stale-heartbeat recovery kills the launcher (the only thing still targeted), the duplicate glitch clears before the post-kill snapshot, and the untargeted descendant is left alive alongside a freshly launched replacement - the duplicate-wrapper hazard again, on the legacy non-wrapped path.
- Fixed both, same rule as everywhere else: an excluded prior entry is now targeted for killing using the prior record's own pid/start (the only identity this attribution model carries for it) via a synthetic row - Stop-Tree's own start-time guard decides whether to actually kill it; and an excluded prior entry is kept unchanged in `managed_by_pid` rather than dropped, preserving it as ambiguous HOLD evidence across the glitched poll.
- Did not extend this to the BFS descendant-walk a few lines below (also reads `idx.get(parent_pid)` the same way) - not named by the connector, and closing it correctly needs a substitute for `_strict_child_edge`'s own start-time-ordering check when the parent row itself is absent, a larger, separate change flagged rather than built speculatively.
- Re-examined the two round-7-reverted dead-code sites and the three fixed-on-principle sites under the sharper question ("what does everything downstream consume", not "what does this site do"): the reverted pair's own output is either a pass-through of an already-correct prior tree or consumed once within the same poll cycle, never persisted or re-derived from later - the argument holds downstream too. No new discriminating scenario found for the other three within this round.

## Round 9: a double-count, a third remedy that refuses the operator, and one genuinely unbounded residual

- **The double-count**: round 3's own "harmless, `rejected_count` is a gate not a tally" justification for `mark_rejected` was true when written and stopped being true the moment round 3 (and round 5) added an operator-facing message that reports the number as a count - a value's tolerance for imprecision is a property of its CONSUMERS, not the value itself. A candidate rejected once during the main walk (e.g. an unproven virtual-parent descendant below a trusted-but-exited intermediate) is also absent from `owned`, so the discovery-closure loop found it again and called `mark_rejected` a second time for the identical pid - one lost candidate reported as two. `mark_rejected` now takes an optional pid and dedupes against a `rejected_pids` set; every call site with an identifiable single candidate now passes it. Verified the exact shape named: a trusted-but-exited intermediate with a brand-new, never-recorded live child now reports `rejected_count == 1`, and the message says "excluded 1 candidate(s)" - asserted the message text, not the counter.
- **The third remedy that refuses the operator**: a configured-agent `--reset-process-tree-ownership` (cli.py) requires the CURRENT wrapper runtime record to read `STATUS_VALID` before it will act, independent of the tree's own entries/`rejected_count`. Rounds 2 and 3 each closed the ONE precondition that had actually bitten (an entryless placeholder's missing nonce; a rejected candidate outside the identity list) by patching that specific case - which is why there was a third: a tree can hold real entries inherited from an earlier complete poll while the runtime record is exactly what made THIS poll invalid. One predicate now gates naming the command as an actionable recommendation: this poll's own liveness read of the same runtime record the command re-reads at reset time. When it's not valid, the message still names the command for context but never recommends running it, and points at operator investigation instead.
- **The malformed-pid residual**: a row whose own pid field is malformed (not `parent_pid` this time) contributes no edge either direction. Traced both sub-cases by execution: for a PRIOR-TRACKED intermediate this is already safe (the trusted-rehydration block reconstructs its identity from the prior record's own start/filetime, bypassing the malformed current row entirely - confirmed by execution, locked in with a regression test). For a first-time-seen row, this is genuinely unbounded - every other fix in this family works by looking a row up BY its own intact pid field, and that is exactly the field missing here; there is no snapshot-only signal distinguishing it from an unrelated malformed row elsewhere on the host. Documented as a residual in `_snap_all_edges`'s own comment with a test that demonstrates the gap by execution, per the connector's own offer to accept this as documented rather than have a fourth algorithm guessed at.

## Round 10: the round-8 deferred BFS gap, now concrete; and a fourth refusing remedy caused by an imprecise predicate

- **The deferred BFS gap, built**: round 8 fixed `_attribution`'s kill-targeting and provenance loops for an excluded prior entry (a tracked pid whose row is merely duplicated, not gone) but explicitly deferred the BFS descendant-walk a few lines below, which seeds from the SAME excluded pid yet still looked it up via `idx.get(parent_pid)` - `None` for the identical reason - and silently skipped it as a BFS parent. The connector's concrete example: a tracked pid with duplicate rows (excluded) has an opaque, never-recorded child underneath it; round 8's fix makes the tracked pid a kill target again, but the child is never even queried, let alone targeted, because the skip happens before `kids.get(parent_pid, [])` is ever consulted. Consequence: the tracked pid gets killed, the opaque child survives it (the launch barrier has no tree evidence to block on for this legacy path either), and a replacement launches alongside a live child of the pid it just replaced - the exact hazard this PR exists to prevent.
- Resolved the deferred design question rather than deferring it again: `_strict_child_edge` only ever reads `parent["pid"]` and `_start_of(parent)` (`parent["start_time"]`) - the same two fields the excluded seed's synthetic row (round 8's own construction) already carries and that Stop-Tree already trusts to order that pid's own kill. The synthetic row is therefore sufficient to stand in as the BFS parent too; built a small `seed_synthetic_rows` map alongside `seed_pids` in the kill-targeting loop and consulted it in the BFS loop only when `idx.get(parent_pid)` misses - every other pid that ever reaches the queue was admitted via a real `idx` row already, so this fallback is scoped exactly to the excluded-seed case, not a general substitute for a real row.
- Verified the operator-visible outcome the lead named, not a changed internal set: a tracked pid with duplicate rows and an opaque child underneath it now has BOTH killed in the same operation - direction-controlled against 070d8dd.
- **The fourth refusing remedy**: round 9's fix gated the reset remedy on `liveness.get("runtime_status") == STATUS_VALID` - the lead's own "one predicate" instruction, but a single SIGNAL rather than the command's actual admission predicate. `--reset-process-tree-ownership` (`process_tree_ownership_reset_evidence`) separately requires the runtime record's own `wrapper_pid`/`wrapper_start` to agree with the stored `launcher_pid`/`launcher_start` - a record can be `STATUS_VALID` (it parses) while still failing that agreement, which is exactly what sends `_wrapped_liveness` down `wrapper_state_mismatch` with a nonempty inherited tree. Extracted the actual shared conjunct into one function, `_wrapper_identity_matches_state(record, st) -> bool`, and call it from all three places that used to check this ad hoc: `_wrapped_liveness`'s own HOLD branch, `process_tree_ownership_reset_evidence`'s admission check, and the remedy-message predicate in `_plan_one` (reading `liveness["runtime_record"]`, the exact record `_wrapped_liveness` already normalized this poll - not a re-derivation). The `elif has_entries` remedy wording now distinguishes the two distinct refusal reasons (runtime not valid vs. valid-but-mismatched identity) instead of collapsing them into one message that would misreport a valid status as "not valid".
- Verified the operator-visible outcome: the recommendation string is absent when a `STATUS_VALID` record's wrapper identity mismatches supervisor state, reaching `process_tree_invalid_wrapper_state_mismatch` with real entries - direction-controlled against 070d8dd.
- Caught and corrected a false-confirming-green during this round's own work: the first cut of the BFS test ran against the MAIN checkout's installed `supervisor.py` (editable install), not this worktree's file, because `git stash`-ing the worktree source has no effect on what gets imported without `PYTHONPATH` pointed at the worktree - the test "passed" identically with the fix present and stashed away. Caught by checking `sup.__file__` directly rather than trusting the stash to isolate anything; every direction-control in this round re-ran with `PYTHONPATH` set to the worktree's `src`.

## Round 11: a zero that survived a walk that never happened; one more excluded-vs-absent consumer; and a sizing decision on the closing question

- **The stale zero**: `_current_proof_failed` converts a previously COMPLETE tree to `invalid` (because THIS poll's runtime record is invalid or wrapper-mismatched, not because of anything about the tree's own entries) via `_unverified_owned_process_tree`'s "held" fallthrough - and that conversion is a relabeling, not a walk. It used to carry the original walk's `rejected_count == 0` forward unchanged, so a LATER poll's `entries_are_complete` eligibility check read that stale zero as proof THIS invalid record was itself complete, re-admitting it for absence-promotion on an accounting question nobody asked this poll. Same rule round 4 already applied to the PowerShell post-kill barrier's own mutation sites ("a producer that doesn't walk must not claim to have walked") - now applied to this Python-side analogue. Fixed by popping `rejected_count` from the converted record; missing reads as unknown, which is already ineligible for re-derivation - the correct meaning, since this poll genuinely does not know. Surveyed the other `copy.deepcopy(prior)`-shaped sites in this file for the same shape: the function's own top-of-function passthrough (prior already ineligible, unchanged either way) and `_owned_process_tree`'s two truncated/invalid passthroughs return prior UNCHANGED (no status relabeling happens there, so nothing to strip); the entryless placeholder builder hardcodes `rejected_count: 0` but pairs it with `entries: []`, and `bool([])` is already falsy, so it can never satisfy `entries_are_complete` regardless of the count - confirmed harmless by construction, not merely by inspection. Left the sibling "absent" promotion (same function, a few lines above) unchanged: `eligible_for_rederivation` never consults `rejected_count` once status is already `absent`, no message path reads it for that status, and the validator accepts either `0` or missing there - proven inert, not merely assumed so.
- **One more excluded-vs-absent consumer**: `_children_map(idx)` is built only from `idx.items()` - a newly discovered (never a prior entry) child excluded this poll (duplicate/ambiguous rows) never contributed a row to `idx` at all, so it never contributes an edge either, regardless of whether its parent is a trusted, non-excluded seed. Structurally different from round 10's finding: an excluded PARENT still has an independently-trusted prior identity to fall back on (the prior record); a first-time-seen EXCLUDED CHILD has no such anchor - the ambiguous current-poll rows are the only information that exists about it, the same "no snapshot-only signal to disambiguate a first-time-seen identity" residual already documented in `_snap_all_edges` for a malformed pid. Inventing a synthetic child row from one of the ambiguous rows would extend trust exactly where round 1's original incident began, so this is not treated the same way as round 8/10's synthetic-row fix. Instead: the BFS loop now also walks the permissive `_snap_all_edges` map per visited parent, and any child pid found there that `idx` excluded gets bumped into a new diagnostic counter (`excluded_live_descendant_unaccounted`, deduped per pid) rather than silently vanishing - never invented as a kill target, never lost either.
- **The closing question**: asked whether the lookup itself could be restructured so "excluded" is impossible to ignore - a discriminated result a caller must destructure, rather than a set a caller can decline to consult. Judgment call, with reasons: not pursuing it this round. `idx`-shaped data has 42 total accessor touch points across this file (`.get`/`.pop`/`.items`/`.values`/subscript), of which only ~8 have ever needed the excluded-vs-absent distinction to make a correct decision - the rest are either indifferent by design or already paired with an explicit `excluded_pids` check. A discriminated-result API would need every one of those 42 sites migrated (including the ones already correct) to stay coherent, and even then Python has no compiler-enforced exhaustiveness check on match/branch handling - it would make the excluded case visible at each site, but the RIGHT handling (synthetic row vs. diagnostic-only vs. genuinely indifferent - three different, correct answers found across rounds 7-11) still requires the same per-site domain judgment a type change cannot automate. That is a large, invasive refactor for a partial benefit. Recommending: accept the current state as enumerated-and-fixed with a bounded, judged residual, not structurally impossible - continuing this file's own established convention of a proof-bearing comment at every indifferent/justified site is the cheaper mechanism doing most of the real work already.
- Both fixes verified against the operator-visible outcome, `PYTHONPATH` pinned throughout: the trusted root is still targeted while the ambiguous child is neither invented as a kill target nor silently lost (diagnostics counter == 1); and the stale-zero conversion no longer carries `rejected_count` forward. Direction-controlled against c05a2b1.

## Round 12: the diagnostic that was never read, a hazard our own round-11 fix created, and a proposed inversion of the whole shape

- **Fix, mandatory regardless of anything else**: round 11's `excluded_live_descendant_unaccounted` diagnostic was computed and never consulted - the legacy manual-restart path still killed only the trusted, accounted-for root and relaunched, exactly the outcome the diagnostic exists to prevent. A check that runs and is never acted on is not a check. Added a HOLD at the same precedence the wrapped path's `tree_status` check already has over even an authorized restart marker: when this diagnostic is nonzero, the legacy path now returns `WARN_ONLY`/`UNACCOUNTED_LIVE_DESCENDANT` (no kill, no relaunch, not even the trusted parent) instead of proceeding on partial accounting.
- **A hazard round 11's own fix created**: round 10's synthetic-row fallback (an excluded seed's own prior pid/start, reused as the `_strict_child_edge` PARENT for BFS descendant discovery) is safe as a KILL TARGET - Stop-Tree re-verifies the live process's actual start time against it before acting, protecting against a recycled pid. It is NOT safe as a time-ordering PARENT for discovering FURTHER descendants: nothing re-verifies that claim before it feeds an independent kill decision about a different pid, and a recycled pid's stale prior start time is almost always earlier than any of the replacement process's own children - the ordering check meant to reject an unrelated descendant would instead pass every one of them. Reverted round 10's synthetic-row reuse in the BFS loop; an excluded parent's children (real row or themselves excluded) are now treated the same way round 11 already treats an excluded first-seen child - unaccounted, never a kill target. This converges rounds 10, 11, and 12's fixes into one uniform rule: an excluded pid touching the discovery graph, as parent or as child, always produces an accounted-for diagnostic, never a kill target built on an unverified time-ordering claim - and the new HOLD above is what actually makes "unaccounted" safe rather than merely visible.
- **A third finding, confirmed but not fixed this round**: a malformed prior with a live wrapper rebuilds only the currently-reachable subset (the prior's own historical entries are discarded entirely, since they never parsed) as `prior_record_invalid`, with `rejected_count == 0` earned honestly by THIS narrowed walk - but that walk never had the chance to check on whatever else the FULL historical tree might have tracked before the malformation. The narrowed record reads as complete when it is only complete relative to a smaller graph than the one that matters. Confirmed by tracing the code, not fixed independently this round: fixing every instance of "a record claims completeness it didn't earn" one producer at a time is exactly the pattern that hasn't converged since round 9, and this is another instance of it, not a new site.
- **The proposed inversion**: replace "eligibility requires the absence of recorded rejections" (`rejected_count == 0`, which is the default state of an integer and therefore free to every new or narrowed code path) with "eligibility requires positive evidence a complete walk happened" - one boolean, `walk_complete`, computed ONCE at the true end of `_owned_process_tree`'s own walk (as `bool(entries) and omitted_count == 0 and rejected_count == 0 and not prior_record_invalid`, i.e. the exact same conjunction `entries_are_complete` already computes today, but stamped at the source instead of re-derived by every later reader from fields that can be inherited, defaulted, or hardcoded without ever having been jointly checked), never set anywhere else, and required present-and-true by `_unverified_owned_process_tree`'s eligibility check in place of the current `entries_are_complete` re-derivation.
  - Sized before recommending: `rejected_count`/`omitted_count` stay as diagnostics (accuracy still matters for the operator-facing message), but stop being independently load-bearing for the safety decision - the walk-complete boolean already folds them in at the moment they're freshly known, so a later reader never re-derives (and cannot mis-derive) the same fact from possibly-stale fields.
  - Answering the posed question directly: yes, there is a path that promotes to absent without a NEW walk running on that specific poll - the canonical case this whole PR exists to fix, a wrapper confirmed absent from an available current snapshot, checked directly against a PRIOR record's entries. This is not a carve-out that complicates the design: `walk_complete` is a persistent fact about the STORED record, earned on whichever earlier poll's walk actually produced it, not something that must be re-earned every poll it's read. The mechanism already works this way today (`entries_are_complete` is also read from `prior`, not recomputed fresh each poll) - the inversion changes WHERE the fact is computed (once, at the source) and HOW it's represented (an explicit claim instead of an inferred one), not WHEN it's allowed to be trusted.
  - This directly explains finding 3 (`3000`) without a separate fix: the narrowed `prior_record_invalid` rebuild is exactly the case where `entries_are_complete`'s existing conjunction reads true when it should not - `walk_complete` closes it by construction, since `not prior_record_invalid` is already one of its own terms.
  - Every OTHER current and future non-walking producer (placeholders, relabelings, the PowerShell post-kill barrier) is safe by omission under the inversion, not by remembering to strip a field - EXCEPT sites that `copy.deepcopy` an existing record forward without a NEW walk (this file's own `_unverified_owned_process_tree` "held" conversion, and the PowerShell barrier's status mutation) still need to explicitly strip `walk_complete`, the same care already applied to `rejected_count` at both those exact sites.
  - Sizing: touches `_owned_process_tree`'s result construction, `_unverified_owned_process_tree`'s eligibility check, the schema/validator (`walk_complete` optional, same v2-migration-safe pattern as `rejected_count`), and the PowerShell template's existing `rejected_count`-stripping mutation sites (would gain a sibling strip). Not built this round - sized and reported per the standing instruction to size before building; recommending it for the next round rather than folding a cross-cutting schema change into an already-large one.
- Both mandatory fixes verified against the operator-visible outcome, `PYTHONPATH` pinned throughout: the poll HOLDS (no kill, no relaunch, empty kill_targets) whenever a live descendant cannot be verified, whether the ambiguity is on the parent or the child side of the discovery graph. Direction-controlled against c74f776.

## Round 13: the safety HOLD we just built expires while the hazard it guards is still observable

- A new class for this PR: not "excluded conflated with absent" but "a TTL conflating unresolved-with-decayed, arriving through the time axis." An excluded prior seed that stays ambiguous (duplicate/conflicting rows) longer than `_PROVENANCE_TTL_SECONDS` (one hour) was preserved unchanged by round 8's fix, but its own `last_fresh_attribution_epoch` was never touched - `_prior_valid`'s TTL check eventually expires it, even though the pid is present in conflicting rows on every single poll in between. For a seed no longer connected to the launcher, dropping it also removes the only root that discovers its child, so round 12's `UNACCOUNTED_LIVE_DESCENDANT` HOLD disappears and a pending authorized restart relaunches without targeting either process.
- A TTL is the right instrument for evidence nobody has rechecked; it is the wrong instrument for an unresolved condition still being observed every poll. Fixed by refreshing `last_fresh_attribution_epoch` on every poll the ambiguity is still directly observed (the excluded branch of the `managed_pids` persistence loop), so the entry cannot lapse while the condition producing it is still present.
- A first attempt generalized the refresh to the validly-matching (non-excluded) branch too, on the reasoning that both branches are equally never re-derived via `_new_provenance_entry` (`prior_only` is set unconditionally for both). This broke an existing, deliberately-pinned test proving a valid match's TTL is meant to age normally - it has other paths to re-earn a fresh stamp (`own_wrapper`/`own_wait`/`live_chain_descendant`/`legacy_rederived`) that an excluded identity does not. Caught by running the full suite before reporting the round done, not assumed correct from the reasoning alone; reverted the valid-branch change and documented explicitly why it stays excluded-only.
- Surveyed the file for other TTL-style checks that might really be unresolved-condition markers: `_PROVENANCE_TTL_SECONDS` is the only safety-gating TTL found. The launch-coordination barrier's own `last_observed_epoch` already refreshes on continued observation of the same blocking condition - the correct pattern, already present elsewhere, not something this round needed to invent. Runtime heartbeat/progress-age staleness is legitimately decaying evidence (an unrefreshed heartbeat really does mean nobody's heard from the process), not an unresolved-condition marker - a different, correctly-TTL'd shape.
- No interaction with the proposed `walk_complete` inversion: `_prior_valid`'s TTL belongs exclusively to `_attribution` (the legacy, non-wrapped path); `walk_complete` would belong exclusively to `_owned_process_tree`/`_unverified_owned_process_tree` (the wrapped path). `_liveness` dispatches each agent to exactly one of the two, never both - disjoint data, disjoint mechanisms, confirmed by tracing the dispatch rather than asserted from the file's own shape.

## Test plan
- [x] Round 1: unit tests on `_unverified_owned_process_tree` (invalid-but-complete promotes; truncated/no-entries never promote; still-alive stays held) + end-to-end `plan_actions`/`evaluate_launch_barrier` test.
- [x] Round 2: the blocker scenario, built and confirmed to actually promote to absent under the round-1 code before being fixed; refreshed-flag, entryless-message, and truncated-remedy tests, each direction-controlled against 43a0484.
- [x] Round 3: schema-migration end-to-end (a v2-shaped prior must not brick a healthy wrapper); validator status/rejected_count constraint; `_snap_index` duplicate-pid exclusion; admit/reject consistency for missing exact filetime; discovery-closure orphan reconciliation; reset-remedy wording - each direction-controlled against 89858e0.
- [x] Round 4: `_snap_index` exclusion no longer orphans a duplicated pid's descendants from the discovery-closure invariant; recycled-root discovery agrees with `evaluate_launch_barrier`'s old-side/new-side line instead of excluding every current child (the two pre-existing recycled-root tests still pass unchanged); post-kill/ephemeral-teardown barrier mutation no longer presents a trustworthy zero `rejected_count` - each direction-controlled against 059a9b7.
- [x] Round 5: a prior entry's malformed-parent-pid current row is now rejected rather than silently unaccounted; the legacy-v2 remedy warns on an unknown `rejected_count` the same as a known nonzero one - each direction-controlled against ca6c7f3.
- [x] Round 6: a prior entry whose current row `_snap_index` excluded (not merely absent) is now rejected too - direction-controlled against ac48478, with a corrected fixture after catching a false-confirming first attempt.
- [x] Round 7: an ephemeral reviewer with a duplicated launcher-pid row now survives the poll instead of being archived failed - direction-controlled against ca0f5a0. The other six surveyed sites are either proven dead code (verified by a discriminating test), genuinely indifferent by design, or fixed defensively with the reachability gap disclosed rather than papered over with a non-discriminating test.
- [x] Round 8: a legacy agent's duplicated-but-tracked descendant is now a kill target on a manual-restart poll (closing the hazard) and survives a routine poll's provenance (verified independently, since a restart poll legitimately resets `managed_pids` on its own) - direction-controlled against 3d8c2d6.
- [x] Round 9: a trusted-but-exited intermediate's brand-new live child now reports `rejected_count == 1` and "excluded 1 candidate(s)" in the message, not 2 (direction-controlled against d8c5000); the reset remedy no longer recommends a command that would refuse the operator when the current runtime record is invalid, even with real entries present (direction-controlled against d8c5000); the malformed-pid residual's two sub-cases (prior-tracked: safe; first-time-seen: unbounded) are each verified by execution and behave identically on d8c5000, confirming they characterize existing/documented behavior rather than a code change.
- [x] Round 10: an opaque child of an excluded-but-tracked pid is now a kill target in the same operation as that pid, closing the deferred BFS gap (direction-controlled against 070d8dd); the reset remedy no longer recommends the command when a `STATUS_VALID` runtime record's wrapper identity mismatches supervisor state (direction-controlled against 070d8dd) - both verified with `PYTHONPATH` pointed at this worktree's `src` after catching a first pass that silently ran against the main checkout's installed package instead.
- [x] Round 11: converting a complete tree to invalid no longer carries the original walk's `rejected_count` forward, closing a re-admission gap on a later poll (direction-controlled against c05a2b1); a newly discovered, excluded (duplicate-row) child of a trusted, non-excluded root is neither invented as a kill target nor silently lost - it surfaces as a new diagnostic counter instead (direction-controlled against c05a2b1).
- [x] Round 12: the legacy path now HOLDS (no kill, no relaunch) whenever `excluded_live_descendant_unaccounted` is nonzero, instead of relaunching on partial accounting; the round-10/11 BFS tests updated to assert this HOLD directly, and confirmed to fail against c74f776 (the old code still relaunches / still invents the child as a kill target via the stale-time hazard) - both direction-controlled against c74f776. Finding 3 (`prior_record_invalid` narrowed rebuild reading complete) confirmed but intentionally not fixed independently this round; sized alongside the proposed `walk_complete` inversion instead.
- [x] Round 13: an excluded prior seed that stays ambiguous longer than `_PROVENANCE_TTL_SECONDS` (one hour) now has its `last_fresh_attribution_epoch` refreshed on every poll the ambiguity is still directly observed, instead of expiring while the pid is present in conflicting rows on every single poll - a TTL is the right instrument for evidence nobody has rechecked, the wrong one for an unresolved condition still being actively observed. Scoped to the excluded branch only: a first attempt also refreshed a validly-matching (non-excluded) prior's epoch, which broke an existing, deliberately-pinned test proving a valid match's TTL is meant to age normally (it has other paths to re-earn a fresh stamp that an excluded identity does not) - caught by the full suite, reverted, documented. Surveyed the file for other TTL-style safety gates (none found beyond this one; the coordination barrier's own `last_observed_epoch` already refreshes correctly on continued observation) and confirmed no coupling with the proposed `walk_complete` inversion (disjoint mechanisms - `_prior_valid`'s TTL belongs to the legacy `_attribution` path, `walk_complete` would belong to the wrapped `_owned_process_tree` path, and a given agent is dispatched to exactly one). Direction-controlled against 32668ee.
- [x] Direction-controlled throughout: every new/changed assertion fails against the code it's fixing (verified by stashing `supervisor.py` alone and re-running).
- [x] Full `tests/test_supervisor.py` suite green on the default interpreter and `py -3.10` (544 passed, 2 skipped, 1 xfailed - 543 + 1 new).
- [x] `ruff check` clean on both touched files.
- [ ] dev-gate/build/wheel/security legs intentionally not run locally (targeted tests only, per standing directive) - left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





