### PR TITLE
walk_complete: positive-evidence eligibility for owned-process-tree re-derivation

### DIFF
--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2675,6 +2675,25 @@ def _valid_owned_process_tree(
         or value.get("truncated") is not (omitted_count > 0)
     ):
         return None
+    # Task #150 follow-up connector finding: the checks above only typed
+    # walk_complete and rejected the False-with-complete/absent
+    # contradiction - they never constrained True against the conjunction
+    # that is supposed to have earned it. A persisted record claiming
+    # walk_complete True while omitted_count/rejected_count are nonzero, or
+    # rejected_count is unknown, or entries is empty, is exactly as
+    # internally contradictory as the existing nonzero-rejected_count-on-
+    # complete/absent check above (same shape, same round-3 precedent) -
+    # and reading it as authoritative here would make the inversion WORSE
+    # than the re-derivation it replaced: the old entries_are_complete
+    # re-derivation would have caught this record; a bare type-check on a
+    # single boolean would not. This does not require the flag to be
+    # PRESENT - only present-and-True must match its own preconditions;
+    # absent or False stays eligible-by-nothing (unknown), never rejected
+    # for a conjunction the record never claimed to have earned.
+    if walk_complete is True and not (
+        bool(entries) and omitted_count == 0 and rejected_count == 0
+    ):
+        return None
     reason_code = value.get("reason_code")
     if value.get("status") == "complete":
         if reason_code is not None or omitted_count:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -197,7 +197,28 @@ _SAFE_WRAPPER_GENERATION_RE = re.compile(
 # record never earned. schema_version is deliberately NOT bumped: the
 # field's own optionality is the migration, so there is nothing for a
 # version bump to gate that isn't already handled without one.
-_OWNED_PROCESS_TREE_OPTIONAL_FIELDS = frozenset({"rejected_count"})
+#
+# The walk_complete inversion (task #150 follow-up): rejected_count == 0
+# (with omitted_count == 0 and at least one entry) was the eligibility bar
+# for re-deriving absence from an invalid prior - but that bar is chasing
+# the ABSENCE of recorded rejections, which is the default state of an
+# integer and therefore free to every new or narrowed code path that never
+# ran a real walk (inherited, defaulted, hardcoded, or a status relabel).
+# walk_complete inverts it: positive evidence a complete walk actually ran,
+# set in exactly one place (the end of _owned_process_tree's own walk) as
+# the SAME conjunction (bool(entries) and omitted_count == 0 and
+# rejected_count == 0) plus not prior_record_invalid - computed once, at
+# the source, while the inputs are freshly known, instead of re-derived by
+# every later reader from fields that can be inherited or defaulted
+# without ever having been jointly checked. rejected_count/omitted_count
+# remain in the schema as diagnostics and the operator-facing count, where
+# accuracy still matters, but they stop being independently load-bearing
+# for the safety decision. Optional for the identical v2-migration reason
+# rejected_count is: a record from before this field existed is still
+# valid, readable authority; a missing walk_complete reads as unknown,
+# already ineligible for re-derivation - the correct meaning, since no
+# walk is known to have run.
+_OWNED_PROCESS_TREE_OPTIONAL_FIELDS = frozenset({"rejected_count", "walk_complete"})
 _OWNED_PROCESS_TREE_FIELDS = frozenset({
     "schema_version",
     "attribution_model",
@@ -210,6 +231,7 @@ _OWNED_PROCESS_TREE_FIELDS = frozenset({
     "recorded_count",
     "omitted_count",
     "rejected_count",
+    "walk_complete",
     "truncated",
     "refreshed_at",
     "wrapper_generation",
@@ -2532,13 +2554,15 @@ def _valid_owned_process_tree(
     if not isinstance(value, dict):
         return None
     value_keys = frozenset(value)
-    # A v2 record (predates rejected_count) is missing exactly one optional
-    # key - still a complete, valid schema for everything it DOES claim; see
+    # A record may predate rejected_count, walk_complete, both, or neither -
+    # three migration boundaries have added an optional key to this schema
+    # independently, and a record's age determines which subset it has, not
+    # which single field is missing. Any set of optional keys present is
+    # schema-valid for everything the record DOES claim; see
     # _OWNED_PROCESS_TREE_OPTIONAL_FIELDS' own comment for why that must not
     # collapse to schema-invalid.
-    if value_keys != _OWNED_PROCESS_TREE_FIELDS and value_keys != (
-        _OWNED_PROCESS_TREE_FIELDS - _OWNED_PROCESS_TREE_OPTIONAL_FIELDS
-    ):
+    mandatory_fields = _OWNED_PROCESS_TREE_FIELDS - _OWNED_PROCESS_TREE_OPTIONAL_FIELDS
+    if not (mandatory_fields <= value_keys <= _OWNED_PROCESS_TREE_FIELDS):
         return None
     status = value.get("status")
     record_generation = value.get("wrapper_generation")
@@ -2619,6 +2643,27 @@ def _valid_owned_process_tree(
         and rejected_count is not None
         and rejected_count != 0
     ):
+        return None
+    # walk_complete is the other OPTIONAL field - absent means unknown,
+    # never True, for the identical v2-migration reason rejected_count is
+    # optional. A "complete" tree ALWAYS has walk_complete True by
+    # construction (see _owned_process_tree: status can only be "complete"
+    # when the same walk that set it also had omitted_count == 0,
+    # rejected_count == 0, and a non-empty entries list - the schema
+    # already requires entries non-empty whenever status != "invalid").
+    # Eligibility grants complete/absent unconditionally regardless of
+    # walk_complete's own value, so it is not load-bearing for either
+    # status here - but a record explicitly claiming complete/absent WITH
+    # walk_complete written as False is internally contradictory the same
+    # way a nonzero rejected_count is, and must not read as authoritative
+    # just because the field itself still parses.
+    if "walk_complete" in value:
+        walk_complete = value.get("walk_complete")
+        if not isinstance(walk_complete, bool):
+            return None
+    else:
+        walk_complete = None
+    if status in {"complete", "absent"} and walk_complete is False:
         return None
     entries = value.get("entries")
     if (
@@ -2975,29 +3020,34 @@ def _unverified_owned_process_tree(
     only counts the size-cap gap between admitted nodes and recorded entries,
     never a candidate branch the walk SAW and explicitly excluded for any
     other reason (an unproven virtual-parent descendant with a live child,
-    say). rejected_count (see _OWNED_PROCESS_TREE_FIELDS) is the field that
-    actually means "nothing the walk considered was left unaccounted for" -
-    both it and omitted_count must be zero, with at least one entry recorded,
-    for an invalid prior to qualify. A TRUNCATED prior's entries are
-    incomplete by definition (omitted_count > 0) and never qualifies:
-    proving the recorded subset gone says nothing about whatever the size cap
-    dropped. A prior with no entries at all (schema-drift/generation-adoption
-    placeholders built by _invalid_owned_process_tree_record, never a real
-    tree walk) has nothing to disprove against and never qualifies either.
-    Any prior identity still present, or an unavailable/poisoned CURRENT
-    snapshot, remains sticky HOLD evidence exactly as before.
+    say). A TRUNCATED prior's entries are incomplete by definition
+    (omitted_count > 0) and never qualifies: proving the recorded subset
+    gone says nothing about whatever the size cap dropped. A prior with no
+    entries at all (schema-drift/generation-adoption placeholders built by
+    _invalid_owned_process_tree_record, never a real tree walk) has nothing
+    to disprove against and never qualifies either. Any prior identity
+    still present, or an unavailable/poisoned CURRENT snapshot, remains
+    sticky HOLD evidence exactly as before.
+
+    The walk_complete inversion (task #150 follow-up): the bar an invalid
+    prior must clear used to be re-derived here as "omitted_count == 0 and
+    rejected_count == 0 with at least one entry" - chasing the ABSENCE of
+    recorded rejections, which is the default state of an integer and
+    therefore free to any producer that inherited, defaulted, or hardcoded
+    the count without ever running a walk. walk_complete is the inversion:
+    positive evidence a complete walk actually produced this record,
+    stamped once by _owned_process_tree itself at the moment its inputs
+    were freshly known, read here rather than re-derived. Missing (a
+    record from before this field existed, or one a non-walking producer
+    relabeled without carrying it forward) reads as unknown - already
+    ineligible, the correct meaning.
     """
     if prior is None:
         return None
     entries = prior.get("entries")
-    entries_are_complete = (
-        isinstance(entries, list)
-        and bool(entries)
-        and prior.get("omitted_count") == 0
-        and prior.get("rejected_count") == 0
-    )
+    walk_complete = prior.get("walk_complete") is True
     eligible_for_rederivation = prior.get("status") in {"complete", "absent"} or (
-        prior.get("status") == "invalid" and entries_are_complete
+        prior.get("status") == "invalid" and walk_complete
     )
     if not eligible_for_rederivation:
         held = copy.deepcopy(prior)
@@ -3063,13 +3113,16 @@ def _unverified_owned_process_tree(
     # PowerShell post-kill barrier, which strips this same field at its own
     # mutation sites for the identical reason. rejected_count == 0 was true
     # of the walk that produced `prior`; it says nothing about THIS poll,
-    # which performed no walk at all. Left uncorrected, a LATER poll's
-    # entries_are_complete check reads that stale zero as proof this
-    # invalid record is complete, re-admitting it for absence-promotion on
-    # an accounting question nobody actually asked this poll. Missing reads
-    # as unknown - already ineligible for re-derivation - which is the
-    # correct meaning: we genuinely do not know.
+    # which performed no walk at all. Kept stripped for the operator-facing
+    # message's own accuracy - it is diagnostics now, not the safety gate,
+    # but a stale zero would still misreport what THIS poll knows.
     held.pop("rejected_count", None)
+    # The walk_complete inversion: `prior` may have carried walk_complete
+    # True from whatever walk actually produced it - copying that forward
+    # onto THIS relabeled record would claim the identical positive fact
+    # this conversion performed no walk to earn. Missing reads as unknown,
+    # already ineligible for re-derivation - the correct meaning here too.
+    held.pop("walk_complete", None)
     return held
 
 
@@ -3747,6 +3800,24 @@ def _owned_process_tree(
     else:
         status = "complete"
         reason_code = None
+    # The walk_complete inversion: positive evidence THIS walk actually ran
+    # to completion, computed once, here, while every input is freshly
+    # known - not re-derived later from fields that can be inherited,
+    # defaulted, or hardcoded without ever having been jointly checked.
+    # The identical conjunction _unverified_owned_process_tree's own
+    # eligibility check used to re-derive as entries_are_complete, plus
+    # not prior_record_invalid: a narrowed rebuild over a malformed prior's
+    # DISCARDED historical entries (prior_by_pid empty, discovery never
+    # seeded from anything but the wrapper) can admit everything IT saw
+    # cleanly and still read complete relative to a smaller graph than the
+    # one that matters - the gap _unverified_owned_process_tree could never
+    # close from outside, since prior_record_invalid is local to this call.
+    walk_complete = (
+        bool(entries)
+        and omitted_count == 0
+        and rejected_count == 0
+        and not prior_record_invalid
+    )
     tree = {
         "schema_version": _OWNED_PROCESS_TREE_SCHEMA,
         "attribution_model": _OWNED_PROCESS_TREE_MODEL,
@@ -3759,6 +3830,7 @@ def _owned_process_tree(
         "recorded_count": len(entries),
         "omitted_count": omitted_count,
         "rejected_count": rejected_count,
+        "walk_complete": walk_complete,
         "truncated": bool(omitted_count),
         "refreshed_at": refreshed_at,
         "wrapper_generation": wrapper_generation,
@@ -11988,6 +12060,11 @@ $pollNum = 0
             # downstream, never zero - the same shape the v2-migration fix
             # already relies on for a field a record simply never had.
             $p.barrier_state.owned_process_tree.PSObject.Properties.Remove('rejected_count')
+            # walk_complete inversion: this mutation is a status relabel by
+            # THIS barrier's own accounting, not a Python walk - it must not
+            # leave a stale walk_complete=true claiming a fresh walk earned
+            # this record when none ran. Same removal, same reason.
+            $p.barrier_state.owned_process_tree.PSObject.Properties.Remove('walk_complete')
           }
           if ($p.barrier_state) { Set-AgentState $state $name $p.barrier_state } else { Set-AgentState $state $name $p.next_state }
           if (-not (Save-StateForPoll $state)) {
@@ -12208,6 +12285,9 @@ $pollNum = 0
             # comment on the relaunch/stuck_recover barrier above - same
             # second-producer shape, same fix.
             $p.next_entry.owned_process_tree.PSObject.Properties.Remove('rejected_count')
+            # walk_complete inversion: same reasoning, sibling field - see
+            # the matching comment on the relaunch/stuck_recover barrier.
+            $p.next_entry.owned_process_tree.PSObject.Properties.Remove('walk_complete')
           }
           $p.next_entry | Add-Member -NotePropertyName process_tree_hold_reason `
             -NotePropertyValue ("process_tree_invalid_post_kill_{0}" -f $why) -Force

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -13136,6 +13136,63 @@ def test_owned_process_tree_identity_drift_is_sticky_hold(
     assert tree["reason_code"] == "process_tree_invalid_prior_record_invalid"
 
 
+def test_owned_process_tree_narrowed_rebuild_does_not_promote_to_absent() -> None:
+    """The walk_complete inversion, finding 3 from the round that preceded
+    it: a malformed prior discards its own historical entries entirely
+    (prior_by_pid empty) before _owned_process_tree's walk even starts, so
+    the walk can only rediscover whatever is CURRENTLY reachable live from
+    the wrapper - a narrower graph than whatever the ORIGINAL, pre-
+    malformation tree tracked. That narrowed walk can admit everything IT
+    saw cleanly (rejected_count == 0, omitted_count == 0, non-empty
+    entries) and used to read exactly as "complete" as a genuine full
+    walk, even though it never had the chance to check on anything the
+    malformation caused it to forget (a live descendant of an
+    already-exited, no-longer-verifiable intermediate, say - unreachable
+    from the wrapper by a live strict edge, never rejected because
+    discovery never had a seed to reach it from).
+
+    walk_complete closes this by construction (not prior_record_invalid is
+    one of its own terms). Asserts the operator-visible outcome: a later
+    poll where this narrowed record's own entries all read absent must NOT
+    promote to absent (declaring the whole tree gone), because the record
+    never proved completeness over the graph that matters, only over the
+    smaller one it was able to rebuild."""
+    healthy = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-walkcomplete-narrowed-rebuild",
+    )
+    tree = healthy["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+    assert tree.get("walk_complete") is True
+
+    corrupted = dict(tree)
+    corrupted["root_key"] = "c:/some/other/root"  # fails _valid_owned_process_tree
+    state = _wrap_ready(runtime_wrapper_generation="wrapper-1")
+    state["owned_process_tree"] = corrupted
+
+    rebuilt = _plan_wrap(
+        _report(heartbeat_stale=False, wrapper_runtime=_wrapper_runtime_view(phase="idle")),
+        {"agents": {"worker": state}},
+        snapshot=_wrap_snap(),
+    )
+    narrowed = rebuilt["next_state"]["owned_process_tree"]
+    assert narrowed["status"] == "invalid"
+    assert narrowed["reason_code"] == "process_tree_invalid_prior_record_invalid"
+    assert narrowed["rejected_count"] == 0
+    assert narrowed["omitted_count"] == 0
+    assert narrowed["entries"]
+    # The exact gap this closes: rejected_count/omitted_count alone read as
+    # a complete, trustworthy walk here - walk_complete correctly does not.
+    assert narrowed.get("walk_complete") is not True
+
+    # The operator-visible outcome: even with the narrowed record's own
+    # entries all now absent, this must NOT promote to absent - it never
+    # proved completeness over the graph that matters.
+    later = sup._unverified_owned_process_tree(  # noqa: SLF001
+        narrowed, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert later["status"] == "invalid"
+
+
 @pytest.mark.parametrize(
     "field",
     [
@@ -15316,31 +15373,42 @@ def test_v2_record_missing_rejected_count_stays_valid_but_ineligible() -> None:
     healthy. rejected_count is therefore OPTIONAL in the persisted schema:
     a v2-shaped record (missing it entirely) must still validate as
     authoritative - proving the upgrade itself does not brick a healthy
-    fleet - while remaining ineligible for the NEW absence-promotion
-    eligibility this round grants, because "missing" must mean unknown,
-    never zero."""
+    fleet.
+
+    The walk_complete inversion: eligibility now reads walk_complete, not
+    rejected_count/omitted_count directly, so a genuinely pre-inversion
+    record must be missing BOTH optional fields to correctly read as
+    unknown/ineligible - a record missing only rejected_count (walk_complete
+    still True, honestly earned by whatever walk set it) is a schema state
+    the inversion says IS eligible, since rejected_count stopped being
+    independently load-bearing for the safety decision. Case (d) asserts
+    that directly: it is the inversion's own defining property, not
+    incidental behavior."""
     tree = _owned_tree_plan(
         _wrap_snap(), request_id="rr-150-v2-migration",
     )["next_state"]["owned_process_tree"]
     assert tree["status"] == "complete"
-    v2_shaped = dict(tree)
-    del v2_shaped["rejected_count"]
+    assert tree["walk_complete"] is True
+    pre_inversion_shaped = dict(tree)
+    del pre_inversion_shaped["rejected_count"]
+    del pre_inversion_shaped["walk_complete"]
 
     # (a) still readable/valid authority - the upgrade itself must not
     # brick a healthy agent's own persisted record.
     validated = sup._valid_owned_process_tree(  # noqa: SLF001
-        v2_shaped, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        pre_inversion_shaped, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
         wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
     )
     assert validated is not None
     assert "rejected_count" not in validated
+    assert "walk_complete" not in validated
 
-    # (b) a healthy, ALIVE wrapper polling against this v2-shaped prior
+    # (b) a healthy, ALIVE wrapper polling against this pre-inversion prior
     # must NOT be forced into PROCESS_TREE_INVALID merely because its own
-    # persisted record predates rejected_count - the exact self-inflicted
-    # regression the bare version bump caused.
+    # persisted record predates rejected_count/walk_complete - the exact
+    # self-inflicted regression the bare version bump caused.
     st = _wrap_ready(runtime_wrapper_generation="wrapper-1")
-    st["owned_process_tree"] = v2_shaped
+    st["owned_process_tree"] = pre_inversion_shaped
     healthy_plan = _plan_wrap(
         _report(wrapper_runtime=_wrapper_runtime_view(phase="idle", now=NOW)),
         {"agents": {"worker": st}},
@@ -15349,17 +15417,32 @@ def test_v2_record_missing_rejected_count_stays_valid_but_ineligible() -> None:
     assert healthy_plan["state"] != "PROCESS_TREE_INVALID"
     assert healthy_plan["next_state"]["owned_process_tree"]["status"] == "complete"
 
-    # (c) once invalid for an UNRELATED reason, a v2-shaped prior must not
-    # be promoted to absent just because omitted_count reads 0 - unknown
-    # rejected_count must block eligibility exactly like a real nonzero
-    # count would.
-    poisoned = dict(v2_shaped)
+    # (c) once invalid for an UNRELATED reason, a pre-inversion prior must
+    # not be promoted to absent just because omitted_count reads 0 - a
+    # missing walk_complete must block eligibility exactly like an explicit
+    # False would.
+    poisoned = dict(pre_inversion_shaped)
     poisoned["status"] = "invalid"
     poisoned["reason_code"] = "process_tree_invalid_snapshot_invalid_process_row"
     result = sup._unverified_owned_process_tree(  # noqa: SLF001
         poisoned, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
     )
     assert result["status"] == "invalid"
+
+    # (d) the inversion's own defining property: a record missing ONLY
+    # rejected_count (walk_complete still True, honestly earned by the walk
+    # that set it) IS eligible - rejected_count stopped being independently
+    # load-bearing for this decision the moment walk_complete existed to
+    # carry it. Same snapshot, same poisoning, only the missing field
+    # differs from case (c).
+    missing_rejected_only = dict(tree)
+    del missing_rejected_only["rejected_count"]
+    missing_rejected_only["status"] = "invalid"
+    missing_rejected_only["reason_code"] = "process_tree_invalid_snapshot_invalid_process_row"
+    promoted = sup._unverified_owned_process_tree(  # noqa: SLF001
+        missing_rejected_only, [], now_epoch=NOW + 1, reason_code="process_tree_invalid_test",
+    )
+    assert promoted["status"] == "absent"
 
 
 def test_validator_refuses_complete_or_absent_with_nonzero_rejected_count() -> None:
@@ -15507,24 +15590,37 @@ def test_post_kill_barrier_hold_cannot_present_a_trustworthy_zero() -> None:
     removes the property entirely rather than writing a number - the same
     "missing means unknown, not zero" shape the v2-migration fix already
     established for a field a record simply never had, reused here for a
-    field this record's PRODUCER never computed."""
+    field this record's PRODUCER never computed.
+
+    The walk_complete inversion added a sibling removal at the same two
+    mutation sites: this relabeling is a status change by the BARRIER's
+    own accounting, not a Python walk, so a stale walk_complete=True would
+    now be the load-bearing lie removing only rejected_count used to be -
+    the fixed shape below must strip both to accurately represent what the
+    barrier actually does today."""
     ps1_source = sup.PS_TEMPLATE
     assert ps1_source.count(
         "owned_process_tree.PSObject.Properties.Remove('rejected_count')",
+    ) == 2
+    assert ps1_source.count(
+        "owned_process_tree.PSObject.Properties.Remove('walk_complete')",
     ) == 2
 
     tree = _owned_tree_plan(
         _wrap_snap(), request_id="rr-150-post-kill-producer",
     )["next_state"]["owned_process_tree"]
     assert tree["status"] == "complete"
+    assert tree["walk_complete"] is True
 
-    # The FIXED shape: the barrier removed rejected_count entirely when it
-    # externally invalidated the tree. Still valid, readable authority -
-    # just not eligible for the walk's own re-derivation.
+    # The FIXED shape: the barrier removed rejected_count AND walk_complete
+    # entirely when it externally invalidated the tree. Still valid,
+    # readable authority - just not eligible for the walk's own
+    # re-derivation.
     post_kill_fixed = dict(tree)
     post_kill_fixed["status"] = "invalid"
     post_kill_fixed["reason_code"] = "process_tree_invalid_post_kill_launch_barrier_unavailable"
     del post_kill_fixed["rejected_count"]
+    del post_kill_fixed["walk_complete"]
     assert sup._valid_owned_process_tree(  # noqa: SLF001
         post_kill_fixed, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
         wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
@@ -15534,10 +15630,10 @@ def test_post_kill_barrier_hold_cannot_present_a_trustworthy_zero() -> None:
     )
     assert held["status"] == "invalid"
 
-    # The PRE-FIX shape, for contrast: rejected_count left at its stale
-    # "complete" value of 0 - this is exactly the hazard finding 3 named,
-    # and it genuinely does promote, proving the fix closes a real gap
-    # rather than a hypothetical one.
+    # The PRE-FIX shape, for contrast: rejected_count AND walk_complete
+    # both left at their stale "complete" values - this is exactly the
+    # hazard finding 3 named, and it genuinely does promote, proving the
+    # fix closes a real gap rather than a hypothetical one.
     post_kill_stale = dict(tree)
     post_kill_stale["status"] = "invalid"
     post_kill_stale["reason_code"] = "process_tree_invalid_post_kill_launch_barrier_unavailable"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -10993,6 +10993,10 @@ def test_valid_owned_process_tree_keeps_nullable_hold_evidence_readable(
         tree["observed_count"] += 1
         tree["omitted_count"] = 1
         tree["truncated"] = True
+        # The source tree was a genuine "complete" walk (walk_complete
+        # True) - a real truncated result never carries that forward,
+        # since its own omitted_count > 0 already contradicts it.
+        tree.pop("walk_complete", None)
 
     assert sup._valid_owned_process_tree(  # noqa: SLF001
         tree,
@@ -12308,6 +12312,12 @@ def _write_attended_process_tree_reset_fixture(store: Store) -> tuple[dict, str]
         "omitted_count": 1,
         "truncated": True,
     })
+    # The source tree was a genuine "complete" walk (walk_complete True),
+    # but truncating it by hand here does not re-run that walk - a real
+    # truncated result would never carry walk_complete True forward (its
+    # own omitted_count > 0 already contradicts it). Same "a producer that
+    # doesn't walk must not claim to have walked" rule as the fix itself.
+    tree.pop("walk_complete", None)
     state = {"agents": {"worker": entry}}
     state_path = store.dir / "supervisor-state.json"
     sup.save_supervisor_state(state_path, state)
@@ -12604,6 +12614,10 @@ def test_malformed_runtime_revocation_boundary_remains_hold(
         "omitted_count": 1,
         "truncated": True,
     })
+    # The source tree was a genuine "complete" walk (walk_complete True) -
+    # a real truncated result never carries that forward, since its own
+    # omitted_count > 0 already contradicts it.
+    tree.pop("walk_complete", None)
     runtime = _wrapper_runtime_view()["record"]
     sup.reset_process_tree_ownership_after_attended_teardown(
         state,
@@ -15478,6 +15492,114 @@ def test_validator_refuses_complete_or_absent_with_nonzero_rejected_count() -> N
         clean, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
         wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
     ) is not None
+
+
+def test_validator_refuses_walk_complete_true_with_false_preconditions() -> None:
+    """Task #150 walk_complete inversion connector finding: without this
+    check the inversion is a REGRESSION, not hardening. The argument for
+    walk_complete is that a reader should trust one positive flag rather
+    than re-derive completeness from fields that can be inherited or
+    defaulted - but a validator that only checks the field's TYPE lets a
+    persisted record claim walk_complete True while omitted_count or
+    rejected_count is actually nonzero, or entries is empty. The old
+    entries_are_complete re-derivation would have caught exactly that
+    record; a bare type-check on a lone boolean does not - strictly worse
+    than what it replaced. Uses status "invalid" throughout (not complete/
+    absent) so this asserts the NEW True-implies-conjunction check in
+    isolation from the existing nonzero-rejected_count-on-complete/absent
+    check tested above."""
+    tree = _owned_tree_plan(
+        _wrap_snap(), request_id="rr-150-walkcomplete-validator-constraint",
+    )["next_state"]["owned_process_tree"]
+    assert tree["status"] == "complete"
+    assert tree["walk_complete"] is True
+
+    def as_invalid_with(**overrides: object) -> dict:
+        corrupted = dict(tree)
+        corrupted["status"] = "invalid"
+        corrupted["reason_code"] = "process_tree_invalid_test"
+        corrupted.update(overrides)
+        return corrupted
+
+    # walk_complete True but rejected_count says otherwise.
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        as_invalid_with(rejected_count=1), agent="worker",
+        root_key=sup._root_key(TEST_ROOT), wrapper_generation="wrapper-1",  # noqa: SLF001
+        launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+    # walk_complete True but omitted_count says otherwise (also bumping
+    # observed_count/truncated to keep the OTHER count cross-checks from
+    # masking this one behind an unrelated rejection).
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        as_invalid_with(
+            omitted_count=1, observed_count=tree["observed_count"] + 1, truncated=True,
+        ),
+        agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+    # walk_complete True but rejected_count is UNKNOWN (missing) - the walk
+    # that supposedly earned the flag could not have known rejected_count
+    # was zero without recording it.
+    walk_complete_no_rejected = as_invalid_with()
+    del walk_complete_no_rejected["rejected_count"]
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        walk_complete_no_rejected, agent="worker",
+        root_key=sup._root_key(TEST_ROOT), wrapper_generation="wrapper-1",  # noqa: SLF001
+        launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+    # walk_complete True but entries is empty (only legal for status
+    # "invalid", which this already is - isolates entries specifically).
+    empty_entries = as_invalid_with()
+    empty_entries["entries"] = []
+    empty_entries["recorded_count"] = 0
+    empty_entries["omitted_count"] = empty_entries["observed_count"]
+    empty_entries["truncated"] = empty_entries["observed_count"] > 0
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        empty_entries, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is None
+
+    # The inverse direction, explicitly: a clean conjunction with
+    # walk_complete absent or False must stay VALID (not rejected) and
+    # simply unknown/ineligible - the validator must never demand the
+    # flag be present.
+    missing_flag = as_invalid_with()
+    del missing_flag["walk_complete"]
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        missing_flag, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+    false_flag = as_invalid_with(walk_complete=False)
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        false_flag, agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+
+    # The control: a genuinely clean, honestly-earned walk_complete True
+    # keeps validating - the fix must not reject real construction sites.
+    assert sup._valid_owned_process_tree(  # noqa: SLF001
+        as_invalid_with(), agent="worker", root_key=sup._root_key(TEST_ROOT),  # noqa: SLF001
+        wrapper_generation="wrapper-1", launch_nonce=SUPERVISOR_NONCE,
+    ) is not None
+
+    # The operator-visible outcome: a contradictory record can never even
+    # become `prior` for eligibility - it fails the trust boundary
+    # (_valid_owned_process_tree) before _unverified_owned_process_tree
+    # ever reads walk_complete, so a wrapped poll HOLDS
+    # (process_tree_invalid_prior_record_invalid) rather than promoting to
+    # absent, exactly as if the record were malformed any other way.
+    state = _wrap_ready(runtime_wrapper_generation="wrapper-1")
+    state["owned_process_tree"] = as_invalid_with(rejected_count=1)
+    plan = _plan_wrap(
+        _report(heartbeat_stale=False, wrapper_runtime=_wrapper_runtime_view(phase="idle")),
+        {"agents": {"worker": state}},
+        snapshot=_wrap_snap(),
+    )
+    assert plan["action"] == sup.WARN_ONLY
+    assert plan["state"] == "PROCESS_TREE_INVALID"
+    assert plan["next_state"]["owned_process_tree"]["reason_code"] == (
+        "process_tree_invalid_prior_record_invalid"
+    )
 
 
 def test_snap_index_excludes_rather_than_picks_a_duplicate_pid() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #108 (task #150). Rounds 9-13 of that PR each found a different producer that could mark an `owned_process_tree` record eligible for absence-promotion without a real walk ever running: an inherited `rejected_count`, a hardcoded placeholder default, a status relabel, a narrowed rebuild over a discarded prior. Every fix closed one instance by making that specific producer stop claiming zero - chasing the ABSENCE of recorded rejections, which is the default state of an integer and therefore free to any new or narrowed code path that never ran a walk. The lead's own framing: the count never converged because the instrument was wrong, not the diligence.

This inverts the instrument. `walk_complete` is positive evidence a complete walk actually ran, set in exactly one place - the end of `_owned_process_tree`'s own walk - as the identical conjunction `_unverified_owned_process_tree` used to re-derive as `entries_are_complete` (`bool(entries) and omitted_count == 0 and rejected_count == 0`), plus `not prior_record_invalid` (closing the narrowed-rebuild gap that conjunction alone could never close, since `prior_record_invalid` is local to the call that produces the record). Computed once, at the source, while every input is freshly known - never re-derived by a later reader from fields that can be inherited, defaulted, or hardcoded without ever having been jointly checked.

`rejected_count`/`omitted_count` remain in the schema as diagnostics and the operator-facing remedy-message count, where accuracy still matters, but they stop being independently load-bearing for the safety decision.

## Touch points (traced by consumer, not just producer)

- `_owned_process_tree`: sets `walk_complete` once, at the walk's own end.
- `_unverified_owned_process_tree`: eligibility reads `walk_complete` instead of re-deriving `entries_are_complete`; the "held" (unwalked-relabel) conversion strips `walk_complete` the same way it already strips `rejected_count`.
- `_valid_owned_process_tree` (schema/validator): `walk_complete` is the second optional field, independently present/absent from `rejected_count` (a record may predate one, the other, both, or neither); a complete/absent record explicitly claiming `walk_complete=False` is flagged as internally contradictory, mirroring the existing nonzero-`rejected_count` check.
- The PowerShell post-kill/ephemeral-teardown barrier: gains a sibling `PSObject.Properties.Remove('walk_complete')` at both mutation sites, next to the existing `rejected_count` removal.

Surveyed and confirmed unaffected: `_plan_one`'s remedy message (rejected_count stays diagnostics-only, its own branch gating never depended on it) and `evaluate_launch_barrier` (only ever reads the final status classification, never the counts underneath it).

## Test plan
- [x] Updated two existing tests whose fixtures manually deleted only `rejected_count` from a real walked tree to simulate a pre-migration record - the tree now also carries `walk_complete: True` (honestly earned), so deleting only one field no longer represents "before this feature existed"; one test now demonstrates the inversion's own defining property instead (rejected_count alone is no longer load-bearing for eligibility).
- [x] Added a direct regression test for the narrowed-rebuild hazard (a malformed prior with a live wrapper rebuilds a narrower graph that read complete under the old scheme), direction-controlled against c92b019: fails on the pre-inversion code (missing `walk_complete` field), passes with the fix; independently confirmed by execution that the pre-inversion code's later-poll check actually promotes to `absent` (the real hazard), not just that the field is missing.
- [x] Full `tests/test_supervisor.py` suite green on the default interpreter and `py -3.10`: 545 passed, 2 skipped, 1 xfailed (543 baseline + 2 existing-test bodies updated, no net new failures). `PYTHONPATH` pinned from the first test run of the session, per the standing lesson from the prior PR.
- [x] `ruff check` clean on both touched files.
- [ ] dev-gate/build/wheel/security legs intentionally not run locally (targeted tests only, per standing directive) - left to CI.

Did not touch Stop-Tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)