### PR TITLE
BLOCKED (redesign): fix(#163 launch half): additive absence proof for evaluate_launch_barrier

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -12509,6 +12509,13 @@ def cmd_supervise(args: argparse.Namespace) -> int:
         state = _read_state()
         config = _load_supervisor_config(store)
         now = args.now if args.now is not None else time.time()
+        # #163 launch half: a fresh read, mirroring how build_report seeds
+        # the planner's own wrapper_runtime - the barrier's alternative
+        # absence path needs the CURRENT runtime record's own wrapper/CLI
+        # launcher identity, not a proxy for it.
+        barrier_runtime_view = runtime_obs.read_runtime(
+            store.state_dir, args.agent, now_epoch=now,
+        )
         result = sup.evaluate_launch_barrier(
             _read_snapshot_file(args.snapshot_file),
             state,
@@ -12516,6 +12523,7 @@ def cmd_supervise(args: argparse.Namespace) -> int:
             args.agent,
             root_key=sup._root_key(str(store.root.resolve())),
             request_id=args.request_id,
+            runtime_view=barrier_runtime_view,
         )
         if result.get("blocked") and getattr(args, "record_events", False):
             with contextlib.suppress(Exception):

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -2382,33 +2382,98 @@ def _named_identities_confirmed_absent(
     return True
 
 
+def _claimed_self_identities(
+    legacy_process_evidence: object,
+    runtime_record: object,
+) -> tuple[list[tuple[object, object, object]], list[tuple[object, object, object]]]:
+    """Every identity this agent's own evidence currently claims as its
+    own, split into ``(legacy_identities, other_identities)``. Legacy
+    pre-v2 candidates (wrapper/brain/managed rows, already deduplicated by
+    ``_legacy_process_migration_evidence``) come first, since they carry no
+    bounded parent graph and callers must apply a stricter bar to them; the
+    runtime record's wrapper pid+start and, when a CLI launcher is expected
+    (phase active), the launcher's pid+start with its exact creation
+    FILETIME when the retained handle provides one, come second. No pid
+    here is checked for aliveness - that is
+    ``_named_identities_confirmed_absent``'s job.
+    """
+    legacy_identities: list[tuple[object, object, object]] = []
+    if isinstance(legacy_process_evidence, dict):
+        for entry in legacy_process_evidence.get("entries") or []:
+            if isinstance(entry, dict):
+                legacy_identities.append((entry.get("pid"), entry.get("start"), None))
+    other_identities: list[tuple[object, object, object]] = []
+    if isinstance(runtime_record, dict):
+        other_identities.append((
+            runtime_record.get("wrapper_pid"),
+            runtime_record.get("wrapper_start"),
+            None,
+        ))
+        if runtime_record.get("phase") == runtime_obs.PHASE_ACTIVE:
+            launcher_lifetime = runtime_record.get("cli_launcher_lifetime")
+            creation_filetime = (
+                launcher_lifetime.get("creation_filetime")
+                if (
+                    isinstance(launcher_lifetime, dict)
+                    and launcher_lifetime.get("source")
+                    == runtime_obs.LAUNCHER_LIFETIME_SOURCE
+                )
+                else None
+            )
+            other_identities.append((
+                runtime_record.get("cli_launcher_pid"),
+                runtime_record.get("cli_launcher_start"),
+                creation_filetime,
+            ))
+    return legacy_identities, other_identities
+
+
 def _no_live_identity_for_launch(
     *,
+    prior_record_invalid: bool,
     owned_tree: dict | None,
     brain_alive: bool,
     managed_pids: object,
     snapshot: list[dict] | None,
-    identities: object,
+    legacy_identities: object,
+    other_identities: object,
 ) -> bool:
-    """#163 launch half: the absence conjunction, one predicate for every
+    """#163 launch half: the absence conjunction, ONE predicate for every
     call site (``_wrapped_liveness``'s generation-mismatch and
-    legacy-managed-pids branches, ``_plan_one``, ``evaluate_launch_barrier``).
-    True only when EVERY claim of this agent's own live identity is proven
-    absent: the persisted record names no live identity, no brain, no
-    managed descendant (both already independently proven by the caller),
-    and ``_named_identities_confirmed_absent`` proves the rest (wrapper,
-    CLI launcher, legacy managed-pid rows - whatever the caller names) gone
-    from the current snapshot. A True here may only ever be used to WITHHOLD
-    an action that would otherwise HOLD; it grants no authority to act on
-    anything it found - that stays exactly as blocked as before.
+    legacy-managed-pids branches, ``_plan_one``, ``evaluate_launch_barrier``'s
+    alternative path). True only when EVERY claim of this agent's own live
+    identity is proven absent:
+
+    - a schema-drifted/corrupted prior record is excluded entirely -
+      corruption of the current authority is not proof of anything;
+    - the persisted record names no live identity, no brain, no managed
+      descendant (all already independently proven by the caller);
+    - legacy pre-v2 identities carry no bounded parent graph (that is
+      exactly why they are being migrated away from), so when any are
+      present the ENTIRE current snapshot must be empty - an unrelated-
+      looking row elsewhere can never be ruled OUT as an untracked
+      descendant the way a walked tree's own strict edges would let it be;
+    - every other named identity (wrapper, CLI launcher, whatever the
+      caller names) is proven gone from the current snapshot via
+      ``_named_identities_confirmed_absent``.
+
+    A True here may only ever be used to WITHHOLD an action that would
+    otherwise HOLD/block; it grants no authority to act on anything it
+    found - that stays exactly as blocked as before.
     """
+    if prior_record_invalid:
+        return False
     if bool((owned_tree or {}).get("entries")):
         return False
     if brain_alive:
         return False
     if managed_pids:
         return False
-    return _named_identities_confirmed_absent(snapshot, identities)
+    if legacy_identities and snapshot:
+        return False
+    return _named_identities_confirmed_absent(
+        snapshot, [*legacy_identities, *other_identities]
+    )
 
 
 def _exact_start_order_key(
@@ -5119,6 +5184,7 @@ def evaluate_launch_barrier(
     *,
     root_key: str | None = None,
     request_id: str | None = None,
+    runtime_view: dict | None = None,
 ) -> dict:
     """Post-kill one-live-wrapper barrier for the generated executor.
 
@@ -5192,14 +5258,68 @@ def evaluate_launch_barrier(
             ),
         )
         if tree is None or tree.get("status") not in {"complete", "absent"}:
-            return {
-                "allow_launch": False,
-                "blocked": True,
-                "reason": "owned_process_tree_unavailable",
-                "snapshot_available": True,
-                "survivor_count": 0,
-                "survivors": [],
-            }
+            # #163 launch half: PRIMARY PATH failed - the tree does not
+            # validate against the generation this state believes, or does
+            # not validate at all. Generation match is an IDENTITY-AGREEMENT
+            # proxy for liveness, and in the not-yet-adopted state that
+            # proxy is simply wrong - loosening it would degrade this
+            # barrier's strictness for every other case, so it stays exactly
+            # as it is. ALTERNATIVE PATH: independent of any generation
+            # match, re-validate the SAME raw record with the generation
+            # constraint dropped (schema/nonce still enforced - a
+            # corrupted or otherwise-invalid record still fails this and
+            # stays blocked), then PROVE from the current snapshot, via the
+            # identical shared predicate the planner side already uses,
+            # that no identity this agent's own evidence claims is alive.
+            # Nothing here is relaxed: this is a second, independent,
+            # sufficient way to reach the same safety property ("nothing a
+            # partial kill could strand"), not a weaker door into it - and
+            # on success it substitutes an entries-empty tree for the rest
+            # of this function's own survivor scan below, so the
+            # state_launcher/own_wrapper/own_wait checks still run exactly
+            # as they do for a genuinely complete/absent tree.
+            alt_tree = _valid_owned_process_tree(
+                raw_tree,
+                agent=agent,
+                root_key=root_key,
+                wrapper_generation=None,
+                launch_nonce=(
+                    st.get("launcher_nonce")
+                    if _valid_launch_nonce(st.get("launcher_nonce"))
+                    else None
+                ),
+            )
+            prior_record_invalid = alt_tree is None
+            runtime_record = (
+                runtime_view.get("record")
+                if (
+                    isinstance(runtime_view, dict)
+                    and runtime_view.get("status") == runtime_obs.STATUS_VALID
+                )
+                else None
+            )
+            legacy_identities, other_identities = _claimed_self_identities(
+                st.get("legacy_process_evidence"), runtime_record
+            )
+            if _no_live_identity_for_launch(
+                prior_record_invalid=prior_record_invalid,
+                owned_tree=alt_tree,
+                brain_alive=False,
+                managed_pids=[],
+                snapshot=snapshot,
+                legacy_identities=legacy_identities,
+                other_identities=other_identities,
+            ):
+                tree = alt_tree
+            else:
+                return {
+                    "allow_launch": False,
+                    "blocked": True,
+                    "reason": "owned_process_tree_unavailable",
+                    "snapshot_available": True,
+                    "survivor_count": 0,
+                    "survivors": [],
+                }
     elif request_id is not None:
         return {
             "allow_launch": False,
@@ -6008,82 +6128,25 @@ def _wrapped_liveness(
             frontier = next_frontier
         return False
 
-    def _self_identities() -> list[tuple[object, object, object]]:
-        """Every identity THIS agent's own evidence currently claims as its
-        own: the legacy pre-v2 candidates (wrapper/brain/managed rows,
-        already deduplicated by ``_legacy_process_migration_evidence``), and
-        - once a runtime record has been read - its wrapper pid+start and,
-        when a CLI launcher is expected (phase active), the launcher's
-        pid+start with its exact creation FILETIME when the retained handle
-        provides one. No pid here is checked for aliveness; that is
-        ``_named_identities_confirmed_absent``'s job.
-        """
-        identities: list[tuple[object, object, object]] = []
-        legacy = base.get("legacy_process_evidence")
-        if isinstance(legacy, dict):
-            for entry in legacy.get("entries") or []:
-                if isinstance(entry, dict):
-                    identities.append((entry.get("pid"), entry.get("start"), None))
-        record = base.get("runtime_record")
-        if isinstance(record, dict):
-            identities.append(
-                (record.get("wrapper_pid"), record.get("wrapper_start"), None)
-            )
-            if record.get("phase") == runtime_obs.PHASE_ACTIVE:
-                launcher_lifetime = record.get("cli_launcher_lifetime")
-                creation_filetime = (
-                    launcher_lifetime.get("creation_filetime")
-                    if (
-                        isinstance(launcher_lifetime, dict)
-                        and launcher_lifetime.get("source")
-                        == runtime_obs.LAUNCHER_LIFETIME_SOURCE
-                    )
-                    else None
-                )
-                identities.append((
-                    record.get("cli_launcher_pid"),
-                    record.get("cli_launcher_start"),
-                    creation_filetime,
-                ))
-        return identities
-
     def _no_live_identity_here() -> bool:
         """#163 launch half: this poll's own answer to the shared absence
-        predicate, using whatever identities THIS agent's own evidence
-        currently names. Safe to call from any hold branch below - it can
-        only ever justify WITHHOLDING the HOLD it is asked about, never
-        granting authority over anything it finds.
-
-        Legacy pre-v2 evidence never recorded a bounded parent graph (that
-        is exactly why it is being migrated away from), so an unrelated-
-        looking row elsewhere in the snapshot can never be ruled OUT as an
-        untracked descendant the way a walked tree's own strict edges would
-        let it be. When any legacy entry is in play, require the entire
-        snapshot to be empty, not merely the named identities absent - the
-        same conservative bar the legacy migration boundary already applies
-        everywhere else it appears.
+        predicate (``_no_live_identity_for_launch``), using whatever
+        identities THIS agent's own evidence currently names
+        (``_claimed_self_identities``). Safe to call from any hold branch
+        below - it can only ever justify WITHHOLDING the HOLD it is asked
+        about, never granting authority over anything it finds.
         """
-        if prior_record_invalid:
-            # A schema-drifted persisted record is corruption of the current
-            # authority, not proof of anything - it might have named an
-            # identity this evidence has no way to reconstruct. Only a
-            # record we understand (a legacy migration placeholder, or a
-            # freshly-observed generation mismatch) is eligible to have its
-            # absence proven at all.
-            return False
-        legacy = base.get("legacy_process_evidence")
-        if (
-            isinstance(legacy, dict)
-            and legacy.get("entries")
-            and snapshot
-        ):
-            return False
+        legacy_identities, other_identities = _claimed_self_identities(
+            base.get("legacy_process_evidence"), base.get("runtime_record")
+        )
         return _no_live_identity_for_launch(
+            prior_record_invalid=prior_record_invalid,
             owned_tree=base.get("owned_process_tree"),
             brain_alive=bool(base.get("brain_alive")),
             managed_pids=base.get("managed_pids") or [],
             snapshot=snapshot,
-            identities=_self_identities(),
+            legacy_identities=legacy_identities,
+            other_identities=other_identities,
         )
 
     def _current_proof_failed(

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -5932,6 +5932,15 @@ def _wrapped_liveness(
     diagnostics = _diag()
     prior_tree = None
     raw_prior = None
+    # #163 hotfix: only ever reassigned inside `if isinstance(root_key, str):`
+    # below, same as prior_tree/raw_prior above it - but _no_live_identity_here
+    # (called unconditionally, from _current_proof_failed, regardless of
+    # root_key) reads it too. A non-string root_key (the ephemeral-reviewer
+    # caller passes one) skipped that block entirely and left this name
+    # unbound - a crash, not a scoping decision. False here means exactly
+    # what raw_prior=None already means for that case: no prior record to
+    # call invalid.
+    prior_record_invalid = False
     legacy_evidence = _legacy_process_migration_evidence(st)
     prior_generation = st.get("runtime_wrapper_generation")
     has_revoked_runtime = "revoked_wrapper_runtime" in st

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14578,6 +14578,132 @@ def test_launch_barrier_rejects_nullable_authoritative_tree(
     assert result["survivors"] == []
 
 
+def test_launch_barrier_alternative_path_allows_generation_mismatch_with_empty_snapshot() -> None:
+    """#163 launch half: the barrier's ALTERNATIVE PATH, flagship case.
+    PRIMARY validation fails on generation mismatch (identity-agreement is
+    a liveness PROXY, wrong in the not-yet-adopted state, unchanged and
+    still strict) - the barrier instead proves absence directly, via the
+    identical shared predicate (_no_live_identity_for_launch /
+    _claimed_self_identities) the planner side already uses, and permits
+    the spawn only because nothing this evidence claims is alive anywhere
+    in the snapshot."""
+    placeholder = sup._invalid_owned_process_tree_record(
+        agent="worker", root_key=sup._root_key(TEST_ROOT),
+        wrapper_generation="wrapper-2", launch_nonce=None,
+        now_epoch=NOW,
+        reason_code="process_tree_invalid_generation_adoption_pending",
+    )
+    state = {"agents": {"worker": {
+        "owned_process_tree": placeholder,
+        "runtime_wrapper_generation": "wrapper-1",
+    }}}
+    runtime_view = _wrapper_runtime_view(
+        phase="idle", wrapper_generation="wrapper-2",
+        wrapper_pid=500, wrapper_start=_ps_iso(990000),
+    )
+
+    result = sup.evaluate_launch_barrier(
+        [], state, _WRAP_CONFIG, "worker",
+        root_key=sup._root_key(TEST_ROOT), runtime_view=runtime_view,
+    )
+
+    assert result["allow_launch"] is True
+    assert result["blocked"] is False
+    assert result["survivors"] == []
+
+
+def test_launch_barrier_alternative_path_still_blocks_when_identity_alive() -> None:
+    """Direction control for the alternative path: the SAME generation-
+    mismatch shape, but the runtime record's own claimed wrapper pid is
+    present in the snapshot - the alternative path must not succeed (an
+    existing row at that pid is ambiguous without an exact FILETIME to
+    compare, which the wrapper's own identity never carries, so it fails
+    closed to present), and the barrier must still block exactly as it
+    does today. This is the orphan-hazard direction control, one level
+    down from the planner-side one."""
+    wrapper_start = _ps_iso(990000)
+    placeholder = sup._invalid_owned_process_tree_record(
+        agent="worker", root_key=sup._root_key(TEST_ROOT),
+        wrapper_generation="wrapper-2", launch_nonce=None,
+        now_epoch=NOW,
+        reason_code="process_tree_invalid_generation_adoption_pending",
+    )
+    state = {"agents": {"worker": {
+        "owned_process_tree": placeholder,
+        "runtime_wrapper_generation": "wrapper-1",
+    }}}
+    runtime_view = _wrapper_runtime_view(
+        phase="idle", wrapper_generation="wrapper-2",
+        wrapper_pid=500, wrapper_start=wrapper_start,
+    )
+    alive_row = _proc(500, 1, "python.exe", "python worker.py", wrapper_start)
+
+    result = sup.evaluate_launch_barrier(
+        [alive_row], state, _WRAP_CONFIG, "worker",
+        root_key=sup._root_key(TEST_ROOT), runtime_view=runtime_view,
+    )
+
+    assert result["allow_launch"] is False
+    assert result["blocked"] is True
+
+
+def test_launch_barrier_alternative_path_excludes_corrupted_prior() -> None:
+    """A schema-drifted/corrupted persisted record is excluded from the
+    alternative path entirely - corruption of the current authority is not
+    proof of anything, even with an empty snapshot and a fresh valid
+    runtime record naming a different generation."""
+    state = {"agents": {"worker": {
+        "owned_process_tree": {"not": "the expected schema at all"},
+        "runtime_wrapper_generation": "wrapper-1",
+    }}}
+    runtime_view = _wrapper_runtime_view(
+        phase="idle", wrapper_generation="wrapper-2",
+        wrapper_pid=500, wrapper_start=_ps_iso(990000),
+    )
+
+    result = sup.evaluate_launch_barrier(
+        [], state, _WRAP_CONFIG, "worker",
+        root_key=sup._root_key(TEST_ROOT), runtime_view=runtime_view,
+    )
+
+    assert result["allow_launch"] is False
+    assert result["blocked"] is True
+
+
+def test_launch_barrier_alternative_path_legacy_evidence_requires_empty_snapshot() -> None:
+    """Legacy pre-v2 evidence has no bounded parent graph, so the
+    alternative path requires the WHOLE snapshot empty, not merely the
+    named identities absent - an unrelated-looking live row elsewhere still
+    blocks, mirroring the deep-orphan safety already proven on the planner
+    side (test_owned_process_tree_adopted_generation_missing_record_holds_
+    deep_orphan). The barrier must not be a softer door than the planner."""
+    placeholder = sup._invalid_owned_process_tree_record(
+        agent="worker", root_key=sup._root_key(TEST_ROOT),
+        wrapper_generation=None, launch_nonce=None,
+        now_epoch=NOW, reason_code="process_tree_invalid_legacy_managed_pids",
+    )
+    orphan = _proc(404, 403, "node.exe", "node orphaned-tool.js", _ps_iso(950000))
+    state = {"agents": {"worker": {
+        "owned_process_tree": placeholder,
+        "legacy_process_evidence": {
+            "schema_version": 1, "status": "migration_hold", "limit": 64,
+            "observed_count": 1, "recorded_count": 1, "omitted_count": 0,
+            "truncated": False, "malformed_count": 0, "source_hash": "x",
+            "entries": [
+                {"pid": WRAP_LAUNCHER_PID, "start": WRAP_START, "source": "wrapper"},
+            ],
+        },
+    }}}
+
+    result = sup.evaluate_launch_barrier(
+        [orphan], state, _WRAP_CONFIG, "worker",
+        root_key=sup._root_key(TEST_ROOT),
+    )
+
+    assert result["allow_launch"] is False
+    assert result["blocked"] is True
+
+
 @pytest.mark.parametrize("ephemeral", [False, True])
 def test_launch_barrier_blocks_exact_owned_leaf_survivor(
     ephemeral: bool,


### PR DESCRIPTION
## Summary
- Second half of the #163 launch-half fix (planner side already merged directly to master in 7de07e4, per an instruction gap now corrected - this half goes through a PR).
- `evaluate_launch_barrier`'s primary generation-match stays exactly as strict as it is today; it gains an additive, independent second sufficient condition (the ALTERNATIVE PATH) that proves absence directly from the current snapshot via the identical shared predicate the planner side already uses, rather than depending on the generation-match proxy in the not-yet-adopted state where that proxy is wrong.
- `_no_live_identity_for_launch` / `_named_identities_confirmed_absent` / `_claimed_self_identities` are now shared across all three call sites (two in `_wrapped_liveness`, one new in `evaluate_launch_barrier`) - one implementation, not three.
- `cli.py`'s `--launch-barrier` handler now reads a fresh wrapper runtime record and threads it through as the barrier's `runtime_view` parameter.

## Test plan
- [x] `tests/test_supervisor.py` + `tests/test_coordination_stall.py`: 582 passed, 2 skipped, 1 xfailed (this interpreter, `PYTHONPATH` pinned to this worktree's `src`, run from the worktree cwd).
- [x] Four new direct tests on `evaluate_launch_barrier`: flagship generation-mismatch + empty snapshot now allows the spawn; the same shape with the claimed identity alive in the snapshot still blocks (direction control); a schema-drifted/corrupted prior is excluded even with an empty snapshot; legacy evidence still blocks on an unrelated live row elsewhere (mirrors the planner-side deep-orphan test).
- [x] Confirmed red-first by direct probe before this change: same tree/call, stale generation -> validator rejects -> barrier blocks; generation dropped -> validates.
- [ ] NOT YET DONE: the red-first fleet-level test with the external effect oracle (exactly one replacement process, reaches readiness, exact identity, no duplicate/no kill, exact cleanup). The supervisor's own spawn step has no pure-Python path - it's `Start-Process`/`CreateProcessW` inside the generated PowerShell executor, a different and heavier shape than the wrapper-level stub-agent canary infra. Flagging this gap rather than building new PowerShell-driving test infra under time pressure in the same PR.

## Reviewer note
Two test assertions in the prior commit (7de07e4, already on master) were updated to reflect intentionally-changed behavior rather than reverted - `test_owned_process_tree_generation_adoption_reaches_recovery_without_visible_roots` and the final scenario of `test_attended_process_tree_reset_retires_stale_runtime_before_relaunch_plan`. Flagging both by name per the operator's request, since an edited expectation is not independent evidence on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)