### PR TITLE
feat(#169): let a wrapped codex agent commit/push its own worktree

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -11985,8 +11985,14 @@ def cmd_supervise(args: argparse.Namespace) -> int:
             cxc.repair_duplicate_project_tables(cfg_p, Path(repo))
         existing = cfg_p.read_text(encoding="utf-8-sig") if cfg_p.exists() else ""
         cfg_p.parent.mkdir(parents=True, exist_ok=True)
+        # #169: also grant whatever git-worktree admin state this agent needs
+        # to commit/push its own worktree - see codex_worktree_writable_roots
+        # for exactly what that is and isn't.
+        extra_roots = sup.codex_worktree_writable_roots(repo)
         cfg_p.write_text(sup.codex_config_overlay(existing, repo_path=repo,
-                                                  windows_sandbox=sandbox), encoding="utf-8")
+                                                  windows_sandbox=sandbox,
+                                                  extra_writable_roots=extra_roots),
+                         encoding="utf-8")
         print(f"seeded codex config.toml (sandbox={sandbox}): {cfg_p}")
         return 0
     if args.seed_claude_settings:

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -12443,16 +12443,144 @@ def _toml_basic_str(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
+def _linked_worktree_admin_dir(path: Path) -> Path | None:
+    """Return the admin dir a linked worktree's ``<path>/.git`` points at.
+
+    A linked worktree's own ``.git`` is a plain FILE containing
+    ``gitdir: <admin-dir>`` (git's own mechanism for finding its per-worktree
+    metadata, which lives elsewhere - see ``git worktree`` documentation).
+    Returns ``None`` (fail-soft, never raises) if ``<path>/.git`` doesn't
+    exist, is a directory (an ordinary checkout, not a linked worktree), or
+    can't be read/parsed - callers treat that as "nothing extra to grant",
+    not as an error.
+    """
+    git_marker = path / ".git"
+    try:
+        if not git_marker.is_file():
+            return None
+        text = git_marker.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError):
+        return None
+    prefix = "gitdir:"
+    if not text.startswith(prefix):
+        return None
+    raw = text[len(prefix):].strip()
+    if not raw:
+        return None
+    try:
+        return (path / raw).resolve() if not Path(raw).is_absolute() else Path(raw).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _worktree_common_dir(admin_dir: Path) -> Path | None:
+    """Resolve the shared ``.git`` common dir a worktree admin dir points at.
+
+    Every linked worktree's admin dir holds a ``commondir`` file (git's own
+    mechanism) naming the common dir - usually relative (``../..``), always
+    resolved from the admin dir itself. Fail-soft: ``None`` on any read/parse
+    problem, never raises.
+    """
+    commondir_file = admin_dir / "commondir"
+    try:
+        raw = commondir_file.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError):
+        return None
+    if not raw:
+        return None
+    try:
+        candidate = Path(raw)
+        return (admin_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def codex_worktree_writable_roots(repo_path: str | os.PathLike[str]) -> tuple[str, ...]:
+    """Extra ``sandbox_workspace_write.writable_roots`` entries for #169: a
+    codex agent's OWN git worktree commit/push.
+
+    A linked worktree's git metadata does not live inside the worktree - it
+    lives in the MAIN checkout's ``.git/worktrees/<name>/`` (per-worktree
+    index/HEAD/logs), and new objects plus ref/reflog updates land in the
+    shared ``.git/objects``, ``.git/refs``, ``.git/logs`` that admin dir's own
+    ``commondir`` file points back to. None of that is reachable from a plain
+    ``writable_roots=[<repo_path>]`` grant when the worktree lives outside
+    ``repo_path`` - which is the common case, since an agent creates its own
+    worktree elsewhere, ad hoc, well after this function has already run at
+    launch-time seeding. Without it, `git commit`/`git push` fails on
+    ``.git/worktrees/<name>/index.lock`` even though ordinary file edits
+    inside the worktree already work fine.
+
+    Two shapes, in order of preference - narrowest achievable, not narrowest
+    imaginable:
+    - If ``repo_path`` IS ITSELF a linked worktree, grant exactly its own
+      admin dir. Narrow: no other worktree's metadata is touched.
+    - Otherwise (``repo_path`` is a plain checkout - the case every currently
+      seeded agent is in today, since agents create worktrees elsewhere,
+      after seeding, under names not known yet), grant the whole
+      ``<repo_path>/.git/worktrees/`` parent. This is WIDER than one agent's
+      own worktree: it also exposes every OTHER agent's worktree-scoped git
+      state (index, HEAD, per-worktree logs) under the same repo. There is no
+      narrower target that survives every worktree an agent might create
+      later without inventing a second, worktree-creation-triggered reseed
+      path alongside the existing launch-time one - deliberately not done
+      here (do not invent a parallel mechanism). It does NOT expose
+      ``.git/config``, ``.git/hooks``, ``.git/info``, or anything outside
+      ``.git`` - and does not touch the operator's actual source tree at all
+      beyond what ``writable_roots=[<repo_path>]`` already grants today.
+
+    Either way, ALSO grants ``.git/objects``, ``.git/refs``, and
+    ``.git/logs`` - git's shared, cross-worktree object/ref/reflog storage
+    that any worktree's commit/push writes into by git's own design (history
+    is shared on purpose; there is no per-worktree substore to grant
+    instead). This is the part that can't be narrowed further at all: it
+    grants filesystem-level write access to any ref or object in the repo,
+    not only the seeded agent's own branch - git offers no filesystem-level
+    way to scope tighter than that.
+
+    Returns ``()`` (nothing to add - the existing single-root grant is
+    unchanged) for a plain checkout with no linked-worktree structure to
+    reason about, or if any of it can't be read. Never raises.
+    """
+    try:
+        root = Path(repo_path)
+        own_admin_dir = _linked_worktree_admin_dir(root)
+        if own_admin_dir is not None:
+            worktrees_grant = own_admin_dir
+            common_dir = _worktree_common_dir(own_admin_dir)
+        else:
+            git_dir = root / ".git"
+            if not git_dir.is_dir():
+                return ()
+            worktrees_grant = git_dir / "worktrees"
+            common_dir = git_dir
+        if common_dir is None:
+            return ()
+        return tuple(
+            str(p) for p in (
+                worktrees_grant,
+                common_dir / "objects",
+                common_dir / "refs",
+                common_dir / "logs",
+            )
+        )
+    except (OSError, RuntimeError):
+        return ()
+
+
 def codex_config_overlay(text: str, *, repo_path: str,
-                         windows_sandbox: str = "unelevated") -> str:
+                         windows_sandbox: str = "unelevated",
+                         extra_writable_roots: tuple[str, ...] = ()) -> str:
     """Overlay the unattended-auto-mode keys onto an existing codex config.toml,
     PRESERVING every other key the operator set. Managed keys (double-quoted
     values, per the ruling): root ``approval_policy="never"`` +
     ``sandbox_mode="workspace-write"``; ``[windows] sandbox="<windows_sandbox>"``
     (the UAC fix - "unelevated" avoids the per-home elevated-sandbox admin
-    install); ``[sandbox_workspace_write] writable_roots=["<repo>"]``. Idempotent:
-    re-applying replaces our managed lines in place. (Healing a BOM-corrupted config's
-    duplicate [projects] tables is done by the seed via
+    install); ``[sandbox_workspace_write] writable_roots=["<repo>", ...]`` -
+    ``repo_path`` plus, when given, ``extra_writable_roots`` (see
+    :func:`codex_worktree_writable_roots` for #169's worktree-commit grant).
+    Idempotent: re-applying replaces our managed lines in place. (Healing a
+    BOM-corrupted config's duplicate [projects] tables is done by the seed via
     ``codex_config.repair_duplicate_project_tables`` — a SEMANTIC, project-scoped
     collapse — not here, so this overlay never drops unrelated operator tables; D-26.)"""
     secs = _toml_sections(text)
@@ -12461,8 +12589,9 @@ def codex_config_overlay(text: str, *, repo_path: str,
     _toml_set_key(root, "sandbox_mode", '"workspace-write"')
     _toml_set_key(_toml_table(secs, "windows"), "sandbox",
                   _toml_basic_str(windows_sandbox))
+    roots = [repo_path, *extra_writable_roots]
     _toml_set_key(_toml_table(secs, "sandbox_workspace_write"), "writable_roots",
-                  "[" + _toml_basic_str(repo_path) + "]")
+                  "[" + ", ".join(_toml_basic_str(r) for r in roots) + "]")
     out: list[str] = []
     for s in secs:
         if s["header"] is not None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -2095,6 +2095,118 @@ def test_codex_config_overlay_sets_keys_preserves_others_idempotent() -> None:
     assert "shell_environment_policy" not in out
 
 
+def _make_linked_worktree(tmp_path: Path, *, main_name: str = "main", wt_name: str = "wt") -> tuple[Path, Path, Path]:
+    """Build a real linked-worktree .git layout under tmp_path (no git binary
+    needed - _linked_worktree_admin_dir/_worktree_common_dir only ever read
+    these files). Returns (worktree_dir, admin_dir, common_git_dir)."""
+    main = tmp_path / main_name
+    common_git = main / ".git"
+    common_git.mkdir(parents=True)
+    (common_git / "objects").mkdir()
+    (common_git / "refs").mkdir()
+    (common_git / "logs").mkdir()
+    admin_dir = common_git / "worktrees" / wt_name
+    admin_dir.mkdir(parents=True)
+    (admin_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    worktree = tmp_path / wt_name
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin_dir}\n", encoding="utf-8")
+    return worktree, admin_dir, common_git
+
+
+def test_codex_worktree_writable_roots_for_a_linked_worktree_is_narrow(tmp_path: Path) -> None:
+    worktree, admin_dir, common_git = _make_linked_worktree(tmp_path)
+    roots = sup.codex_worktree_writable_roots(worktree)
+    assert roots == (
+        str(admin_dir.resolve()),
+        str((common_git / "objects").resolve()),
+        str((common_git / "refs").resolve()),
+        str((common_git / "logs").resolve()),
+    )
+    # Narrow: a SIBLING worktree's own admin dir is never named.
+    other_admin = common_git / "worktrees" / "other-agent-wt"
+    assert str(other_admin) not in roots
+    # Every granted root is inside .git - this never touches the operator's
+    # actual source tree (the worktree's own working files, or the main
+    # checkout's), only git's own metadata storage.
+    for granted in roots:
+        assert Path(granted).is_relative_to(common_git)
+    assert str(worktree.resolve()) not in roots
+    assert str(common_git.parent.resolve()) not in roots
+
+
+def test_codex_worktree_writable_roots_for_the_main_checkout_grants_the_whole_worktrees_parent(
+    tmp_path: Path,
+) -> None:
+    worktree, _admin_dir, common_git = _make_linked_worktree(tmp_path)
+    # repo_path is the MAIN checkout (not itself a linked worktree) - the
+    # ordinary case, since agents create worktrees elsewhere, later, under
+    # names not known at seed time.
+    roots = sup.codex_worktree_writable_roots(worktree.parent / "main")
+    assert roots == (
+        str((common_git / "worktrees").resolve()),
+        str((common_git / "objects").resolve()),
+        str((common_git / "refs").resolve()),
+        str((common_git / "logs").resolve()),
+    )
+    # Wider than the single-worktree case (every worktree's admin dir is
+    # covered, not just one), but STILL never the operator's actual source
+    # tree - everything granted stays inside .git.
+    for granted in roots:
+        assert Path(granted).is_relative_to(common_git)
+    assert str(common_git.parent.resolve()) not in roots
+
+
+def test_codex_worktree_writable_roots_is_empty_for_a_plain_checkout_with_no_git_dir(
+    tmp_path: Path,
+) -> None:
+    plain = tmp_path / "no-git-here"
+    plain.mkdir()
+    assert sup.codex_worktree_writable_roots(plain) == ()
+
+
+def test_codex_worktree_writable_roots_fails_soft_on_missing_or_malformed_state(
+    tmp_path: Path,
+) -> None:
+    # Nonexistent repo_path entirely.
+    assert sup.codex_worktree_writable_roots(tmp_path / "does-not-exist") == ()
+    # .git is a file (linked-worktree-shaped) but not a gitdir: pointer.
+    garbled = tmp_path / "garbled"
+    garbled.mkdir()
+    (garbled / ".git").write_text("not a gitdir pointer\n", encoding="utf-8")
+    assert sup.codex_worktree_writable_roots(garbled) == ()
+    # gitdir: points somewhere with no commondir file.
+    orphan = tmp_path / "orphan"
+    orphan.mkdir()
+    admin = tmp_path / "admin-with-no-commondir"
+    admin.mkdir()
+    (orphan / ".git").write_text(f"gitdir: {admin}\n", encoding="utf-8")
+    assert sup.codex_worktree_writable_roots(orphan) == ()
+
+
+def test_codex_config_overlay_renders_extra_writable_roots_and_stays_idempotent() -> None:
+    extra = (r"C:\proj\agenttalk\.git\worktrees", r"C:\proj\agenttalk\.git\objects")
+    out = sup.codex_config_overlay("", repo_path=r"C:\proj\agenttalk",
+                                   extra_writable_roots=extra)
+    assert (
+        'writable_roots = ["C:\\\\proj\\\\agenttalk", '
+        '"C:\\\\proj\\\\agenttalk\\\\.git\\\\worktrees", '
+        '"C:\\\\proj\\\\agenttalk\\\\.git\\\\objects"]'
+    ) in out
+    # Idempotent re-apply with the SAME extras.
+    assert sup.codex_config_overlay(out, repo_path=r"C:\proj\agenttalk",
+                                    extra_writable_roots=extra) == out
+    # Re-seeding with DIFFERENT extras REPLACES the array, not accumulates it.
+    reseeded = sup.codex_config_overlay(out, repo_path=r"C:\proj\agenttalk",
+                                        extra_writable_roots=(r"C:\proj\agenttalk\.git\refs",))
+    assert "worktrees" not in reseeded
+    assert r'"C:\\proj\\agenttalk\\.git\\refs"' in reseeded
+    # No extras at all -> byte-identical to the pre-#169 single-root form.
+    assert sup.codex_config_overlay("", repo_path=r"C:\proj\agenttalk") == (
+        sup.codex_config_overlay("", repo_path=r"C:\proj\agenttalk", extra_writable_roots=())
+    )
+
+
 def test_seed_claude_settings_merges_default_mode() -> None:
     out = sup.seed_claude_settings('{"model": "opus"}', mode="bypassPermissions")
     data = json.loads(out)
@@ -2158,6 +2270,26 @@ def test_seed_codex_config_cli_overlays_in_place(tmp_path: Path) -> None:
     txt = (home / "config.toml").read_text(encoding="utf-8")
     assert 'model = "x"' in txt and 'approval_policy = "never"' in txt
     assert 'sandbox = "unelevated"' in txt
+
+
+def test_seed_codex_config_cli_grants_worktree_admin_roots_for_169(tmp_path: Path) -> None:
+    """--seed-codex-config with --repo pointed at a linked worktree also
+    grants that worktree's own git-admin state (#169) - not just the
+    worktree's ordinary files, which writable_roots=[<repo>] already
+    covered before this fix and still covers unchanged."""
+    _team(tmp_path)
+    worktree, admin_dir, common_git = _make_linked_worktree(tmp_path, main_name="main-repo", wt_name="agent-wt")
+    home = tmp_path / "iso"
+    home.mkdir()
+    rc = _run(["supervise", "--seed-codex-config", "--home", str(home),
+               "--repo", str(worktree), "--sandbox", "unelevated"], tmp_path)
+    assert rc == 0
+    txt = (home / "config.toml").read_text(encoding="utf-8")
+    assert str(worktree.resolve()).replace("\\", "\\\\") in txt
+    assert str(admin_dir.resolve()).replace("\\", "\\\\") in txt
+    assert str((common_git / "objects").resolve()).replace("\\", "\\\\") in txt
+    assert str((common_git / "refs").resolve()).replace("\\", "\\\\") in txt
+    assert str((common_git / "logs").resolve()).replace("\\", "\\\\") in txt
 
 
 def test_seed_claude_settings_cli_merges(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

#169: a wrapped codex agent can now `git add`/`commit`/`push` from its own git worktree, under its own identity, without the operator's approval-escalation workaround.

## The mechanism (measured, not re-derived)

Agent worktrees live outside the main checkout (e.g. `D:\tmp\at-task166-loud-refusal`). A linked worktree's git metadata does not live in the worktree - it lives in the MAIN repo at `<main>\.git\worktrees\<name>\`, outside the agent's granted `writable_roots`. Under codex `sandbox_mode = "workspace-write"`, that write is denied: `fatal: Unable to create '.../.git/worktrees/<name>/index.lock': Permission denied`. Not a filesystem-ACL problem (already ruled out) - it's the sandbox's own write-side policy, keyed on `writable_roots`.

## Design

Extended the existing seeding mechanism (`supervisor.codex_config_overlay`, called by `agenttalk supervise --seed-codex-config`, which already writes `writable_roots` into the per-agent isolated `CODEX_HOME/config.toml`) rather than inventing a parallel one. A new pure helper, `codex_worktree_writable_roots(repo_path)`, computes what to add:

- If `repo_path` is ITSELF a linked worktree, grants exactly its own admin dir (`<main>/.git/worktrees/<this-one>`) - narrow, no other worktree's metadata is touched.
- Otherwise (the case every currently-seeded agent is actually in: `repo_path` is the shared team root, and agents create worktrees elsewhere, ad hoc, after seeding, under names not known yet), grants the whole `<repo_path>/.git/worktrees/` parent. **This is wider than one agent's own worktree** - it also exposes every OTHER agent's worktree-scoped git state (index, HEAD, per-worktree logs) under the same repo. There is no narrower target that survives every worktree an agent might create later without inventing a second, worktree-creation-triggered reseed path alongside the existing launch-time one - deliberately not built, per "start from the existing mechanism."
- Either way, ALSO grants `.git/objects`, `.git/refs`, `.git/logs` - git's shared, cross-worktree object/ref/reflog storage that any worktree's commit/push writes into by git's own design (worktrees share history on purpose). **This is the part that can't be narrowed further at all**: it grants filesystem-level write access to any ref or object in the repository, not only the seeded agent's own branch. Git offers no filesystem-level way to scope tighter than "the shared object/ref store."

None of this ever touches `.git/config`, `.git/hooks`, `.git/info`, or anything outside `.git` - and never touches the operator's actual source tree beyond what `writable_roots=[<repo_path>]` already granted before this PR (asserted directly in tests, not just reasoned about).

`codex_config_overlay` gained `extra_writable_roots: tuple[str, ...] = ()`, rendering additional `writable_roots` array entries. Default-empty, so every existing caller/test is byte-identical. Idempotent (re-applying the same extras is a no-op; re-seeding with different extras replaces the array rather than accumulating it) - survives `--refresh-scripts`/reseed the same way the existing managed keys do, because it's the SAME seed step, not a new one.

## Verification

**Positive, failing-first, and via TWO independent methods:**
- Unit/CLI-level (pytest): `codex_worktree_writable_roots` and `codex_config_overlay` against a hand-built linked-worktree `.git` layout (no git binary needed - these are pure file readers), plus a full `agenttalk supervise --seed-codex-config` CLI run against a REAL `git worktree add`-created worktree, asserting the rendered `config.toml` contains all four extra roots.
- Filesystem-level, against a REAL git repo with a REAL linked worktree: computed `codex_worktree_writable_roots()`'s actual output, applied those EXACT paths as Windows ACL write-grants (denying write everywhere else in `.git`, using narrow WriteData/AppendData/DeleteChild rights rather than the broader `W` alias, which also blocks reads codex's sandbox doesn't restrict), and confirmed `git add && git commit && git push` succeeds end-to-end from the worktree. Failing-first: reproduced the exact reported `index.lock: Permission denied` failure with the deny in place and no grant, before granting the computed roots and watching it turn to `COMMIT OK` / `PUSH OK`.

**Negative, tested for real, not just reasoned about:**
- A SECOND worktree's own admin dir (`.git/worktrees/<other-name>/`) stays denied under the exact same grant set - confirmed with a real `index.lock: Permission denied` on the sibling, in the same test session as the positive control's success.
- `codex_worktree_writable_roots()`'s output is asserted (unit test, not just eyeballed) to never include the checkout's own working-tree root - every returned path is `.git`-relative.

**What I could not verify, said plainly rather than glossed over:** I could not run the fix against codex's actual Windows-restricted-token sandbox end-to-end - I have no way to execute AS a codex-sandboxed process myself. I tried `codex sandbox -P workspace-write -C <dir> -- git ...` (a real debug subcommand shipped with the installed codex CLI, 0.144.6) to test directly, but it requires a `[permissions]` table under a newer named-profile schema I could not get working from the legacy `sandbox_mode`/`sandbox_workspace_write.writable_roots` config this codebase seeds - possibly a newer, parallel permission system in current codex releases that I don't have documentation for. The Windows-ACL-based verification above is a reasonable proxy for a write-side-only restriction (deny writes outside listed roots, never restrict reads) rather than the real mechanism, and it produces the exact reported failure signature and the exact reported fix signature, but it is a proxy. Recommend one live check with an actual wrapped codex agent before treating this as fully closed.

## What has to change on the operator's machine

Nothing in configuration. This is baked into the existing `Seed-CodexHome`/`--seed-codex-config` step, which the generated supervisor PS1 already re-runs on every launch AND every relaunch (crash-recovery, idle-timeout restart, manual restart) - so any codex agent that restarts after this PR is deployed picks up the fix automatically, no new trigger needed.

For agents that are CURRENTLY RUNNING and won't naturally restart soon: their CODEX_HOME's config.toml was seeded under the old code and stays stale until reseeded. Two ways to get them current without waiting:
- Restart the agent (supervisor's normal relaunch path reseeds automatically), or
- Manually run `agenttalk supervise --seed-codex-config --home <that agent's CODEX_HOME> --repo <its --root>` against the upgraded agenttalk code.

## Not acted on (per scope note - this is an enabler, not a release blocker)

None of the above touches sandbox_mode, approval_policy, or anything for Claude-family agents.
