### PR TITLE
gateway: runtime rebind as a first-class serialized operation (preserves agenttalk's own state; candidate code is trusted)

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -8708,6 +8708,11 @@ def cmd_gateway(args: argparse.Namespace) -> int:
             result = service.stop_task(store.root, timeout_seconds=args.timeout)
         elif action == "reconfigure":
             result = service.reconfigure_endpoint(store.root)
+        elif action == "runtime-rebind":
+            result = service.rebind_runtime(
+                store.root,
+                litellm_executable=args.litellm_executable,
+            )
         elif action == "run":
             return service.run_service(store.root)
         elif action == "reconcile":
@@ -15067,6 +15072,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     gw_reconfigure.set_defaults(func=cmd_gateway)
+    gw_runtime_rebind = gwsub.add_parser(
+        "runtime-rebind",
+        help=(
+            "Verify and rebind the LiteLLM runtime "
+            "(ledger/token/task-preserving; the gateway must be stopped first)."
+        ),
+    )
+    gw_runtime_rebind.add_argument("--litellm-executable", required=True)
+    gw_runtime_rebind.set_defaults(func=cmd_gateway)
     gw_reconcile = gwsub.add_parser(
         "reconcile",
         help="Explicitly resolve one uncertain provider attempt.",

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -8741,6 +8741,12 @@ def cmd_gateway(args: argparse.Namespace) -> int:
             result = service.gateway_status(store.root)
         else:
             raise ValueError(f"unsupported gateway action {action!r}")
+    except (
+        service.GatewayLifecycleUnknown,
+        service.LiteLLMRuntimeProbeUnknown,
+    ) as exc:
+        sys.stderr.write(f"agenttalk gateway {action}: {exc}\n")
+        return 3
     except (gateway.GatewayError, OSError, ValueError) as exc:
         sys.stderr.write(f"agenttalk gateway {action}: {exc}\n")
         return 2
@@ -15075,11 +15081,21 @@ def build_parser() -> argparse.ArgumentParser:
     gw_runtime_rebind = gwsub.add_parser(
         "runtime-rebind",
         help=(
-            "Verify and rebind the LiteLLM runtime "
-            "(ledger/token/task-preserving; the gateway must be stopped first)."
+            "Probe and rebind a trusted LiteLLM runtime. The unsandboxed candidate "
+            "has your filesystem authority; exit 3 means unknown and exit 2 means refusal."
+        ),
+        description=(
+            "Probe and rebind a trusted LiteLLM runtime while the gateway is stopped. "
+            "The candidate runs unsandboxed with your filesystem authority. AgentTalk "
+            "rewrites only the manifest runtime field. Exit 3 is a retryable unknown "
+            "probe outcome; exit 2 is a determinate refusal."
         ),
     )
-    gw_runtime_rebind.add_argument("--litellm-executable", required=True)
+    gw_runtime_rebind.add_argument(
+        "--litellm-executable",
+        required=True,
+        help="Path to a trusted LiteLLM launcher to execute for the capability probe.",
+    )
     gw_runtime_rebind.set_defaults(func=cmd_gateway)
     gw_reconcile = gwsub.add_parser(
         "reconcile",

--- a/src/agenttalk/lifecycle_lock.py
+++ b/src/agenttalk/lifecycle_lock.py
@@ -30,6 +30,10 @@ _LOCK_OFFSET = _ARTIFACT_BYTES - 1
 _METADATA_BYTES = _LOCK_OFFSET
 _MAX_WINDOWS_PID = (1 << 32) - 1
 _MAX_FILETIME = (1 << 64) - 1
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_SYNCHRONIZE = 0x00100000
+_WAIT_OBJECT_0 = 0
+_WAIT_TIMEOUT = 0x00000102
 _SAFE_LABEL = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}")
 _HEX_GENERATION = re.compile(r"[0-9a-f]{32}")
 _UTC_TIMESTAMP = re.compile(
@@ -218,11 +222,8 @@ def _windows_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
         kernel32.OpenProcess.restype = wintypes.HANDLE
         kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
-        kernel32.GetExitCodeProcess.argtypes = [
-            wintypes.HANDLE,
-            ctypes.POINTER(wintypes.DWORD),
-        ]
+        kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
         kernel32.GetProcessTimes.restype = wintypes.BOOL
         kernel32.GetProcessTimes.argtypes = [
             wintypes.HANDLE,
@@ -233,15 +234,19 @@ def _windows_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]
         ]
         kernel32.CloseHandle.restype = wintypes.BOOL
         kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
-        handle = kernel32.OpenProcess(0x1000, False, pid)
+        handle = kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION | _SYNCHRONIZE,
+            False,
+            pid,
+        )
         if not handle:
             return ("dead", None) if ctypes.get_last_error() == 87 else ("unknown", None)
         try:
-            exit_code = wintypes.DWORD()
-            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-                return "unknown", None
-            if exit_code.value != 259:
+            wait_result = kernel32.WaitForSingleObject(handle, 0)
+            if wait_result == _WAIT_OBJECT_0:
                 return "dead", None
+            if wait_result != _WAIT_TIMEOUT:
+                return "unknown", None
             creation = wintypes.FILETIME()
             exit_time = wintypes.FILETIME()
             kernel = wintypes.FILETIME()
@@ -258,6 +263,13 @@ def _windows_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]
                 creation.dwLowDateTime
             )
             if ticks <= 0:
+                return "unknown", None
+            # Close the exit-after-observation race before reporting a live
+            # exact identity. A signaled process can never become live again.
+            wait_result = kernel32.WaitForSingleObject(handle, 0)
+            if wait_result == _WAIT_OBJECT_0:
+                return "dead", None
+            if wait_result != _WAIT_TIMEOUT:
                 return "unknown", None
             return "alive", ProcessIdentity("win32-filetime-v1", str(ticks))
         finally:
@@ -356,7 +368,7 @@ def _darwin_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]:
         received = libproc.proc_pidinfo(
             pid,
             3,  # PROC_PIDTBSDINFO
-            0,
+            1,  # Ask XNU to include a matching zombie in the BSD-info lookup.
             ctypes.byref(info),
             ctypes.sizeof(info),
         )

--- a/src/agenttalk/lifecycle_lock.py
+++ b/src/agenttalk/lifecycle_lock.py
@@ -1,0 +1,780 @@
+"""Exact-process, cross-process lifecycle serialization.
+
+The persistent artifact is never replaced.  Its last byte is reserved for the
+kernel lock; bounded JSON authority remains readable while another process owns
+that byte.  A crashed holder leaves an exact PID/start record behind, and a new
+holder may replace it only after proving that exact process dead or PID-reused.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import errno
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import threading
+import time
+from typing import Iterator
+import uuid
+
+
+_SCHEMA_VERSION = 1
+_ARTIFACT_BYTES = 4096
+_LOCK_OFFSET = _ARTIFACT_BYTES - 1
+_METADATA_BYTES = _LOCK_OFFSET
+_MAX_WINDOWS_PID = (1 << 32) - 1
+_MAX_FILETIME = (1 << 64) - 1
+_SAFE_LABEL = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}")
+_HEX_GENERATION = re.compile(r"[0-9a-f]{32}")
+_UTC_TIMESTAMP = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z"
+)
+_BOOT_ID = re.compile(r"[0-9A-Fa-f-]{32,64}")
+_LOCAL_LOCKS_GUARD = threading.Lock()
+_LOCAL_LOCKS: dict[str, threading.Lock] = {}
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """One exact OS process-start identity."""
+
+    scheme: str
+    value: str
+
+
+class LifecycleLockError(RuntimeError):
+    """Base class for typed lifecycle-lock refusals."""
+
+    retryable = True
+
+
+class LifecycleLockContended(LifecycleLockError):
+    """A known exact holder retained the lifecycle authority."""
+
+    reason_code = "lifecycle_lock_contended"
+
+    def __init__(self, record: dict) -> None:
+        identity = record["process_identity"]
+        self.holder_pid = record["pid"]
+        self.holder_identity = dict(identity)
+        self.holder_operation = record["operation"]
+        self.holder_since = record["acquired_at"]
+        super().__init__(
+            f"{self.reason_code}: held by pid {self.holder_pid} "
+            f"({identity['scheme']}:{identity['value']}) for "
+            f"{self.holder_operation} since {self.holder_since}; wait for that "
+            "operation to finish, then retry"
+        )
+
+
+class LifecycleLockUnknown(LifecycleLockError):
+    """The lifecycle authority could not be classified safely."""
+
+    reason_code = "lifecycle_lock_unknown"
+
+    def __init__(self, path: Path, detail: str) -> None:
+        self.path = path
+        self.detail = detail
+        super().__init__(
+            f"{self.reason_code}: {detail}; confirm no lifecycle operation is "
+            f"running, then remove {path} and retry"
+        )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _released_record(authority: str) -> dict:
+    return {
+        "authority": authority,
+        "schema_version": _SCHEMA_VERSION,
+        "state": "released",
+    }
+
+
+def _identity_value_valid(identity: object) -> bool:
+    if not isinstance(identity, dict) or set(identity) != {"scheme", "value"}:
+        return False
+    scheme = identity.get("scheme")
+    value = identity.get("value")
+    if scheme == "win32-filetime-v1":
+        if not isinstance(value, str) or re.fullmatch(r"[1-9][0-9]{0,19}", value) is None:
+            return False
+        return int(value) <= _MAX_FILETIME
+    if scheme == "linux-proc-start-v1":
+        if not isinstance(value, str) or ":" not in value:
+            return False
+        boot_id, start_ticks = value.rsplit(":", 1)
+        return _BOOT_ID.fullmatch(boot_id) is not None and bool(
+            re.fullmatch(r"[1-9][0-9]*", start_ticks)
+        )
+    if scheme == "darwin-proc-bsdinfo-v1":
+        if not isinstance(value, str) or ":" not in value:
+            return False
+        seconds, microseconds = value.split(":", 1)
+        return bool(re.fullmatch(r"[1-9][0-9]*", seconds)) and bool(
+            re.fullmatch(r"(?:0|[1-9][0-9]{0,5})", microseconds)
+        ) and int(microseconds) <= 999_999
+    return False
+
+
+def _validate_record(value: object, authority: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("lock metadata is not an object")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != _SCHEMA_VERSION:
+        raise ValueError("lock metadata schema is corrupt")
+    if value.get("authority") != authority:
+        raise ValueError("lock metadata authority is corrupt")
+    state = value.get("state")
+    if state == "released":
+        if set(value) != {"authority", "schema_version", "state"}:
+            raise ValueError("released lock metadata is corrupt")
+        return value
+    expected = {
+        "authority",
+        "schema_version",
+        "state",
+        "generation",
+        "pid",
+        "process_identity",
+        "operation",
+        "acquired_at",
+    }
+    if state != "held" or set(value) != expected:
+        raise ValueError("held lock metadata is corrupt")
+    generation = value.get("generation")
+    pid = value.get("pid")
+    operation = value.get("operation")
+    acquired_at = value.get("acquired_at")
+    if not isinstance(generation, str) or _HEX_GENERATION.fullmatch(generation) is None:
+        raise ValueError("lock generation is corrupt")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        raise ValueError("lock holder pid is corrupt")
+    if os.name == "nt" and pid > _MAX_WINDOWS_PID:
+        raise ValueError("lock holder pid is corrupt")
+    if not _identity_value_valid(value.get("process_identity")):
+        raise ValueError("lock holder process identity is corrupt")
+    if not isinstance(operation, str) or _SAFE_LABEL.fullmatch(operation) is None:
+        raise ValueError("lock operation is corrupt")
+    if not isinstance(acquired_at, str) or _UTC_TIMESTAMP.fullmatch(acquired_at) is None:
+        raise ValueError("lock acquisition time is corrupt")
+    try:
+        datetime.fromisoformat(acquired_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("lock acquisition time is corrupt") from exc
+    return value
+
+
+def _decode_record(raw: bytes, authority: str) -> dict:
+    if len(raw) != _METADATA_BYTES:
+        raise ValueError("lock metadata length is corrupt")
+    payload, separator, padding = raw.partition(b"\0")
+    if not separator or any(padding):
+        raise ValueError("lock metadata padding is corrupt")
+    if not payload.endswith(b"\n"):
+        raise ValueError("lock metadata terminator is corrupt")
+
+    def strict_object(pairs: list[tuple[str, object]]) -> dict:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("lock metadata contains a duplicate key")
+            value[key] = item
+        return value
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=strict_object,
+        )
+    except (UnicodeDecodeError, ValueError, RecursionError) as exc:
+        raise ValueError("lock metadata JSON is corrupt") from exc
+    return _validate_record(value, authority)
+
+
+def _encode_record(value: dict) -> bytes:
+    payload = (
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    if len(payload) >= _METADATA_BYTES:
+        raise ValueError("lock metadata exceeds its fixed bound")
+    return payload + b"\0" * (_METADATA_BYTES - len(payload))
+
+
+def _windows_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]:
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.GetExitCodeProcess.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        kernel32.GetProcessTimes.restype = wintypes.BOOL
+        kernel32.GetProcessTimes.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+        ]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return ("dead", None) if ctypes.get_last_error() == 87 else ("unknown", None)
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return "unknown", None
+            if exit_code.value != 259:
+                return "dead", None
+            creation = wintypes.FILETIME()
+            exit_time = wintypes.FILETIME()
+            kernel = wintypes.FILETIME()
+            user = wintypes.FILETIME()
+            if not kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            ):
+                return "unknown", None
+            ticks = (int(creation.dwHighDateTime) << 32) | int(
+                creation.dwLowDateTime
+            )
+            if ticks <= 0:
+                return "unknown", None
+            return "alive", ProcessIdentity("win32-filetime-v1", str(ticks))
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:  # noqa: BLE001 - authority ambiguity is UNKNOWN
+        return "unknown", None
+
+
+def _linux_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return "dead", None
+    except PermissionError:
+        pass
+    except (OSError, OverflowError):
+        return "unknown", None
+    try:
+        text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        closing = text.rfind(")")
+        if closing < 0:
+            return "unknown", None
+        fields = text[closing + 2 :].split()
+        if len(fields) < 20 or re.fullmatch(r"[1-9][0-9]*", fields[19]) is None:
+            return "unknown", None
+        if fields[0] == "Z":
+            return "dead", None
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+            encoding="utf-8"
+        ).strip()
+        if _BOOT_ID.fullmatch(boot_id) is None:
+            return "unknown", None
+        return "alive", ProcessIdentity(
+            "linux-proc-start-v1", f"{boot_id}:{fields[19]}"
+        )
+    except FileNotFoundError:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return "dead", None
+        except (OSError, OverflowError):
+            pass
+        return "unknown", None
+    except (OSError, UnicodeError):
+        return "unknown", None
+
+
+def _darwin_process_observation(pid: int) -> tuple[str, ProcessIdentity | None]:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return "dead", None
+    except PermissionError:
+        pass
+    except (OSError, OverflowError):
+        return "unknown", None
+    try:
+        import ctypes
+
+        class ProcBSDInfo(ctypes.Structure):
+            _fields_ = [
+                ("pbi_flags", ctypes.c_uint32),
+                ("pbi_status", ctypes.c_uint32),
+                ("pbi_xstatus", ctypes.c_uint32),
+                ("pbi_pid", ctypes.c_uint32),
+                ("pbi_ppid", ctypes.c_uint32),
+                ("pbi_uid", ctypes.c_uint32),
+                ("pbi_gid", ctypes.c_uint32),
+                ("pbi_ruid", ctypes.c_uint32),
+                ("pbi_rgid", ctypes.c_uint32),
+                ("pbi_svuid", ctypes.c_uint32),
+                ("pbi_svgid", ctypes.c_uint32),
+                ("rfu_1", ctypes.c_uint32),
+                ("pbi_comm", ctypes.c_char * 16),
+                ("pbi_name", ctypes.c_char * 32),
+                ("pbi_nfiles", ctypes.c_uint32),
+                ("pbi_pgid", ctypes.c_uint32),
+                ("pbi_pjobc", ctypes.c_uint32),
+                ("e_tdev", ctypes.c_uint32),
+                ("e_tpgid", ctypes.c_uint32),
+                ("pbi_nice", ctypes.c_int32),
+                ("pbi_start_tvsec", ctypes.c_uint64),
+                ("pbi_start_tvusec", ctypes.c_uint64),
+            ]
+
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        libproc.proc_pidinfo.restype = ctypes.c_int
+        libproc.proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        info = ProcBSDInfo()
+        received = libproc.proc_pidinfo(
+            pid,
+            3,  # PROC_PIDTBSDINFO
+            0,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        )
+        if received != ctypes.sizeof(info):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return "dead", None
+            except (OSError, OverflowError):
+                pass
+            return "unknown", None
+        if info.pbi_pid != pid:
+            return "unknown", None
+        if info.pbi_status == 5:  # SZOMB
+            return "dead", None
+        if info.pbi_status not in {1, 2, 3, 4}:  # SIDL, SRUN, SSLEEP, SSTOP
+            return "unknown", None
+        seconds = int(info.pbi_start_tvsec)
+        microseconds = int(info.pbi_start_tvusec)
+        if seconds <= 0 or not 0 <= microseconds <= 999_999:
+            return "unknown", None
+        return "alive", ProcessIdentity(
+            "darwin-proc-bsdinfo-v1", f"{seconds}:{microseconds}"
+        )
+    except Exception:  # noqa: BLE001 - authority ambiguity is UNKNOWN
+        return "unknown", None
+
+
+def _process_observation(pid: object) -> tuple[str, ProcessIdentity | None]:
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return "unknown", None
+    if os.name == "nt":
+        if pid > _MAX_WINDOWS_PID:
+            return "unknown", None
+        return _windows_process_observation(pid)
+    if sys_platform_linux():
+        return _linux_process_observation(pid)
+    if sys_platform_darwin():
+        return _darwin_process_observation(pid)
+    return "unknown", None
+
+
+def sys_platform_linux() -> bool:
+    """Keep the unsupported-platform refusal explicit and easy to test."""
+    return sys.platform.startswith("linux")
+
+
+def sys_platform_darwin() -> bool:
+    """Return whether the native ``proc_pidinfo`` identity source is available."""
+    return sys.platform == "darwin"
+
+
+def process_identity(pid: int) -> ProcessIdentity | None:
+    """Return an exact live-process identity, or ``None`` on any ambiguity."""
+    status, identity = _process_observation(pid)
+    return identity if status == "alive" else None
+
+
+def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _is_reparse(value: os.stat_result) -> bool:
+    return bool(getattr(value, "st_file_attributes", 0) & 0x400)
+
+
+def _validate_parent(path: Path) -> None:
+    try:
+        value = os.lstat(path)
+    except OSError as exc:
+        raise ValueError(f"lock parent is unavailable: {exc}") from exc
+    if not stat.S_ISDIR(value.st_mode) or stat.S_ISLNK(value.st_mode) or _is_reparse(value):
+        raise ValueError("lock parent must be a plain directory")
+
+
+def _validate_artifact_stat(value: os.stat_result) -> None:
+    if (
+        not stat.S_ISREG(value.st_mode)
+        or stat.S_ISLNK(value.st_mode)
+        or _is_reparse(value)
+        or value.st_nlink != 1
+    ):
+        raise ValueError("lock artifact must be a plain single-link regular file")
+
+
+def _local_lock(path: Path) -> threading.Lock:
+    key = os.path.normcase(os.path.abspath(path))
+    with _LOCAL_LOCKS_GUARD:
+        return _LOCAL_LOCKS.setdefault(key, threading.Lock())
+
+
+def _try_os_lock(fd: int) -> bool:
+    os.lseek(fd, _LOCK_OFFSET, os.SEEK_SET)
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                return False
+            raise
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock_os(fd: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(fd, _LOCK_OFFSET, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+class CrossProcessLifecycleLock:
+    """One bounded, exact-owner lifecycle lock over a stable artifact."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        authority: str,
+        timeout_seconds: float = 10.0,
+        poll_seconds: float = 0.05,
+    ) -> None:
+        if _SAFE_LABEL.fullmatch(authority) is None:
+            raise ValueError("lifecycle lock authority is invalid")
+        if timeout_seconds < 0 or poll_seconds <= 0:
+            raise ValueError("lifecycle lock timing bounds are invalid")
+        self.path = Path(os.path.abspath(path))
+        self.authority = authority
+        self.timeout_seconds = float(timeout_seconds)
+        self.poll_seconds = float(poll_seconds)
+
+    def _unknown(self, detail: str) -> LifecycleLockUnknown:
+        return LifecycleLockUnknown(self.path, detail)
+
+    def _open_artifact(self) -> tuple[int, bool, os.stat_result]:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            _validate_parent(self.path.parent)
+        except (OSError, ValueError) as exc:
+            raise self._unknown(str(exc)) from exc
+        flags = os.O_RDWR | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        created = False
+        fd = -1
+        try:
+            fd = os.open(self.path, flags | nofollow | os.O_CREAT | os.O_EXCL, 0o600)
+            created = True
+            os.ftruncate(fd, _ARTIFACT_BYTES)
+            os.fsync(fd)
+        except FileExistsError:
+            try:
+                before = os.lstat(self.path)
+                _validate_artifact_stat(before)
+                fd = os.open(self.path, flags | nofollow)
+            except (OSError, ValueError) as exc:
+                raise self._unknown(str(exc)) from exc
+        except OSError as exc:
+            if fd >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            raise self._unknown(f"lock artifact could not be created: {exc}") from exc
+        try:
+            opened = os.fstat(fd)
+            current = os.lstat(self.path)
+            _validate_artifact_stat(opened)
+            _validate_artifact_stat(current)
+            if not _same_file(opened, current):
+                raise ValueError("lock artifact pathname changed during open")
+            return fd, created, opened
+        except (OSError, ValueError) as exc:
+            os.close(fd)
+            raise self._unknown(str(exc)) from exc
+
+    def _recheck_artifact(self, opened: os.stat_result) -> None:
+        try:
+            current = os.lstat(self.path)
+            _validate_parent(self.path.parent)
+            _validate_artifact_stat(current)
+            if not _same_file(opened, current):
+                raise ValueError("lock artifact pathname changed while held")
+            if current.st_size != _ARTIFACT_BYTES:
+                raise ValueError("lock artifact length is corrupt")
+        except (OSError, ValueError) as exc:
+            raise self._unknown(str(exc)) from exc
+
+    def _read_record_fd(self, fd: int) -> dict:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            raw = bytearray()
+            while len(raw) < _METADATA_BYTES:
+                chunk = os.read(fd, _METADATA_BYTES - len(raw))
+                if not chunk:
+                    break
+                raw.extend(chunk)
+            return _decode_record(bytes(raw), self.authority)
+        except (OSError, ValueError) as exc:
+            raise self._unknown(str(exc)) from exc
+
+    def _read_record_path(self) -> dict:
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        try:
+            before = os.lstat(self.path)
+            _validate_artifact_stat(before)
+            fd = os.open(self.path, flags | nofollow)
+            try:
+                opened = os.fstat(fd)
+                _validate_artifact_stat(opened)
+                if not _same_file(before, opened) or opened.st_size != _ARTIFACT_BYTES:
+                    raise ValueError("lock artifact changed during observation")
+                os.lseek(fd, 0, os.SEEK_SET)
+                raw = bytearray()
+                while len(raw) < _METADATA_BYTES:
+                    chunk = os.read(fd, _METADATA_BYTES - len(raw))
+                    if not chunk:
+                        break
+                    raw.extend(chunk)
+            finally:
+                os.close(fd)
+            return _decode_record(bytes(raw), self.authority)
+        except (OSError, ValueError) as exc:
+            raise self._unknown(f"lock metadata is corrupt or unreadable: {exc}") from exc
+
+    def _write_record_fd(self, fd: int, opened: os.stat_result, value: dict) -> None:
+        self._recheck_artifact(opened)
+        try:
+            raw = _encode_record(value)
+            os.lseek(fd, 0, os.SEEK_SET)
+            written = 0
+            while written < len(raw):
+                count = os.write(fd, raw[written:])
+                if count <= 0:
+                    raise OSError("lock metadata write made no progress")
+                written += count
+            os.fsync(fd)
+        except (OSError, ValueError) as exc:
+            raise self._unknown(f"lock metadata write failed: {exc}") from exc
+        self._recheck_artifact(opened)
+
+    def _held_record(self, operation: str, identity: ProcessIdentity) -> dict:
+        return {
+            "authority": self.authority,
+            "schema_version": _SCHEMA_VERSION,
+            "state": "held",
+            "generation": uuid.uuid4().hex,
+            "pid": os.getpid(),
+            "process_identity": {
+                "scheme": identity.scheme,
+                "value": identity.value,
+            },
+            "operation": operation,
+            "acquired_at": _utc_now(),
+        }
+
+    def _classify_recorded_owner(self, record: dict) -> str:
+        status, observed = _process_observation(record["pid"])
+        if status == "dead":
+            return "gone"
+        if status != "alive" or observed is None:
+            return "unknown"
+        recorded = record["process_identity"]
+        return (
+            "same"
+            if observed.scheme == recorded["scheme"] and observed.value == recorded["value"]
+            else "reused"
+        )
+
+    def _raise_wait_outcome(self, record: dict | None, problem: str | None) -> None:
+        if record is not None and record.get("state") == "held":
+            classification = self._classify_recorded_owner(record)
+            if classification == "same":
+                raise LifecycleLockContended(record)
+            if classification in {"gone", "reused"}:
+                raise self._unknown(
+                    "the OS lock remained occupied after its recorded exact holder was gone"
+                )
+            raise self._unknown("the recorded holder identity could not be observed exactly")
+        if problem:
+            raise self._unknown(problem)
+        raise self._unknown("the OS lock is held without valid held-owner metadata")
+
+    @contextlib.contextmanager
+    def hold(self, operation: str) -> Iterator[dict]:
+        """Acquire, identify, and durably release one lifecycle operation."""
+        if _SAFE_LABEL.fullmatch(operation) is None:
+            raise ValueError("lifecycle lock operation is invalid")
+        self_identity = process_identity(os.getpid())
+        if self_identity is None:
+            raise self._unknown("the caller process identity could not be observed exactly")
+        deadline = time.monotonic() + self.timeout_seconds
+        local = _local_lock(self.path)
+        if not local.acquire(timeout=max(0.0, deadline - time.monotonic())):
+            try:
+                record = self._read_record_path()
+            except LifecycleLockUnknown as exc:
+                self._raise_wait_outcome(None, exc.detail)
+            self._raise_wait_outcome(record, None)
+        fd = -1
+        os_locked = False
+        claim: dict | None = None
+        try:
+            fd, created, opened = self._open_artifact()
+            last_record: dict | None = None
+            last_problem: str | None = None
+            while True:
+                if not os_locked:
+                    try:
+                        os_locked = _try_os_lock(fd)
+                    except OSError as exc:
+                        raise self._unknown(
+                            f"kernel lock acquisition failed: {exc}"
+                        ) from exc
+                if os_locked:
+                    try:
+                        self._recheck_artifact(opened)
+                        if created:
+                            self._write_record_fd(
+                                fd, opened, _released_record(self.authority)
+                            )
+                            created = False
+                        record = self._read_record_fd(fd)
+                    except LifecycleLockUnknown as exc:
+                        last_problem = exc.detail
+                        try:
+                            _unlock_os(fd)
+                        except OSError as unlock_exc:
+                            raise self._unknown(
+                                f"kernel lock release failed: {unlock_exc}"
+                            ) from unlock_exc
+                        os_locked = False
+                        if time.monotonic() >= deadline:
+                            raise self._unknown(last_problem) from exc
+                        time.sleep(
+                            min(self.poll_seconds, max(0.0, deadline - time.monotonic()))
+                        )
+                        continue
+                    if record["state"] == "held":
+                        classification = self._classify_recorded_owner(record)
+                        if classification == "same":
+                            raise self._unknown(
+                                "the kernel lock was free while its exact recorded holder was alive"
+                            )
+                        if classification == "unknown":
+                            raise self._unknown(
+                                "the abandoned holder identity could not be observed exactly"
+                            )
+                    claim = self._held_record(operation, self_identity)
+                    self._write_record_fd(fd, opened, claim)
+                    break
+                try:
+                    last_record = self._read_record_path()
+                    last_problem = None
+                except LifecycleLockUnknown as exc:
+                    last_record = None
+                    last_problem = exc.detail
+                if time.monotonic() >= deadline:
+                    # One final kernel attempt closes the release-at-deadline race.
+                    try:
+                        os_locked = _try_os_lock(fd)
+                    except OSError as exc:
+                        raise self._unknown(f"kernel lock acquisition failed: {exc}") from exc
+                    if os_locked:
+                        continue
+                    try:
+                        last_record = self._read_record_path()
+                        last_problem = None
+                    except LifecycleLockUnknown as exc:
+                        last_record = None
+                        last_problem = exc.detail
+                    self._raise_wait_outcome(last_record, last_problem)
+                time.sleep(
+                    min(self.poll_seconds, max(0.0, deadline - time.monotonic()))
+                )
+            try:
+                yield dict(claim)
+            finally:
+                release_error: BaseException | None = None
+                try:
+                    self._recheck_artifact(opened)
+                    current = self._read_record_fd(fd)
+                    if (
+                        current.get("state") != "held"
+                        or current.get("generation") != claim["generation"]
+                    ):
+                        raise self._unknown(
+                            "lock authority changed before its holder could release it"
+                        )
+                    self._write_record_fd(fd, opened, _released_record(self.authority))
+                except BaseException as exc:  # noqa: BLE001 - release must still unlock
+                    release_error = exc
+                try:
+                    if os_locked:
+                        _unlock_os(fd)
+                        os_locked = False
+                except OSError as exc:
+                    release_error = release_error or self._unknown(
+                        f"kernel lock release failed: {exc}"
+                    )
+                if release_error is not None:
+                    raise release_error
+        finally:
+            if os_locked and fd >= 0:
+                with contextlib.suppress(OSError):
+                    _unlock_os(fd)
+            if fd >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            local.release()

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -10,6 +10,8 @@ import json
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+import re
+import signal
 import socket
 import subprocess  # nosec B404 - fixed schtasks/LiteLLM argv lists; shell is never used
 import sys
@@ -42,6 +44,12 @@ from .ovh_gateway import (
     write_secret_file,
 )
 from .ovh_gateway_front import CONFIG_ERROR_CODE, PUBLIC_ROUTE, FrontConfig, GatewayFront
+from .lifecycle_lock import (
+    CrossProcessLifecycleLock,
+    LifecycleLockContended,
+    LifecycleLockUnknown,
+)
+from .powershell_host import _attach_kill_on_close_job
 from .redaction import redact_diagnostic_text
 
 
@@ -59,6 +67,8 @@ DEFAULT_API_BASE = "https://qwen-3-5-397b.endpoints.kepler.ai.cloud.ovh.net/api/
 STOP_TIMEOUT_SECONDS = 30.0
 LITELLM_READINESS_TIMEOUT_SECONDS = 120.0
 LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS = 120.0
+LITELLM_RUNTIME_PROBE_OUTPUT_MAX_BYTES = 512
+GATEWAY_LIFECYCLE_LOCK_TIMEOUT_SECONDS = 10.0
 LITELLM_LOG_MAX_BYTES = 1024 * 1024
 LITELLM_LOG_BACKUP_COUNT = 2
 LITELLM_LOG_RECORD_MAX_BYTES = 64 * 1024
@@ -66,6 +76,64 @@ MAX_TASK_RESTARTS = 3
 TASK_RESTART_INTERVAL = "PT1M"
 TASK_PREFIX = "agenttalk-qwen-gateway"
 _TASK_NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+_LITELLM_VERSION_LINE = re.compile(
+    rb"LiteLLM: Current Version = [0-9A-Za-z][0-9A-Za-z.!+_-]{0,127}"
+)
+_RUNTIME_PROBE_BOOTSTRAP = """import subprocess
+import sys
+
+if sys.stdin.buffer.read(1) != b"1":
+    raise SystemExit(125)
+result = subprocess.run(sys.argv[1:], stdin=subprocess.DEVNULL, check=False)
+raise SystemExit(result.returncode)
+"""
+
+
+class LiteLLMRuntimeProbeError(GatewayConfigError):
+    """Typed candidate-probe refusal for programmatic callers."""
+
+    reason_code = "litellm_runtime_probe_error"
+    retryable = False
+
+    def __init__(self, message: str) -> None:
+        super().__init__(f"{self.reason_code}: {message}")
+
+
+class LiteLLMRuntimeProbeFailed(LiteLLMRuntimeProbeError):
+    reason_code = "litellm_runtime_probe_failed"
+
+
+class LiteLLMRuntimeProbeUnknown(LiteLLMRuntimeProbeError):
+    reason_code = "litellm_runtime_probe_unknown"
+    retryable = True
+
+
+class _RuntimeProbeInfrastructureError(OSError):
+    """The probe could not establish or clean up its observation boundary."""
+
+
+class GatewayLifecycleLockError(GatewayConfigError):
+    """Typed gateway adapter for the generic lifecycle authority."""
+
+    retryable = True
+
+
+class GatewayLifecycleContended(GatewayLifecycleLockError):
+    reason_code = "gateway_lifecycle_contended"
+
+    def __init__(self, cause: LifecycleLockContended) -> None:
+        self.holder_pid = cause.holder_pid
+        self.holder_identity = dict(cause.holder_identity)
+        self.holder_operation = cause.holder_operation
+        self.holder_since = cause.holder_since
+        super().__init__(f"{self.reason_code}: {cause}")
+
+
+class GatewayLifecycleUnknown(GatewayLifecycleLockError):
+    reason_code = "gateway_lifecycle_unknown"
+
+    def __init__(self, cause: LifecycleLockUnknown) -> None:
+        super().__init__(f"{self.reason_code}: {cause}")
 
 
 @dataclass(frozen=True)
@@ -368,7 +436,14 @@ class TaskCommands:
 
 
 class RuntimeProbeCommands:
-    """Narrow injectable wrapper around the selected LiteLLM launcher."""
+    """Run one bounded candidate probe inside an owned process tree."""
+
+    def __init__(self, *, timeout_seconds: float | None = None) -> None:
+        self.timeout_seconds = (
+            LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS
+            if timeout_seconds is None
+            else max(0.0, float(timeout_seconds))
+        )
 
     def run(
         self,
@@ -376,18 +451,142 @@ class RuntimeProbeCommands:
         *,
         cwd: str,
         env: dict[str, str],
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(  # nosec B603  # noqa: S603
-            argv,
-            cwd=cwd,
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            check=False,
-            timeout=LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS,
-        )
+    ) -> subprocess.CompletedProcess[bytes]:
+        # The trusted bootstrap waits on stdin until containment is attached.
+        # Only then can it spawn the operator-selected candidate, eliminating
+        # the direct-Popen race where a fast shim creates an escaped child
+        # before AssignProcessToJobObject runs.
+        bootstrap_argv = [sys.executable, "-c", _RUNTIME_PROBE_BOOTSTRAP, *argv]
+        popen_kwargs: dict[str, object] = {
+            "cwd": cwd,
+            "env": env,
+            "stdin": subprocess.PIPE,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.DEVNULL,
+            "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        }
+        if os.name != "nt":
+            popen_kwargs["start_new_session"] = True
+        try:
+            process = subprocess.Popen(  # nosec B603  # noqa: S603
+                bootstrap_argv,
+                **popen_kwargs,
+            )
+        except OSError as exc:
+            raise _RuntimeProbeInfrastructureError(
+                f"probe bootstrap could not start: {exc}"
+            ) from exc
+        if process.stdin is None or process.stdout is None:
+            with contextlib.suppress(OSError):
+                process.kill()
+            raise _RuntimeProbeInfrastructureError(
+                "probe bootstrap pipes are unavailable"
+            )
+
+        def close_job() -> None:
+            return None
+        output = bytearray()
+        output_overflow = threading.Event()
+        reader_errors: list[OSError] = []
+
+        def drain_stdout() -> None:
+            try:
+                while chunk := process.stdout.read(4096):
+                    remaining = (
+                        LITELLM_RUNTIME_PROBE_OUTPUT_MAX_BYTES + 1 - len(output)
+                    )
+                    if remaining > 0:
+                        output.extend(chunk[:remaining])
+                    if len(output) > LITELLM_RUNTIME_PROBE_OUTPUT_MAX_BYTES:
+                        output_overflow.set()
+            except OSError as exc:
+                reader_errors.append(exc)
+
+        reader: threading.Thread | None = None
+        returncode: int | None = None
+        timed_out = False
+        infrastructure_error: BaseException | None = None
+        try:
+            try:
+                _, close_job = _attach_kill_on_close_job(process)
+            except OSError as exc:
+                infrastructure_error = _RuntimeProbeInfrastructureError(
+                    f"probe process containment failed: {exc}"
+                )
+            if infrastructure_error is None:
+                reader = threading.Thread(
+                    target=drain_stdout,
+                    daemon=True,
+                    name="agenttalk-litellm-probe-output",
+                )
+                reader.start()
+                try:
+                    process.stdin.write(b"1")
+                    process.stdin.close()
+                except (OSError, ValueError) as exc:
+                    infrastructure_error = _RuntimeProbeInfrastructureError(
+                        f"probe bootstrap gate failed: {exc}"
+                    )
+            if infrastructure_error is None:
+                deadline = time.monotonic() + self.timeout_seconds
+                while returncode is None and not output_overflow.is_set():
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        timed_out = True
+                        break
+                    try:
+                        returncode = process.wait(timeout=min(0.05, remaining))
+                    except subprocess.TimeoutExpired:
+                        continue
+        finally:
+            with contextlib.suppress(OSError, ValueError):
+                process.stdin.close()
+            try:
+                close_job()
+            except OSError as exc:
+                infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
+                    f"probe process containment release failed: {exc}"
+                )
+            if os.name != "nt":
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                except OSError as exc:
+                    infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
+                        f"probe process-group teardown failed: {exc}"
+                    )
+            if process.poll() is None:
+                with contextlib.suppress(OSError):
+                    process.kill()
+            try:
+                process.wait(timeout=5.0)
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
+                    f"probe process reap failed: {exc}"
+                )
+            if reader is not None:
+                reader.join(timeout=5.0)
+                if reader.is_alive():
+                    infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
+                        "probe output drain did not terminate"
+                    )
+            with contextlib.suppress(OSError):
+                process.stdout.close()
+
+        if infrastructure_error is not None:
+            raise infrastructure_error
+        if reader_errors:
+            raise _RuntimeProbeInfrastructureError(
+                f"probe output capture failed: {reader_errors[0]}"
+            ) from reader_errors[0]
+        if timed_out:
+            raise subprocess.TimeoutExpired(argv, self.timeout_seconds)
+        if output_overflow.is_set():
+            raise ValueError("LiteLLM entry-point probe output exceeded the limit")
+        if returncode is None:
+            raise _RuntimeProbeInfrastructureError("probe result is unavailable")
+        return subprocess.CompletedProcess(argv, returncode, stdout=bytes(output))
 
 
 def install_task(
@@ -427,6 +626,23 @@ def install_task(
     return {"installed": True, "changed": True, **asdict(identity)}
 
 
+@contextlib.contextmanager
+def _gateway_lifecycle_lock(root: Path, operation: str):
+    """Adapt the generic exact-owner lock to gateway refusal vocabulary."""
+    lock = CrossProcessLifecycleLock(
+        gateway_state_dir(root) / "lifecycle.lock",
+        authority="agenttalk-gateway-lifecycle-v1",
+        timeout_seconds=GATEWAY_LIFECYCLE_LOCK_TIMEOUT_SECONDS,
+    )
+    try:
+        with lock.hold(operation):
+            yield
+    except LifecycleLockContended as exc:
+        raise GatewayLifecycleContended(exc) from exc
+    except LifecycleLockUnknown as exc:
+        raise GatewayLifecycleUnknown(exc) from exc
+
+
 def initialize_install(
     root: str | os.PathLike[str],
     *,
@@ -440,6 +656,31 @@ def initialize_install(
 ) -> dict:
     """One-time state setup. It intentionally does not activate a task or key."""
     root = canonical_project_root(root)
+    root.mkdir(parents=True, exist_ok=True)
+    with _gateway_lifecycle_lock(root, "initialize"):
+        return _initialize_install_locked(
+            root,
+            litellm_executable=litellm_executable,
+            opening_micro_eur=opening_micro_eur,
+            opening_evidence=opening_evidence,
+            api_base=api_base,
+            ledger=ledger,
+            front_token_path=front_token_path,
+            internal_token_path=internal_token_path,
+        )
+
+
+def _initialize_install_locked(
+    root: Path,
+    *,
+    litellm_executable: str | os.PathLike[str],
+    opening_micro_eur: int,
+    opening_evidence: str,
+    api_base: str,
+    ledger: SpendLedger | None,
+    front_token_path: Path | None,
+    internal_token_path: Path | None,
+) -> dict:
     if api_base != DEFAULT_API_BASE:
         raise GatewayConfigError("gateway install requires the pinned OVH API base")
     config_path = litellm_config_path(root)
@@ -515,6 +756,11 @@ def reconfigure_endpoint(root: str | os.PathLike[str]) -> dict:
     new endpoint takes effect on the next ``start``.
     """
     root = canonical_project_root(root)
+    with _gateway_lifecycle_lock(root, "reconfigure"):
+        return _reconfigure_endpoint_locked(root)
+
+
+def _reconfigure_endpoint_locked(root: Path) -> dict:
     config_path = litellm_config_path(root)
     manifest_path = install_manifest_path(root)
     missing = [p.name for p in (config_path, manifest_path) if not p.exists()]
@@ -637,15 +883,31 @@ def _read_install_manifest(
     *,
     require_litellm_executable: bool,
 ) -> dict:
+    value, _ = _read_install_manifest_snapshot(
+        root,
+        require_litellm_executable=require_litellm_executable,
+    )
+    return value
+
+
+def _read_install_manifest_snapshot(
+    root: str | os.PathLike[str],
+    *,
+    require_litellm_executable: bool,
+) -> tuple[dict, bytes]:
     path = install_manifest_path(root)
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        raw = path.read_bytes()
+        value = json.loads(raw)
     except (OSError, ValueError) as exc:
         raise GatewayConfigError("gateway install manifest is unreadable") from exc
-    return _validate_install_manifest(
-        root,
-        value,
-        require_litellm_executable=require_litellm_executable,
+    return (
+        _validate_install_manifest(
+            root,
+            value,
+            require_litellm_executable=require_litellm_executable,
+        ),
+        raw,
     )
 
 
@@ -673,19 +935,35 @@ def _probe_litellm_runtime(
             env=_runtime_probe_environment(),
         )
     except subprocess.TimeoutExpired as exc:
-        raise GatewayConfigError(
-            "litellm_runtime_probe_unknown: LiteLLM entry-point probe timed out; "
+        raise LiteLLMRuntimeProbeUnknown(
+            "LiteLLM entry-point probe timed out; "
             f"retry {remedy} after system load drops"
         ) from exc
+    except _RuntimeProbeInfrastructureError as exc:
+        raise LiteLLMRuntimeProbeUnknown(
+            "LiteLLM entry-point probe containment or cleanup was inconclusive; "
+            f"retry {remedy} after checking system health"
+        ) from exc
     except (OSError, ValueError) as exc:
-        raise GatewayConfigError(
-            "litellm_runtime_probe_failed: LiteLLM entry-point probe could not run; "
+        raise LiteLLMRuntimeProbeFailed(
+            "LiteLLM entry-point probe could not establish a valid result; "
             f"repair or rebuild that runtime, then rerun {remedy}"
         ) from exc
     if result.returncode != 0:
-        raise GatewayConfigError(
-            "litellm_runtime_probe_failed: LiteLLM entry-point probe failed "
+        raise LiteLLMRuntimeProbeFailed(
+            "LiteLLM entry-point probe failed "
             f"with exit {result.returncode}; repair or rebuild that runtime, then rerun {remedy}"
+        )
+    output = result.stdout if isinstance(result.stdout, bytes) else b""
+    nonempty_lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if (
+        len(output) > LITELLM_RUNTIME_PROBE_OUTPUT_MAX_BYTES
+        or len(nonempty_lines) != 1
+        or _LITELLM_VERSION_LINE.fullmatch(nonempty_lines[0]) is None
+    ):
+        raise LiteLLMRuntimeProbeFailed(
+            "candidate did not emit the bounded LiteLLM version identity record; "
+            f"repair or rebuild that runtime, then rerun {remedy}"
         )
 
 
@@ -697,6 +975,20 @@ def rebind_runtime(
 ) -> dict:
     """Verify and rebind the stopped gateway to a replacement LiteLLM runtime."""
     root = canonical_project_root(root)
+    with _gateway_lifecycle_lock(root, "runtime-rebind"):
+        return _rebind_runtime_locked(
+            root,
+            litellm_executable=litellm_executable,
+            probe_commands=probe_commands,
+        )
+
+
+def _rebind_runtime_locked(
+    root: Path,
+    *,
+    litellm_executable: str | os.PathLike[str],
+    probe_commands: RuntimeProbeCommands | None,
+) -> dict:
     config_path = litellm_config_path(root)
     manifest_path = install_manifest_path(root)
     missing = [path.name for path in (config_path, manifest_path) if not path.exists()]
@@ -713,7 +1005,7 @@ def rebind_runtime(
     # The outgoing runtime is deliberately exempt: a broken or missing launcher
     # must never be able to seal off the operation that repairs it. Every other
     # manifest authority remains mandatory.
-    manifest = _read_install_manifest(
+    manifest, manifest_snapshot = _read_install_manifest_snapshot(
         root,
         require_litellm_executable=False,
     )
@@ -734,6 +1026,18 @@ def rebind_runtime(
             "litellm_runtime_missing: selected LiteLLM executable disappeared during validation; "
             f"install or repair it, then rerun {remedy}"
         )
+    try:
+        current_manifest = manifest_path.read_bytes()
+    except OSError as exc:
+        raise GatewayConfigError(
+            "gateway_runtime_manifest_changed: install manifest became unreadable "
+            f"during validation; retry {remedy}"
+        ) from exc
+    if current_manifest != manifest_snapshot:
+        raise GatewayConfigError(
+            "gateway_runtime_manifest_changed: install manifest changed during "
+            f"validation; inspect the other writer, then retry {remedy}"
+        )
 
     previous = manifest.get("litellm_executable")
     next_manifest = dict(manifest)
@@ -746,6 +1050,7 @@ def rebind_runtime(
     changed = previous != str(executable)
     if changed:
         _durable_write_json(manifest_path, next_manifest)
+        load_install_manifest(root)
     return {
         "runtime_rebound": True,
         "changed": changed,
@@ -976,48 +1281,63 @@ def run_service(
 ) -> int:
     """Run LiteLLM plus the public front. Called only by the managed task."""
     root = canonical_project_root(root)
-    if not actions_enabled(root):
-        raise GatewayConfigError("gateway.kill is present; actions are disabled")
-    ledger = ledger or SpendLedger()
-    ledger_status = ledger.status()
-    # A watched front must be able to restart under a manual/accounting HOLD;
-    # reserve_for_child remains the paid-transport authority and rejects it.
-    if not ledger_status["child_cap_ready"]:
-        raise LedgerBlocked("child turn cap is not structurally ready")
-    exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
-    exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
-    ovh_key = read_secret_file(key_path or default_key_path())
-    front_token = read_secret_file(front_token_path or default_front_token_path())
-    ledger.verify_child_cap_issuer(front_token)
-    internal_token = read_secret_file(internal_token_path or default_internal_token_path())
-    manifest = load_install_manifest(root)
-    configured_executable = str(Path(manifest["litellm_executable"]).resolve())
-    if (
-        litellm_executable is not None
-        and str(Path(litellm_executable).resolve()) != configured_executable
-    ):
-        raise GatewayConfigError("requested LiteLLM executable differs from installed manifest")
-    executable = configured_executable
-    config_path = litellm_config_path(root)
-    if not config_path.is_file():
-        raise GatewayConfigError("LiteLLM config is missing")
-    argv = [
-        executable,
-        "--config",
-        str(config_path),
-        "--host",
-        INTERNAL_HOST,
-        "--port",
-        str(INTERNAL_PORT),
-        "--num_workers",
-        "1",
-    ]
-    log_handler = _open_litellm_log(Path(child_log_path or default_litellm_log_path()))
+    lifecycle = contextlib.ExitStack()
     process = None
     pump_thread = None
     server = None
+    monitor_thread = None
+    log_handler = None
     monitor_stop = threading.Event()
+    marker_written = False
+    marker_snapshot: bytes | None = None
+    startup_release_attempted = False
     try:
+        lifecycle.enter_context(
+            _gateway_lifecycle_lock(root, "run-service-startup")
+        )
+        if not actions_enabled(root):
+            raise GatewayConfigError("gateway.kill is present; actions are disabled")
+        ledger = ledger or SpendLedger()
+        ledger_status = ledger.status()
+        # A watched front must be able to restart under a manual/accounting HOLD;
+        # reserve_for_child remains the paid-transport authority and rejects it.
+        if not ledger_status["child_cap_ready"]:
+            raise LedgerBlocked("child turn cap is not structurally ready")
+        exclusive_bind_probe(PUBLIC_HOST, PUBLIC_PORT)
+        exclusive_bind_probe(INTERNAL_HOST, INTERNAL_PORT)
+        ovh_key = read_secret_file(key_path or default_key_path())
+        front_token = read_secret_file(front_token_path or default_front_token_path())
+        ledger.verify_child_cap_issuer(front_token)
+        internal_token = read_secret_file(
+            internal_token_path or default_internal_token_path()
+        )
+        manifest = load_install_manifest(root)
+        configured_executable = str(Path(manifest["litellm_executable"]).resolve())
+        if (
+            litellm_executable is not None
+            and str(Path(litellm_executable).resolve()) != configured_executable
+        ):
+            raise GatewayConfigError(
+                "requested LiteLLM executable differs from installed manifest"
+            )
+        executable = configured_executable
+        config_path = litellm_config_path(root)
+        if not config_path.is_file():
+            raise GatewayConfigError("LiteLLM config is missing")
+        argv = [
+            executable,
+            "--config",
+            str(config_path),
+            "--host",
+            INTERNAL_HOST,
+            "--port",
+            str(INTERNAL_PORT),
+            "--num_workers",
+            "1",
+        ]
+        log_handler = _open_litellm_log(
+            Path(child_log_path or default_litellm_log_path())
+        )
         process = popen(
             argv,
             cwd=str(root),
@@ -1045,8 +1365,9 @@ def run_service(
         )
         _wait_liveliness(front, process)
         server = front.make_server()
+        marker_path = runtime_marker_path(root)
         _durable_write_json(
-            runtime_marker_path(root),
+            marker_path,
             {
                 "schema_version": RUNTIME_SCHEMA_VERSION,
                 "runner_pid": os.getpid(),
@@ -1059,9 +1380,18 @@ def run_service(
                 "config_sha256": manifest["litellm_config_sha256"],
                 "public_bind": f"{PUBLIC_HOST}:{PUBLIC_PORT}",
                 "internal_bind": f"{INTERNAL_HOST}:{INTERNAL_PORT}",
-                "front_token_sha256": hashlib.sha256(front_token.encode("utf-8")).hexdigest(),
+                "front_token_sha256": hashlib.sha256(
+                    front_token.encode("utf-8")
+                ).hexdigest(),
             },
         )
+        marker_written = True
+        marker_snapshot = marker_path.read_bytes()
+        # Both sockets are now owned and the runtime marker is durable. A
+        # concurrent writer can observe the running-state refusal, so the
+        # startup transaction no longer needs to hold the lifecycle lock.
+        startup_release_attempted = True
+        lifecycle.close()
 
         def monitor() -> None:
             while not monitor_stop.wait(0.25):
@@ -1077,21 +1407,60 @@ def run_service(
         monitor_thread.join(timeout=2)
         return 0 if process.poll() is None or not actions_enabled(root) else 1
     finally:
+        cleanup_errors: list[BaseException] = []
+
+        def cleanup(action) -> None:
+            try:
+                action()
+            except BaseException as exc:  # noqa: BLE001 - finish all cleanup first
+                cleanup_errors.append(exc)
+
         monitor_stop.set()
         if server is not None:
-            server.server_close()
-        if process is not None and process.poll() is None:
-            process.terminate()
+            cleanup(server.server_close)
+        if process is not None:
             try:
-                process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5)
+                process_alive = process.poll() is None
+            except BaseException as exc:  # noqa: BLE001 - continue other cleanup
+                cleanup_errors.append(exc)
+                process_alive = False
+            if process_alive:
+                cleanup(process.terminate)
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    cleanup(process.kill)
+                    cleanup(lambda: process.wait(timeout=5))
+                except BaseException as exc:  # noqa: BLE001 - continue cleanup
+                    cleanup_errors.append(exc)
+                    cleanup(process.kill)
+                    cleanup(lambda: process.wait(timeout=5))
         if pump_thread is not None:
-            pump_thread.join(timeout=5)
-        log_handler.close()
-        with contextlib.suppress(FileNotFoundError):
-            runtime_marker_path(root).unlink()
+            cleanup(lambda: pump_thread.join(timeout=5))
+        if monitor_thread is not None:
+            cleanup(lambda: monitor_thread.join(timeout=2))
+        if log_handler is not None:
+            cleanup(log_handler.close)
+        if marker_written:
+            marker_path = runtime_marker_path(root)
+
+            def remove_owned_marker() -> None:
+                if not startup_release_attempted:
+                    marker_path.unlink(missing_ok=True)
+                    return
+                try:
+                    current = marker_path.read_bytes()
+                except FileNotFoundError:
+                    return
+                if marker_snapshot is not None and current == marker_snapshot:
+                    marker_path.unlink()
+
+            cleanup(remove_owned_marker)
+        # On startup failure, cleanup completes before another lifecycle
+        # operation can inspect sockets or mutate the manifest.
+        cleanup(lifecycle.close)
+        if cleanup_errors:
+            raise cleanup_errors[0]
 
 
 def stop_task(

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -468,26 +468,33 @@ class RuntimeProbeCommands:
         if os.name != "nt":
             popen_kwargs["start_new_session"] = True
         try:
+            output = bytearray()
+            output_overflow = threading.Event()
+            reader_errors: list[Exception] = []
+        except Exception as exc:
+            raise _RuntimeProbeInfrastructureError(
+                f"probe output capture could not be initialized: {exc}"
+            ) from exc
+        try:
             process = subprocess.Popen(  # nosec B603  # noqa: S603
                 bootstrap_argv,
                 **popen_kwargs,
             )
-        except OSError as exc:
+        except Exception as exc:
             raise _RuntimeProbeInfrastructureError(
                 f"probe bootstrap could not start: {exc}"
             ) from exc
         if process.stdin is None or process.stdout is None:
-            with contextlib.suppress(OSError):
+            with contextlib.suppress(Exception):
                 process.kill()
+            with contextlib.suppress(Exception):
+                process.wait(timeout=5.0)
             raise _RuntimeProbeInfrastructureError(
                 "probe bootstrap pipes are unavailable"
             )
 
         def close_job() -> None:
             return None
-        output = bytearray()
-        output_overflow = threading.Event()
-        reader_errors: list[OSError] = []
 
         def drain_stdout() -> None:
             try:
@@ -499,87 +506,146 @@ class RuntimeProbeCommands:
                         output.extend(chunk[:remaining])
                     if len(output) > LITELLM_RUNTIME_PROBE_OUTPUT_MAX_BYTES:
                         output_overflow.set()
-            except OSError as exc:
+            except Exception as exc:
                 reader_errors.append(exc)
 
         reader: threading.Thread | None = None
+        reader_started = False
         returncode: int | None = None
         timed_out = False
-        infrastructure_error: BaseException | None = None
+        infrastructure_error: _RuntimeProbeInfrastructureError | None = None
+
+        def remember_infrastructure_error(detail: str, exc: Exception) -> None:
+            nonlocal infrastructure_error
+            if infrastructure_error is None:
+                infrastructure_error = _RuntimeProbeInfrastructureError(
+                    f"{detail}: {exc}"
+                )
+
         try:
             try:
                 _, close_job = _attach_kill_on_close_job(process)
-            except OSError as exc:
-                infrastructure_error = _RuntimeProbeInfrastructureError(
-                    f"probe process containment failed: {exc}"
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe process containment failed",
+                    exc,
                 )
             if infrastructure_error is None:
-                reader = threading.Thread(
-                    target=drain_stdout,
-                    daemon=True,
-                    name="agenttalk-litellm-probe-output",
-                )
-                reader.start()
+                try:
+                    reader = threading.Thread(
+                        target=drain_stdout,
+                        daemon=True,
+                        name="agenttalk-litellm-probe-output",
+                    )
+                    reader.start()
+                    reader_started = True
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe output drain could not start",
+                        exc,
+                    )
+            if infrastructure_error is None:
                 try:
                     process.stdin.write(b"1")
                     process.stdin.close()
-                except (OSError, ValueError) as exc:
-                    infrastructure_error = _RuntimeProbeInfrastructureError(
-                        f"probe bootstrap gate failed: {exc}"
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe bootstrap gate failed",
+                        exc,
                     )
             if infrastructure_error is None:
-                deadline = time.monotonic() + self.timeout_seconds
-                while returncode is None and not output_overflow.is_set():
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        timed_out = True
-                        break
-                    try:
-                        returncode = process.wait(timeout=min(0.05, remaining))
-                    except subprocess.TimeoutExpired:
-                        continue
+                try:
+                    deadline = time.monotonic() + self.timeout_seconds
+                    while returncode is None and not output_overflow.is_set():
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            timed_out = True
+                            break
+                        try:
+                            returncode = process.wait(timeout=min(0.05, remaining))
+                        except subprocess.TimeoutExpired:
+                            continue
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe process observation failed",
+                        exc,
+                    )
         finally:
-            with contextlib.suppress(OSError, ValueError):
-                process.stdin.close()
+            try:
+                if not process.stdin.closed:
+                    process.stdin.close()
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe bootstrap input cleanup failed",
+                    exc,
+                )
             try:
                 close_job()
-            except OSError as exc:
-                infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
-                    f"probe process containment release failed: {exc}"
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe process containment release failed",
+                    exc,
                 )
             if os.name != "nt":
                 try:
                     os.killpg(process.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pass
-                except OSError as exc:
-                    infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
-                        f"probe process-group teardown failed: {exc}"
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe process-group teardown failed",
+                        exc,
                     )
-            if process.poll() is None:
-                with contextlib.suppress(OSError):
+            process_running = True
+            try:
+                process_running = process.poll() is None
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe process state observation failed",
+                    exc,
+                )
+            if process_running:
+                try:
                     process.kill()
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe process teardown failed",
+                        exc,
+                    )
             try:
                 process.wait(timeout=5.0)
-            except (OSError, subprocess.TimeoutExpired) as exc:
-                infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
-                    f"probe process reap failed: {exc}"
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe process reap failed",
+                    exc,
                 )
-            if reader is not None:
-                reader.join(timeout=5.0)
-                if reader.is_alive():
-                    infrastructure_error = infrastructure_error or _RuntimeProbeInfrastructureError(
-                        "probe output drain did not terminate"
+            if reader is not None and reader_started:
+                try:
+                    reader.join(timeout=5.0)
+                    if reader.is_alive():
+                        remember_infrastructure_error(
+                            "probe output drain did not terminate",
+                            RuntimeError("reader remained alive after the cleanup bound"),
+                        )
+                except Exception as exc:
+                    remember_infrastructure_error(
+                        "probe output drain cleanup failed",
+                        exc,
                     )
-            with contextlib.suppress(OSError):
+            try:
                 process.stdout.close()
+            except Exception as exc:
+                remember_infrastructure_error(
+                    "probe output pipe cleanup failed",
+                    exc,
+                )
 
+        if reader_errors and infrastructure_error is None:
+            infrastructure_error = _RuntimeProbeInfrastructureError(
+                f"probe output capture failed: {reader_errors[0]}"
+            )
         if infrastructure_error is not None:
             raise infrastructure_error
-        if reader_errors:
-            raise _RuntimeProbeInfrastructureError(
-                f"probe output capture failed: {reader_errors[0]}"
-            ) from reader_errors[0]
         if timed_out:
             raise subprocess.TimeoutExpired(argv, self.timeout_seconds)
         if output_overflow.is_set():

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -652,7 +652,13 @@ class RuntimeProbeCommands:
             raise ValueError("LiteLLM entry-point probe output exceeded the limit")
         if returncode is None:
             raise _RuntimeProbeInfrastructureError("probe result is unavailable")
-        return subprocess.CompletedProcess(argv, returncode, stdout=bytes(output))
+        try:
+            captured_output = bytes(output)
+        except Exception as exc:
+            raise _RuntimeProbeInfrastructureError(
+                f"probe output materialization failed: {exc}"
+            ) from exc
+        return subprocess.CompletedProcess(argv, returncode, stdout=captured_output)
 
 
 def install_task(
@@ -1007,7 +1013,7 @@ def _probe_litellm_runtime(
         ) from exc
     except _RuntimeProbeInfrastructureError as exc:
         raise LiteLLMRuntimeProbeUnknown(
-            "LiteLLM entry-point probe containment or cleanup was inconclusive; "
+            "LiteLLM entry-point probe infrastructure or cleanup was inconclusive; "
             f"retry {remedy} after checking system health"
         ) from exc
     except (OSError, ValueError) as exc:

--- a/src/agenttalk/ovh_gateway_service.py
+++ b/src/agenttalk/ovh_gateway_service.py
@@ -58,6 +58,7 @@ RUNTIME_SCHEMA_VERSION = 2
 DEFAULT_API_BASE = "https://qwen-3-5-397b.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1"
 STOP_TIMEOUT_SECONDS = 30.0
 LITELLM_READINESS_TIMEOUT_SECONDS = 120.0
+LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS = 120.0
 LITELLM_LOG_MAX_BYTES = 1024 * 1024
 LITELLM_LOG_BACKUP_COUNT = 2
 LITELLM_LOG_RECORD_MAX_BYTES = 64 * 1024
@@ -366,6 +367,29 @@ class TaskCommands:
             raise GatewayConfigError("gateway task stop failed")
 
 
+class RuntimeProbeCommands:
+    """Narrow injectable wrapper around the selected LiteLLM launcher."""
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        cwd: str,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # nosec B603  # noqa: S603
+            argv,
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS,
+        )
+
+
 def install_task(
     root: str | os.PathLike[str],
     *,
@@ -547,7 +571,7 @@ def reconfigure_endpoint(root: str | os.PathLike[str]) -> dict:
     }
 
 
-def _safe_gateway_environment(ovh_key: str, internal_token: str) -> dict[str, str]:
+def _base_gateway_environment() -> dict[str, str]:
     allowed = (
         "PATH",
         "SystemRoot",
@@ -560,17 +584,28 @@ def _safe_gateway_environment(ovh_key: str, internal_token: str) -> dict[str, st
     env = {key: os.environ[key] for key in allowed if key in os.environ}
     env["PYTHONUTF8"] = "1"
     env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _runtime_probe_environment() -> dict[str, str]:
+    env = _base_gateway_environment()
+    env["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    return env
+
+
+def _safe_gateway_environment(ovh_key: str, internal_token: str) -> dict[str, str]:
+    env = _base_gateway_environment()
     env["OVH_KEY"] = ovh_key
     env["LITELLM_MASTER_KEY"] = internal_token
     return env
 
 
-def load_install_manifest(root: str | os.PathLike[str]) -> dict:
-    path = install_manifest_path(root)
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        raise GatewayConfigError("gateway install manifest is unreadable") from exc
+def _validate_install_manifest(
+    root: str | os.PathLike[str],
+    value: object,
+    *,
+    require_litellm_executable: bool,
+) -> dict:
     if not isinstance(value, dict) or value.get("schema_version") != 1:
         raise GatewayConfigError("gateway install manifest schema mismatch")
     if value.get("price_policy_hash") != price_policy_hash():
@@ -582,16 +617,143 @@ def load_install_manifest(root: str | os.PathLike[str]) -> dict:
     for key, expected in expected_binds.items():
         if value.get(key) != expected:
             raise GatewayConfigError(f"gateway install manifest {key} mismatch")
-    executable = Path(str(value.get("litellm_executable") or "")).resolve()
     config = Path(str(value.get("litellm_config") or "")).resolve()
     if config != litellm_config_path(root).resolve():
         raise GatewayConfigError("gateway install manifest config path mismatch")
-    if not executable.is_file() or not config.is_file():
+    if not config.is_file():
         raise GatewayConfigError("gateway install manifest references a missing artifact")
+    if require_litellm_executable:
+        executable = Path(str(value.get("litellm_executable") or "")).resolve()
+        if not executable.is_file():
+            raise GatewayConfigError("gateway install manifest references a missing artifact")
     digest = hashlib.sha256(config.read_bytes()).hexdigest()
     if digest != value.get("litellm_config_sha256"):
         raise GatewayConfigError("LiteLLM config hash mismatch")
     return value
+
+
+def _read_install_manifest(
+    root: str | os.PathLike[str],
+    *,
+    require_litellm_executable: bool,
+) -> dict:
+    path = install_manifest_path(root)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GatewayConfigError("gateway install manifest is unreadable") from exc
+    return _validate_install_manifest(
+        root,
+        value,
+        require_litellm_executable=require_litellm_executable,
+    )
+
+
+def load_install_manifest(root: str | os.PathLike[str]) -> dict:
+    return _read_install_manifest(root, require_litellm_executable=True)
+
+
+def _runtime_rebind_command(root: Path, executable: Path) -> str:
+    return (
+        f'agenttalk --root "{root}" gateway runtime-rebind --litellm-executable '
+        f'"{executable}"'
+    )
+
+
+def _probe_litellm_runtime(
+    root: Path,
+    executable: Path,
+    commands: RuntimeProbeCommands,
+) -> None:
+    remedy = _runtime_rebind_command(root, executable)
+    try:
+        result = commands.run(
+            [str(executable), "--version"],
+            cwd=str(root),
+            env=_runtime_probe_environment(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GatewayConfigError(
+            "litellm_runtime_probe_unknown: LiteLLM entry-point probe timed out; "
+            f"retry {remedy} after system load drops"
+        ) from exc
+    except (OSError, ValueError) as exc:
+        raise GatewayConfigError(
+            "litellm_runtime_probe_failed: LiteLLM entry-point probe could not run; "
+            f"repair or rebuild that runtime, then rerun {remedy}"
+        ) from exc
+    if result.returncode != 0:
+        raise GatewayConfigError(
+            "litellm_runtime_probe_failed: LiteLLM entry-point probe failed "
+            f"with exit {result.returncode}; repair or rebuild that runtime, then rerun {remedy}"
+        )
+
+
+def rebind_runtime(
+    root: str | os.PathLike[str],
+    *,
+    litellm_executable: str | os.PathLike[str],
+    probe_commands: RuntimeProbeCommands | None = None,
+) -> dict:
+    """Verify and rebind the stopped gateway to a replacement LiteLLM runtime."""
+    root = canonical_project_root(root)
+    config_path = litellm_config_path(root)
+    manifest_path = install_manifest_path(root)
+    missing = [path.name for path in (config_path, manifest_path) if not path.exists()]
+    if missing:
+        raise GatewayConfigError(
+            "gateway runtime rebind requires an existing install; missing: "
+            + ", ".join(missing)
+        )
+    if not _both_sockets_free():
+        raise GatewayConfigError(
+            "refusing to rebind runtime while the gateway is running; stop it first"
+        )
+
+    # The outgoing runtime is deliberately exempt: a broken or missing launcher
+    # must never be able to seal off the operation that repairs it. Every other
+    # manifest authority remains mandatory.
+    manifest = _read_install_manifest(
+        root,
+        require_litellm_executable=False,
+    )
+    executable = Path(litellm_executable).resolve()
+    remedy = _runtime_rebind_command(root, executable)
+    if not executable.is_file():
+        raise GatewayConfigError(
+            "litellm_runtime_missing: selected LiteLLM executable is missing or not a file; "
+            f"install or repair it, then rerun {remedy}"
+        )
+    _probe_litellm_runtime(
+        root,
+        executable,
+        probe_commands if probe_commands is not None else RuntimeProbeCommands(),
+    )
+    if not executable.is_file():
+        raise GatewayConfigError(
+            "litellm_runtime_missing: selected LiteLLM executable disappeared during validation; "
+            f"install or repair it, then rerun {remedy}"
+        )
+
+    previous = manifest.get("litellm_executable")
+    next_manifest = dict(manifest)
+    next_manifest["litellm_executable"] = str(executable)
+    _validate_install_manifest(
+        root,
+        next_manifest,
+        require_litellm_executable=True,
+    )
+    changed = previous != str(executable)
+    if changed:
+        _durable_write_json(manifest_path, next_manifest)
+    return {
+        "runtime_rebound": True,
+        "changed": changed,
+        "litellm_executable": str(executable),
+        "previous_litellm_executable": previous if isinstance(previous, str) else None,
+        "config_sha256": next_manifest["litellm_config_sha256"],
+        "price_policy_hash": next_manifest["price_policy_hash"],
+    }
 
 
 def _process_start_token(pid: int) -> str:

--- a/tests/test_lifecycle_lock.py
+++ b/tests/test_lifecycle_lock.py
@@ -37,6 +37,24 @@ with CrossProcessLifecycleLock(
         time.sleep(0.01)
 """
 
+_EXIT_259_HOLDER_SCRIPT = r"""
+import os
+import sys
+from pathlib import Path
+
+from agenttalk.lifecycle_lock import CrossProcessLifecycleLock
+
+lock_path = Path(sys.argv[1])
+ready_path = Path(sys.argv[2])
+with CrossProcessLifecycleLock(
+    lock_path,
+    authority="test-lifecycle-v1",
+    timeout_seconds=2.0,
+).hold("test-holder"):
+    ready_path.write_text("ready\n", encoding="ascii")
+    os._exit(259)
+"""
+
 
 def _lock_api():
     from agenttalk.lifecycle_lock import (
@@ -381,6 +399,40 @@ def test_lifecycle_lock_takes_over_after_exact_holder_dies(tmp_path) -> None:
         _kill_and_reap(holder)
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows retained process-handle semantics")
+@pytest.mark.subprocess
+def test_lifecycle_lock_takes_over_when_retained_holder_exits_with_code_259(
+    tmp_path,
+) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    ready = tmp_path / "holder.ready"
+    holder = subprocess.Popen(  # noqa: S603 - exact local interpreter and test script
+        [sys.executable, "-c", _EXIT_259_HOLDER_SCRIPT, str(lock_path), str(ready)],
+        env=_subprocess_env(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    try:
+        _wait_for_path(ready, holder)
+        crashed_owner = _read_record(lock_path)
+        assert holder.wait(timeout=5) == 259
+
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=1.0,
+        ).hold("exit-259-takeover"):
+            replacement = _read_record(lock_path)
+            assert replacement["generation"] != crashed_owner["generation"]
+            assert replacement["pid"] == os.getpid()
+    finally:
+        _kill_and_reap(holder)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX zombie ownership semantics")
 @pytest.mark.subprocess
 def test_lifecycle_lock_takes_over_from_unreaped_zombie_holder(tmp_path) -> None:
@@ -392,6 +444,7 @@ def test_lifecycle_lock_takes_over_from_unreaped_zombie_holder(tmp_path) -> None
     try:
         _wait_for_path(ready, holder)
         crashed_owner = _read_record(lock_path)
+        assert crashed_owner["process_identity"] == _identity_record(holder.pid)
         holder.kill()
         _wait_for_posix_zombie(holder.pid)
 
@@ -475,6 +528,51 @@ def test_lifecycle_lock_refuses_free_kernel_lock_with_exact_live_owner(
             timeout_seconds=0.1,
         ).hold("must-not-steal"):
             raise AssertionError("exact live ownership must never be stolen")
+
+    assert lock_path.read_bytes() == original
+
+
+def test_lifecycle_lock_refuses_unobservable_recorded_owner_as_unknown(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from agenttalk import lifecycle_lock as lock_module
+
+    CrossProcessLifecycleLock, _, LifecycleLockUnknown = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    held = {
+        "authority": _AUTHORITY,
+        "schema_version": 1,
+        "state": "held",
+        "generation": "0" * 32,
+        "pid": os.getpid(),
+        "process_identity": _identity_record(os.getpid()),
+        "operation": "unobservable-owner",
+        "acquired_at": "2026-08-17T13:00:00.000000Z",
+    }
+    original = _write_record(lock_path, held)
+    real_observation = lock_module._process_observation
+    observations = 0
+
+    def caller_then_unknown(pid):
+        nonlocal observations
+        observations += 1
+        if observations == 1:
+            return real_observation(pid)
+        return "unknown", None
+
+    monkeypatch.setattr(lock_module, "_process_observation", caller_then_unknown)
+
+    with pytest.raises(
+        LifecycleLockUnknown,
+        match="abandoned holder identity could not be observed exactly",
+    ):
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=0.1,
+        ).hold("must-not-steal-unknown"):
+            raise AssertionError("unobservable ownership must never be stolen")
 
     assert lock_path.read_bytes() == original
 

--- a/tests/test_lifecycle_lock.py
+++ b/tests/test_lifecycle_lock.py
@@ -74,6 +74,12 @@ def _subprocess_env() -> dict[str, str]:
     return env
 
 
+def _direct_python_executable() -> str:
+    # A copied Windows venv may expose a redirector at sys.executable.  Its
+    # CreateProcess PID is not the interpreter PID that owns the lock (#50).
+    return getattr(sys, "_base_executable", None) or sys.executable
+
+
 def _wait_for_path(path: Path, process: subprocess.Popen, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -91,7 +97,14 @@ def _wait_for_path(path: Path, process: subprocess.Popen, timeout: float = 5.0) 
 
 def _spawn_holder(lock_path: Path, ready: Path, release: Path) -> subprocess.Popen:
     return subprocess.Popen(  # noqa: S603 - exact local interpreter and test script
-        [sys.executable, "-c", _HOLDER_SCRIPT, str(lock_path), str(ready), str(release)],
+        [
+            _direct_python_executable(),
+            "-c",
+            _HOLDER_SCRIPT,
+            str(lock_path),
+            str(ready),
+            str(release),
+        ],
         env=_subprocess_env(),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
@@ -408,7 +421,13 @@ def test_lifecycle_lock_takes_over_when_retained_holder_exits_with_code_259(
     lock_path = tmp_path / "gateway" / "lifecycle.lock"
     ready = tmp_path / "holder.ready"
     holder = subprocess.Popen(  # noqa: S603 - exact local interpreter and test script
-        [sys.executable, "-c", _EXIT_259_HOLDER_SCRIPT, str(lock_path), str(ready)],
+        [
+            _direct_python_executable(),
+            "-c",
+            _EXIT_259_HOLDER_SCRIPT,
+            str(lock_path),
+            str(ready),
+        ],
         env=_subprocess_env(),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,

--- a/tests/test_lifecycle_lock.py
+++ b/tests/test_lifecycle_lock.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from agenttalk.store import Store
+
+
+_AUTHORITY = "test-lifecycle-v1"
+_ARTIFACT_BYTES = 4096
+_METADATA_BYTES = _ARTIFACT_BYTES - 1
+_HOLDER_SCRIPT = r"""
+import sys
+import time
+from pathlib import Path
+
+from agenttalk.lifecycle_lock import CrossProcessLifecycleLock
+
+lock_path = Path(sys.argv[1])
+ready_path = Path(sys.argv[2])
+release_path = Path(sys.argv[3])
+with CrossProcessLifecycleLock(
+    lock_path,
+    authority="test-lifecycle-v1",
+    timeout_seconds=2.0,
+).hold("test-holder"):
+    ready_path.write_text("ready\n", encoding="ascii")
+    while not release_path.exists():
+        time.sleep(0.01)
+"""
+
+
+def _lock_api():
+    from agenttalk.lifecycle_lock import (
+        CrossProcessLifecycleLock,
+        LifecycleLockContended,
+        LifecycleLockUnknown,
+    )
+
+    return CrossProcessLifecycleLock, LifecycleLockContended, LifecycleLockUnknown
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    source = str(Path(__file__).resolve().parents[1] / "src")
+    inherited = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = source if not inherited else source + os.pathsep + inherited
+    return env
+
+
+def _wait_for_path(path: Path, process: subprocess.Popen, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"holder exited {process.returncode} before readiness: "
+                f"stdout={stdout!r}, stderr={stderr!r}"
+            )
+        time.sleep(0.01)
+    raise AssertionError(f"holder did not publish {path} within {timeout:g}s")
+
+
+def _spawn_holder(lock_path: Path, ready: Path, release: Path) -> subprocess.Popen:
+    return subprocess.Popen(  # noqa: S603 - exact local interpreter and test script
+        [sys.executable, "-c", _HOLDER_SCRIPT, str(lock_path), str(ready), str(release)],
+        env=_subprocess_env(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _wait_clean(process: subprocess.Popen) -> tuple[str, str]:
+    try:
+        return process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate(timeout=5)
+        raise AssertionError(
+            f"holder did not exit after release: stdout={stdout!r}, stderr={stderr!r}"
+        ) from None
+
+
+def _kill_and_reap(process: subprocess.Popen) -> tuple[str, str]:
+    if process.poll() is None:
+        process.kill()
+    return process.communicate(timeout=5)
+
+
+def _wait_for_posix_zombie(pid: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(  # noqa: S603,S607 - read-only exact-pid test oracle
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip().startswith("Z"):
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"pid {pid} did not become an unreaped zombie")
+
+
+def _read_record(path: Path) -> dict:
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_BINARY", 0))
+    try:
+        raw = os.read(fd, _METADATA_BYTES)
+    finally:
+        os.close(fd)
+    assert len(raw) == _METADATA_BYTES
+    payload, separator, padding = raw.partition(b"\0")
+    assert separator == b"\0"
+    assert not padding.strip(b"\0")
+    return json.loads(payload)
+
+
+def _write_record(path: Path, value: object) -> bytes:
+    payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+    assert len(payload) < _METADATA_BYTES
+    raw = payload + b"\0" * (_ARTIFACT_BYTES - len(payload))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(raw)
+    return raw
+
+
+def _exact_process_identity(pid: int) -> tuple[str, str]:
+    if os.name == "nt":
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.GetProcessTimes.restype = wintypes.BOOL
+        kernel32.GetProcessTimes.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+        ]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        assert handle
+        try:
+            creation = wintypes.FILETIME()
+            exit_time = wintypes.FILETIME()
+            kernel = wintypes.FILETIME()
+            user = wintypes.FILETIME()
+            assert kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            )
+            ticks = (int(creation.dwHighDateTime) << 32) | int(
+                creation.dwLowDateTime
+            )
+            assert ticks > 0
+            return "win32-filetime-v1", str(ticks)
+        finally:
+            kernel32.CloseHandle(handle)
+    if sys.platform == "darwin":
+        class ProcBSDInfo(ctypes.Structure):
+            _fields_ = [
+                ("pbi_flags", ctypes.c_uint32),
+                ("pbi_status", ctypes.c_uint32),
+                ("pbi_xstatus", ctypes.c_uint32),
+                ("pbi_pid", ctypes.c_uint32),
+                ("pbi_ppid", ctypes.c_uint32),
+                ("pbi_uid", ctypes.c_uint32),
+                ("pbi_gid", ctypes.c_uint32),
+                ("pbi_ruid", ctypes.c_uint32),
+                ("pbi_rgid", ctypes.c_uint32),
+                ("pbi_svuid", ctypes.c_uint32),
+                ("pbi_svgid", ctypes.c_uint32),
+                ("rfu_1", ctypes.c_uint32),
+                ("pbi_comm", ctypes.c_char * 16),
+                ("pbi_name", ctypes.c_char * 32),
+                ("pbi_nfiles", ctypes.c_uint32),
+                ("pbi_pgid", ctypes.c_uint32),
+                ("pbi_pjobc", ctypes.c_uint32),
+                ("e_tdev", ctypes.c_uint32),
+                ("e_tpgid", ctypes.c_uint32),
+                ("pbi_nice", ctypes.c_int32),
+                ("pbi_start_tvsec", ctypes.c_uint64),
+                ("pbi_start_tvusec", ctypes.c_uint64),
+            ]
+
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib")
+        libproc.proc_pidinfo.restype = ctypes.c_int
+        libproc.proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        info = ProcBSDInfo()
+        assert libproc.proc_pidinfo(
+            pid,
+            3,
+            0,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ) == ctypes.sizeof(info)
+        assert info.pbi_pid == pid
+        assert info.pbi_start_tvsec > 0
+        assert 0 <= info.pbi_start_tvusec <= 999_999
+        return (
+            "darwin-proc-bsdinfo-v1",
+            f"{info.pbi_start_tvsec}:{info.pbi_start_tvusec}",
+        )
+    stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    fields = stat_text[stat_text.rfind(")") + 2 :].split()
+    start_ticks = fields[19]
+    boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+        encoding="utf-8"
+    ).strip()
+    assert start_ticks.isdigit()
+    return "linux-proc-start-v1", f"{boot_id}:{start_ticks}"
+
+
+def _different_exact_identity(identity: tuple[str, str]) -> dict[str, str]:
+    scheme, value = identity
+    prefix, numeric = value.rsplit(":", 1) if ":" in value else ("", value)
+    changed = "2" if numeric == "1" else "1"
+    return {"scheme": scheme, "value": f"{prefix}:{changed}" if prefix else changed}
+
+
+def _identity_record(pid: int) -> dict[str, str]:
+    scheme, value = _exact_process_identity(pid)
+    return {"scheme": scheme, "value": value}
+
+
+@pytest.mark.subprocess
+def test_lifecycle_lock_reports_real_process_holder_on_contention(tmp_path) -> None:
+    CrossProcessLifecycleLock, LifecycleLockContended, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    ready = tmp_path / "holder.ready"
+    release = tmp_path / "holder.release"
+    holder = _spawn_holder(lock_path, ready, release)
+    try:
+        _wait_for_path(ready, holder)
+        held_record = _read_record(lock_path)
+        assert held_record["process_identity"] == _identity_record(holder.pid)
+
+        with pytest.raises(LifecycleLockContended) as exc_info:
+            with CrossProcessLifecycleLock(
+                lock_path,
+                authority=_AUTHORITY,
+                timeout_seconds=0.2,
+                poll_seconds=0.01,
+            ).hold("contender"):
+                raise AssertionError("a live holder must exclude the contender")
+
+        refusal = exc_info.value
+        assert refusal.reason_code == "lifecycle_lock_contended"
+        assert refusal.holder_pid == holder.pid
+        assert refusal.holder_operation == "test-holder"
+        assert refusal.holder_identity == held_record["process_identity"]
+        assert refusal.holder_since.endswith("Z")
+        assert str(holder.pid) in str(refusal)
+        assert "test-holder" in str(refusal)
+        assert "retry" in str(refusal).casefold()
+        assert _read_record(lock_path) == held_record
+    finally:
+        release.write_text("release\n", encoding="ascii")
+        stdout, stderr = _wait_clean(holder)
+    assert holder.returncode == 0, (stdout, stderr)
+    assert _read_record(lock_path) == {
+        "authority": _AUTHORITY,
+        "schema_version": 1,
+        "state": "released",
+    }
+
+
+@pytest.mark.subprocess
+def test_lifecycle_lock_contention_names_holder_after_real_process_handoff(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from agenttalk import lifecycle_lock as lock_module
+
+    CrossProcessLifecycleLock, LifecycleLockContended, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    first_ready = tmp_path / "first.ready"
+    first_release = tmp_path / "first.release"
+    first = _spawn_holder(lock_path, first_ready, first_release)
+    second: subprocess.Popen | None = None
+    second_release = tmp_path / "second.release"
+    try:
+        _wait_for_path(first_ready, first)
+        real_try_os_lock = lock_module._try_os_lock
+        calls = 0
+
+        def handoff_before_final_attempt(fd: int) -> bool:
+            nonlocal calls, second
+            calls += 1
+            if calls == 2:
+                first_release.write_text("release\n", encoding="ascii")
+                stdout, stderr = _wait_clean(first)
+                assert first.returncode == 0, (stdout, stderr)
+                second_ready = tmp_path / "second.ready"
+                second = _spawn_holder(lock_path, second_ready, second_release)
+                _wait_for_path(second_ready, second)
+            return real_try_os_lock(fd)
+
+        monkeypatch.setattr(lock_module, "_try_os_lock", handoff_before_final_attempt)
+
+        with pytest.raises(LifecycleLockContended) as exc_info:
+            with CrossProcessLifecycleLock(
+                lock_path,
+                authority=_AUTHORITY,
+                timeout_seconds=0,
+            ).hold("handoff-contender"):
+                raise AssertionError("the second real holder must retain the lock")
+
+        assert second is not None
+        assert calls == 2
+        assert exc_info.value.holder_pid == second.pid
+        assert exc_info.value.holder_operation == "test-holder"
+    finally:
+        first_release.write_text("release\n", encoding="ascii")
+        if first.poll() is None:
+            _kill_and_reap(first)
+        if second is not None:
+            second_release.write_text("release\n", encoding="ascii")
+            stdout, stderr = _wait_clean(second)
+            assert second.returncode == 0, (stdout, stderr)
+
+
+@pytest.mark.subprocess
+def test_lifecycle_lock_takes_over_after_exact_holder_dies(tmp_path) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    ready = tmp_path / "holder.ready"
+    release = tmp_path / "holder.release"
+    holder = _spawn_holder(lock_path, ready, release)
+    try:
+        _wait_for_path(ready, holder)
+        crashed_owner = _read_record(lock_path)
+        assert crashed_owner["process_identity"] == _identity_record(holder.pid)
+        holder.kill()
+        holder.communicate(timeout=5)
+        inode_before = os.stat(lock_path)
+
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=1.0,
+        ).hold("takeover"):
+            replacement = _read_record(lock_path)
+            assert replacement["pid"] == os.getpid()
+            assert replacement["process_identity"] == _identity_record(os.getpid())
+            assert replacement["generation"] != crashed_owner["generation"]
+
+        inode_after = os.stat(lock_path)
+        assert (inode_after.st_dev, inode_after.st_ino) == (
+            inode_before.st_dev,
+            inode_before.st_ino,
+        )
+        assert _read_record(lock_path)["state"] == "released"
+    finally:
+        _kill_and_reap(holder)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX zombie ownership semantics")
+@pytest.mark.subprocess
+def test_lifecycle_lock_takes_over_from_unreaped_zombie_holder(tmp_path) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    ready = tmp_path / "holder.ready"
+    release = tmp_path / "holder.release"
+    holder = _spawn_holder(lock_path, ready, release)
+    try:
+        _wait_for_path(ready, holder)
+        crashed_owner = _read_record(lock_path)
+        holder.kill()
+        _wait_for_posix_zombie(holder.pid)
+
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=1.0,
+        ).hold("zombie-takeover"):
+            replacement = _read_record(lock_path)
+            assert replacement["generation"] != crashed_owner["generation"]
+            assert replacement["pid"] == os.getpid()
+    finally:
+        _kill_and_reap(holder)
+
+
+@pytest.mark.subprocess
+def test_lifecycle_lock_pid_reuse_imposter_allows_takeover_without_kill(
+    tmp_path,
+) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    imposter = subprocess.Popen(  # noqa: S603 - exact local inert child
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        current_identity = _exact_process_identity(imposter.pid)
+        _write_record(
+            lock_path,
+            {
+                "authority": _AUTHORITY,
+                "schema_version": 1,
+                "state": "held",
+                "generation": "0" * 32,
+                "pid": imposter.pid,
+                "process_identity": _different_exact_identity(current_identity),
+                "operation": "dead-holder",
+                "acquired_at": "2026-08-17T13:00:00.000000Z",
+            },
+        )
+
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=1.0,
+        ).hold("pid-reuse-takeover"):
+            assert imposter.poll() is None
+            assert _read_record(lock_path)["pid"] == os.getpid()
+
+        assert imposter.poll() is None
+    finally:
+        _kill_and_reap(imposter)
+
+
+def test_lifecycle_lock_refuses_free_kernel_lock_with_exact_live_owner(
+    tmp_path,
+) -> None:
+    CrossProcessLifecycleLock, _, LifecycleLockUnknown = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    contradictory = {
+        "authority": _AUTHORITY,
+        "schema_version": 1,
+        "state": "held",
+        "generation": "0" * 32,
+        "pid": os.getpid(),
+        "process_identity": _identity_record(os.getpid()),
+        "operation": "impossible-free-lock",
+        "acquired_at": "2026-08-17T13:00:00.000000Z",
+    }
+    original = _write_record(lock_path, contradictory)
+
+    with pytest.raises(
+        LifecycleLockUnknown,
+        match="kernel lock was free while its exact recorded holder was alive",
+    ):
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=0.1,
+        ).hold("must-not-steal"):
+            raise AssertionError("exact live ownership must never be stolen")
+
+    assert lock_path.read_bytes() == original
+
+
+def test_lifecycle_lock_body_exception_durably_releases_and_allows_reacquire(
+    tmp_path,
+) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    lock = CrossProcessLifecycleLock(
+        lock_path,
+        authority=_AUTHORITY,
+        timeout_seconds=0.1,
+    )
+
+    with pytest.raises(RuntimeError, match="injected body failure"):
+        with lock.hold("failing-body"):
+            raise RuntimeError("injected body failure")
+
+    assert _read_record(lock_path) == {
+        "authority": _AUTHORITY,
+        "schema_version": 1,
+        "state": "released",
+    }
+    with lock.hold("after-body-failure"):
+        assert _read_record(lock_path)["operation"] == "after-body-failure"
+
+
+@pytest.mark.parametrize(
+    "corrupt_payload",
+    [
+        b'{"schema_version":1,"state":"held","pid":"not-an-int"}\n',
+        b'{"authority":"test-lifecycle-v1","schema_version":true,"state":"released"}\n',
+        b'{"authority":"test-lifecycle-v1","schema_version":1.0,"state":"released"}\n',
+        b'{"authority":"test-lifecycle-v1","schema_version":1,'
+        b'"schema_version":1,"state":"released"}\n',
+        (
+            json.dumps(
+                {
+                    "authority": _AUTHORITY,
+                    "schema_version": 1,
+                    "state": "held",
+                    "generation": "0" * 32,
+                    "pid": 1,
+                    "process_identity": {
+                        "scheme": "win32-filetime-v1",
+                        "value": "",
+                    },
+                    "operation": "corrupt",
+                    "acquired_at": "2026-08-17T13:00:00.000000Z",
+                }
+            )
+            + "\n"
+        ).encode("utf-8"),
+    ],
+)
+def test_lifecycle_lock_refuses_corrupt_artifact_as_unknown(
+    tmp_path,
+    corrupt_payload,
+) -> None:
+    CrossProcessLifecycleLock, _, LifecycleLockUnknown = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    assert len(corrupt_payload) < _METADATA_BYTES
+    corrupt = corrupt_payload + b"\0" * (_ARTIFACT_BYTES - len(corrupt_payload))
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_bytes(corrupt)
+
+    with pytest.raises(LifecycleLockUnknown) as exc_info:
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=0.1,
+        ).hold("corruption-control"):
+            raise AssertionError("corrupt authority must never grant the lock")
+
+    assert exc_info.value.reason_code == "lifecycle_lock_unknown"
+    message = str(exc_info.value).casefold()
+    assert "corrupt" in message
+    assert "confirm no lifecycle operation is running" in message
+    assert str(lock_path).casefold() in message
+    assert "remove" in message
+    assert lock_path.read_bytes() == corrupt
+    if b'"process_identity"' in corrupt_payload:
+        assert "lock holder process identity is corrupt" in exc_info.value.detail
+
+
+def test_lifecycle_lock_refuses_hardlinked_artifact_without_touching_target(
+    tmp_path,
+) -> None:
+    CrossProcessLifecycleLock, _, LifecycleLockUnknown = _lock_api()
+    lock_path = tmp_path / "gateway" / "lifecycle.lock"
+    victim = tmp_path / "victim.bin"
+    original = b"v" * _ARTIFACT_BYTES
+    victim.write_bytes(original)
+    lock_path.parent.mkdir(parents=True)
+    os.link(victim, lock_path)
+
+    with pytest.raises(LifecycleLockUnknown, match="single-link regular file"):
+        with CrossProcessLifecycleLock(
+            lock_path,
+            authority=_AUTHORITY,
+            timeout_seconds=0.1,
+        ).hold("hardlink-control"):
+            raise AssertionError("a hardlinked authority must not be opened for mutation")
+
+    assert victim.read_bytes() == original
+    assert lock_path.read_bytes() == original
+    assert os.stat(victim).st_nlink == 2
+
+
+@pytest.mark.subprocess
+def test_gateway_lifecycle_lock_never_contends_with_store_config_lock(tmp_path) -> None:
+    CrossProcessLifecycleLock, _, _ = _lock_api()
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    lock_path = root / ".agenttalk" / "gateway" / "lifecycle.lock"
+    ready = tmp_path / "holder.ready"
+    release = tmp_path / "holder.release"
+    holder = _spawn_holder(lock_path, ready, release)
+    try:
+        _wait_for_path(ready, holder)
+        with Store(root).config_lock(timeout=0.5):
+            pass
+    finally:
+        release.write_text("release\n", encoding="ascii")
+        stdout, stderr = _wait_clean(holder)
+    assert holder.returncode == 0, (stdout, stderr)
+
+    reverse_ready = tmp_path / "reverse.ready"
+    reverse_release = tmp_path / "reverse.release"
+    with Store(root).config_lock(timeout=0.5):
+        reverse = _spawn_holder(lock_path, reverse_ready, reverse_release)
+        try:
+            _wait_for_path(reverse_ready, reverse)
+        finally:
+            reverse_release.write_text("release\n", encoding="ascii")
+            stdout, stderr = _wait_clean(reverse)
+    assert reverse.returncode == 0, (stdout, stderr)

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -238,6 +238,98 @@ def test_gateway_cli_runtime_rebind_surfaces_named_probe_refusal(
     assert output.err == f"agenttalk gateway runtime-rebind: {refusal}\n"
 
 
+def test_gateway_cli_runtime_rebind_final_probe_copy_failure_is_named_unknown(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    old_runtime = tmp_path / "old-runtime" / "litellm.exe"
+    old_runtime.parent.mkdir()
+    old_runtime.write_bytes(b"old runtime")
+    ledger = SpendLedger(
+        tmp_path / "spend" / "ledger.sqlite3",
+        tmp_path / "spend" / "install.json",
+    )
+    ovh_gateway_service.initialize_install(
+        root,
+        litellm_executable=old_runtime,
+        opening_micro_eur=580_000,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        ledger=ledger,
+        front_token_path=tmp_path / "secrets" / "front.txt",
+        internal_token_path=tmp_path / "secrets" / "internal.txt",
+    )
+
+    runtime_dir = tmp_path / "candidate-runtime"
+    runtime_dir.mkdir()
+    if sys.platform == "win32":
+        candidate = runtime_dir / "litellm.cmd"
+        candidate.write_text(
+            (
+                "@echo off\r\n"
+                'if not "%~1"=="--version" exit /b 2\r\n'
+                'if not "%~2"=="" exit /b 2\r\n'
+                "echo LiteLLM: Current Version = 1.91.3\r\n"
+            ),
+            encoding="utf-8",
+        )
+    else:
+        candidate = runtime_dir / "litellm"
+        candidate.write_text(
+            (
+                "#!/bin/sh\n"
+                '[ "$#" -eq 1 ] && [ "$1" = "--version" ] || exit 2\n'
+                "printf '%s\\n' 'LiteLLM: Current Version = 1.91.3'\n"
+            ),
+            encoding="utf-8",
+        )
+        candidate.chmod(0o755)
+
+    manifest_path = ovh_gateway_service.install_manifest_path(root)
+    manifest_before = manifest_path.read_bytes()
+    copy_attempts: list[bytearray] = []
+    real_bytearray = bytearray
+
+    class FinalCopyFailure(real_bytearray):
+        def __bytes__(self) -> bytes:
+            captured = real_bytearray(self)
+            assert captured.splitlines() == [
+                real_bytearray(b"LiteLLM: Current Version = 1.91.3")
+            ]
+            copy_attempts.append(captured)
+            raise MemoryError("forced final probe output copy failure")
+
+    monkeypatch.setattr(ovh_gateway_service, "_both_sockets_free", lambda: True)
+    monkeypatch.setattr(
+        ovh_gateway_service,
+        "bytearray",
+        FinalCopyFailure,
+        raising=False,
+    )
+
+    rc = cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "runtime-rebind",
+        "--litellm-executable",
+        str(candidate),
+    ])
+
+    output = capsys.readouterr()
+    assert len(copy_attempts) == 1
+    assert rc == 3
+    assert output.out == ""
+    assert output.err.startswith(
+        "agenttalk gateway runtime-rebind: litellm_runtime_probe_unknown: "
+    )
+    assert "probe infrastructure or cleanup was inconclusive" in output.err
+    assert "retry " in output.err
+    assert manifest_path.read_bytes() == manifest_before
+
+
 @pytest.mark.parametrize(
     ("error_factory", "reason", "expected_rc"),
     [

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -168,15 +168,43 @@ def test_gateway_cli_runtime_rebind_routes_candidate_and_prints_result(
     assert result["litellm_executable"] == str(candidate)
 
 
+def test_gateway_cli_runtime_rebind_help_states_probe_authority_and_exit_contract(
+    capsys,
+) -> None:
+    for argv in (["gateway", "--help"], ["gateway", "runtime-rebind", "--help"]):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(argv)
+        assert exc_info.value.code == 0
+        rendered = capsys.readouterr().out.casefold()
+        assert "trusted" in rendered
+        assert "filesystem authority" in rendered
+        assert "unsandboxed" in rendered
+        assert "exit 3" in rendered
+        assert "exit 2" in rendered
+
+
 @pytest.mark.parametrize(
-    "reason",
-    ["litellm_runtime_probe_failed", "litellm_runtime_probe_unknown"],
+    ("error_type", "reason", "expected_rc"),
+    [
+        (
+            ovh_gateway_service.LiteLLMRuntimeProbeFailed,
+            "litellm_runtime_probe_failed",
+            2,
+        ),
+        (
+            ovh_gateway_service.LiteLLMRuntimeProbeUnknown,
+            "litellm_runtime_probe_unknown",
+            3,
+        ),
+    ],
 )
 def test_gateway_cli_runtime_rebind_surfaces_named_probe_refusal(
     tmp_path,
     monkeypatch,
     capsys,
+    error_type,
     reason,
+    expected_rc,
 ) -> None:
     root = tmp_path / "project"
     Store(root).init(["lead"])
@@ -190,7 +218,8 @@ def test_gateway_cli_runtime_rebind_surfaces_named_probe_refusal(
     def refuse_rebind(_root, *, litellm_executable):
         assert _root == root.resolve()
         assert litellm_executable == str(candidate)
-        raise ovh_gateway.GatewayConfigError(refusal)
+        message = refusal.removeprefix(f"{reason}: ")
+        raise error_type(message)
 
     monkeypatch.setattr(ovh_gateway_service, "rebind_runtime", refuse_rebind)
 
@@ -204,9 +233,73 @@ def test_gateway_cli_runtime_rebind_surfaces_named_probe_refusal(
     ])
 
     output = capsys.readouterr()
-    assert rc == 2
+    assert rc == expected_rc
     assert output.out == ""
     assert output.err == f"agenttalk gateway runtime-rebind: {refusal}\n"
+
+
+@pytest.mark.parametrize(
+    ("error_factory", "reason", "expected_rc"),
+    [
+        (
+            lambda path: ovh_gateway_service.GatewayLifecycleContended(
+                ovh_gateway_service.LifecycleLockContended({
+                    "pid": 42,
+                    "process_identity": {
+                        "scheme": "win32-filetime-v1",
+                        "value": "123",
+                    },
+                    "operation": "reconfigure",
+                    "acquired_at": "2026-08-17T12:00:00.000000Z",
+                })
+            ),
+            "gateway_lifecycle_contended",
+            2,
+        ),
+        (
+            lambda path: ovh_gateway_service.GatewayLifecycleUnknown(
+                ovh_gateway_service.LifecycleLockUnknown(path, "metadata is corrupt")
+            ),
+            "gateway_lifecycle_unknown",
+            3,
+        ),
+    ],
+)
+def test_gateway_cli_runtime_rebind_surfaces_typed_lifecycle_refusal(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    error_factory,
+    reason,
+    expected_rc,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    candidate = tmp_path / "runtime.exe"
+    refusal = error_factory(root / ".agenttalk" / "gateway" / "lifecycle.lock")
+
+    def refuse_rebind(_root, *, litellm_executable):
+        assert _root == root.resolve()
+        assert litellm_executable == str(candidate)
+        raise refusal
+
+    monkeypatch.setattr(ovh_gateway_service, "rebind_runtime", refuse_rebind)
+
+    rc = cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "runtime-rebind",
+        "--litellm-executable",
+        str(candidate),
+    ])
+
+    output = capsys.readouterr()
+    assert rc == expected_rc
+    assert output.out == ""
+    assert output.err.startswith(
+        f"agenttalk gateway runtime-rebind: {reason}: "
+    )
 
 
 def test_gateway_cli_rejects_caller_supplied_actual_reconciliation(

--- a/tests/test_ovh_gateway_cli.py
+++ b/tests/test_ovh_gateway_cli.py
@@ -128,6 +128,87 @@ def test_gateway_cli_initializes_once_and_controls_manual_hold(
     assert canary["expected_micro_eur"] == 960
 
 
+def test_gateway_cli_runtime_rebind_routes_candidate_and_prints_result(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    candidate = tmp_path / "unusual runtime" / "launcher.shim"
+    captured: dict[str, object] = {}
+
+    def fake_rebind(received_root, *, litellm_executable):
+        captured["root"] = received_root
+        captured["litellm_executable"] = litellm_executable
+        return {
+            "runtime_rebound": True,
+            "changed": True,
+            "litellm_executable": str(candidate),
+        }
+
+    monkeypatch.setattr(ovh_gateway_service, "rebind_runtime", fake_rebind)
+
+    rc = cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "runtime-rebind",
+        "--litellm-executable",
+        str(candidate),
+    ])
+
+    assert rc == 0
+    assert captured == {
+        "root": root.resolve(),
+        "litellm_executable": str(candidate),
+    }
+    result = json.loads(capsys.readouterr().out)
+    assert result["runtime_rebound"] is True
+    assert result["litellm_executable"] == str(candidate)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["litellm_runtime_probe_failed", "litellm_runtime_probe_unknown"],
+)
+def test_gateway_cli_runtime_rebind_surfaces_named_probe_refusal(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    reason,
+) -> None:
+    root = tmp_path / "project"
+    Store(root).init(["lead"])
+    candidate = tmp_path / "runtime.exe"
+    refusal = (
+        f"{reason}: retry "
+        f'agenttalk --root "{root.resolve()}" gateway runtime-rebind '
+        f'--litellm-executable "{candidate}"'
+    )
+
+    def refuse_rebind(_root, *, litellm_executable):
+        assert _root == root.resolve()
+        assert litellm_executable == str(candidate)
+        raise ovh_gateway.GatewayConfigError(refusal)
+
+    monkeypatch.setattr(ovh_gateway_service, "rebind_runtime", refuse_rebind)
+
+    rc = cli.main([
+        "--root",
+        str(root),
+        "gateway",
+        "runtime-rebind",
+        "--litellm-executable",
+        str(candidate),
+    ])
+
+    output = capsys.readouterr()
+    assert rc == 2
+    assert output.out == ""
+    assert output.err == f"agenttalk gateway runtime-rebind: {refusal}\n"
+
+
 def test_gateway_cli_rejects_caller_supplied_actual_reconciliation(
     tmp_path,
     capsys,

--- a/tests/test_ovh_gateway_lifecycle_integration.py
+++ b/tests/test_ovh_gateway_lifecycle_integration.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from agenttalk import ovh_gateway_service as service
+from agenttalk.ovh_gateway import SpendLedger
+
+
+pytestmark = [
+    pytest.mark.skipif(os.name != "nt", reason="gateway lifecycle is Windows-first"),
+    pytest.mark.subprocess,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SOURCE_ROOT = (_REPO_ROOT / "src").resolve()
+
+_REBIND_CHILD = r"""
+import json
+import os
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).resolve()
+root = Path(sys.argv[2])
+candidate = Path(sys.argv[3])
+result_path = Path(sys.argv[4])
+
+from agenttalk import ovh_gateway_service as service
+
+assert os.path.commonpath([str(Path(service.__file__).resolve()), str(source)]) == str(source)
+try:
+    value = service.rebind_runtime(root, litellm_executable=candidate)
+    payload = {"ok": True, "value": value}
+except BaseException as exc:
+    payload = {"ok": False, "type": type(exc).__name__, "message": str(exc)}
+result_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+"""
+
+_RECONFIGURE_CHILD = r"""
+import contextlib
+import json
+import os
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).resolve()
+root = Path(sys.argv[2])
+attempted_path = Path(sys.argv[3])
+result_path = Path(sys.argv[4])
+
+from agenttalk import lifecycle_lock
+from agenttalk import ovh_gateway_service as service
+
+assert os.path.commonpath([str(Path(service.__file__).resolve()), str(source)]) == str(source)
+original_hold = lifecycle_lock.CrossProcessLifecycleLock.hold
+
+@contextlib.contextmanager
+def observed_hold(self, operation):
+    if operation == "reconfigure":
+        attempted_path.write_text("attempted\n", encoding="ascii")
+    with original_hold(self, operation) as claim:
+        yield claim
+
+lifecycle_lock.CrossProcessLifecycleLock.hold = observed_hold
+try:
+    value = service.reconfigure_endpoint(root)
+    payload = {"ok": True, "value": value}
+except BaseException as exc:
+    payload = {"ok": False, "type": type(exc).__name__, "message": str(exc)}
+result_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+"""
+
+_RUN_SERVICE_CHILD = r"""
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+
+source = Path(sys.argv[1]).resolve()
+root = Path(sys.argv[2])
+ledger_db = Path(sys.argv[3])
+ledger_install = Path(sys.argv[4])
+provider_key = Path(sys.argv[5])
+front_token = Path(sys.argv[6])
+internal_token = Path(sys.argv[7])
+child_log = Path(sys.argv[8])
+startup_spawned = Path(sys.argv[9])
+allow_bind = Path(sys.argv[10])
+provider_bound = Path(sys.argv[11])
+public_bound = Path(sys.argv[12])
+stop_serving = Path(sys.argv[13])
+result_path = Path(sys.argv[14])
+
+from agenttalk import ovh_gateway_service as service
+from agenttalk.ovh_gateway import SpendLedger
+
+assert os.path.commonpath([str(Path(service.__file__).resolve()), str(source)]) == str(source)
+
+provider_script = r'''import socket
+from pathlib import Path
+import sys
+import time
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+allow = Path(sys.argv[3])
+ready = Path(sys.argv[4])
+while not allow.exists():
+    time.sleep(0.01)
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.bind((host, port))
+sock.listen(1)
+ready.write_text("bound\n", encoding="ascii")
+while True:
+    time.sleep(1)
+'''
+
+def provider_popen(_argv, **kwargs):
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            provider_script,
+            service.INTERNAL_HOST,
+            str(service.INTERNAL_PORT),
+            str(allow_bind),
+            str(provider_bound),
+        ],
+        **kwargs,
+    )
+    startup_spawned.write_text("spawned\n", encoding="ascii")
+    return process
+
+class BoundFrontServer:
+    def __init__(self):
+        self._shutdown = False
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.bind((service.PUBLIC_HOST, service.PUBLIC_PORT))
+        self._socket.listen(1)
+        public_bound.write_text("bound\n", encoding="ascii")
+
+    def serve_forever(self, poll_interval=None):
+        while not self._shutdown and not stop_serving.exists():
+            time.sleep(0.01)
+
+    def shutdown(self):
+        self._shutdown = True
+
+    def server_close(self):
+        self._socket.close()
+
+class BoundFront:
+    def __init__(self, _config, _ledger):
+        pass
+
+    def internal_liveliness(self):
+        return provider_bound.exists()
+
+    def make_server(self):
+        return BoundFrontServer()
+
+    def drain(self, _timeout):
+        return None
+
+service.GatewayFront = BoundFront
+try:
+    value = service.run_service(
+        root,
+        ledger=SpendLedger(ledger_db, ledger_install),
+        key_path=provider_key,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+        child_log_path=child_log,
+        popen=provider_popen,
+    )
+    payload = {"ok": True, "value": value}
+except BaseException as exc:
+    payload = {"ok": False, "type": type(exc).__name__, "message": str(exc)}
+result_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+"""
+
+_OBSERVED_REBIND_CHILD = r"""
+import contextlib
+import json
+import os
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).resolve()
+root = Path(sys.argv[2])
+candidate = Path(sys.argv[3])
+attempted_path = Path(sys.argv[4])
+socket_checked_path = Path(sys.argv[5])
+result_path = Path(sys.argv[6])
+
+from agenttalk import lifecycle_lock
+from agenttalk import ovh_gateway_service as service
+
+assert os.path.commonpath([str(Path(service.__file__).resolve()), str(source)]) == str(source)
+original_hold = lifecycle_lock.CrossProcessLifecycleLock.hold
+original_sockets_free = service._both_sockets_free
+
+@contextlib.contextmanager
+def observed_hold(self, operation):
+    if operation == "runtime-rebind":
+        attempted_path.write_text("attempted\n", encoding="ascii")
+    with original_hold(self, operation) as claim:
+        yield claim
+
+def observed_sockets_free():
+    socket_checked_path.write_text("checked\n", encoding="ascii")
+    return original_sockets_free()
+
+lifecycle_lock.CrossProcessLifecycleLock.hold = observed_hold
+service._both_sockets_free = observed_sockets_free
+try:
+    value = service.rebind_runtime(root, litellm_executable=candidate)
+    payload = {"ok": True, "value": value}
+except BaseException as exc:
+    payload = {"ok": False, "type": type(exc).__name__, "message": str(exc)}
+result_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+"""
+
+
+def _child_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_SOURCE_ROOT)
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _spawn(script: str, *args: Path) -> subprocess.Popen[str]:
+    return subprocess.Popen(  # noqa: S603 - exact local interpreter and test script
+        [sys.executable, "-c", script, str(_SOURCE_ROOT), *(str(arg) for arg in args)],
+        env=_child_env(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+    )
+
+
+def _wait_for_path(
+    path: Path,
+    processes: tuple[subprocess.Popen[str], ...],
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        exited = [process for process in processes if process.poll() is not None]
+        if exited:
+            details = []
+            for process in exited:
+                stdout, stderr = process.communicate()
+                details.append(
+                    f"pid={process.pid}, rc={process.returncode}, "
+                    f"stdout={stdout!r}, stderr={stderr!r}"
+                )
+            raise AssertionError(
+                f"process exited before publishing {path}: " + "; ".join(details)
+            )
+        time.sleep(0.01)
+    raise AssertionError(f"process did not publish {path} within {timeout:g}s")
+
+
+def _wait_process(process: subprocess.Popen[str], timeout: float = 15.0) -> None:
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_tree(process)
+        stdout, stderr = process.communicate(timeout=5)
+        raise AssertionError(
+            f"child pid {process.pid} did not exit: stdout={stdout!r}, stderr={stderr!r}"
+        ) from None
+    assert process.returncode == 0, (stdout, stderr)
+
+
+def _kill_tree(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    subprocess.run(  # noqa: S603,S607 - bounded cleanup of the exact test process tree
+        ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+        check=False,
+    )
+
+
+def _read_result(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _write_runtime_shim(path: Path, script_path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'@echo off\r\n"{sys.executable}" "{script_path}" %*\r\n',
+        encoding="utf-8",
+    )
+
+
+def _initialize_gateway(tmp_path: Path):
+    root = tmp_path / "project"
+    old_runtime = tmp_path / "old-runtime" / "litellm.exe"
+    old_runtime.parent.mkdir(parents=True)
+    old_runtime.write_bytes(b"old runtime")
+    ledger_db = tmp_path / "spend" / "ledger.sqlite3"
+    ledger_install = tmp_path / "spend" / "install.json"
+    ledger = SpendLedger(ledger_db, ledger_install)
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    service.initialize_install(
+        root,
+        litellm_executable=old_runtime,
+        opening_micro_eur=580_000,
+        opening_evidence="integration test observation",
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    return (
+        root,
+        old_runtime,
+        ledger_db,
+        ledger_install,
+        front_token,
+        internal_token,
+    )
+
+
+def _assert_ports_free() -> None:
+    service.exclusive_bind_probe(service.PUBLIC_HOST, service.PUBLIC_PORT)
+    service.exclusive_bind_probe(service.INTERNAL_HOST, service.INTERNAL_PORT)
+
+
+def test_real_process_rebind_serializes_reconfigure_without_stale_manifest_write(
+    tmp_path: Path,
+) -> None:
+    _assert_ports_free()
+    root, _, _, _, _, _ = _initialize_gateway(tmp_path)
+    config_path = service.litellm_config_path(root)
+    manifest_path = service.install_manifest_path(root)
+    stale_config = service.render_litellm_config(
+        api_base="https://stale.example/v1"
+    ).encode("utf-8")
+    config_path.write_bytes(stale_config)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["litellm_config_sha256"] = hashlib.sha256(stale_config).hexdigest()
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    probe_ready = tmp_path / "probe.ready"
+    probe_release = tmp_path / "probe.release"
+    candidate_script = tmp_path / "candidate.py"
+    candidate_script.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        "import time\n"
+        f"ready = Path({str(probe_ready)!r})\n"
+        f"release = Path({str(probe_release)!r})\n"
+        "assert sys.argv[1:] == ['--version']\n"
+        "ready.write_text('ready\\n', encoding='ascii')\n"
+        "while not release.exists():\n"
+        "    time.sleep(0.01)\n"
+        "print('LiteLLM: Current Version = 1.91.3')\n",
+        encoding="utf-8",
+    )
+    candidate = tmp_path / "candidate" / "litellm.cmd"
+    _write_runtime_shim(candidate, candidate_script)
+    rebind_result = tmp_path / "rebind-result.json"
+    reconfigure_attempted = tmp_path / "reconfigure.attempted"
+    reconfigure_result = tmp_path / "reconfigure-result.json"
+    rebind = _spawn(_REBIND_CHILD, root, candidate, rebind_result)
+    reconfigure = None
+    try:
+        _wait_for_path(probe_ready, (rebind,))
+        reconfigure = _spawn(
+            _RECONFIGURE_CHILD,
+            root,
+            reconfigure_attempted,
+            reconfigure_result,
+        )
+        _wait_for_path(reconfigure_attempted, (rebind, reconfigure))
+        assert reconfigure.poll() is None
+        assert not reconfigure_result.exists()
+        assert service.load_install_manifest(root)["litellm_executable"] != str(
+            candidate.resolve()
+        )
+
+        probe_release.write_text("release\n", encoding="ascii")
+        _wait_for_path(rebind_result, (rebind, reconfigure))
+        _wait_for_path(reconfigure_result, (reconfigure,))
+        _wait_process(rebind)
+        _wait_process(reconfigure)
+
+        assert _read_result(rebind_result)["ok"] is True
+        assert _read_result(reconfigure_result)["ok"] is True
+        final_manifest = service.load_install_manifest(root)
+        expected_config = service.render_litellm_config(
+            api_base=service.DEFAULT_API_BASE
+        ).encode("utf-8")
+        assert config_path.read_bytes() == expected_config
+        assert final_manifest["litellm_executable"] == str(candidate.resolve())
+        assert final_manifest["litellm_config_sha256"] == hashlib.sha256(
+            expected_config
+        ).hexdigest()
+    finally:
+        probe_release.write_text("release\n", encoding="ascii")
+        _kill_tree(rebind)
+        if reconfigure is not None:
+            _kill_tree(reconfigure)
+
+
+def test_real_process_service_startup_excludes_rebind_until_sockets_are_owned(
+    tmp_path: Path,
+) -> None:
+    _assert_ports_free()
+    (
+        root,
+        old_runtime,
+        ledger_db,
+        ledger_install,
+        front_token,
+        internal_token,
+    ) = _initialize_gateway(tmp_path)
+    provider_key = tmp_path / "secrets" / "provider.txt"
+    provider_key.write_text("provider-secret\n", encoding="utf-8")
+    candidate_script = tmp_path / "candidate.py"
+    candidate_script.write_text(
+        "import sys\n"
+        "assert sys.argv[1:] == ['--version']\n"
+        "print('LiteLLM: Current Version = 1.91.3')\n",
+        encoding="utf-8",
+    )
+    candidate = tmp_path / "candidate" / "litellm.cmd"
+    _write_runtime_shim(candidate, candidate_script)
+
+    startup_spawned = tmp_path / "startup.spawned"
+    allow_bind = tmp_path / "startup.allow-bind"
+    provider_bound = tmp_path / "provider.bound"
+    public_bound = tmp_path / "public.bound"
+    stop_serving = tmp_path / "service.stop"
+    run_result = tmp_path / "run-result.json"
+    rebind_attempted = tmp_path / "rebind.attempted"
+    socket_checked = tmp_path / "rebind.socket-checked"
+    rebind_result = tmp_path / "rebind-result.json"
+
+    runner = _spawn(
+        _RUN_SERVICE_CHILD,
+        root,
+        ledger_db,
+        ledger_install,
+        provider_key,
+        front_token,
+        internal_token,
+        tmp_path / "litellm.log",
+        startup_spawned,
+        allow_bind,
+        provider_bound,
+        public_bound,
+        stop_serving,
+        run_result,
+    )
+    rebind = None
+    try:
+        _wait_for_path(startup_spawned, (runner,))
+        rebind = _spawn(
+            _OBSERVED_REBIND_CHILD,
+            root,
+            candidate,
+            rebind_attempted,
+            socket_checked,
+            rebind_result,
+        )
+        _wait_for_path(rebind_attempted, (runner, rebind))
+        assert rebind.poll() is None
+        assert not socket_checked.exists()
+        assert not rebind_result.exists()
+
+        allow_bind.write_text("bind\n", encoding="ascii")
+        _wait_for_path(provider_bound, (runner, rebind))
+        _wait_for_path(public_bound, (runner, rebind))
+        _wait_for_path(service.runtime_marker_path(root), (runner, rebind))
+        _wait_for_path(socket_checked, (runner, rebind))
+        _wait_for_path(rebind_result, (runner, rebind))
+        _wait_process(rebind)
+
+        refusal = _read_result(rebind_result)
+        assert refusal["ok"] is False
+        assert refusal["type"] == "GatewayConfigError"
+        assert "while the gateway is running" in refusal["message"]
+        assert service.load_install_manifest(root)["litellm_executable"] == str(
+            old_runtime.resolve()
+        )
+
+        stop_serving.write_text("stop\n", encoding="ascii")
+        _wait_for_path(run_result, (runner,))
+        _wait_process(runner)
+        assert _read_result(run_result) == {"ok": True, "value": 0}
+        assert not service.runtime_marker_path(root).exists()
+        _assert_ports_free()
+    finally:
+        allow_bind.write_text("bind\n", encoding="ascii")
+        stop_serving.write_text("stop\n", encoding="ascii")
+        _kill_tree(runner)
+        if rebind is not None:
+            _kill_tree(rebind)

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -1201,6 +1201,80 @@ def test_runtime_rebind_refuses_candidate_without_mutating_install(
     assert _file_snapshot(tmp_path) == before
 
 
+@pytest.mark.parametrize("failure_at", ["construction", "start"])
+def test_runtime_rebind_reader_thread_failure_is_retryable_unknown(
+    tmp_path,
+    monkeypatch,
+    failure_at,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "candidate-runtime"
+    candidate.write_bytes(b"candidate")
+    candidate_started = tmp_path / "candidate.started"
+    real_popen = subprocess.Popen
+    spawned: list[subprocess.Popen] = []
+    reader_calls: list[str] = []
+
+    def capturing_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        spawned.append(process)
+        return process
+
+    class StartFailureThread:
+        ident = None
+
+        def start(self) -> None:
+            reader_calls.append("start")
+            raise RuntimeError("reader thread could not start")
+
+        def join(self, timeout=None) -> None:
+            _ = timeout
+            reader_calls.append("join")
+            raise AssertionError("a never-started reader must not be joined")
+
+        def is_alive(self) -> bool:
+            reader_calls.append("is_alive")
+            raise AssertionError("a never-started reader has no liveness state")
+
+    def failing_thread(*_args, **_kwargs):
+        if failure_at == "construction":
+            raise RuntimeError("reader thread could not be constructed")
+        return StartFailureThread()
+
+    monkeypatch.setattr(service.threading, "Thread", failing_thread)
+    monkeypatch.setattr(service.subprocess, "Popen", capturing_popen)
+    monkeypatch.setattr(
+        service,
+        "_RUNTIME_PROBE_BOOTSTRAP",
+        (
+            "import sys\n"
+            "from pathlib import Path\n"
+            "if sys.stdin.buffer.read(1) == b'1':\n"
+            f"    Path({str(candidate_started)!r}).write_text('started', encoding='ascii')\n"
+        ),
+    )
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    before = _file_snapshot(tmp_path)
+
+    with pytest.raises(service.LiteLLMRuntimeProbeUnknown) as exc_info:
+        service.rebind_runtime(root, litellm_executable=candidate)
+
+    assert exc_info.value.reason_code == "litellm_runtime_probe_unknown"
+    assert exc_info.value.retryable is True
+    expected_detail = (
+        "reader thread could not be constructed"
+        if failure_at == "construction"
+        else "reader thread could not start"
+    )
+    assert expected_detail in str(exc_info.value.__cause__)
+    assert "never-started reader" not in str(exc_info.value.__cause__)
+    assert reader_calls == ([] if failure_at == "construction" else ["start"])
+    assert len(spawned) == 1
+    assert spawned[0].poll() is not None
+    assert not candidate_started.exists()
+    assert _file_snapshot(tmp_path) == before
+
+
 @pytest.mark.parametrize("corruption", ["config_hash", "price_policy"])
 def test_runtime_rebind_refuses_invalid_bound_manifest_before_probe(
     tmp_path,

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -6,6 +6,9 @@ import json
 import os
 import socket
 import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -71,16 +74,59 @@ class RacingInstallCommands(FakeCommands):
 
 
 class FakeRuntimeProbeCommands:
-    def __init__(self, *, returncode: int = 0, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        error: Exception | None = None,
+        stdout: bytes = b"\r\nLiteLLM: Current Version = 1.91.3\r\n\r\n",
+        side_effect=None,
+    ) -> None:
         self.returncode = returncode
         self.error = error
+        self.stdout = stdout
+        self.side_effect = side_effect
         self.calls: list[dict[str, object]] = []
 
     def run(self, argv, *, cwd, env):
         self.calls.append({"argv": list(argv), "cwd": cwd, "env": dict(env)})
         if self.error is not None:
             raise self.error
-        return subprocess.CompletedProcess(argv, self.returncode)
+        if self.side_effect is not None:
+            self.side_effect()
+        return subprocess.CompletedProcess(argv, self.returncode, stdout=self.stdout)
+
+
+def _write_windows_batch_forwarder(candidate: Path, implementation: Path) -> None:
+    assert candidate.parent.resolve() == implementation.parent.resolve()
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    candidate.write_text(
+        f'@echo off\r\n"{sys.executable}" "%~dp0{implementation.name}" %*\r\n',
+        encoding="utf-8",
+    )
+
+
+def _write_windows_litellm_identity_shim(
+    directory: Path,
+    *,
+    suffix: str = ".cmd",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    implementation = directory / "litellm_identity.py"
+    implementation.write_text(
+        """import sys
+
+if sys.argv[1:] != [\"--version\"]:
+    raise SystemExit(2)
+print()
+print(\"LiteLLM: Current Version = 1.91.3\")
+print()
+""",
+        encoding="utf-8",
+    )
+    candidate = directory / f"litellm{suffix}"
+    _write_windows_batch_forwarder(candidate, implementation)
+    return candidate
 
 
 def test_project_task_name_is_canonical_and_collision_resistant(tmp_path) -> None:
@@ -375,6 +421,123 @@ def test_runner_uses_env_only_secrets_and_can_start_under_manual_hold(
     assert env["LITELLM_MASTER_KEY"] not in logged
     assert "[REDACTED]" in logged
     assert not runtime_marker_path(root).exists()
+
+
+def test_run_service_lock_refusal_preserves_an_existing_runtime_marker(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    marker = runtime_marker_path(root)
+    marker.parent.mkdir(parents=True)
+    marker.write_bytes(b"existing live-owner marker")
+    holder = service.LifecycleLockContended({
+        "pid": os.getpid(),
+        "process_identity": {
+            "scheme": "win32-filetime-v1",
+            "value": "123",
+        },
+        "operation": "run-service-startup",
+        "acquired_at": "2026-08-17T12:00:00.000000Z",
+    })
+
+    class RefusingLock:
+        def __enter__(self):
+            raise service.GatewayLifecycleContended(holder)
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(
+        service,
+        "_gateway_lifecycle_lock",
+        lambda _root, _operation: RefusingLock(),
+    )
+
+    with pytest.raises(service.GatewayLifecycleContended):
+        run_service(root)
+
+    assert marker.read_bytes() == b"existing live-owner marker"
+
+
+def test_run_service_startup_failure_finishes_cleanup_before_releasing_lock(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, ledger, front_token, internal_token = _install_for_runtime_rebind(
+        tmp_path
+    )
+    provider_key = tmp_path / "secrets" / "provider.txt"
+    provider_key.write_text("provider-secret\n", encoding="utf-8")
+    cleanup_started = threading.Event()
+    allow_cleanup = threading.Event()
+    runner_error: list[BaseException] = []
+
+    class FakeProcess:
+        pid = os.getpid()
+
+        def __init__(self) -> None:
+            self.stdout = io.StringIO("")
+            self.alive = True
+
+        def poll(self):
+            return None if self.alive else 0
+
+        def terminate(self) -> None:
+            cleanup_started.set()
+            if not allow_cleanup.wait(timeout=10.0):
+                raise AssertionError("test did not allow startup cleanup")
+            self.alive = False
+
+        def kill(self) -> None:
+            self.alive = False
+
+        def wait(self, timeout=None) -> int:
+            self.alive = False
+            return 0
+
+    class FakeFront:
+        def __init__(self, _config, _ledger) -> None:
+            return
+
+    def fail_startup(_front, _process) -> None:
+        raise GatewayConfigError("injected startup failure")
+
+    def run() -> None:
+        try:
+            run_service(
+                root,
+                ledger=ledger,
+                key_path=provider_key,
+                front_token_path=front_token,
+                internal_token_path=internal_token,
+                child_log_path=tmp_path / "litellm.log",
+                popen=lambda *_args, **_kwargs: FakeProcess(),
+            )
+        except BaseException as exc:  # noqa: BLE001 - asserted across thread boundary
+            runner_error.append(exc)
+
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+    monkeypatch.setattr(service, "_wait_liveliness", fail_startup)
+    monkeypatch.setattr(service, "GatewayFront", FakeFront)
+    monkeypatch.setattr(service, "GATEWAY_LIFECYCLE_LOCK_TIMEOUT_SECONDS", 0.1)
+    runner = threading.Thread(target=run, daemon=True)
+    runner.start()
+    assert cleanup_started.wait(timeout=10.0)
+
+    with pytest.raises(service.GatewayLifecycleContended) as exc_info:
+        with service._gateway_lifecycle_lock(root, "reconfigure"):
+            raise AssertionError("cleanup released the lock too early")
+    assert exc_info.value.holder_operation == "run-service-startup"
+
+    allow_cleanup.set()
+    runner.join(timeout=10.0)
+    assert not runner.is_alive()
+    assert len(runner_error) == 1
+    assert isinstance(runner_error[0], GatewayConfigError)
+    assert "injected startup failure" in str(runner_error[0])
+    with service._gateway_lifecycle_lock(root, "reconfigure"):
+        pass
 
 
 def test_litellm_readiness_allows_cold_start_beyond_thirty_seconds(
@@ -1028,6 +1191,13 @@ def test_runtime_rebind_refuses_candidate_without_mutating_install(
     if case == "timeout":
         assert "retry" in message
         assert "probe_failed" not in message
+        assert type(exc_info.value) is not GatewayConfigError
+        assert exc_info.value.retryable is True
+        assert exc_info.value.reason_code == "litellm_runtime_probe_unknown"
+    elif case in {"nonzero", "oserror"}:
+        assert type(exc_info.value) is not GatewayConfigError
+        assert exc_info.value.retryable is False
+        assert exc_info.value.reason_code == "litellm_runtime_probe_failed"
     assert _file_snapshot(tmp_path) == before
 
 
@@ -1084,7 +1254,7 @@ def test_runtime_rebind_same_path_reprobes_and_is_byte_idempotent(
     assert _file_snapshot(tmp_path) == before
 
 
-def test_runtime_rebind_accepts_successful_probe_without_path_shape_or_output_rules(
+def test_runtime_rebind_accepts_valid_identity_without_path_shape_rules(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -1185,6 +1355,345 @@ def test_runtime_rebind_keeps_registered_task_bytes_but_run_uses_new_manifest_ru
     assert str(candidate.resolve()) not in registered_before
     assert commands.started == []
     assert commands.stopped == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows launcher identity boundary")
+def test_runtime_rebind_real_probe_rejects_zero_exit_non_litellm_executable(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = Path(os.environ["COMSPEC"])
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    before = _file_snapshot(tmp_path)
+
+    with pytest.raises(GatewayConfigError, match="litellm_runtime_probe_failed"):
+        service.rebind_runtime(root, litellm_executable=candidate)
+
+    assert _file_snapshot(tmp_path) == before
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows launcher identity boundary")
+@pytest.mark.parametrize("suffix", [".cmd", ".bat"])
+def test_runtime_rebind_real_probe_accepts_relative_forwarding_shim_with_odd_path(
+    tmp_path,
+    monkeypatch,
+    suffix,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = _write_windows_litellm_identity_shim(
+        tmp_path / "runtime path & Unicode Ω",
+        suffix=suffix,
+    )
+    monkeypatch.chdir(tmp_path)
+    relative_candidate = candidate.relative_to(tmp_path)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=relative_candidate,
+    )
+
+    assert result["litellm_executable"] == str(candidate.resolve())
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree boundary")
+def test_runtime_rebind_real_probe_timeout_tears_down_candidate_descendants(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    runtime_dir = tmp_path / "timeout runtime"
+    runtime_dir.mkdir()
+    ready = runtime_dir / "child.ready"
+    release = runtime_dir / "child.release"
+    sentinel = runtime_dir / "child.survived"
+    child = runtime_dir / "child.py"
+    child.write_text(
+        """import os
+import sys
+import time
+from pathlib import Path
+
+ready, release, sentinel = map(Path, sys.argv[1:])
+ready.write_text(str(os.getpid()), encoding=\"ascii\")
+while not release.exists():
+    time.sleep(0.02)
+sentinel.write_text(\"survived\", encoding=\"ascii\")
+""",
+        encoding="utf-8",
+    )
+    candidate = runtime_dir / "litellm.cmd"
+    candidate.write_text(
+        (
+            "@echo off\r\n"
+            ">nul ping -n 2 -w 1000 127.0.0.1\r\n"
+            f'start "" /b "{sys.executable}" "{child}" "{ready}" "{release}" "{sentinel}"\r\n'
+            ":wait_ready\r\n"
+            f'if not exist "{ready}" (\r\n'
+            "  >nul ping -n 2 -w 100 127.0.0.1\r\n"
+            "  goto wait_ready\r\n"
+            ")\r\n"
+            ":hang\r\n"
+            ">nul ping -n 2 -w 1000 127.0.0.1\r\n"
+            "goto hang\r\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(service, "LITELLM_RUNTIME_PROBE_TIMEOUT_SECONDS", 3.0)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    manifest_before = service.install_manifest_path(root).read_bytes()
+
+    with pytest.raises(GatewayConfigError, match="litellm_runtime_probe_unknown"):
+        service.rebind_runtime(root, litellm_executable=candidate)
+
+    assert ready.is_file(), "fixture never proved that the descendant started"
+    release.write_text("release", encoding="ascii")
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not sentinel.exists():
+        time.sleep(0.02)
+    assert not sentinel.exists()
+    assert service.install_manifest_path(root).read_bytes() == manifest_before
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows launcher identity boundary")
+def test_runtime_rebind_real_probe_rejects_oversized_untrusted_output(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    runtime_dir = tmp_path / "noisy runtime"
+    runtime_dir.mkdir()
+    implementation = runtime_dir / "noisy.py"
+    implementation.write_text(
+        "print('LiteLLM: Current Version = 1.91.3')\nprint('x' * 4096)\n",
+        encoding="utf-8",
+    )
+    candidate = runtime_dir / "litellm.cmd"
+    _write_windows_batch_forwarder(candidate, implementation)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    with pytest.raises(GatewayConfigError, match="litellm_runtime_probe_failed"):
+        service.rebind_runtime(root, litellm_executable=candidate)
+
+
+def test_runtime_rebind_compare_and_swap_refuses_candidate_manifest_mutation(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "candidate-runtime.exe"
+    candidate.write_bytes(b"candidate")
+    manifest_path = service.install_manifest_path(root)
+    mutated: dict[str, bytes] = {}
+
+    def mutate_manifest() -> None:
+        value = json.loads(manifest_path.read_text(encoding="utf-8"))
+        value["candidate_touch"] = True
+        manifest_path.write_text(json.dumps(value), encoding="utf-8")
+        mutated["bytes"] = manifest_path.read_bytes()
+
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    with pytest.raises(GatewayConfigError, match="gateway_runtime_manifest_changed"):
+        service.rebind_runtime(
+            root,
+            litellm_executable=candidate,
+            probe_commands=FakeRuntimeProbeCommands(side_effect=mutate_manifest),
+        )
+
+    assert manifest_path.read_bytes() == mutated["bytes"]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows subprocess race boundary")
+def test_runtime_rebind_serializes_supported_reconfigure_before_manifest_write(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = _write_windows_litellm_identity_shim(tmp_path / "race runtime")
+    manifest_path = service.install_manifest_path(root)
+    before_candidate_write = threading.Event()
+    release_candidate_write = threading.Event()
+    reconfigure_done = threading.Event()
+    errors: dict[str, BaseException] = {}
+    real_write_json = service._durable_write_json
+
+    def blocking_write(path, value) -> None:
+        if (
+            Path(path) == manifest_path
+            and isinstance(value, dict)
+            and value.get("litellm_executable") == str(candidate.resolve())
+        ):
+            before_candidate_write.set()
+            if not release_candidate_write.wait(timeout=10.0):
+                raise AssertionError("test did not release the rebind manifest write")
+        real_write_json(path, value)
+
+    def do_rebind() -> None:
+        try:
+            service.rebind_runtime(root, litellm_executable=candidate)
+        except BaseException as exc:  # noqa: BLE001 - asserted across the thread boundary
+            errors["rebind"] = exc
+
+    def do_reconfigure() -> None:
+        try:
+            service.reconfigure_endpoint(root)
+        except BaseException as exc:  # noqa: BLE001 - asserted across the thread boundary
+            errors["reconfigure"] = exc
+        finally:
+            reconfigure_done.set()
+
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    monkeypatch.setattr(service, "_durable_write_json", blocking_write)
+    monkeypatch.setattr(service, "DEFAULT_API_BASE", "https://fresh.example/v1")
+    rebind_thread = threading.Thread(target=do_rebind, daemon=True)
+    rebind_thread.start()
+    assert before_candidate_write.wait(timeout=10.0)
+    reconfigure_thread = threading.Thread(target=do_reconfigure, daemon=True)
+    reconfigure_thread.start()
+    interleaved = reconfigure_done.wait(timeout=1.0)
+    release_candidate_write.set()
+    rebind_thread.join(timeout=10.0)
+    reconfigure_thread.join(timeout=10.0)
+
+    assert not rebind_thread.is_alive()
+    assert not reconfigure_thread.is_alive()
+    assert interleaved is False
+    assert errors == {}
+    manifest = service.load_install_manifest(root)
+    assert manifest["litellm_executable"] == str(candidate.resolve())
+    assert manifest["litellm_config_sha256"] == hashlib.sha256(
+        litellm_config_path(root).read_bytes()
+    ).hexdigest()
+
+
+def test_runtime_rebind_waits_for_service_startup_then_refuses_owned_sockets(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, ledger, front_token, internal_token = _install_for_runtime_rebind(
+        tmp_path
+    )
+    candidate = tmp_path / "candidate-runtime.exe"
+    candidate.write_bytes(b"candidate")
+    provider_key = tmp_path / "secrets" / "provider.txt"
+    provider_key.write_text("provider-secret\n", encoding="utf-8")
+    startup_spawned = threading.Event()
+    allow_bind = threading.Event()
+    sockets_owned = threading.Event()
+    serving = threading.Event()
+    stop_serving = threading.Event()
+    rebind_checked_sockets = threading.Event()
+    results: dict[str, object] = {}
+    errors: dict[str, BaseException] = {}
+
+    class FakeProcess:
+        pid = os.getpid()
+
+        def __init__(self) -> None:
+            self.stdout = io.StringIO("")
+            self.alive = True
+
+        def poll(self):
+            return None if self.alive else 0
+
+        def terminate(self) -> None:
+            self.alive = False
+
+        def kill(self) -> None:
+            self.alive = False
+
+        def wait(self, timeout=None):
+            self.alive = False
+            return 0
+
+    class FakeServer:
+        def serve_forever(self, poll_interval=None) -> None:
+            serving.set()
+            if not stop_serving.wait(timeout=10.0):
+                raise AssertionError("test did not stop the fake server")
+
+        def shutdown(self) -> None:
+            stop_serving.set()
+
+        def server_close(self) -> None:
+            return None
+
+    class FakeFront:
+        def __init__(self, _config, _ledger) -> None:
+            pass
+
+        def make_server(self):
+            sockets_owned.set()
+            return FakeServer()
+
+        def drain(self, _timeout) -> None:
+            return None
+
+    def fake_popen(_argv, **_kwargs):
+        startup_spawned.set()
+        return FakeProcess()
+
+    def wait_until_allowed(_front, _process) -> None:
+        if not allow_bind.wait(timeout=10.0):
+            raise AssertionError("test did not allow the service to bind")
+
+    def observed_sockets_free() -> bool:
+        rebind_checked_sockets.set()
+        return not sockets_owned.is_set()
+
+    def do_run() -> None:
+        try:
+            results["run"] = run_service(
+                root,
+                ledger=ledger,
+                key_path=provider_key,
+                front_token_path=front_token,
+                internal_token_path=internal_token,
+                child_log_path=tmp_path / "litellm.log",
+                popen=fake_popen,
+            )
+        except BaseException as exc:  # noqa: BLE001 - asserted across the thread boundary
+            errors["run"] = exc
+
+    def do_rebind() -> None:
+        try:
+            results["rebind"] = service.rebind_runtime(
+                root,
+                litellm_executable=candidate,
+                probe_commands=FakeRuntimeProbeCommands(),
+            )
+        except BaseException as exc:  # noqa: BLE001 - asserted across the thread boundary
+            errors["rebind"] = exc
+
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+    monkeypatch.setattr(service, "_wait_liveliness", wait_until_allowed)
+    monkeypatch.setattr(service, "GatewayFront", FakeFront)
+    monkeypatch.setattr(service, "_process_start_token", lambda _pid: "start")
+    monkeypatch.setattr(service, "_both_sockets_free", observed_sockets_free)
+    run_thread = threading.Thread(target=do_run, daemon=True)
+    run_thread.start()
+    assert startup_spawned.wait(timeout=10.0)
+    rebind_thread = threading.Thread(target=do_rebind, daemon=True)
+    rebind_thread.start()
+    checked_before_bind = rebind_checked_sockets.wait(timeout=1.0)
+    allow_bind.set()
+    assert serving.wait(timeout=10.0)
+    rebind_thread.join(timeout=10.0)
+    stop_serving.set()
+    run_thread.join(timeout=10.0)
+
+    assert checked_before_bind is False
+    assert not rebind_thread.is_alive()
+    assert not run_thread.is_alive()
+    assert results == {"run": 0}
+    assert isinstance(errors.get("rebind"), GatewayConfigError)
+    assert "while the gateway is running" in str(errors["rebind"])
+    assert "run" not in errors
+    assert service.load_install_manifest(root)["litellm_executable"] == str(
+        old_runtime.resolve()
+    )
 
 
 def test_reconfigure_rebinds_config_and_manifest_and_preserves_ledger_and_tokens(

--- a/tests/test_ovh_gateway_service.py
+++ b/tests/test_ovh_gateway_service.py
@@ -70,6 +70,19 @@ class RacingInstallCommands(FakeCommands):
         raise GatewayConfigError("concurrent installer won")
 
 
+class FakeRuntimeProbeCommands:
+    def __init__(self, *, returncode: int = 0, error: Exception | None = None) -> None:
+        self.returncode = returncode
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    def run(self, argv, *, cwd, env):
+        self.calls.append({"argv": list(argv), "cwd": cwd, "env": dict(env)})
+        if self.error is not None:
+            raise self.error
+        return subprocess.CompletedProcess(argv, self.returncode)
+
+
 def test_project_task_name_is_canonical_and_collision_resistant(tmp_path) -> None:
     first = project_task_name(tmp_path / "Project")
     same = project_task_name(tmp_path / "Project" / ".." / "Project")
@@ -782,6 +795,396 @@ def _install_for_reconfigure(tmp_path, ledger):
         internal_token_path=internal_token,
     )
     return root, front_token, internal_token
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _install_for_runtime_rebind(tmp_path):
+    root = tmp_path / "project"
+    old_runtime = tmp_path / "old-runtime" / "litellm.exe"
+    old_runtime.parent.mkdir(parents=True)
+    old_runtime.write_bytes(b"old runtime")
+    install_json = tmp_path / "spend" / "install.json"
+    ledger = SpendLedger(tmp_path / "spend" / "ledger.sqlite3", install_json)
+    front_token = tmp_path / "secrets" / "front.txt"
+    internal_token = tmp_path / "secrets" / "internal.txt"
+    initialize_install(
+        root,
+        litellm_executable=old_runtime,
+        opening_micro_eur=580_000,
+        opening_evidence="test dashboard, observed 2026-07-16",
+        ledger=ledger,
+        front_token_path=front_token,
+        internal_token_path=internal_token,
+    )
+    return root, old_runtime, ledger, front_token, internal_token
+
+
+def test_runtime_rebind_changes_only_manifest_executable_and_preserves_install_authorities(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "unusual runtime" / "launcher.shim"
+    candidate.parent.mkdir()
+    candidate.write_bytes(b"capable shim")
+    execute = tmp_path / "agenttalk-python.exe"
+    execute.write_bytes(b"python")
+    commands = FakeCommands()
+    install_task(root, commands=commands, execute=execute, principal="D\\u")
+    identity = expected_task_identity(root, execute=execute, principal="D\\u")
+    registered_before = commands.tasks[identity.task_name]
+    before_files = _file_snapshot(tmp_path)
+    manifest_path = service.install_manifest_path(root)
+    manifest_before = json.loads(manifest_path.read_text(encoding="utf-8"))
+    probe = FakeRuntimeProbeCommands()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=probe,
+    )
+
+    manifest_after = json.loads(manifest_path.read_text(encoding="utf-8"))
+    changed_keys = {
+        key
+        for key in manifest_before.keys() | manifest_after.keys()
+        if manifest_before.get(key) != manifest_after.get(key)
+    }
+    manifest_relative = manifest_path.relative_to(tmp_path).as_posix()
+    after_files = _file_snapshot(tmp_path)
+    assert changed_keys == {"litellm_executable"}
+    assert {
+        key: value for key, value in after_files.items() if key != manifest_relative
+    } == {
+        key: value for key, value in before_files.items() if key != manifest_relative
+    }
+    assert commands.tasks[identity.task_name] == registered_before
+    assert manifest_after["litellm_executable"] == str(candidate.resolve())
+    assert manifest_after["litellm_config_sha256"] == hashlib.sha256(
+        litellm_config_path(root).read_bytes()
+    ).hexdigest()
+    assert manifest_after["price_policy_hash"] == price_policy_hash()
+    assert service.load_install_manifest(root) == manifest_after
+    assert result == {
+        "runtime_rebound": True,
+        "changed": True,
+        "litellm_executable": str(candidate.resolve()),
+        "previous_litellm_executable": str(old_runtime.resolve()),
+        "config_sha256": manifest_after["litellm_config_sha256"],
+        "price_policy_hash": manifest_after["price_policy_hash"],
+    }
+    assert probe.calls[0]["argv"] == [str(candidate.resolve()), "--version"]
+    assert probe.calls[0]["cwd"] == str(root.resolve())
+    probe_env = probe.calls[0]["env"]
+    assert probe_env["LITELLM_LOCAL_MODEL_COST_MAP"] == "True"
+    assert "OVH_KEY" not in probe_env
+    assert "LITELLM_MASTER_KEY" not in probe_env
+
+
+def test_runtime_rebind_repairs_missing_outgoing_runtime_without_probing_it(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    old_runtime.unlink()
+    candidate = tmp_path / "new-runtime.exe"
+    candidate.write_bytes(b"working")
+    probe = FakeRuntimeProbeCommands()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=probe,
+    )
+
+    assert result["runtime_rebound"] is True
+    assert probe.calls[0]["argv"] == [str(candidate.resolve()), "--version"]
+
+
+def test_runtime_rebind_probes_only_candidate_not_unusable_outgoing_runtime(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "working-runtime.exe"
+    candidate.write_bytes(b"working")
+    probe = FakeRuntimeProbeCommands()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=probe,
+    )
+
+    assert old_runtime.is_file()
+    assert [call["argv"] for call in probe.calls] == [
+        [str(candidate.resolve()), "--version"]
+    ]
+
+
+def test_runtime_rebind_refuses_running_gateway_before_candidate_probe(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "missing-runtime.exe"
+    probe = FakeRuntimeProbeCommands(error=AssertionError("probe must not run"))
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: False)
+    before = _file_snapshot(tmp_path)
+
+    with pytest.raises(GatewayConfigError, match="while the gateway is running; stop it first"):
+        service.rebind_runtime(
+            root,
+            litellm_executable=candidate,
+            probe_commands=probe,
+        )
+
+    assert probe.calls == []
+    assert _file_snapshot(tmp_path) == before
+
+
+def test_runtime_rebind_requires_existing_install_before_candidate_probe(
+    tmp_path,
+) -> None:
+    probe = FakeRuntimeProbeCommands(error=AssertionError("probe must not run"))
+
+    with pytest.raises(GatewayConfigError, match="requires an existing install"):
+        service.rebind_runtime(
+            tmp_path / "project",
+            litellm_executable=tmp_path / "runtime.exe",
+            probe_commands=probe,
+        )
+
+    assert probe.calls == []
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("missing", "litellm_runtime_missing"),
+        ("nonzero", "litellm_runtime_probe_failed"),
+        ("oserror", "litellm_runtime_probe_failed"),
+        ("timeout", "litellm_runtime_probe_unknown"),
+    ],
+)
+def test_runtime_rebind_refuses_candidate_without_mutating_install(
+    tmp_path,
+    monkeypatch,
+    case,
+    expected_reason,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "candidate-runtime.exe"
+    if case != "missing":
+        candidate.write_bytes(b"candidate")
+    error = None
+    returncode = 0
+    if case == "nonzero":
+        returncode = 1
+    elif case == "oserror":
+        error = OSError("invalid executable")
+    elif case == "timeout":
+        error = subprocess.TimeoutExpired([str(candidate), "--version"], 30)
+    probe = FakeRuntimeProbeCommands(returncode=returncode, error=error)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    before = _file_snapshot(tmp_path)
+
+    with pytest.raises(GatewayConfigError) as exc_info:
+        service.rebind_runtime(
+            root,
+            litellm_executable=candidate,
+            probe_commands=probe,
+        )
+
+    message = str(exc_info.value)
+    outcome_reasons = {
+        "litellm_runtime_missing",
+        "litellm_runtime_probe_failed",
+        "litellm_runtime_probe_unknown",
+    }
+    assert {reason for reason in outcome_reasons if reason in message} == {
+        expected_reason
+    }
+    assert (
+        f'agenttalk --root "{root.resolve()}" gateway runtime-rebind '
+        "--litellm-executable"
+    ) in message
+    if case == "missing":
+        assert probe.calls == []
+    else:
+        assert [call["argv"] for call in probe.calls] == [
+            [str(candidate.resolve()), "--version"]
+        ]
+    if case == "timeout":
+        assert "retry" in message
+        assert "probe_failed" not in message
+    assert _file_snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("corruption", ["config_hash", "price_policy"])
+def test_runtime_rebind_refuses_invalid_bound_manifest_before_probe(
+    tmp_path,
+    monkeypatch,
+    corruption,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "candidate-runtime.exe"
+    candidate.write_bytes(b"candidate")
+    manifest_path = service.install_manifest_path(root)
+    if corruption == "config_hash":
+        litellm_config_path(root).write_bytes(b"changed outside the manifest")
+        expected = "LiteLLM config hash mismatch"
+    else:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["price_policy_hash"] = "stale"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        expected = "price policy mismatch"
+    probe = FakeRuntimeProbeCommands(error=AssertionError("probe must not run"))
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    before = _file_snapshot(tmp_path)
+
+    with pytest.raises(GatewayConfigError, match=expected):
+        service.rebind_runtime(
+            root,
+            litellm_executable=candidate,
+            probe_commands=probe,
+        )
+
+    assert probe.calls == []
+    assert _file_snapshot(tmp_path) == before
+
+
+def test_runtime_rebind_same_path_reprobes_and_is_byte_idempotent(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    probe = FakeRuntimeProbeCommands()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    before = _file_snapshot(tmp_path)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=old_runtime,
+        probe_commands=probe,
+    )
+
+    assert result["changed"] is False
+    assert probe.calls[0]["argv"] == [str(old_runtime.resolve()), "--version"]
+    assert _file_snapshot(tmp_path) == before
+
+
+def test_runtime_rebind_accepts_successful_probe_without_path_shape_or_output_rules(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    candidate = tmp_path / "odd path" / "launcher.with-unfamiliar-suffix"
+    candidate.parent.mkdir()
+    candidate.write_bytes(b"shim")
+    probe = FakeRuntimeProbeCommands(returncode=0)
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=probe,
+    )
+
+    assert result["litellm_executable"] == str(candidate.resolve())
+
+
+def test_runtime_rebind_accepts_symlinked_launcher_when_host_supports_it(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, _, _, _, _ = _install_for_runtime_rebind(tmp_path)
+    target = tmp_path / "runtime-target.exe"
+    target.write_bytes(b"working")
+    candidate = tmp_path / "runtime-link.exe"
+    try:
+        candidate.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"host cannot create a test symlink: {exc}")
+    probe = FakeRuntimeProbeCommands()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+
+    result = service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=probe,
+    )
+
+    assert result["litellm_executable"] == str(target.resolve())
+    assert probe.calls[0]["argv"] == [str(target.resolve()), "--version"]
+
+
+def test_runtime_rebind_keeps_registered_task_bytes_but_run_uses_new_manifest_runtime(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root, old_runtime, ledger, front_token, internal_token = _install_for_runtime_rebind(
+        tmp_path
+    )
+    candidate = tmp_path / "new-runtime.exe"
+    candidate.write_bytes(b"working")
+    execute = tmp_path / "agenttalk-python.exe"
+    execute.write_bytes(b"python")
+    commands = FakeCommands()
+    identity = expected_task_identity(root, execute=execute, principal="D\\u")
+    install_task(root, commands=commands, execute=execute, principal="D\\u")
+    registered_before = commands.tasks[identity.task_name]
+    task_xml = service.gateway_state_dir(root) / "task.xml"
+    task_xml_before = task_xml.read_bytes()
+    task_identity_before = task_identity_path(root).read_bytes()
+    monkeypatch.setattr(service, "_both_sockets_free", lambda: True)
+    service.rebind_runtime(
+        root,
+        litellm_executable=candidate,
+        probe_commands=FakeRuntimeProbeCommands(),
+    )
+    provider_key = tmp_path / "secrets" / "provider.txt"
+    provider_key.write_text("provider-secret\n", encoding="utf-8")
+    monkeypatch.setattr(service, "exclusive_bind_probe", lambda _host, _port: None)
+    captured: dict[str, object] = {}
+
+    class SpawnObserved(Exception):
+        pass
+
+    def capture_spawn(argv, **_kwargs):
+        captured["argv"] = list(argv)
+        raise SpawnObserved
+
+    with pytest.raises(SpawnObserved):
+        run_service(
+            root,
+            ledger=ledger,
+            key_path=provider_key,
+            front_token_path=front_token,
+            internal_token_path=internal_token,
+            child_log_path=tmp_path / "litellm.log",
+            popen=capture_spawn,
+        )
+
+    assert captured["argv"][0] == str(candidate.resolve())
+    assert commands.tasks[identity.task_name] == registered_before
+    assert task_xml.read_bytes() == task_xml_before
+    assert task_identity_path(root).read_bytes() == task_identity_before
+    assert "gateway run" in registered_before
+    assert str(old_runtime.resolve()) not in registered_before
+    assert str(candidate.resolve()) not in registered_before
+    assert commands.started == []
+    assert commands.stopped == []
 
 
 def test_reconfigure_rebinds_config_and_manifest_and_preserves_ledger_and_tokens(


### PR DESCRIPTION
## Why

The Qwen gateway failed on every scheduled start from 21 July to 11 August. Its LiteLLM runtime had been installed under an ephemeral session path; cleanup left the launcher present but unable to import the entry point. The manifest could not be repaired without replacing unrelated durable state.

## What this adds

`agenttalk gateway runtime-rebind --litellm-executable PATH`

- Serializes gateway initialization, endpoint reconfiguration, runtime rebinding, and service startup with a gateway-scoped cross-process lifecycle authority. The lock records the holder's PID plus exact process-start identity, operation, and acquisition time; abandoned holders are taken over only after exact death or PID-reuse proof.
- Requires the gateway to be stopped. Rebind holds the lifecycle authority across its candidate probe and manifest write; service startup holds it until both sockets are owned and the runtime marker is durable, including startup-failure cleanup.
- Validates every existing manifest authority except the outgoing runtime, so a broken runtime cannot block its own repair. A byte snapshot/CAS check also refuses if the manifest changes during validation.
- Runs the candidate with `--version` in a credential-free filtered environment with the local cost map forced on. Success requires exactly one bounded canonical `LiteLLM: Current Version = ...` record. This rejects unrelated zero-exit programs such as `cmd.exe` while retaining working `.cmd`/`.bat` shims, paths with spaces/Unicode/metacharacters, symlinks, and relocated launchers.
- Places the real probe in the existing owned process-tree job/group. The real timeout control confirms descendant teardown, and observable containment, reap, or output-drain failures become UNKNOWN rather than a false validity verdict.
- Changes only `litellm_executable` within the install manifest. The config bytes/hash, price-policy binding, other binds, spend ledger, token files, and registered task are not rewritten by AgentTalk. The task already invokes `agenttalk gateway run` and reads the runtime path from the manifest, so no task reinstall is needed.
- Re-probes a same-path candidate without rewriting the manifest.

### Outcome vocabulary

- Determinate missing, launch, exit-status, or identity failures use `litellm_runtime_probe_failed` and CLI exit 2.
- A timeout or inconclusive containment/cleanup uses retryable `litellm_runtime_probe_unknown` and CLI exit 3. A slow host is not classified as a bad runtime.
- A known live lifecycle holder uses named `gateway_lifecycle_contended` and CLI exit 2, including who holds it and what to do next.
- Corrupt or unclassifiable lifecycle authority uses `gateway_lifecycle_unknown` and CLI exit 3 with a fail-closed recovery instruction.

## Trust boundary

The selected candidate is trusted, unsandboxed code executed with the invoking operator's filesystem authority. The probe is not a sandbox: a malicious candidate can modify the ledger, tokens, task files, or other same-user state. Accordingly, the preservation guarantee above describes AgentTalk's own writes and a well-behaved candidate, not protection from the candidate itself.

The bounded banner proves conformance to the expected probe protocol, not executable provenance. A deceptive launcher can spoof that record, and an in-place replacement after validation is not detected. Operators must select a runtime they trust.

## Evidence

- Failing-first: the held-finding matrix produced 10 failures on unchanged production, and the purpose-built lock controls initially failed because no primitive existed.
- Green: **81 passed, 2 skipped** across the targeted lifecycle-lock, gateway-service, gateway-CLI, and real-process gateway-race files.
- Real-process controls cover live contention, exact abandoned-holder takeover, PID-reuse imposters without killing them, holder handoff diagnostics, rebind/reconfigure ordering, and startup/rebind ordering through real socket ownership and durable marker publication.
- A real timeout shim proved descendant teardown; unrelated zero-exit executables were refused; odd-path forwarding shims were admitted.
- The durable LiteLLM 1.91.3 runtime emitted the accepted single identity record and returned zero.
- The skips are platform-specific controls: POSIX unreaped-zombie takeover on this Windows host, and a symlink control when Windows symlink privilege is unavailable.

## Not verified here

No test in this PR starts the attended production gateway against the rebound manifest and observes real model traffic. The real-process integration controls exercise the lifecycle authority, candidate probe, socket ownership, marker publication, manifest bindings, and cleanup with isolated collaborators; they are not live-provider acceptance evidence.

The existing Windows job helper does not surface the kernel `CloseHandle` return value. The normal timeout path is exercised, but a rare job-handle close failure cannot be machine-classified within this module's current boundary.

Two related defects remain separately tracked and are not addressed here: the managed task's interpreter/version skew (#193), and missing escalation after repeated scheduled-start failures (#192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
