### PR TITLE
fix(#181): require live owner proof before automatic archive retires an agent

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from agenttalk import __version__
 from agenttalk import avatars as avatar_mod
+from agenttalk import store as store_mod
 from agenttalk.display import render
 from agenttalk.store import (
     COMPOSING_INTENT_STALE_SECONDS,
@@ -12472,6 +12473,13 @@ def cmd_supervise(args: argparse.Namespace) -> int:
                              "--request-id <rid>, --terminal-state <state>, and "
                              "--state-file <path>\n")
             return 2
+        if not args.instance_token or args.pid is None:
+            sys.stderr.write(
+                "agenttalk supervise --archive-launch-request: "
+                "supervisor_owner_identity_missing: need the live supervisor "
+                "--instance-token and --pid identity\n"
+            )
+            return 3
         completion = None
         if args.completion_json:
             try:
@@ -12484,21 +12492,75 @@ def cmd_supervise(args: argparse.Namespace) -> int:
                 sys.stderr.write("agenttalk supervise --archive-launch-request: "
                                  "--completion-json must be a JSON object\n")
                 return 2
-        state = _read_state()
         try:
-            sup.archive_ephemeral_request(
-                store, state, args.request_id,
-                terminal_state=args.terminal_state,
-                reason=args.reason or "",
-                now_epoch=(args.now if args.now is not None else time.time()),
-                completion=completion,
-            )
-        except eph.EphemeralError as exc:
+            with store._supervisor_lifecycle_lock():
+                marker_status, instance, marker_detail = (
+                    store._read_supervisor_instance_strict_locked()
+                )
+                if marker_status != "valid" or not isinstance(instance, dict):
+                    sys.stderr.write(
+                        "agenttalk supervise --archive-launch-request: "
+                        f"supervisor_owner_marker_{marker_status}: "
+                        f"{marker_detail or 'no live supervisor identity is available'}\n"
+                    )
+                    return 3
+                if (
+                    instance.get("token") != args.instance_token
+                    or instance.get("pid") != args.pid
+                    or instance.get("pid_start") != args.pid_start
+                ):
+                    sys.stderr.write(
+                        "agenttalk supervise --archive-launch-request: "
+                        "supervisor_owner_identity_mismatch: supplied "
+                        "token/pid/start did not match the supervisor marker\n"
+                    )
+                    return 3
+                owner_status = store_mod._probe_owner_identity(
+                    instance.get("pid"),
+                    instance.get("pid_start"),
+                )
+                refusal_code = {
+                    store_mod.OWNER_IDENTITY_DEAD: "supervisor_owner_dead",
+                    store_mod.OWNER_IDENTITY_PID_REUSED: "supervisor_owner_pid_reused",
+                    store_mod.OWNER_IDENTITY_UNKNOWN: "supervisor_owner_liveness_unknown",
+                    store_mod.OWNER_IDENTITY_START_UNMATCHABLE:
+                        "supervisor_owner_start_unmatchable",
+                }.get(owner_status)
+                if owner_status != store_mod.OWNER_IDENTITY_ALIVE:
+                    sys.stderr.write(
+                        "agenttalk supervise --archive-launch-request: "
+                        f"{refusal_code or 'supervisor_owner_probe_invalid'}: "
+                        "positive supervisor owner identity was not proven\n"
+                    )
+                    return 3
+                marker_status_after, instance_after, marker_detail_after = (
+                    store._read_supervisor_instance_strict_locked()
+                )
+                if marker_status_after != "valid" or instance_after != instance:
+                    detail_suffix = (
+                        f": {marker_detail_after}" if marker_detail_after else ""
+                    )
+                    sys.stderr.write(
+                        "agenttalk supervise --archive-launch-request: "
+                        "supervisor_owner_marker_changed: marker changed during "
+                        f"owner verification{detail_suffix}\n"
+                    )
+                    return 3
+                state = _read_state()
+                sup.archive_ephemeral_request(
+                    store, state, args.request_id,
+                    terminal_state=args.terminal_state,
+                    reason=args.reason or "",
+                    now_epoch=(args.now if args.now is not None else time.time()),
+                    completion=completion,
+                )
+                _write_state(state)
+        except (OSError, ValueError, eph.EphemeralError,
+                sup.SupervisorPersistenceError) as exc:
             sys.stderr.write(
                 f"agenttalk supervise --archive-launch-request: {exc}\n"
             )
             return 3
-        _write_state(state)
         return 0
 
     if args.launch_barrier:
@@ -14470,10 +14532,11 @@ def build_parser() -> argparse.ArgumentParser:
                                      "(default 'bypassPermissions').")
     psup.add_argument("--cli", help="(--record-launch) the agent CLI ('claude'|'codex').")
     psup.add_argument("--pid", type=int, default=None,
-                      help="(--record-launch) the LAUNCHER process id from Start-Process.")
+                      help="Launcher pid for record-launch, or live supervisor pid "
+                           "for instance-bound mutations.")
     psup.add_argument("--pid-start", dest="pid_start", default=None,
-                      help="(--record-launch) the launcher process start-time "
-                           "(anti-pid-reuse guard).")
+                      help="Process start-time for record-launch or live-supervisor "
+                           "anti-pid-reuse checks.")
     psup.add_argument("--pwsh",
                       help="Absolute pwsh.exe path (terminal explicit selection; no fallback).")
     psup.add_argument("--artifact-boundary", dest="artifact_boundary",
@@ -14520,7 +14583,8 @@ def build_parser() -> argparse.ArgumentParser:
              "recording the attended reset.",
     )
     psup.add_argument("--instance-token", dest="instance_token",
-                      help="(--release-instance/--drain-intents) supervisor instance token.")
+                      help="(--release-instance/--drain-intents/"
+                           "--archive-launch-request) supervisor instance token.")
     psup.add_argument("--max-per-tick", dest="max_per_tick", type=int, default=25,
                       help="(--drain-intents) maximum queued intents to claim in one tick.")
     psup.add_argument("--session-id", dest="session_id",

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -7268,11 +7268,14 @@ def _probe_owner_identity(pid: object, recorded_pid_start: object = None) -> str
 
     Unlike :func:`_owner_identity_gone`, this is an admission probe: UNKNOWN
     and an unobservable start identity are refusals, not alternate ways to
-    spell "alive".  An omitted start token retains compatibility, but only
-    after the operating system has positively confirmed the pid is running.
+    spell "alive".  An omitted start token is unmatchable without probing the
+    pid: liveness alone cannot prove that the running process is the recorded
+    owner rather than a later process that reused its number.
     """
     if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
         return OWNER_IDENTITY_UNKNOWN
+    if recorded_pid_start is None:
+        return OWNER_IDENTITY_START_UNMATCHABLE
     try:
         liveness = _process_liveness(pid)
     except Exception:  # noqa: BLE001 - a failed authority probe is UNKNOWN
@@ -7281,8 +7284,6 @@ def _probe_owner_identity(pid: object, recorded_pid_start: object = None) -> str
         return OWNER_IDENTITY_DEAD
     if liveness != PROC_ALIVE:
         return OWNER_IDENTITY_UNKNOWN
-    if recorded_pid_start is None:
-        return OWNER_IDENTITY_ALIVE
     try:
         observed_pid_start = _process_start_token(pid)
     except Exception:  # noqa: BLE001 - live pid, but its start cannot be matched

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -7038,6 +7038,11 @@ def _process_alive(pid: int) -> bool:
 PROC_ALIVE = "alive"
 PROC_DEAD = "dead"
 PROC_UNKNOWN = "unknown"
+OWNER_IDENTITY_ALIVE = PROC_ALIVE
+OWNER_IDENTITY_DEAD = PROC_DEAD
+OWNER_IDENTITY_PID_REUSED = "pid_reused"
+OWNER_IDENTITY_UNKNOWN = PROC_UNKNOWN
+OWNER_IDENTITY_START_UNMATCHABLE = "start_unmatchable"
 # Anti-reuse compares should be tight: widening this risks false-matching a
 # recycled pid. Ambiguous tokens already degrade to None and are not stealable.
 _START_TOKEN_COMPARE_TOLERANCE_SECONDS = 0.001
@@ -7247,6 +7252,50 @@ def _start_tokens_same(left: object, right: object) -> bool:
         abs(left_dt.timestamp() - right_dt.timestamp())
         <= _START_TOKEN_COMPARE_TOLERANCE_SECONDS
     )
+
+
+def _start_token_kind(value: object) -> str | None:
+    """Return the comparable start-token family, or None when unusable."""
+    if not isinstance(value, str) or not value:
+        return None
+    if re.fullmatch(r"linux:[0-9a-fA-F-]{32,64}:[0-9]+", value):
+        return "linux"
+    return "iso" if _parse_start_token(value) is not None else None
+
+
+def _probe_owner_identity(pid: object, recorded_pid_start: object = None) -> str:
+    """Positively classify whether ``pid`` is the recorded live process.
+
+    Unlike :func:`_owner_identity_gone`, this is an admission probe: UNKNOWN
+    and an unobservable start identity are refusals, not alternate ways to
+    spell "alive".  An omitted start token retains compatibility, but only
+    after the operating system has positively confirmed the pid is running.
+    """
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return OWNER_IDENTITY_UNKNOWN
+    try:
+        liveness = _process_liveness(pid)
+    except Exception:  # noqa: BLE001 - a failed authority probe is UNKNOWN
+        return OWNER_IDENTITY_UNKNOWN
+    if liveness == PROC_DEAD:
+        return OWNER_IDENTITY_DEAD
+    if liveness != PROC_ALIVE:
+        return OWNER_IDENTITY_UNKNOWN
+    if recorded_pid_start is None:
+        return OWNER_IDENTITY_ALIVE
+    try:
+        observed_pid_start = _process_start_token(pid)
+    except Exception:  # noqa: BLE001 - live pid, but its start cannot be matched
+        return OWNER_IDENTITY_START_UNMATCHABLE
+    recorded_kind = _start_token_kind(recorded_pid_start)
+    observed_kind = _start_token_kind(observed_pid_start)
+    if recorded_kind is None or observed_kind != recorded_kind:
+        return OWNER_IDENTITY_START_UNMATCHABLE
+    if _start_tokens_same(observed_pid_start, recorded_pid_start):
+        return OWNER_IDENTITY_ALIVE
+    if _start_tokens_differ(observed_pid_start, recorded_pid_start):
+        return OWNER_IDENTITY_PID_REUSED
+    return OWNER_IDENTITY_START_UNMATCHABLE
 
 
 def _windows_owner_identity_gone_exact(

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -9731,6 +9731,10 @@ function Supervisor-IdentityArgs {
   if ($SupervisorStart) { $argv += @('--pid-start', $SupervisorStart) }
   return $argv
 }
+function Supervisor-InstanceIdentityArgs {
+  if (-not $InstanceToken) { throw 'supervisor instance token is unavailable' }
+  return @('--instance-token', $InstanceToken) + (Supervisor-IdentityArgs)
+}
 $InstanceToken = $null
 if (Test-Path $KillSwitchPath) { exit 3 }
 if ($DryRun) {
@@ -12198,7 +12202,8 @@ $pollNum = 0
         if (-not (Assert-ActionsEnabled ("archive-launch-request {0}" -f $rid))) { continue }
         $archiveArgs = @('--root', $Root, 'supervise', '--archive-launch-request',
           '--request-id', $rid, '--terminal-state', 'denied', '--reason', $p.reason,
-          '--state-file', $StatePath, '--now', [string]$now)
+          '--state-file', $StatePath, '--now', [string]$now) +
+          (Supervisor-InstanceIdentityArgs)
         if (-not (Invoke-CheckedSupervisorMutation ("archive-launch-request {0}" -f $rid) $archiveArgs)) {
           Wait-ForNextPoll $cfg
           continue supervisorPoll
@@ -12221,7 +12226,8 @@ $pollNum = 0
             if (-not (Assert-ActionsEnabled ("archive-launch-request {0}" -f $rid))) { continue }
             $archiveArgs = @('--root', $Root, 'supervise', '--archive-launch-request',
               '--request-id', $rid, '--terminal-state', 'failed', '--reason',
-              'codex home seed failed', '--state-file', $StatePath, '--now', [string]$now)
+              'codex home seed failed', '--state-file', $StatePath, '--now', [string]$now) +
+              (Supervisor-InstanceIdentityArgs)
             if (-not (Invoke-CheckedSupervisorMutation ("archive-launch-request {0}" -f $rid) $archiveArgs)) {
               Wait-ForNextPoll $cfg
               continue supervisorPoll
@@ -12257,7 +12263,8 @@ $pollNum = 0
           if (-not (Assert-ActionsEnabled ("archive-launch-request {0}" -f $rid))) { continue }
           $archiveArgs = @('--root', $Root, 'supervise', '--archive-launch-request',
             '--request-id', $rid, '--terminal-state', 'failed', '--reason',
-            'launch returned no pid', '--state-file', $StatePath, '--now', [string]$now)
+            'launch returned no pid', '--state-file', $StatePath, '--now', [string]$now) +
+            (Supervisor-InstanceIdentityArgs)
           if (-not (Invoke-CheckedSupervisorMutation ("archive-launch-request {0}" -f $rid) $archiveArgs)) {
             Wait-ForNextPoll $cfg
             continue supervisorPoll
@@ -12324,7 +12331,7 @@ $pollNum = 0
         $archiveArgs = @('--root', $Root, 'supervise', '--archive-launch-request',
           '--request-id', $rid, '--terminal-state', $p.terminal_state, '--reason', $p.reason,
           '--completion-json', $completionJson, '--state-file', $StatePath,
-          '--now', [string]$now)
+          '--now', [string]$now) + (Supervisor-InstanceIdentityArgs)
         if (-not (Invoke-CheckedSupervisorMutation ("archive-launch-request {0}" -f $rid) $archiveArgs)) {
           Wait-ForNextPoll $cfg
           continue supervisorPoll

--- a/tests/test_ephemeral_reviewers.py
+++ b/tests/test_ephemeral_reviewers.py
@@ -710,7 +710,7 @@ def _claim_current_supervisor(store: Store) -> dict:
 @pytest.mark.parametrize(
     ("pid", "liveness", "recorded_start", "expected"),
     [
-        (123, store_mod.PROC_ALIVE, None, "alive"),
+        (123, store_mod.PROC_ALIVE, None, "start_unmatchable"),
         (123, store_mod.PROC_DEAD, "2026-08-08T00:00:00Z", "dead"),
         (123, store_mod.PROC_UNKNOWN, "2026-08-08T00:00:00Z", "unknown"),
         (True, store_mod.PROC_ALIVE, None, "unknown"),
@@ -732,6 +732,17 @@ def test_probe_owner_identity_short_circuits_without_start_observation(
     monkeypatch.setattr(store_mod, "_process_start_token", unexpected_start_observation)
 
     assert store_mod._probe_owner_identity(pid, recorded_start) == expected
+
+
+def test_probe_owner_identity_refuses_missing_start_without_pid_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_pid_probe(_pid: object) -> str:
+        raise AssertionError("an unbound pid cannot prove recorded process identity")
+
+    monkeypatch.setattr(store_mod, "_process_liveness", unexpected_pid_probe)
+
+    assert store_mod._probe_owner_identity(123, None) == "start_unmatchable"
 
 
 @pytest.mark.parametrize(
@@ -784,7 +795,7 @@ def test_probe_owner_identity_classifies_start_identity(
 
 def test_probe_owner_identity_confirms_current_process() -> None:
     pid = os.getpid()
-    assert store_mod._probe_owner_identity(pid, None) == "alive"
+    assert store_mod._probe_owner_identity(pid, None) == "start_unmatchable"
     observed_start = store_mod._process_start_token(pid)
     if observed_start is not None:
         assert store_mod._probe_owner_identity(pid, observed_start) == "alive"
@@ -819,7 +830,10 @@ def test_cli_archive_launch_request_with_stale_pid_refuses_without_effects(
         tmp_path,
         request_id=request_id,
     )
-    instance = s.claim_supervisor_instance(pid=2 ** 31 - 1, pid_start=None)
+    instance = s.claim_supervisor_instance(
+        pid=2 ** 31 - 1,
+        pid_start="2026-08-08T00:00:00Z",
+    )
     assert instance is not None
     before = _archive_effect_bytes(s, request_id, state_path)
 
@@ -870,32 +884,55 @@ def test_cli_archive_launch_request_preserves_completion_evidence(tmp_path: Path
     assert agent in s.retired_agents()
 
 
-def test_cli_archive_launch_request_allows_live_owner_without_start_token(
+@pytest.mark.parametrize(
+    ("supplied_start", "reason_code"),
+    [
+        (None, "supervisor_owner_start_unmatchable"),
+        ("2026-08-08T00:00:00Z", "supervisor_owner_identity_mismatch"),
+    ],
+    ids=["omitted-start", "forged-start"],
+)
+def test_cli_archive_launch_request_refuses_reused_live_pid_with_null_start_marker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    supplied_start: str | None,
+    reason_code: str,
 ) -> None:
-    request_id = "lr-cli-live-no-start"
+    request_id = f"lr-cli-null-start-{supplied_start is not None}"
     s, agent, state_path = _prepared_cli_archive_fixture(
         tmp_path,
         request_id=request_id,
     )
-    instance = s.claim_supervisor_instance(pid=os.getpid(), pid_start=None)
+    reused_pid = os.getpid()
+    assert store_mod._process_liveness(reused_pid) == store_mod.PROC_ALIVE
+    instance = s.claim_supervisor_instance(pid=reused_pid, pid_start=None)
     assert instance is not None
+    supplied = {**instance, "pid_start": supplied_start}
+    before = _archive_effect_bytes(s, request_id, state_path)
 
-    def unexpected_start_observation(_pid: object) -> str:
-        raise AssertionError("an absent recorded start must use pid liveness only")
+    def unexpected_pid_probe(_pid: object) -> str:
+        raise AssertionError("a null-start identity must refuse before probing the pid")
 
-    monkeypatch.setattr(store_mod, "_process_start_token", unexpected_start_observation)
+    monkeypatch.setattr(store_mod, "_process_liveness", unexpected_pid_probe)
 
-    assert cli.main(_archive_cli_args(
+    def unexpected_state_load(_path: Path) -> dict:
+        raise AssertionError("null-start refusal must precede state load")
+
+    monkeypatch.setattr(sup, "load_supervisor_state", unexpected_state_load)
+
+    rc = cli.main(_archive_cli_args(
         tmp_path,
         request_id,
         state_path,
-        instance=instance,
-    )) == 0
-    assert not (s.launch_requests_dir / f"{request_id}.json").exists()
-    assert (s.launch_requests_archive_dir / f"{request_id}.json").exists()
-    assert agent in s.retired_agents()
+        instance=supplied,
+    ))
+
+    assert rc == 3
+    assert reason_code in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
 
 
 @pytest.mark.parametrize("identity_break", ["token", "pid", "pid_start"])

--- a/tests/test_ephemeral_reviewers.py
+++ b/tests/test_ephemeral_reviewers.py
@@ -606,25 +606,244 @@ def test_prepare_inactive_lane_worktree_archives_denied_after_claim(tmp_path: Pa
     assert "not active" in archived["reason"]
 
 
-def test_cli_archive_launch_request_preserves_completion_evidence(tmp_path: Path) -> None:
+def _prepared_cli_archive_fixture(
+    tmp_path: Path,
+    *,
+    request_id: str = "lr-cli-archive",
+    lane_id: str | None = None,
+) -> tuple[Store, str, Path]:
     s = _store(tmp_path)
-    agent = "adversary-lr-cli-archive"
-    marker = _marker("lr-cli-archive", state=eph.STATE_REQUESTED, agent=agent)
+    marker = _marker(request_id)
     s.write_launch_request(marker)
-    s.add_agent(agent, role="reviewer", groups=["ephemeral-reviewers"])
-    state_path = tmp_path / "supervisor-state.json"
-    state_path.write_text(json.dumps({
-        "ephemeral_reviewers": {
-            "active": {
-                "lr-cli-archive": {
-                    "request_id": "lr-cli-archive",
-                    "agent": agent,
-                    "requested_by": "lead",
-                    "phase": eph.STATE_LAUNCHED,
-                }
-            }
-        }
-    }), encoding="utf-8")
+    state: dict = {}
+    spec = sup.prepare_launch_request(
+        s,
+        state,
+        _cfg(),
+        request_id,
+        now_epoch=NOW,
+    )
+    if lane_id is not None:
+        marker = s.read_launch_request(request_id)
+        assert marker is not None
+        scope = {**marker["scope"], "lane_id": lane_id}
+        assert s.update_launch_request(
+            request_id,
+            {"lane_id": lane_id, "scope": scope},
+        ) is not None
+    state_path = s.dir / "supervisor-state.json"
+    sup.save_supervisor_state(state_path, state)
+    return s, spec["agent"], state_path
+
+
+def _archive_cli_args(
+    root: Path,
+    request_id: str,
+    state_path: Path,
+    *,
+    instance: dict | None = None,
+    completion: dict | None = None,
+) -> list[str]:
+    args = [
+        "--root", str(root),
+        "supervise",
+        "--archive-launch-request",
+        "--request-id", request_id,
+        "--terminal-state", eph.STATE_COMPLETED,
+        "--reason", "typed review-result status=rejected",
+        "--state-file", str(state_path),
+        "--now", str(NOW + 1),
+    ]
+    if completion is not None:
+        args.extend(["--completion-json", json.dumps(completion)])
+    if instance is not None:
+        args.extend([
+            "--instance-token", instance["token"],
+            "--pid", str(instance["pid"]),
+        ])
+        if instance.get("pid_start") is not None:
+            args.extend(["--pid-start", instance["pid_start"]])
+    return args
+
+
+def _file_bytes(path: Path) -> bytes | None:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def _tree_bytes(path: Path) -> dict[str, bytes]:
+    if not path.exists():
+        return {}
+    return {
+        item.relative_to(path).as_posix(): item.read_bytes()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+def _archive_effect_bytes(
+    store: Store,
+    request_id: str,
+    state_path: Path,
+) -> dict[str, object]:
+    # config.json is both the active roster and the permanent retirement registry.
+    return {
+        "launch_marker": _file_bytes(store.launch_requests_dir / f"{request_id}.json"),
+        "instance_marker": _file_bytes(store.supervisor_instance_path()),
+        "archive": _tree_bytes(store.launch_requests_archive_dir),
+        "config_and_roster": store.config_path.read_bytes(),
+        "state": state_path.read_bytes(),
+    }
+
+
+def _claim_current_supervisor(store: Store) -> dict:
+    instance = store.claim_supervisor_instance(
+        pid=os.getpid(),
+        pid_start=store_mod._process_start_token(os.getpid()),
+    )
+    assert instance is not None
+    return instance
+
+
+@pytest.mark.parametrize(
+    ("pid", "liveness", "recorded_start", "expected"),
+    [
+        (123, store_mod.PROC_ALIVE, None, "alive"),
+        (123, store_mod.PROC_DEAD, "2026-08-08T00:00:00Z", "dead"),
+        (123, store_mod.PROC_UNKNOWN, "2026-08-08T00:00:00Z", "unknown"),
+        (True, store_mod.PROC_ALIVE, None, "unknown"),
+        (0, store_mod.PROC_ALIVE, None, "unknown"),
+    ],
+)
+def test_probe_owner_identity_short_circuits_without_start_observation(
+    monkeypatch: pytest.MonkeyPatch,
+    pid: object,
+    liveness: str,
+    recorded_start: str | None,
+    expected: str,
+) -> None:
+    monkeypatch.setattr(store_mod, "_process_liveness", lambda _pid: liveness)
+
+    def unexpected_start_observation(_pid: object) -> str:
+        raise AssertionError("start observation was not needed")
+
+    monkeypatch.setattr(store_mod, "_process_start_token", unexpected_start_observation)
+
+    assert store_mod._probe_owner_identity(pid, recorded_start) == expected
+
+
+@pytest.mark.parametrize(
+    ("recorded_start", "observed_start", "expected"),
+    [
+        (
+            "2026-08-08T00:00:00.123456Z",
+            "2026-08-08T02:00:00.123456+02:00",
+            "alive",
+        ),
+        (
+            "2026-08-08T00:00:00Z",
+            "2026-08-08T00:00:01Z",
+            "pid_reused",
+        ),
+        (
+            "linux:12345678-1234-1234-1234-123456789abc:123",
+            "linux:12345678-1234-1234-1234-123456789abc:123",
+            "alive",
+        ),
+        (
+            "linux:12345678-1234-1234-1234-123456789abc:123",
+            "linux:12345678-1234-1234-1234-123456789abc:456",
+            "pid_reused",
+        ),
+        ("2026-08-08T00:00:00Z", None, "start_unmatchable"),
+        ("not-a-start", "not-a-start", "start_unmatchable"),
+        (
+            "2026-08-08T00:00:00Z",
+            "linux:12345678-1234-1234-1234-123456789abc:123",
+            "start_unmatchable",
+        ),
+    ],
+)
+def test_probe_owner_identity_classifies_start_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    recorded_start: str,
+    observed_start: str | None,
+    expected: str,
+) -> None:
+    monkeypatch.setattr(
+        store_mod,
+        "_process_liveness",
+        lambda _pid: store_mod.PROC_ALIVE,
+    )
+    monkeypatch.setattr(store_mod, "_process_start_token", lambda _pid: observed_start)
+
+    assert store_mod._probe_owner_identity(123, recorded_start) == expected
+
+
+def test_probe_owner_identity_confirms_current_process() -> None:
+    pid = os.getpid()
+    assert store_mod._probe_owner_identity(pid, None) == "alive"
+    observed_start = store_mod._process_start_token(pid)
+    if observed_start is not None:
+        assert store_mod._probe_owner_identity(pid, observed_start) == "alive"
+
+
+def test_cli_archive_launch_request_without_owner_identity_refuses_without_effects(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    request_id = "lr-cli-no-owner"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    before = _archive_effect_bytes(s, request_id, state_path)
+
+    rc = cli.main(_archive_cli_args(tmp_path, request_id, state_path))
+
+    assert rc == 3
+    assert "supervisor_owner_identity_missing" in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+def test_cli_archive_launch_request_with_stale_pid_refuses_without_effects(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    request_id = "lr-cli-stale-owner"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = s.claim_supervisor_instance(pid=2 ** 31 - 1, pid_start=None)
+    assert instance is not None
+    before = _archive_effect_bytes(s, request_id, state_path)
+
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    ))
+
+    assert rc == 3
+    assert "supervisor_owner_dead" in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+def test_cli_archive_launch_request_preserves_completion_evidence(tmp_path: Path) -> None:
+    request_id = "lr-cli-archive"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
     completion = {
         "status": eph.COMPLETION_REJECTED,
         "terminal": True,
@@ -634,25 +853,277 @@ def test_cli_archive_launch_request_preserves_completion_evidence(tmp_path: Path
         "evidence_only": True,
     }
 
-    rc = cli.main([
-        "--root", str(tmp_path),
-        "supervise",
-        "--archive-launch-request",
-        "--request-id", "lr-cli-archive",
-        "--terminal-state", eph.STATE_COMPLETED,
-        "--reason", "typed review-result status=rejected",
-        "--completion-json", json.dumps(completion),
-        "--state-file", str(state_path),
-        "--now", str(NOW + 1),
-    ])
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+        completion=completion,
+    ))
 
     assert rc == 0
     archived = json.loads(
-        (s.launch_requests_archive_dir / "lr-cli-archive.json").read_text(encoding="utf-8"))
+        (s.launch_requests_archive_dir / f"{request_id}.json").read_text(encoding="utf-8"))
     assert archived["completion"] == completion
     saved_state = json.loads(state_path.read_text(encoding="utf-8"))
-    assert "lr-cli-archive" not in saved_state["ephemeral_reviewers"]["active"]
+    assert request_id not in saved_state["ephemeral_reviewers"]["active"]
     assert agent in s.retired_agents()
+
+
+def test_cli_archive_launch_request_allows_live_owner_without_start_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_id = "lr-cli-live-no-start"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = s.claim_supervisor_instance(pid=os.getpid(), pid_start=None)
+    assert instance is not None
+
+    def unexpected_start_observation(_pid: object) -> str:
+        raise AssertionError("an absent recorded start must use pid liveness only")
+
+    monkeypatch.setattr(store_mod, "_process_start_token", unexpected_start_observation)
+
+    assert cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    )) == 0
+    assert not (s.launch_requests_dir / f"{request_id}.json").exists()
+    assert (s.launch_requests_archive_dir / f"{request_id}.json").exists()
+    assert agent in s.retired_agents()
+
+
+@pytest.mark.parametrize("identity_break", ["token", "pid", "pid_start"])
+def test_cli_archive_launch_request_requires_exact_marker_identity_before_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    identity_break: str,
+) -> None:
+    request_id = f"lr-cli-mismatch-{identity_break.replace('_', '-')}"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
+    supplied = dict(instance)
+    if identity_break == "token":
+        supplied["token"] = "0" * 32
+    elif identity_break == "pid":
+        supplied["pid"] += 1
+    else:
+        supplied["pid_start"] = (
+            None
+            if instance.get("pid_start") is not None
+            else "2026-08-08T00:00:00Z"
+        )
+    before = _archive_effect_bytes(s, request_id, state_path)
+
+    def unexpected_probe(*_args) -> str:
+        raise AssertionError("mismatched marker bytes must refuse before probing")
+
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", unexpected_probe)
+
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=supplied,
+    ))
+
+    assert rc == 3
+    assert "supervisor_owner_identity_mismatch" in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+def test_cli_archive_launch_request_requires_present_instance_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    request_id = "lr-cli-marker-absent"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
+    s.supervisor_instance_path().unlink()
+    before = _archive_effect_bytes(s, request_id, state_path)
+
+    def unexpected_probe(*_args) -> str:
+        raise AssertionError("an absent marker must refuse before probing")
+
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", unexpected_probe)
+
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    ))
+
+    assert rc == 3
+    assert "supervisor_owner_marker_absent" in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+@pytest.mark.parametrize(
+    ("probe_result", "reason_code"),
+    [
+        ("dead", "supervisor_owner_dead"),
+        ("pid_reused", "supervisor_owner_pid_reused"),
+        ("unknown", "supervisor_owner_liveness_unknown"),
+        ("start_unmatchable", "supervisor_owner_start_unmatchable"),
+    ],
+)
+def test_cli_archive_launch_request_owner_probe_refusals_change_no_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    probe_result: str,
+    reason_code: str,
+) -> None:
+    request_id = f"lr-cli-{probe_result.replace('_', '-')}"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
+    before = _archive_effect_bytes(s, request_id, state_path)
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", lambda *_args: probe_result)
+
+    def unexpected_state_load(_path: Path) -> dict:
+        raise AssertionError("owner proof must precede state load")
+
+    monkeypatch.setattr(sup, "load_supervisor_state", unexpected_state_load)
+
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    ))
+
+    assert rc == 3
+    assert reason_code in capsys.readouterr().err
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+def test_cli_archive_launch_request_rereads_instance_after_owner_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    request_id = "lr-cli-marker-swap"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
+    before = _archive_effect_bytes(s, request_id, state_path)
+    replacement = {**instance, "token": "f" * 32}
+    replacement_bytes = json.dumps(replacement, indent=2, ensure_ascii=False).encode("utf-8")
+
+    def swap_marker_then_confirm_alive(*_args) -> str:
+        s.supervisor_instance_path().write_bytes(replacement_bytes)
+        return "alive"
+
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", swap_marker_then_confirm_alive)
+
+    rc = cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    ))
+
+    assert rc == 3
+    assert "supervisor_owner_marker_changed" in capsys.readouterr().err
+    after = _archive_effect_bytes(s, request_id, state_path)
+    assert after["instance_marker"] == replacement_bytes
+    assert {key: value for key, value in after.items() if key != "instance_marker"} == {
+        key: value for key, value in before.items() if key != "instance_marker"
+    }
+    assert agent in s.load_config()["agents"]
+    assert agent not in s.retired_agents()
+
+
+def test_archive_liveness_refusal_preserves_owed_review_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_id = "lr-cli-owed-result"
+    s, agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+    )
+    instance = _claim_current_supervisor(s)
+    before = _archive_effect_bytes(s, request_id, state_path)
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", lambda *_args: "dead")
+
+    assert cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    )) == 3
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+
+    message = s.send(
+        sender=agent,
+        recipient="lead",
+        body="no blocking findings",
+        kind="review-result",
+        meta={"request_id": request_id, "status": "approved"},
+    )
+    result = eph.classify_review_result(
+        s.messages_for("lead"),
+        request_id=request_id,
+        agent=agent,
+        requester="lead",
+    )
+    assert result["message_id"] == message.id
+    assert result["status"] == eph.COMPLETION_APPROVED
+    assert result["terminal"] is True
+
+
+def test_archive_liveness_refusal_preserves_lane_busy_fact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_id = "lr-cli-lane-busy"
+    lane_id = "busy"
+    s, _agent, state_path = _prepared_cli_archive_fixture(
+        tmp_path,
+        request_id=request_id,
+        lane_id=lane_id,
+    )
+    instance = _claim_current_supervisor(s)
+    before = _archive_effect_bytes(s, request_id, state_path)
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", lambda *_args: "unknown")
+
+    assert cli.main(_archive_cli_args(
+        tmp_path,
+        request_id,
+        state_path,
+        instance=instance,
+    )) == 3
+    assert _archive_effect_bytes(s, request_id, state_path) == before
+    assert cli._lane_worktree_idle(s, {
+        "lane_id": lane_id,
+        "worktree_path": str(tmp_path / "lane-worktree"),
+    }) is False
 
 
 def test_archive_failure_retains_ephemeral_active_state(

--- a/tests/test_ephemeral_reviewers.py
+++ b/tests/test_ephemeral_reviewers.py
@@ -851,13 +851,24 @@ def test_cli_archive_launch_request_with_stale_pid_refuses_without_effects(
     assert agent not in s.retired_agents()
 
 
-def test_cli_archive_launch_request_preserves_completion_evidence(tmp_path: Path) -> None:
+def test_cli_archive_launch_request_preserves_completion_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     request_id = "lr-cli-archive"
     s, agent, state_path = _prepared_cli_archive_fixture(
         tmp_path,
         request_id=request_id,
     )
+    # Darwin has no native start locator; this success path requires a strong marker.
+    pid_start = "2026-08-08T00:00:00Z"
+    monkeypatch.setattr(
+        store_mod,
+        "_process_start_token",
+        lambda pid: pid_start if pid == os.getpid() else None,
+    )
     instance = _claim_current_supervisor(s)
+    assert instance["pid_start"] == pid_start
     completion = {
         "status": eph.COMPLETION_REJECTED,
         "terminal": True,

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -28,6 +28,7 @@ from agenttalk import (
     cli,
     ephemeral as eph,
     health as hm,
+    store as store_mod,
     supervisor as sup,
     wrapper_runtime as wrt,
 )
@@ -185,6 +186,26 @@ def test_supervise_drain_intents_manual_claims_and_releases_instance(tmp_path: P
     s.write_intent("send", {"target": "worker", "body": "hello"})
 
     rc = _run(["supervise", "--drain-intents", "--pid", "123", "--pid-start", "start"], tmp_path)
+
+    assert rc == 0
+    assert s.read_supervisor_instance() is None
+    assert s.messages_for("worker")[0].body == "hello"
+
+
+def test_supervise_drain_intents_without_pid_start_keeps_generic_claim_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    s = _team(tmp_path)
+    s.set_role("lead", "lead")
+    s.write_intent("send", {"target": "worker", "body": "hello"})
+
+    def unexpected_archive_probe(*_args: object) -> str:
+        raise AssertionError("generic claim/release must not use archive admission")
+
+    monkeypatch.setattr(store_mod, "_probe_owner_identity", unexpected_archive_probe)
+
+    rc = _run(["supervise", "--drain-intents", "--pid", "123"], tmp_path)
 
     assert rc == 0
     assert s.read_supervisor_instance() is None

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -163,6 +163,8 @@ def test_ps_template_claims_instance_drains_and_releases_under_brake() -> None:
     assert "'supervise', '--release-instance'" in ps
     assert "supervise --launch-barrier" in ps
     assert "'--pid-start', $SupervisorStart" in ps
+    assert "function Supervisor-InstanceIdentityArgs" in ps
+    assert ps.count("(Supervisor-InstanceIdentityArgs)") == 4
     assert "Assert-ActionsEnabled 'drain-intents'" in ps
     assert "finally" in ps
 


### PR DESCRIPTION
## What this fixes

Automatic archive of an ephemeral launch request could retire a **live** agent. It validated the request id, the state file, the terminal label and optional completion evidence — then archived, unlinked the active launch marker, removed active supervisor state and retired the roster identity, **without ever checking that a live owner existed**.

Reproduced against a clean export of `master` with a real live child PID in official supervisor state: archive returned `rc=0`, the claimed process was **still running**, the marker was gone, active state was gone, the identity was retired, and a subsequent send from it failed as a tombstone.

## Severity, stated honestly

- **Current v0.81+ normal operation does not fire this.** The owned-tree evidence gate holds the request active on missing, corrupt, ambiguous or surviving-owner evidence, which defeats the completion race, timeout, crash/restart, duplicate-poll and second-supervisor cases.
- **The current trigger is a direct or replayed internal command** (`supervise --archive-launch-request …`) while the reviewer is live. Plausible during manual troubleshooting or local automation; not a documented ritual.
- **v0.36–v0.80 had a genuinely automatic trigger**: a transient process-table capture failure yielded no kill targets, so the executor skipped the stop and called raw archive with no barrier. Closed by `587e7c1`, first shipped in v0.81.0.

No repository artifact shows an actual field occurrence, so this is **not** a claim that supervisors are spontaneously retiring live agents today.

## What the operator lost when it fired

- An **unmanaged orphan**: the process is not killed and can finish a paid turn while invisible to status, report and attention.
- **Destroyed work** if archive won the race against publication — the store rejects a retired sender, so the typed result and the owed reply are lost.
- The identity cannot be recovered or rebound; a later request gets a different one.
- Lane idleness is derived from the active launch marker and supervisor state. Erasing both can declare a **live** lane-backed reviewer idle, so a later remove can run beneath it.

## The change

One **positive** five-outcome owner probe — `alive`, `dead`, `pid_reused`, `unknown`, `start_unmatchable`. It never inverts `owner_gone`, which deliberately collapses live and unknown so teardown fails safe; reusing it would have reproduced this defect wearing a guard's name. An absent start is `start_unmatchable`: PID liveness alone cannot prove the recorded process identity.

Automatic archive now requires exact identity equality with the strict instance marker, holds the lifecycle lock, positively probes the recorded owner, **strictly rereads the marker to close the probe/swap race**, and only then loads state or performs any effect. Dead, reused, unknown and unmatchable each refuse with a distinct stable code. All four generated PowerShell archive calls carry the claimed identity.

**Attended archive is untouched** — it has the opposite authority contract (supervisor absent, operator-attested) and keeps its passing control.

## The shipped test that certified the bug

`test_cli_archive_launch_request_preserves_completion_evidence` called this with **no identity at all** and asserted `rc=0`, removal and retirement. It has passed every review since 2026-06-27 while pinning the defect as correct. Replacing it is the point of this change, not a side effect: it is now a no-effect refusal plus a live-positive success.

The later `test_cli_archive_launch_request_allows_live_owner_without_start_token` then certified the same defect one level deeper by treating a live numeric PID without a recorded start as owner proof. It is now a full-byte null-start refusal control, alongside a positive public drain control proving the supported generic null-start claim/release path remains intact.

Added byte-for-byte no-effect controls for the launch marker, instance marker, archive tree, config, active roster, retirement registry and supervisor state; plus stale PID, PID reuse, unknown, unmatchable, marker swap, null-start refusal, public null-start drain compatibility, **owed-result publication** and **lane-busy preservation**.

## Residual risk

- This proves the **singleton supervisor owner** is live; it does not independently prove the ephemeral worker is dead. A deliberate replay carrying a genuinely live supervisor's identity still passes. Worker safety remains the kill/teardown barrier.
- The generated supervisor claim is Windows-only today. The probe works with native Linux start tokens and fails closed when no comparable start token exists, but a future POSIX supervisor must canonicalize its start token and needs a real platform test.
Automatic archive still retires the roster identity before publishing and unlinking the archive, and before the later supervisor-state save. That ordering and its partial-effect failure window are pre-existing at base `a8f5f468`, remain unfixed here, and belong to the deferred journal work. This change guarantees byte-identical no-effect behavior only for the new pre-admission refusal paths; a strongly admitted archive can still return `rc=3` after partial effects if archive publication, unlink, or the final state save fails.
- `ruff format --check` wants to reformat the touched baseline files wholesale; that churn was deliberately not introduced here.

Scope: production +138/−18, controls +503/−30.

Authored by codex-agenttalk-developer-8; committed in its own clone and pushed by the operator as courier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
