### PR TITLE
feat(#171): keep the part of a failure that says which test failed

### DIFF
--- a/dev-gate.json
+++ b/dev-gate.json
@@ -67,7 +67,9 @@
         "tests"
       ],
       "args": [
-        "-q"
+        "-q",
+        "-o",
+        "verbosity_assertions=2"
       ],
       "test_requirement": "pytest>=8.0",
       "timeout_seconds": 2700

--- a/docs/DEV-GATE.md
+++ b/docs/DEV-GATE.md
@@ -88,14 +88,20 @@ the evidence never presents them as content-addressed inputs.
 ## Evidence contract
 
 Run artifacts use `artifact_type: agenttalk-dev-gate-run`. They contain exact required check IDs, commands,
-resolved tool paths and versions, exit codes, durations, log hashes and tails, isolated-venv creator/prefix
-proofs, pip-configuration and child-`PATH` isolation assertions, import provenance, package
+resolved tool paths and versions, exit codes, durations, log hashes and bounded diagnostics, isolated-venv
+creator/prefix proofs, pip-configuration and child-`PATH` isolation assertions, import provenance, package
 artifact hashes, isolation assertions, blockers, and recomputed summary counts. The writer validates the full
 schema before and after a normalized durable JSON write.
 
+For a pytest failure, the 2,000-character diagnostic prioritizes the first failing test, phase, frame, and
+assertion before using any remaining space for the terminal log tail. If the gate-owned reporter is missing,
+invalid, incomplete, or unavailable, the diagnostic labels that fallback explicitly and keeps a bounded
+terminal tail. Reporter failure never changes pytest's exit status.
+
 Aggregate artifacts use `artifact_type: agenttalk-dev-gate-aggregate`. Each leg entry binds the raw input
 artifact SHA-256. A passing aggregate proves that all declared legs share the same candidate SHA, tree,
-version, manifest blob/digest, and logical plan digest and that the current checkout still matches them.
+version, manifest blob/digest, and logical plan digest and that the current checkout still matches them. A
+blocked aggregate carries the first failed check and its bounded diagnostic for each blocked leg.
 
 CI uploads every leg artifact even when its gate command blocks. The always-run aggregate converts a crashed
 or evidence-less leg into an incomplete blocking artifact instead of silently reducing the matrix.

--- a/src/agenttalk/dev_gate.py
+++ b/src/agenttalk/dev_gate.py
@@ -39,6 +39,9 @@ AGGREGATE_ARTIFACT_TYPE = "agenttalk-dev-gate-aggregate"
 PREFLIGHT_ARTIFACT_TYPE = "agenttalk-dev-gate-preflight-block"
 DEFAULT_MANIFEST = "dev-gate.json"
 DEFAULT_PROFILE = "release"
+DIAGNOSTIC_LIMIT = 2000
+_PYTEST_REPORT_SIDECAR_LIMIT = 32_768
+_PYTEST_REPORT_TRACEBACK_LIMIT = 12_000
 
 REQUIRED_CI_OSES = ("linux", "windows", "macos")
 REQUIRED_CI_PYTHONS = ("3.10", "3.11", "3.12", "3.13")
@@ -102,6 +105,52 @@ namespace = {
     "__spec__": spec,
 }
 exec(code, namespace, namespace)
+""".strip()
+
+
+# Pytest needs one extra fail-soft boundary: the gate-owned reporter is useful
+# evidence, not part of the test vote.  Resolve the real pytest package before
+# exposing the candidate import root, then load the reporter opportunistically.
+# A reporter import or construction failure is recorded in its private sidecar
+# and pytest still runs without the plugin.
+_ISOLATED_PYTEST_LAUNCHER = """
+import importlib
+import json
+import sys
+from pathlib import Path
+
+candidate_import_root = sys.argv.pop(1)
+report_path = Path(sys.argv.pop(1))
+pytest = importlib.import_module("pytest")
+if candidate_import_root:
+    sys.path.insert(0, candidate_import_root)
+plugins = []
+try:
+    reporter_module = importlib.import_module("agenttalk.dev_gate")
+    plugins.append(reporter_module._PytestFailureReporter(report_path))
+except BaseException as exc:
+    reporter_error = "unprintable reporter failure"
+    try:
+        reporter_error = (type(exc).__name__ + ": " + str(exc))[:1000]
+    except BaseException:  # noqa: S110 - diagnostics must not change the test vote
+        pass
+    payload = {
+        "schema_version": 1,
+        "status": "unavailable",
+        "complete": False,
+        "observed_failures": 0,
+        "first_failure": None,
+        "reporter_error": reporter_error,
+    }
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\\n",
+            encoding="utf-8",
+        )
+    except BaseException:
+        pass
+raise SystemExit(pytest.main(sys.argv[1:], plugins=plugins))
 """.strip()
 
 
@@ -278,7 +327,11 @@ def validate_manifest(data: Any) -> dict[str, Any]:
             raise GateBlock("manifest_schema_invalid", f"checks.{check_id}.timeout_seconds must be positive")
 
     required_contract = {
-        "pytest": {"paths": ["tests"], "args": ["-q"], "test_requirement": "pytest>=8.0"},
+        "pytest": {
+            "paths": ["tests"],
+            "args": ["-q", "-o", "verbosity_assertions=2"],
+            "test_requirement": "pytest>=8.0",
+        },
         "ruff": {"paths": ["src", "tests"]},
         "bandit": {"paths": ["src"], "exclude": ["src/agenttalk/skills"]},
         "gitleaks": {"config": ".gitleaks.toml", "require_full_history": True},
@@ -576,20 +629,21 @@ def _validate_check_command(
         minor = f"{suffix[2]}.{suffix[3:]}"
         python = require_python(minor) if mode == "source" else require_runtime_python(minor, "test")
         spec = manifest["checks"]["pytest"]
-        launcher = [python, "-I", "-c", _ISOLATED_TOOL_LAUNCHER, "pytest"]
+        launcher = [python, "-I", "-c", _ISOLATED_PYTEST_LAUNCHER]
         suffix_args = [*spec["args"], "-p", "no:cacheprovider", "--basetemp"]
         valid = (
             item["mode"] == mode
-            and len(argv) == len(launcher) + 1 + len(suffix_args) + 1 + len(spec["paths"])
+            and len(argv) == len(launcher) + 2 + len(suffix_args) + 1 + len(spec["paths"])
             and argv[: len(launcher)] == launcher
             and (
                 _is_absolute_path_text(argv[len(launcher)])
                 if mode == "source"
                 else argv[len(launcher)] == ""
             )
-            and argv[len(launcher) + 1 : len(launcher) + 1 + len(suffix_args)] == suffix_args
-            and _is_absolute_path_text(argv[len(launcher) + 1 + len(suffix_args)])
-            and argv[len(launcher) + 2 + len(suffix_args) :] == spec["paths"]
+            and _is_absolute_path_text(argv[len(launcher) + 1])
+            and argv[len(launcher) + 2 : len(launcher) + 2 + len(suffix_args)] == suffix_args
+            and _is_absolute_path_text(argv[len(launcher) + 2 + len(suffix_args)])
+            and argv[len(launcher) + 3 + len(suffix_args) :] == spec["paths"]
         )
     elif check_id == "package-build":
         python = require_python(expected_minors[0])
@@ -981,6 +1035,7 @@ def validate_run_artifact(artifact: Any, manifest: dict[str, Any]) -> dict[str, 
             or isinstance(item["duration_ms"], bool)
             or item["duration_ms"] < 0
             or not isinstance(item["diagnostic"], str)
+            or len(item["diagnostic"]) > DIAGNOSTIC_LIMIT
         ):
             raise GateBlock("evidence_schema_invalid", f"checks[{index}] semantics are invalid")
         if not isinstance(item["argv"], list) or not all(isinstance(arg, str) for arg in item["argv"]):
@@ -1394,6 +1449,34 @@ def write_preflight_block_evidence(
     return output_path, sha256_bytes(raw), artifact
 
 
+def _aggregate_leg_blocker(artifact: dict[str, Any]) -> dict[str, str]:
+    first_blocker = artifact["blockers"][0] if artifact["blockers"] else None
+    failed = (
+        next(
+            (
+                check
+                for check in artifact["checks"]
+                if check["id"] == first_blocker["check_id"]
+            ),
+            None,
+        )
+        if first_blocker is not None
+        else None
+    )
+    if failed is None:
+        return {
+            "code": "ci_leg_blocked",
+            "check_id": artifact["ci_leg"],
+            "detail": "CI leg blocked without a failed check result",
+        }
+    detail = failed["diagnostic"] or f"{failed['id']} did not pass"
+    return {
+        "code": failed["reason_code"] or failed["status"],
+        "check_id": artifact["ci_leg"],
+        "detail": _bounded_text(f"[{failed['id']}]\n{detail}", DIAGNOSTIC_LIMIT),
+    }
+
+
 def aggregate_leg_artifacts(
     manifest: dict[str, Any],
     profile: str,
@@ -1484,7 +1567,7 @@ def aggregate_leg_artifacts(
             for artifact in ordered
         ],
         "blockers": [
-            {"code": "ci_leg_blocked", "check_id": artifact["ci_leg"], "detail": "CI leg blocked"}
+            _aggregate_leg_blocker(artifact)
             for artifact in ordered
             if artifact["verdict"] != "pass"
         ],
@@ -1816,12 +1899,344 @@ def source_environment(base: dict[str, str], source_root: Path) -> dict[str, str
     return env
 
 
-def _log_tail(path: Path, limit: int = 2000) -> str:
+def _bounded_text(value: str, limit: int) -> str:
+    """Keep a stable prefix and make truncation explicit."""
+
+    value = value.encode("utf-8", errors="replace").decode("utf-8")
+    if limit <= 0:
+        return ""
+    if len(value) <= limit:
+        return value
+    digest = hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()[:12]
+    marker = f"...[truncated sha256:{digest}]"
+    if len(marker) >= limit:
+        return marker[:limit]
+    return value[: limit - len(marker)] + marker
+
+
+def _bounded_excerpt(value: str, limit: int) -> str:
+    """Keep both ends of a traceback excerpt inside a fixed budget."""
+
+    value = value.encode("utf-8", errors="replace").decode("utf-8")
+    if limit <= 0:
+        return ""
+    if len(value) <= limit:
+        return value
+    digest = hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()[:12]
+    marker = f"\n...[truncated sha256:{digest}]...\n"
+    if len(marker) >= limit:
+        return marker[:limit]
+    remaining = limit - len(marker)
+    head = remaining // 2
+    return value[:head] + marker + value[-(remaining - head) :]
+
+
+def _safe_exception_text(exc: BaseException, limit: int) -> str:
+    text = "unprintable reporter failure"
+    try:
+        text = f"{type(exc).__name__}: {exc}"
+    except BaseException:  # noqa: S110 - diagnostics must not change the test vote
+        pass
+    return _bounded_text(text, limit)
+
+
+def _is_utf8_scalar_text(value: str) -> bool:
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+class _PytestFailureReporter:
+    """Fail-soft pytest plugin that records the first failure as it happens."""
+
+    def __init__(self, path: str | Path):
+        self._path = Path(path)
+        self._observed_failures = 0
+        self._first_failure: dict[str, str] | None = None
+        self._reporter_error: str | None = None
+        self._complete = False
+        self._persist()
+
+    def _payload(self) -> dict[str, Any]:
+        if self._reporter_error is not None:
+            status = "error"
+        elif self._first_failure is not None:
+            status = "captured"
+        elif self._complete:
+            status = "no_failure"
+        else:
+            status = "running"
+        return {
+            "schema_version": 1,
+            "status": status,
+            "complete": self._complete,
+            "observed_failures": self._observed_failures,
+            "first_failure": (
+                None if self._first_failure is None else dict(self._first_failure)
+            ),
+            "reporter_error": self._reporter_error,
+        }
+
+    def _persist(self) -> None:
+        payload = self._payload()
+        raw = json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n"
+        if len(raw.encode("utf-8")) > _PYTEST_REPORT_SIDECAR_LIMIT:
+            failure = payload.get("first_failure")
+            if isinstance(failure, dict):
+                failure["nodeid"] = _bounded_text(str(failure.get("nodeid", "")), 240)
+                failure["frame"] = _bounded_text(str(failure.get("frame", "")), 240)
+                failure["assertion"] = _bounded_text(str(failure.get("assertion", "")), 500)
+                failure["traceback"] = _bounded_excerpt(str(failure.get("traceback", "")), 1500)
+            raw = json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n"
+        if len(raw.encode("utf-8")) > _PYTEST_REPORT_SIDECAR_LIMIT:
+            raise ValueError("pytest reporter sidecar exceeded its fixed bound")
+        write_text(self._path, raw, encoding="utf-8", newline="\n")
+
+    def _remember_error(self, exc: BaseException) -> None:
+        self._reporter_error = _safe_exception_text(exc, 500)
+        try:
+            self._persist()
+        except BaseException:  # noqa: S110 - reporter failure cannot change the test vote
+            pass
+
+    def _guard(self, action: Any) -> None:
+        try:
+            action()
+        except BaseException as exc:
+            self._remember_error(exc)
+
+    @staticmethod
+    def _failure_from_report(report: Any, default_phase: str) -> dict[str, str]:
+        nodeid = str(getattr(report, "nodeid", ""))
+        phase = str(getattr(report, "when", default_phase) or default_phase)
+        location = getattr(report, "location", None)
+        function = ""
+        if isinstance(location, tuple) and len(location) >= 3:
+            function = str(location[2])
+
+        longrepr = getattr(report, "longrepr", None)
+        crash = getattr(longrepr, "reprcrash", None)
+        crash_path = str(getattr(crash, "path", "") or "")
+        crash_line = getattr(crash, "lineno", None)
+        crash_message = str(getattr(crash, "message", "") or "")
+        if crash_path and isinstance(crash_line, int):
+            frame = f"{crash_path}:{crash_line}"
+        elif isinstance(location, tuple) and len(location) >= 2:
+            location_line = location[1]
+            if isinstance(location_line, int):
+                location_line += 1
+            frame = f"{location[0]}:{location_line}"
+            if function:
+                frame += f" in {function}"
+        else:
+            frame = "unavailable"
+
+        longrepr_text = str(getattr(report, "longreprtext", "") or "")
+        if not longrepr_text and longrepr is not None:
+            longrepr_text = str(longrepr)
+        assertion_lines = []
+        for line in longrepr_text.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("E "):
+                assertion_lines.append(stripped[1:].lstrip())
+        summary_prefixes = (
+            "AssertionError",
+            "assert ",
+            "At index ",
+            "Differing items:",
+            "Extra items",
+            "Left contains",
+            "Right contains",
+            "where ",
+        )
+        priority_lines = [
+            line
+            for line in assertion_lines
+            if line.startswith(summary_prefixes) and len(line) <= 1000
+        ]
+        assertion = (
+            "\n".join(priority_lines[:8])
+            or crash_message
+            or "failure detail unavailable"
+        )
+        return {
+            "nodeid": _bounded_text(nodeid or "collection", 600),
+            "phase": _bounded_text(phase, 40),
+            "frame": _bounded_text(frame, 600),
+            "assertion": _bounded_text(assertion, 2000),
+            "traceback": _bounded_excerpt(longrepr_text, _PYTEST_REPORT_TRACEBACK_LIMIT),
+        }
+
+    def _observe(self, report: Any, default_phase: str) -> None:
+        if not bool(getattr(report, "failed", False)):
+            return
+        self._observed_failures += 1
+        if self._first_failure is None:
+            self._first_failure = self._failure_from_report(report, default_phase)
+        self._persist()
+
+    def pytest_collectreport(self, report: Any) -> None:
+        self._guard(lambda: self._observe(report, "collect"))
+
+    def pytest_runtest_logreport(self, report: Any) -> None:
+        self._guard(lambda: self._observe(report, "call"))
+
+    def pytest_sessionfinish(self, session: Any, exitstatus: Any) -> None:
+        del session, exitstatus
+
+        def finish() -> None:
+            self._complete = True
+            self._persist()
+
+        self._guard(finish)
+
+
+def _log_tail(path: Path, limit: int = DIAGNOSTIC_LIMIT) -> str:
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
     return text[-limit:]
+
+
+def _load_pytest_report(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(_PYTEST_REPORT_SIDECAR_LIMIT + 1)
+    except FileNotFoundError:
+        return None, "sidecar missing"
+    except OSError:
+        return None, "sidecar unreadable"
+    if not raw:
+        return None, "sidecar empty"
+    if len(raw) > _PYTEST_REPORT_SIDECAR_LIMIT:
+        return None, "sidecar oversized"
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "sidecar corrupt"
+    if not isinstance(payload, dict):
+        return None, "sidecar invalid"
+    required = {
+        "schema_version",
+        "status",
+        "complete",
+        "observed_failures",
+        "first_failure",
+        "reporter_error",
+    }
+    if set(payload) != required:
+        return None, "sidecar invalid"
+    status = payload.get("status")
+    observed = payload.get("observed_failures")
+    reporter_error = payload.get("reporter_error")
+    if (
+        payload.get("schema_version") != 1
+        or status not in {"running", "captured", "no_failure", "error", "unavailable"}
+        or not isinstance(payload.get("complete"), bool)
+        or not isinstance(observed, int)
+        or isinstance(observed, bool)
+        or observed < 0
+        or not (
+            reporter_error is None
+            or (isinstance(reporter_error, str) and _is_utf8_scalar_text(reporter_error))
+        )
+    ):
+        return None, "sidecar invalid"
+    failure = payload.get("first_failure")
+    if failure is not None:
+        failure_fields = {"nodeid", "phase", "frame", "assertion", "traceback"}
+        if (
+            not isinstance(failure, dict)
+            or set(failure) != failure_fields
+            or not all(
+                isinstance(failure.get(field), str)
+                and _is_utf8_scalar_text(failure[field])
+                for field in failure_fields
+            )
+        ):
+            return None, "sidecar invalid"
+    return payload, None
+
+
+def _pytest_tail_fallback(tail: str, reason: str) -> str:
+    prefix = (
+        "[agenttalk pytest diagnostic v1]\n"
+        "source: terminal-tail fallback\n"
+        f"reason: {_bounded_text(reason, 300)}\n"
+        "--- terminal tail ---\n"
+    )
+    remaining = max(0, DIAGNOSTIC_LIMIT - len(prefix))
+    return prefix + tail[-remaining:] if remaining else prefix[:DIAGNOSTIC_LIMIT]
+
+
+def _reported_pytest_diagnostic(report: dict[str, Any], tail: str) -> str:
+    failure = report["first_failure"]
+    if not isinstance(failure, dict):
+        raise ValueError("pytest report lacks a first failure")
+    omitted = max(0, int(report["observed_failures"]) - 1)
+    priority = "\n".join(
+        [
+            "[agenttalk pytest diagnostic v1]",
+            "source: gate reporter",
+            f"test: {_bounded_text(failure['nodeid'], 300)}",
+            f"phase: {_bounded_text(failure['phase'], 40)}",
+            f"failing frame: {_bounded_text(failure['frame'], 300)}",
+            "assertion:",
+            _bounded_text(failure["assertion"], 420),
+            f"additional failures omitted: {omitted}",
+            "traceback excerpt:",
+            _bounded_excerpt(failure["traceback"], 380),
+        ]
+    )
+    priority = _bounded_text(priority, DIAGNOSTIC_LIMIT)
+    separator = "\n--- terminal tail ---\n"
+    remaining = DIAGNOSTIC_LIMIT - len(priority) - len(separator)
+    if remaining <= 0:
+        return priority
+    return priority + separator + tail[-remaining:]
+
+
+def _pytest_diagnostic(outcome: CommandOutcome, sidecar: Path) -> str:
+    """Select a bounded pytest diagnostic without ever changing the test vote."""
+
+    try:
+        if outcome.status in {"timeout", "error", "missing"}:
+            return _pytest_tail_fallback(outcome.diagnostic, f"pytest process {outcome.status}")
+        report, problem = _load_pytest_report(sidecar)
+        if problem is not None or report is None:
+            return _pytest_tail_fallback(outcome.diagnostic, problem or "sidecar unavailable")
+        status = report["status"]
+        reporter_error = report["reporter_error"]
+        if status == "unavailable":
+            detail = "reporter unavailable"
+            if reporter_error:
+                detail += f": {reporter_error}"
+            return _pytest_tail_fallback(outcome.diagnostic, detail)
+        if status == "error" or reporter_error:
+            detail = "reporter error"
+            if reporter_error:
+                detail += f": {reporter_error}"
+            return _pytest_tail_fallback(outcome.diagnostic, detail)
+        if report["complete"] is not True:
+            return _pytest_tail_fallback(outcome.diagnostic, "reporter incomplete")
+        failure = report["first_failure"]
+        if outcome.status == "fail":
+            if status != "captured" or not isinstance(failure, dict):
+                return _pytest_tail_fallback(outcome.diagnostic, "reporter produced no failure")
+            if report["observed_failures"] < 1 or not failure["nodeid"]:
+                return _pytest_tail_fallback(outcome.diagnostic, "reporter produced invalid failure")
+            return _reported_pytest_diagnostic(report, outcome.diagnostic)
+        if status != "no_failure" or failure is not None or report["observed_failures"] != 0:
+            return _pytest_tail_fallback(outcome.diagnostic, "reporter result disagrees with pytest")
+        return outcome.diagnostic
+    except BaseException as exc:
+        return _pytest_tail_fallback(
+            outcome.diagnostic,
+            f"diagnostic selector error: {_safe_exception_text(exc, 100)}",
+        )
 
 
 def _sha256_file(path: Path) -> str:
@@ -1904,6 +2319,7 @@ def _record_from_outcome(
     python: str | None = None,
     import_provenance: dict[str, Any] | None = None,
     runtime_environment: dict[str, Any] | None = None,
+    diagnostic: str | None = None,
 ) -> dict[str, Any]:
     log_hash = _sha256_file(outcome.log_path) if outcome.log_path.exists() else ""
     return {
@@ -1918,7 +2334,7 @@ def _record_from_outcome(
         "exit_code": outcome.returncode,
         "duration_ms": outcome.duration_ms,
         "reason_code": outcome.reason_code,
-        "diagnostic": outcome.diagnostic,
+        "diagnostic": outcome.diagnostic if diagnostic is None else diagnostic,
         "log": {"path": str(outcome.log_path), "sha256": log_hash},
         "import_provenance": import_provenance,
         "runtime_environment": runtime_environment,
@@ -1942,7 +2358,7 @@ def _blocked_record(check_id: str, detail: str, logs_dir: Path) -> dict[str, Any
         "exit_code": None,
         "duration_ms": 0,
         "reason_code": "blocked_dependency",
-        "diagnostic": detail,
+        "diagnostic": detail[-DIAGNOSTIC_LIMIT:],
         "log": {"path": str(log_path), "sha256": _sha256_file(log_path)},
         "import_provenance": None,
         "runtime_environment": None,
@@ -2075,6 +2491,26 @@ def isolated_tool_argv(
         _ISOLATED_TOOL_LAUNCHER,
         module,
         import_root,
+        *args,
+    ]
+
+
+def isolated_pytest_argv(
+    interpreter: str | Path,
+    report_path: str | Path,
+    *args: str,
+    candidate_import_root: Path | None = None,
+) -> list[str]:
+    """Return an isolated pytest argv with a fail-soft gate reporter."""
+
+    import_root = "" if candidate_import_root is None else str(candidate_import_root.resolve())
+    return [
+        str(interpreter),
+        "-I",
+        "-c",
+        _ISOLATED_PYTEST_LAUNCHER,
+        import_root,
+        str(Path(report_path).resolve()),
         *args,
     ]
 
@@ -2323,7 +2759,7 @@ def _change_record_failure(record: dict[str, Any], code: str, detail: str) -> di
     changed = dict(record)
     changed["status"] = "fail"
     changed["reason_code"] = code
-    changed["diagnostic"] = detail[-2000:]
+    changed["diagnostic"] = detail[-DIAGNOSTIC_LIMIT:]
     if changed.get("exit_code") == 0:
         changed["exit_code"] = 1
     return changed
@@ -2478,9 +2914,12 @@ def _run_pytest_mode(
         )
     except GateBlock as exc:
         return _blocked_record(check_id, exc.detail, logs_dir)
-    argv = isolated_tool_argv(
+    report_path = (
+        logs_dir / (re.sub(r"[^A-Za-z0-9_.-]+", "-", check_id) + ".pytest.json")
+    ).resolve()
+    argv = isolated_pytest_argv(
         interpreter.path,
-        "pytest",
+        report_path,
         *spec.get("args", []),
         "-p",
         "no:cacheprovider",
@@ -2507,6 +2946,7 @@ def _run_pytest_mode(
         python=interpreter.requested,
         import_provenance=provenance,
         runtime_environment=runtime_environment,
+        diagnostic=_pytest_diagnostic(outcome, report_path),
     )
 
 
@@ -3014,6 +3454,7 @@ def _synthetic_record(
     tool_path: str,
     tool_version: str,
 ) -> dict[str, Any]:
+    diagnostic = diagnostic[-DIAGNOSTIC_LIMIT:]
     log_path = logs_dir / f"{check_id}.log"
     logs_dir.mkdir(parents=True, exist_ok=True)
     write_text(log_path, diagnostic + ("\n" if diagnostic else ""), encoding="utf-8", newline="\n")
@@ -3649,7 +4090,10 @@ def validate_aggregate_artifact(
     for index, blocker in enumerate(blockers):
         item = _require_object(blocker, f"aggregate.blockers[{index}]")
         _require_artifact_fields(item, {"code", "check_id", "detail"}, f"aggregate.blockers[{index}]")
-        if not all(_is_nonempty_string(item[field]) for field in ("code", "check_id", "detail")):
+        if (
+            not all(_is_nonempty_string(item[field]) for field in ("code", "check_id", "detail"))
+            or len(item["detail"]) > DIAGNOSTIC_LIMIT
+        ):
             raise GateBlock("evidence_schema_invalid", f"aggregate.blockers[{index}] is invalid")
     if record["complete"]:
         if leg_ids != expected:

--- a/tests/test_dev_gate.py
+++ b/tests/test_dev_gate.py
@@ -20,6 +20,53 @@ def _manifest() -> dict:
     return json.loads(Path("dev-gate.json").read_text(encoding="utf-8"))
 
 
+def _pytest_sidecar_payload(
+    *,
+    status: str = "captured",
+    complete: bool = True,
+    observed_failures: int = 1,
+    first_failure: dict[str, str] | None = None,
+    reporter_error: str | None = None,
+) -> dict:
+    if first_failure is None and status == "captured":
+        first_failure = {
+            "nodeid": "tests/test_failure.py::test_first",
+            "phase": "call",
+            "frame": "tests/test_failure.py:12 in test_first",
+            "assertion": "AssertionError: expected != actual",
+            "traceback": "priority traceback",
+        }
+    return {
+        "schema_version": 1,
+        "status": status,
+        "complete": complete,
+        "observed_failures": observed_failures,
+        "first_failure": first_failure,
+        "reporter_error": reporter_error,
+    }
+
+
+def _pytest_report(nodeid: str, phase: str, *, detail: str = "EXPECTED != ACTUAL") -> SimpleNamespace:
+    crash = SimpleNamespace(
+        path="tests/test_failure.py",
+        lineno=37,
+        message=f"AssertionError: {detail}",
+    )
+    longrepr = SimpleNamespace(reprcrash=crash)
+    return SimpleNamespace(
+        failed=True,
+        nodeid=nodeid,
+        when=phase,
+        location=("tests/test_failure.py", 36, nodeid.rsplit("::", 1)[-1]),
+        longrepr=longrepr,
+        longreprtext=(
+            f"{nodeid}\n"
+            "tests/test_failure.py:37: AssertionError\n"
+            f"E       AssertionError: {detail}\n"
+        ),
+    )
+
+
 def _check(check_id: str, manifest: dict, minor: str, *, status: str = "pass") -> dict:
     kind = check_id.split("-", 1)[0]
     mode = None
@@ -77,9 +124,9 @@ def _check(check_id: str, manifest: dict, minor: str, *, status: str = "pass") -
         argv = [tool_path, "status", "--porcelain=v1", "--untracked-files=all"]
     elif check_id.startswith("pytest-"):
         spec = manifest["checks"]["pytest"]
-        argv = dev_gate.isolated_tool_argv(
+        argv = dev_gate.isolated_pytest_argv(
             tool_path,
-            "pytest",
+            (Path.cwd() / f"{check_id}.pytest.json").resolve(),
             *spec["args"],
             "-p",
             "no:cacheprovider",
@@ -435,6 +482,7 @@ def test_manifest_declares_real_ci_matrix_separately_from_local_interpreters() -
         lambda data: data["checks"].pop("semgrep"),
         lambda data: data.update({"ci_native_exceptions": []}),
         lambda data: data["checks"]["pytest"].update({"paths": ["tests/test_dev_gate.py"]}),
+        lambda data: data["checks"]["pytest"].update({"args": ["-q"]}),
         lambda data: data["checks"]["ruff"].update({"paths": []}),
         lambda data: data["checks"]["bandit"].update({"exclude": ["src"]}),
         lambda data: data["checks"]["gitleaks"].update({"require_full_history": False}),
@@ -589,6 +637,25 @@ def test_passing_check_command_must_match_committed_plan() -> None:
         dev_gate.validate_run_artifact(artifact, manifest)
 
 
+@pytest.mark.parametrize("mutation", ["launcher", "sidecar", "verbosity"])
+def test_pytest_command_contract_requires_reporter_and_assertion_verbosity(
+    mutation: str,
+) -> None:
+    manifest = dev_gate.validate_manifest(_manifest())
+    artifact = _leg_artifact(manifest, "windows/3.10")
+    record = next(check for check in artifact["checks"] if check["id"].startswith("pytest-source"))
+    if mutation == "launcher":
+        record["argv"][3] = dev_gate._ISOLATED_TOOL_LAUNCHER
+    elif mutation == "sidecar":
+        record["argv"][5] = "relative-report.json"
+    else:
+        option_index = record["argv"].index("verbosity_assertions=2")
+        record["argv"][option_index] = "verbosity_assertions=0"
+
+    with pytest.raises(dev_gate.GateBlock, match="command"):
+        dev_gate.validate_run_artifact(artifact, manifest)
+
+
 def test_import_provenance_rejects_parent_traversal() -> None:
     manifest = dev_gate.validate_manifest(_manifest())
     artifact = _leg_artifact(manifest, "windows/3.10")
@@ -650,6 +717,66 @@ def test_aggregate_is_complete_but_blocked_when_one_leg_failed(tmp_path: Path) -
 
     assert aggregate["complete"] is True
     assert aggregate["verdict"] == "block"
+
+
+def test_aggregate_propagates_first_failed_check_summary(tmp_path: Path) -> None:
+    manifest = dev_gate.validate_manifest(_manifest())
+    artifacts = [_leg_artifact(manifest, leg) for leg in dev_gate.expected_ci_legs(manifest, "release")]
+    failed = artifacts[0]
+    source = next(check for check in failed["checks"] if check["id"].startswith("pytest-source"))
+    wheel = next(check for check in failed["checks"] if check["id"].startswith("pytest-wheel"))
+    first_detail = (
+        "[agenttalk pytest diagnostic v1]\n"
+        "source: gate reporter\n"
+        "test: tests/test_failure.py::test_first\n"
+        "failing frame: tests/test_failure.py:37 in test_first\n"
+        "assertion: FIRST_ASSERTION_SENTINEL\n"
+    )
+    for check, detail in (
+        (source, first_detail),
+        (wheel, "SECOND_FAILURE_MUST_NOT_REPLACE_FIRST"),
+    ):
+        check.update(
+            {
+                "status": "fail",
+                "exit_code": 1,
+                "reason_code": "check_failed",
+                "diagnostic": detail,
+            }
+        )
+    failed["verdict"] = "block"
+    failed["blockers"] = [
+        {
+            "code": "check_failed",
+            "check_id": check["id"],
+            "detail": "stale leg blocker detail",
+        }
+        for check in failed["checks"]
+        if check["status"] != "pass"
+    ]
+    failed["summary"] = {
+        "required": len(failed["checks"]),
+        "passed": len(failed["checks"]) - 2,
+        "blocked": 2,
+    }
+
+    aggregate = dev_gate.aggregate_leg_artifacts(
+        manifest,
+        "release",
+        artifacts,
+        _binding(manifest, root=_gate_repo(tmp_path)),
+    )
+
+    blocker = aggregate["blockers"][0]
+    assert blocker["code"] == "check_failed"
+    assert blocker["check_id"] == failed["ci_leg"]
+    assert blocker["detail"].startswith(f"[{source['id']}]\n")
+    assert "tests/test_failure.py::test_first" in blocker["detail"]
+    assert "FIRST_ASSERTION_SENTINEL" in blocker["detail"]
+    assert "SECOND_FAILURE_MUST_NOT_REPLACE_FIRST" not in blocker["detail"]
+    assert "stale leg blocker detail" not in blocker["detail"]
+    assert len(blocker["detail"]) <= dev_gate.DIAGNOSTIC_LIMIT
+    dev_gate.validate_aggregate_artifact(aggregate, manifest)
 
 
 def test_malformed_aggregate_header_blocks_without_type_error(tmp_path: Path) -> None:
@@ -789,6 +916,541 @@ def test_isolated_tool_launcher_cannot_be_shadowed_by_candidate_module(tmp_path:
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert not sentinel.exists()
+
+
+def test_pytest_diagnostic_keeps_reported_failure_when_terminal_tail_evicted(
+    tmp_path: Path,
+) -> None:
+    nodeid = "tests/test_large_failure.py::test_priority_failure"
+    assertion = "AssertionError: EXPECTED_SENTINEL != ACTUAL_SENTINEL"
+    frame = "tests/test_large_failure.py:37 in test_priority_failure"
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text(
+        f"{nodeid}\n{frame}\n{assertion}\n" + ("late teardown noise\n" * 400),
+        encoding="utf-8",
+    )
+    terminal_tail = dev_gate._log_tail(log_path)
+    assert all(marker not in terminal_tail for marker in (nodeid, frame, assertion))
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "captured",
+                "complete": True,
+                "observed_failures": 2,
+                "first_failure": {
+                    "nodeid": nodeid,
+                    "phase": "call",
+                    "frame": frame,
+                    "assertion": assertion,
+                    "traceback": "short priority traceback",
+                },
+                "reporter_error": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable, "-m", "pytest"),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=terminal_tail,
+        log_path=log_path,
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert len(diagnostic) <= 2000
+    assert "source: gate reporter" in diagnostic
+    assert "additional failures omitted: 1" in diagnostic
+    assert all(marker in diagnostic for marker in (nodeid, frame, assertion))
+
+
+@pytest.mark.parametrize(
+    ("sidecar_text", "reason"),
+    [(None, "sidecar missing"), ("{not-json", "sidecar corrupt")],
+)
+def test_pytest_invalid_sidecar_uses_labelled_bounded_tail(
+    tmp_path: Path, sidecar_text: str | None, reason: str
+) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text(("old output\n" * 400) + "TAIL_SENTINEL\n", encoding="utf-8")
+    sidecar = tmp_path / "pytest-report.json"
+    if sidecar_text is not None:
+        sidecar.write_text(sidecar_text, encoding="utf-8")
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable, "-m", "pytest"),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=dev_gate._log_tail(log_path),
+        log_path=log_path,
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert len(diagnostic) <= 2000
+    assert "source: terminal-tail fallback" in diagnostic
+    assert f"reason: {reason}" in diagnostic
+    assert "TAIL_SENTINEL" in diagnostic
+
+
+@pytest.mark.parametrize("phase", ["collect", "setup", "call", "teardown"])
+def test_pytest_reporter_writes_first_failure_immediately(tmp_path: Path, phase: str) -> None:
+    sidecar = tmp_path / "pytest-report.json"
+    reporter = dev_gate._PytestFailureReporter(sidecar)
+    report = _pytest_report(f"tests/test_failure.py::test_{phase}", phase)
+
+    if phase == "collect":
+        del report.when
+        reporter.pytest_collectreport(report)
+    else:
+        reporter.pytest_runtest_logreport(report)
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["status"] == "captured"
+    assert payload["complete"] is False
+    assert payload["observed_failures"] == 1
+    assert payload["first_failure"]["nodeid"].endswith(f"test_{phase}")
+    assert payload["first_failure"]["phase"] == phase
+    assert "tests/test_failure.py:37" in payload["first_failure"]["frame"]
+    assert "EXPECTED != ACTUAL" in payload["first_failure"]["assertion"]
+
+
+def test_pytest_reporter_does_not_mislabel_a_helper_failure_frame(tmp_path: Path) -> None:
+    sidecar = tmp_path / "pytest-report.json"
+    reporter = dev_gate._PytestFailureReporter(sidecar)
+    report = _pytest_report("tests/test_failure.py::test_calls_helper", "call")
+    report.longrepr.reprcrash.path = "src/agenttalk/helper.py"
+    report.longrepr.reprcrash.lineno = 20
+
+    reporter.pytest_runtest_logreport(report)
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["first_failure"]["frame"] == "src/agenttalk/helper.py:20"
+
+
+def test_pytest_reporter_keeps_first_failure_counts_later_and_bounds_sidecar(
+    tmp_path: Path,
+) -> None:
+    sidecar = tmp_path / "pytest-report.json"
+    reporter = dev_gate._PytestFailureReporter(sidecar)
+    first = _pytest_report(
+        "tests/test_failure.py::test_first",
+        "call",
+        detail="FIRST_SENTINEL " + ("wide-Δ" * 10_000),
+    )
+    second = _pytest_report("tests/test_failure.py::test_second", "call", detail="SECOND_SENTINEL")
+
+    reporter.pytest_runtest_logreport(first)
+    reporter.pytest_runtest_logreport(second)
+    reporter.pytest_sessionfinish(None, 1)
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert len(sidecar.read_bytes()) <= dev_gate._PYTEST_REPORT_SIDECAR_LIMIT
+    assert payload["status"] == "captured"
+    assert payload["complete"] is True
+    assert payload["observed_failures"] == 2
+    assert payload["first_failure"]["nodeid"].endswith("test_first")
+    assert "SECOND_SENTINEL" not in json.dumps(payload["first_failure"])
+
+
+def test_pytest_reporter_hook_error_is_fail_soft(tmp_path: Path) -> None:
+    class BrokenReport:
+        failed = True
+        nodeid = "tests/test_failure.py::test_broken_report"
+        when = "call"
+        location = ("tests/test_failure.py", 4, "test_broken_report")
+        longrepr = SimpleNamespace(reprcrash=None)
+
+        @property
+        def longreprtext(self) -> str:
+            raise RuntimeError("REPORT_HOOK_SENTINEL")
+
+    sidecar = tmp_path / "pytest-report.json"
+    reporter = dev_gate._PytestFailureReporter(sidecar)
+
+    reporter.pytest_runtest_logreport(BrokenReport())
+    reporter.pytest_sessionfinish(None, 1)
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["complete"] is True
+    assert "REPORT_HOOK_SENTINEL" in payload["reporter_error"]
+
+
+def test_pytest_reporter_unprintable_hook_error_is_fail_soft(tmp_path: Path) -> None:
+    class UnprintableError(RuntimeError):
+        def __str__(self) -> str:
+            raise RuntimeError("BROKEN_EXCEPTION_STRING")
+
+    class BrokenReport:
+        failed = True
+        nodeid = "tests/test_failure.py::test_unprintable_error"
+        when = "call"
+        location = ("tests/test_failure.py", 4, "test_unprintable_error")
+        longrepr = SimpleNamespace(reprcrash=None)
+
+        @property
+        def longreprtext(self) -> str:
+            raise UnprintableError()
+
+    sidecar = tmp_path / "pytest-report.json"
+    reporter = dev_gate._PytestFailureReporter(sidecar)
+
+    reporter.pytest_runtest_logreport(BrokenReport())
+    reporter.pytest_sessionfinish(None, 1)
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["reporter_error"] == "unprintable reporter failure"
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (
+            _pytest_sidecar_payload(
+                status="unavailable",
+                complete=False,
+                observed_failures=0,
+                first_failure=None,
+                reporter_error="RuntimeError: load failed",
+            ),
+            "reporter unavailable",
+        ),
+        (
+            _pytest_sidecar_payload(
+                status="error",
+                observed_failures=0,
+                first_failure=None,
+                reporter_error="RuntimeError: hook failed",
+            ),
+            "reporter error",
+        ),
+        (
+            _pytest_sidecar_payload(
+                status="no_failure",
+                observed_failures=0,
+                first_failure=None,
+            ),
+            "reporter produced no failure",
+        ),
+        (
+            _pytest_sidecar_payload(
+                status="running",
+                complete=False,
+                observed_failures=0,
+                first_failure=None,
+            ),
+            "reporter incomplete",
+        ),
+    ],
+)
+def test_pytest_unusable_sidecar_falls_back_without_changing_vote(
+    tmp_path: Path, payload: dict, reason: str
+) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text("TAIL_SENTINEL\n", encoding="utf-8")
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable,),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=dev_gate._log_tail(log_path),
+        log_path=log_path,
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert outcome.status == "fail"
+    assert len(diagnostic) <= dev_gate.DIAGNOSTIC_LIMIT
+    assert reason in diagnostic
+    assert "TAIL_SENTINEL" in diagnostic
+
+
+def test_pytest_oversized_sidecar_falls_back(tmp_path: Path) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text("TAIL_SENTINEL\n", encoding="utf-8")
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_bytes(b"x" * (dev_gate._PYTEST_REPORT_SIDECAR_LIMIT + 1))
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable,),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=dev_gate._log_tail(log_path),
+        log_path=log_path,
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert "sidecar oversized" in diagnostic
+    assert "TAIL_SENTINEL" in diagnostic
+    assert len(diagnostic) <= dev_gate.DIAGNOSTIC_LIMIT
+
+
+def test_pytest_sidecar_reader_never_allocates_beyond_its_bound() -> None:
+    observed: list[int] = []
+
+    class GuardedHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, size: int) -> bytes:
+            observed.append(size)
+            return b"x" * size
+
+    class GuardedPath:
+        @staticmethod
+        def open(_mode: str) -> GuardedHandle:
+            return GuardedHandle()
+
+    report, problem = dev_gate._load_pytest_report(GuardedPath())
+
+    assert report is None
+    assert problem == "sidecar oversized"
+    assert observed == [dev_gate._PYTEST_REPORT_SIDECAR_LIMIT + 1]
+
+
+def test_pytest_sidecar_with_lone_surrogate_uses_serializable_fallback(tmp_path: Path) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text("TAIL_SENTINEL\n", encoding="utf-8")
+    payload = _pytest_sidecar_payload()
+    payload["first_failure"]["nodeid"] = "\ud800"
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable,),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=dev_gate._log_tail(log_path),
+        log_path=log_path,
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert "reason: sidecar invalid" in diagnostic
+    assert "TAIL_SENTINEL" in diagnostic
+    json.dumps({"diagnostic": diagnostic}, ensure_ascii=False).encode("utf-8")
+
+
+def test_pytest_timeout_uses_labelled_tail_when_reporter_cannot_finish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def time_out(argv, **kwargs):
+        kwargs["stdout"].write(("late process output\n" * 300) + "KILL_TAIL_SENTINEL\n")
+        kwargs["stdout"].flush()
+        raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(dev_gate.subprocess, "run", time_out)
+    outcome = dev_gate.run_command(
+        check_id="pytest-source-py314",
+        argv=[sys.executable, "-c", "pass"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=1,
+        logs_dir=tmp_path / "logs",
+    )
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_text(
+        json.dumps(_pytest_sidecar_payload(complete=False)),
+        encoding="utf-8",
+    )
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+
+    assert outcome.status == "timeout"
+    assert outcome.reason_code == "check_timeout"
+    assert "reason: pytest process timeout" in diagnostic
+    assert "timed out after 1s" in diagnostic
+    assert len(diagnostic) <= dev_gate.DIAGNOSTIC_LIMIT
+
+
+def test_pytest_selector_exception_cannot_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text("TAIL_SENTINEL\n", encoding="utf-8")
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable,),
+        returncode=1,
+        duration_ms=1,
+        status="fail",
+        reason_code="check_failed",
+        diagnostic=dev_gate._log_tail(log_path),
+        log_path=log_path,
+    )
+
+    def explode(_path: Path):
+        raise RuntimeError("SELECTOR_SENTINEL")
+
+    monkeypatch.setattr(dev_gate, "_load_pytest_report", explode)
+
+    diagnostic = dev_gate._pytest_diagnostic(outcome, tmp_path / "sidecar.json")
+
+    assert "diagnostic selector error: RuntimeError" in diagnostic
+    assert "TAIL_SENTINEL" in diagnostic
+
+
+def test_successful_pytest_without_failures_keeps_existing_diagnostic(tmp_path: Path) -> None:
+    log_path = tmp_path / "pytest.log"
+    log_path.write_text("7 passed\n", encoding="utf-8")
+    sidecar = tmp_path / "pytest-report.json"
+    sidecar.write_text(
+        json.dumps(
+            _pytest_sidecar_payload(
+                status="no_failure",
+                observed_failures=0,
+                first_failure=None,
+            )
+        ),
+        encoding="utf-8",
+    )
+    outcome = dev_gate.CommandOutcome(
+        argv=(sys.executable,),
+        returncode=0,
+        duration_ms=1,
+        status="pass",
+        reason_code=None,
+        diagnostic="7 passed\n",
+        log_path=log_path,
+    )
+
+    assert dev_gate._pytest_diagnostic(outcome, sidecar) == outcome.diagnostic
+
+
+def test_isolated_pytest_launcher_captures_verbose_assertion(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_verbose_failure.py"
+    test_file.write_text(
+        "def test_verbose_failure():\n"
+        "    left = [f'item-{index}' for index in range(180)]\n"
+        "    right = list(left)\n"
+        "    left[90] = 'LEFT_ASSERTION_SENTINEL'\n"
+        "    right[90] = 'RIGHT_ASSERTION_SENTINEL'\n"
+        "    assert left == right\n",
+        encoding="utf-8",
+    )
+    shadow = tmp_path / "pytest.py"
+    shadow_sentinel = tmp_path / "shadow-ran.txt"
+    shadow.write_text(
+        f"from pathlib import Path\nPath({str(shadow_sentinel)!r}).write_text('shadow')\n",
+        encoding="utf-8",
+    )
+    sidecar = tmp_path / "pytest-report.json"
+    child_temp = tmp_path / "child-temp"
+    child_temp.mkdir()
+    argv = dev_gate.isolated_pytest_argv(
+        sys.executable,
+        sidecar,
+        "-q",
+        "-o",
+        "verbosity_assertions=2",
+        "-p",
+        "no:cacheprovider",
+        "--basetemp",
+        str((tmp_path / "pytest-temp").resolve()),
+        str(test_file.resolve()),
+        candidate_import_root=(Path.cwd() / "src").resolve(),
+    )
+
+    outcome = dev_gate.run_command(
+        check_id="pytest-reporter-integration",
+        argv=argv,
+        cwd=tmp_path,
+        env=dev_gate._base_env(child_temp),
+        timeout_seconds=30,
+        logs_dir=tmp_path / "logs",
+    )
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    captured = json.dumps(payload["first_failure"], ensure_ascii=False)
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+    assert outcome.status == "fail"
+    assert payload["status"] == "captured"
+    assert payload["complete"] is True
+    assert payload["first_failure"]["nodeid"].endswith("test_verbose_failure")
+    assert "test_verbose_failure.py:6" in payload["first_failure"]["frame"]
+    assert "LEFT_ASSERTION_SENTINEL" in captured
+    assert "RIGHT_ASSERTION_SENTINEL" in captured
+    assert "LEFT_ASSERTION_SENTINEL" in diagnostic
+    assert "RIGHT_ASSERTION_SENTINEL" in diagnostic
+    assert len(diagnostic) <= dev_gate.DIAGNOSTIC_LIMIT
+    assert not shadow_sentinel.exists()
+
+
+@pytest.mark.parametrize("failure_mode", ["import", "construct", "unprintable"])
+def test_isolated_pytest_reporter_unavailable_does_not_vote(
+    tmp_path: Path, failure_mode: str
+) -> None:
+    candidate = tmp_path / "candidate"
+    package = candidate / "agenttalk"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    if failure_mode == "import":
+        module_text = "raise RuntimeError('REPORTER_IMPORT_SENTINEL')\n"
+    elif failure_mode == "construct":
+        module_text = (
+            "class _PytestFailureReporter:\n"
+            "    def __init__(self, path):\n"
+            "        raise RuntimeError('REPORTER_CONSTRUCT_SENTINEL')\n"
+        )
+    else:
+        module_text = (
+            "class UnprintableError(RuntimeError):\n"
+            "    def __str__(self):\n"
+            "        raise RuntimeError('BROKEN_EXCEPTION_STRING')\n"
+            "raise UnprintableError()\n"
+        )
+    (package / "dev_gate.py").write_text(module_text, encoding="utf-8")
+    test_file = tmp_path / "test_pass.py"
+    test_file.write_text("def test_pass():\n    assert True\n", encoding="utf-8")
+    sidecar = tmp_path / "pytest-report.json"
+    child_temp = tmp_path / "child-temp"
+    child_temp.mkdir()
+    argv = dev_gate.isolated_pytest_argv(
+        sys.executable,
+        sidecar,
+        "-q",
+        "-p",
+        "no:cacheprovider",
+        "--basetemp",
+        str((tmp_path / "pytest-temp").resolve()),
+        str(test_file.resolve()),
+        candidate_import_root=candidate,
+    )
+
+    outcome = dev_gate.run_command(
+        check_id=f"pytest-reporter-{failure_mode}",
+        argv=argv,
+        cwd=tmp_path,
+        env=dev_gate._base_env(child_temp),
+        timeout_seconds=30,
+        logs_dir=tmp_path / "logs",
+    )
+    diagnostic = dev_gate._pytest_diagnostic(outcome, sidecar)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+
+    assert outcome.status == "pass"
+    assert outcome.returncode == 0
+    assert payload["status"] == "unavailable"
+    assert failure_mode in payload["reporter_error"].casefold()
+    assert "source: terminal-tail fallback" in diagnostic
+    assert "reason: reporter unavailable" in diagnostic
+    assert len(diagnostic) <= dev_gate.DIAGNOSTIC_LIMIT
 
 
 def test_isolated_source_launcher_prefers_committed_export_over_candidate_cwd(


### PR DESCRIPTION
When a gate leg goes red, the CI log says only `exit code 1`. The stored evidence was meant to carry the rest, and it kept the **last** two thousand characters of output — which on a real failure is the tail of a diff.

Measured on a real 12,718-character failure: the retained text contained none of the test name, the assertion, the failing frame, the FAILURES header, or the FAILED token.

**The bound was not the defect. Keeping the wrong end was.** The two-thousand-character ceiling is unchanged on purpose — raising it would have hidden the real problem behind more text.

## What changed

- A gate-owned reporter captures the first failure the moment pytest reports it. The record is now a labelled envelope in priority order: which test, which phase, which frame, the assertion, how many further failures were omitted, an excerpt — and only then whatever tail still fits.
- A second, independent loss is closed: quiet mode elides comparison detail *before* our code sees it, so the selector was choosing from data pytest had already discarded. Assertion verbosity is now on.
- The aggregate no longer replaces a leg's diagnosis with "CI leg blocked".

## Fail-safe

This machinery lives inside the gate, so it must never be the reason a gate fails. A missing, empty, corrupt, oversized, incomplete or killed capture falls back to the previous bounded tail **and labels the record as having done so** — a diagnostic that fails silently would make an unhelpful artifact look like a deliberate one.

## Deferred deliberately

Publishing the same summary as build annotations (which outlive artifacts by a wide margin) adds an output channel with a text-injection surface, and gets its own review rather than riding along here.

## Evidence

Failing-first: the new selector regressions failed before the capture existed. 114 gate tests pass. Two independent reviews approved; both found real issues that were fixed first — a lost right-hand assertion value, exception objects whose string form could alter pytest's verdict, oversized sidecars fully allocated before rejection, and lone-surrogate data that could break JSON serialisation.

Authored by codex-agenttalk-developer-8, couriered by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)