### PR TITLE
MOOT (superseded by revert): hotfix(#163): fix unbound prior_record_invalid crash

### DIFF
--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -5661,6 +5661,15 @@ def _wrapped_liveness(
     diagnostics = _diag()
     prior_tree = None
     raw_prior = None
+    # #163 hotfix: only ever reassigned inside `if isinstance(root_key, str):`
+    # below, same as prior_tree/raw_prior above it - but _no_live_identity_here
+    # (called unconditionally, from _current_proof_failed, regardless of
+    # root_key) reads it too. A non-string root_key (the ephemeral-reviewer
+    # caller passes one) skipped that block entirely and left this name
+    # unbound - a crash, not a scoping decision. False here means exactly
+    # what raw_prior=None already means for that case: no prior record to
+    # call invalid.
+    prior_record_invalid = False
     legacy_evidence = _legacy_process_migration_evidence(st)
     prior_generation = st.get("runtime_wrapper_generation")
     has_revoked_runtime = "revoked_wrapper_runtime" in st


### PR DESCRIPTION
## Summary
- Master went red immediately after 7de07e4: `tests/test_ephemeral_reviewers.py::test_launched_exit_without_fresh_tree_holds_without_restart_or_archive` fails on every platform.
- Root cause is a `NameError`, not the cross-module semantic conflict it looked like from the test name: `prior_record_invalid` is only assigned inside `if isinstance(root_key, str):` in `_wrapped_liveness`, but `_no_live_identity_here` (called unconditionally from `_current_proof_failed`) reads it regardless. The ephemeral-reviewer path (`_ephemeral_owned_process_view`) calls `_wrapped_liveness` with `root_key=None` for a launched reviewer with no fresh runtime record - a combination the wrapped-agent path never produces, since `plan_actions` always normalizes `root_key` to a string first.
- Fix: initialize `prior_record_invalid = False` alongside the existing `prior_tree = None` / `raw_prior = None` pre-initialization.
- Confirmed the named test passes with its ORIGINAL, unmodified assertions once this one line is fixed - it was never touched.

## Caller audit (requested)
- `_wrapped_liveness` has exactly two callers: `_liveness` (feeds `_plan_one`) and `_ephemeral_owned_process_view` (feeds `_plan_ephemeral_active`).
- `_plan_ephemeral_active` computes `no_live_identity_for_launch` as a side effect of flowing through `_current_proof_failed`, but never reads that field for its own decision - so its behavior is unchanged, not coincidentally passing.
- `evaluate_launch_barrier` has exactly one caller (`cli.py --launch-barrier`).
- No fourth call site exists.

## Test plan
- [x] `tests/test_ephemeral_reviewers.py` + `tests/test_supervisor.py` + `tests/test_coordination_stall.py`: 611 passed, 2 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)