### PR TITLE
v0.83 item 1: testable supervisor spawn seam with a closed typed outcome set

### DIFF
--- a/dev-gate.json
+++ b/dev-gate.json
@@ -70,7 +70,7 @@
         "-q"
       ],
       "test_requirement": "pytest>=8.0",
-      "timeout_seconds": 2700
+      "timeout_seconds": 3600
     },
     "ruff": {
       "kind": "ruff",

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -13034,6 +13034,7 @@ function Test-RunningOnWindows {
   # in hermetic launch environments.
   return [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 }
+# region wrapper-process-launcher
 $script:WrapperLogLauncherTypeReady = $false
 function Initialize-WrapperLogLauncherType {
   if (-not (Test-RunningOnWindows)) { return $false }
@@ -13363,8 +13364,9 @@ namespace Agenttalk {
   }
 }
 function Start-WrapperProcess([hashtable]$startArgs) {
-  # Returns [pscustomobject]@{ Process = <process>; Redirected = <bool> } -
-  # NEVER the bare process object. I1: logging capability (the env vars
+  # Returns [pscustomobject]@{ Process = <process>;
+  # CreationFiletime = <string|null>; Redirected = <bool> } - NEVER the bare
+  # process object. I1: logging capability (the env vars
   # and the nonce - a wrapper that never actually got redirected has no
   # channel to confirm anything through) is granted if and only if the
   # child's output is ACTUALLY redirected.
@@ -13487,6 +13489,7 @@ function Start-WrapperProcess([hashtable]$startArgs) {
     Redirected = $redirected
   }
 }
+# endregion wrapper-process-launcher
 if (-not ('AgenttalkSupervisorNativePosix' -as [type])) {
   Add-Type -TypeDefinition @'
 using System.Runtime.InteropServices;

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -13044,6 +13044,7 @@ function Initialize-WrapperLogLauncherType {
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -13051,12 +13052,15 @@ using System.Text;
 namespace Agenttalk {
   public sealed class ExactHandleLaunchResult {
     public Process Process { get; private set; }
+    public string CreationFiletime { get; private set; }
     public bool StdoutDegraded { get; private set; }
     public bool StderrDegraded { get; private set; }
 
     internal ExactHandleLaunchResult(
-        Process process, bool stdoutDegraded, bool stderrDegraded) {
+        Process process, string creationFiletime,
+        bool stdoutDegraded, bool stderrDegraded) {
       Process = process;
+      CreationFiletime = creationFiletime;
       StdoutDegraded = stdoutDegraded;
       StderrDegraded = stderrDegraded;
     }
@@ -13158,6 +13162,12 @@ namespace Agenttalk {
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetProcessTimes(
+      IntPtr process, out long creationTime, out long exitTime,
+      out long kernelTime, out long userTime);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -13288,13 +13298,24 @@ namespace Agenttalk {
         }
         processCreated = true;
 
+        string creationFiletime = null;
+        long creationTime;
+        long exitTime;
+        long kernelTime;
+        long userTime;
+        if (GetProcessTimes(processInfo.hProcess,
+            out creationTime, out exitTime,
+            out kernelTime, out userTime)) {
+          creationFiletime = creationTime.ToString(CultureInfo.InvariantCulture);
+        }
+
         Process process = Process.GetProcessById((int)processInfo.dwProcessId);
         if (ResumeThread(processInfo.hThread) == UInt32.MaxValue) {
           throw new Win32Exception(
             Marshal.GetLastWin32Error(), "ResumeThread failed");
         }
         return new ExactHandleLaunchResult(
-          process, stdoutDegraded, stderrDegraded);
+          process, creationFiletime, stdoutDegraded, stderrDegraded);
       } catch {
         if (processCreated && processInfo.hProcess != IntPtr.Zero) {
           TerminateProcess(processInfo.hProcess, 127);
@@ -13411,6 +13432,7 @@ function Start-WrapperProcess([hashtable]$startArgs) {
         # exact-handle-unavailable fallback path below.
         return [pscustomobject]@{
           Process = $launchResult.Process
+          CreationFiletime = $launchResult.CreationFiletime
           Redirected = -not ($launchResult.StdoutDegraded -and $launchResult.StderrDegraded)
         }
       } catch {
@@ -13443,13 +13465,25 @@ function Start-WrapperProcess([hashtable]$startArgs) {
     foreach ($key in $WrapperLogEnvKeys) {
       Remove-Item -LiteralPath ("Env:" + $key) -ErrorAction SilentlyContinue
     }
+    $process = Start-Process @startArgs
+    $creationFiletime = $null
+    try {
+      $creationFiletime = Get-AgenttalkProcessHandleStartFiletime $process.Handle
+    } catch {}
     return [pscustomobject]@{
-      Process = (Start-Process @startArgs)
+      Process = $process
+      CreationFiletime = $creationFiletime
       Redirected = $false
     }
   }
+  $process = Start-Process @startArgs
+  $creationFiletime = $null
+  try {
+    $creationFiletime = Get-AgenttalkProcessHandleStartFiletime $process.Handle
+  } catch {}
   return [pscustomobject]@{
-    Process = (Start-Process @startArgs)
+    Process = $process
+    CreationFiletime = $creationFiletime
     Redirected = $redirected
   }
 }
@@ -14091,6 +14125,106 @@ function Get-LaunchAdmissionPrefixTokens($admission) {
   return ,@(@($admission.argv)[0..([int]$index - 1)])
 }
 # endregion launch-admission-helpers
+# region supervisor-spawn-step
+function Invoke-SupervisorSpawnStep(
+    [hashtable]$startArgs,
+    [string]$operation) {
+  # This is the single process-creation seam used by both launch populations.
+  # It observes the process returned by the shipped launcher; it does not wait
+  # for wrapper readiness, which remains later-poll evidence.
+  if ($null -eq $startArgs -or
+      -not $startArgs.ContainsKey('FilePath') -or
+      [string]::IsNullOrWhiteSpace([string]$startArgs.FilePath)) {
+    return [pscustomobject]@{
+      schema = 'agenttalk-supervisor-spawn-step'
+      schema_version = 1
+      outcome = 'refused'
+      reason_code = 'spawn_args_invalid'
+      remedy = 'regenerate the supervisor script and retry the launch'
+      cleanup_status = 'not_started'
+      operation = $operation
+      pid = $null
+      process_identity = $null
+      redirected = $false
+      _process = $null
+      _error_record = $null
+      _compatibility_disposition = 'no_pid'
+    }
+  }
+  try {
+    $rawLaunch = Start-WrapperProcess $startArgs
+    $process = $rawLaunch.Process
+    $spawnProcessId = if ($null -ne $process -and $process.Id) {
+      [int]$process.Id
+    } else { $null }
+    if ($null -eq $spawnProcessId) {
+      return [pscustomobject]@{
+        schema = 'agenttalk-supervisor-spawn-step'
+        schema_version = 1
+        outcome = 'unknown'
+        reason_code = 'spawn_pid_unavailable'
+        remedy = 'inspect the process table before retrying the launch'
+        cleanup_status = 'unknown'
+        operation = $operation
+        pid = $null
+        process_identity = $null
+        redirected = [bool]$rawLaunch.Redirected
+        _process = $process
+        _error_record = $null
+        _compatibility_disposition = 'no_pid'
+      }
+    }
+    $creationFiletime = [string]$rawLaunch.CreationFiletime
+    $identity = if ($creationFiletime -match '^[1-9][0-9]*$') {
+      [pscustomobject]@{
+        scheme = 'win32-filetime-v1'
+        value = $creationFiletime
+      }
+    } else { $null }
+    $outcome = if ($null -ne $identity) { 'spawned' } else { 'unknown' }
+    return [pscustomobject]@{
+      schema = 'agenttalk-supervisor-spawn-step'
+      schema_version = 1
+      outcome = $outcome
+      reason_code = if ($null -ne $identity) {
+        $null
+      } else { 'spawn_identity_unavailable' }
+      remedy = if ($null -ne $identity) {
+        $null
+      } else {
+        'do not retry until an operator resolves the reported PID'
+      }
+      cleanup_status = 'not_needed'
+      operation = $operation
+      pid = $spawnProcessId
+      process_identity = $identity
+      redirected = [bool]$rawLaunch.Redirected
+      _process = $process
+      _error_record = $null
+      # Increment 1 preserves the old record-by-PID behavior when identity
+      # observation is UNKNOWN. Increment 2 replaces that disposition.
+      _compatibility_disposition = 'record_pid'
+    }
+  } catch {
+    return [pscustomobject]@{
+      schema = 'agenttalk-supervisor-spawn-step'
+      schema_version = 1
+      outcome = 'unknown'
+      reason_code = 'spawn_step_exception'
+      remedy = 'inspect the process table before retrying the launch'
+      cleanup_status = 'unknown'
+      operation = $operation
+      pid = $null
+      process_identity = $null
+      redirected = $false
+      _process = $null
+      _error_record = $_
+      # Preserve the existing throw path until increment 2 owns cleanup.
+      _compatibility_disposition = 'rethrow'
+    }
+  }
+}
+# endregion supervisor-spawn-step
 function Launch($name, $plan, $codexHome, $acceptedAdmission = $null) {
   $admission = $acceptedAdmission
   if ($null -eq $admission) {
@@ -14192,15 +14326,17 @@ function Launch($name, $plan, $codexHome, $acceptedAdmission = $null) {
       $argline = (@($argv) | ForEach-Object { Quote-Arg ([string]$_) }) -join ' '
       $startArgs['ArgumentList'] = $argline
     }
-    $launch = Start-WrapperProcess $startArgs
+    $launch = Invoke-SupervisorSpawnStep $startArgs ("regular:{0}" -f $name)
+    if ($launch._compatibility_disposition -eq 'rethrow') {
+      throw $launch._error_record
+    }
   } catch {
     Discard-PendingWrapperLogTargets $logTargets
     throw
   } finally {
     Restore-AgenttalkEnvironment $saved
   }
-  $proc = $launch.Process
-  if ($proc -and $proc.Id) {
+  if ($launch._compatibility_disposition -eq 'record_pid') {
     # Round 23: committing is no longer this call's decision. If
     # Start-Process itself never redirected, there is no channel a
     # confirmation could ever arrive through, so discarding immediately is
@@ -14217,15 +14353,25 @@ function Launch($name, $plan, $codexHome, $acceptedAdmission = $null) {
     if ($null -ne $logTargets -and -not $launch.Redirected) {
       Discard-PendingWrapperLogTargets $logTargets
     }
-    $out = @{ pid = $proc.Id; session_id = $sid; start = (Proc-Start $proc.Id);
-              launcher_nonce_injected = [bool]$nonceResult.injected;
-              launcher_nonce_source = $nonceResult.source;
-              launcher_nonce_missing_reason = $nonceResult.missing_reason }
-    if ($nonceResult.injected -and $nonceResult.nonce) { $out.launcher_nonce = $nonceResult.nonce }
-    return $out
+    $launch | Add-Member -NotePropertyName session_id `
+      -NotePropertyValue $sid -Force
+    $launch | Add-Member -NotePropertyName start `
+      -NotePropertyValue (Proc-Start $launch.pid) -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_injected `
+      -NotePropertyValue ([bool]$nonceResult.injected) -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_source `
+      -NotePropertyValue $nonceResult.source -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_missing_reason `
+      -NotePropertyValue $nonceResult.missing_reason -Force
+    if ($nonceResult.injected -and $nonceResult.nonce) {
+      $launch | Add-Member -NotePropertyName launcher_nonce `
+        -NotePropertyValue $nonceResult.nonce -Force
+    }
+    return $launch
   }
   Discard-PendingWrapperLogTargets $logTargets
-  Write-Warning "supervisor: launch of '$name' returned no PID; not auto-restarting it"; return $null
+  Write-Warning "supervisor: launch of '$name' returned no PID; not auto-restarting it"
+  return $launch
 }
 
 function Launch-Spec($name, $spec, $codexHome, $acceptedAdmission = $null) {
@@ -14307,29 +14453,39 @@ function Launch-Spec($name, $spec, $codexHome, $acceptedAdmission = $null) {
       $argline = (@($argv) | ForEach-Object { Quote-Arg ([string]$_) }) -join ' '
       $startArgs['ArgumentList'] = $argline
     }
-    $launch = Start-WrapperProcess $startArgs
+    $launch = Invoke-SupervisorSpawnStep $startArgs ("ephemeral:{0}" -f $name)
+    if ($launch._compatibility_disposition -eq 'rethrow') {
+      throw $launch._error_record
+    }
   } catch {
     Discard-PendingWrapperLogTargets $logTargets
     throw
   } finally {
     Restore-AgenttalkEnvironment $saved
   }
-  $proc = $launch.Process
-  if ($proc -and $proc.Id) {
+  if ($launch._compatibility_disposition -eq 'record_pid') {
     # Round 23: see Launch's own comment - committing is the wrapper's own
     # job now, from evidence, not this call's decision.
     if ($null -ne $logTargets -and -not $launch.Redirected) {
       Discard-PendingWrapperLogTargets $logTargets
     }
-    $out = @{ pid = $proc.Id; start = (Proc-Start $proc.Id);
-              launcher_nonce_injected = [bool]$nonceResult.injected;
-              launcher_nonce_source = $nonceResult.source;
-              launcher_nonce_missing_reason = $nonceResult.missing_reason }
-    if ($nonceResult.injected -and $nonceResult.nonce) { $out.launcher_nonce = $nonceResult.nonce }
-    return $out
+    $launch | Add-Member -NotePropertyName start `
+      -NotePropertyValue (Proc-Start $launch.pid) -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_injected `
+      -NotePropertyValue ([bool]$nonceResult.injected) -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_source `
+      -NotePropertyValue $nonceResult.source -Force
+    $launch | Add-Member -NotePropertyName launcher_nonce_missing_reason `
+      -NotePropertyValue $nonceResult.missing_reason -Force
+    if ($nonceResult.injected -and $nonceResult.nonce) {
+      $launch | Add-Member -NotePropertyName launcher_nonce `
+        -NotePropertyValue $nonceResult.nonce -Force
+    }
+    return $launch
   }
   Discard-PendingWrapperLogTargets $logTargets
-  Write-Warning "supervisor: ephemeral launch of '$name' returned no PID"; return $null
+  Write-Warning "supervisor: ephemeral launch of '$name' returned no PID"
+  return $launch
 }
 
 # Console action log (0.29.0 observability): $lastLogged remembers the last state
@@ -14544,8 +14700,11 @@ $pollNum = 0
           $postLaunchPath = Join-Path $PSScriptRoot ("supervisor-postlaunch-{0}.json" -f $name)
           Get-ProcSnapshot $preLaunchPath | Out-Null
           $res = Launch $name $p $homeEnv $launchAdmission
-          if ($res) { Get-ProcSnapshot $postLaunchPath | Out-Null }
-          if ($res) {
+          $spawnRecorded = (
+            $null -ne $res -and
+            $res._compatibility_disposition -eq 'record_pid')
+          if ($spawnRecorded) { Get-ProcSnapshot $postLaunchPath | Out-Null }
+          if ($spawnRecorded) {
             # Record the LAUNCHER pid + start (anti-reuse) + open grace via Python
             # (authoritative: claude pins the minted id; codex resumes by --last).
             $extra = @(); if ($res.session_id) { $extra += @('--session-id', $res.session_id) }
@@ -14648,8 +14807,11 @@ $pollNum = 0
         $postLaunchPath = Join-Path $PSScriptRoot ("supervisor-postlaunch-{0}.json" -f $rid)
         Get-ProcSnapshot $preLaunchPath | Out-Null
         $res = Launch-Spec $prep.agent $prep $homeEnv $launchAdmission
-        if ($res) { Get-ProcSnapshot $postLaunchPath | Out-Null }
-        if ($res) {
+        $spawnRecorded = (
+          $null -ne $res -and
+          $res._compatibility_disposition -eq 'record_pid')
+        if ($spawnRecorded) { Get-ProcSnapshot $postLaunchPath | Out-Null }
+        if ($spawnRecorded) {
           $extra = @(); if ($res.start) { $extra += @('--pid-start', $res.start) }
           if ($res.launcher_nonce_injected -and $res.launcher_nonce) {
             $extra += @('--launcher-nonce', $res.launcher_nonce, '--launcher-nonce-injected', '--launcher-nonce-source', $res.launcher_nonce_source)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -871,7 +871,7 @@ def test_supervise_init_generates_and_is_idempotent(tmp_path: Path, capsys) -> N
     assert "supervise --plan --state-file" in ps
     assert "--record-events" in ps
     assert "--json" not in ps                       # blocker regression guard
-    assert "Start-WrapperProcess $startArgs" in ps
+    assert "Invoke-SupervisorSpawnStep $startArgs" in ps
     assert "ArgumentList" in ps and "PassThru = $true" in ps
     assert "Invoke-Expression" not in ps            # file/args executor, no expr
     assert "windows_file" in ps                     # launches the real exe
@@ -4766,7 +4766,7 @@ def test_ephemeral_launcher_applies_environment_names_literally(
         return
     helpers = _exec_helpers(tmp_path)
     launchers = sup.PS_TEMPLATE[
-        sup.PS_TEMPLATE.index("function Launch($name"):
+        sup.PS_TEMPLATE.index("# region supervisor-spawn-step"):
         sup.PS_TEMPLATE.index("# Console action log")
     ]
     output = tmp_path / "literal-environment.json"
@@ -6488,7 +6488,7 @@ def test_ps_template_prepares_redirects_for_regular_and_ephemeral_launches() -> 
         assert "RedirectStandardOutput" in block
         assert "RedirectStandardError" in block
         assert "AGENTTALK_WRAPPER_LOG_NONCE" in block
-        assert "Start-WrapperProcess $startArgs" in block
+        assert "Invoke-SupervisorSpawnStep $startArgs" in block
         assert block.index(configured_env) < block.index(
             "AGENTTALK_WRAPPER_LOG_NONCE"
         )
@@ -8030,7 +8030,7 @@ def test_launch_environment_apply_failure_restores_parent_without_spawn(
         pytest.skip("Windows PowerShell hosts are unavailable")
     helpers = _exec_helpers(tmp_path)
     launchers = sup.PS_TEMPLATE[
-        sup.PS_TEMPLATE.index("function Launch($name"):
+        sup.PS_TEMPLATE.index("# region supervisor-spawn-step"):
         sup.PS_TEMPLATE.index("# Console action log")
     ]
     output = tmp_path / "environment-rollback.json"
@@ -8507,7 +8507,7 @@ def test_ps_regular_wrapped_launch_consumes_planned_loop_admission(
 
     helpers = _exec_helpers(tmp_path)
     launchers = sup.PS_TEMPLATE[
-        sup.PS_TEMPLATE.index("function Launch($name"):
+        sup.PS_TEMPLATE.index("# region supervisor-spawn-step"):
         sup.PS_TEMPLATE.index("# Console action log")
     ]
     out = tmp_path / "wrapped-loop-admission.json"
@@ -9457,7 +9457,7 @@ def _launch_admission_runtime_blocks(tmp_path: Path) -> tuple[str, str, str]:
         sup.PS_TEMPLATE.index("# endregion quote-arg")
     ]
     launchers = sup.PS_TEMPLATE[
-        sup.PS_TEMPLATE.index("function Launch($name"):
+        sup.PS_TEMPLATE.index("# region supervisor-spawn-step"):
         sup.PS_TEMPLATE.index("# Console action log")
     ]
     return helpers, quote_arg, launchers
@@ -9940,7 +9940,7 @@ def test_supervisor_wrapper_logging_is_driven_by_typed_admission(
         return
     helpers = _exec_helpers(tmp_path)
     launchers = sup.PS_TEMPLATE[
-        sup.PS_TEMPLATE.index("function Launch($name"):
+        sup.PS_TEMPLATE.index("# region supervisor-spawn-step"):
         sup.PS_TEMPLATE.index("# Console action log")
     ]
     root = str(tmp_path)

--- a/tests/test_supervisor_spawn_seam.py
+++ b/tests/test_supervisor_spawn_seam.py
@@ -61,10 +61,6 @@ def _region(text: str, name: str) -> str:
     return text[start:end]
 
 
-def _powershell_code(text: str) -> str:
-    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
-
-
 def _generated_executor(tmp_path: Path) -> tuple[Store, str]:
     store = Store(tmp_path)
     store.init(["lead", "worker"])
@@ -125,7 +121,15 @@ def _stop_exact_process_tree(
     )
 
 
-def _assert_single_spawn_door(text: str) -> None:
+def _assert_spawn_door_regression_tripwire(text: str) -> None:
+    """Catch common direct spawn-door regressions; this is not a sound sandbox.
+
+    The lexical tripwire catches Start-WrapperProcess calls with any argument
+    spelling outside the seam, plus direct Start-Process or .NET Process.Start
+    spellings outside the approved launcher. It does not catch the PowerShell
+    call operator, Invoke-Expression, aliases, or string-obscured invocations.
+    Task #199 owns the sound PowerShell AST guard.
+    """
     launcher = _region(text, "wrapper-process-launcher")
     seam = _region(text, "supervisor-spawn-step")
     outside = text.replace(launcher, "", 1).replace(seam, "", 1)
@@ -136,41 +140,31 @@ def _assert_single_spawn_door(text: str) -> None:
         text.index("function Launch-Spec") : text.index("# Console action log")
     ]
 
-    launcher_code = _powershell_code(launcher)
-    seam_code = _powershell_code(seam)
-    outside_code = _powershell_code(outside)
-    all_code = _powershell_code(text)
-    assert len(re.findall(r"\bStart-WrapperProcess\b", launcher_code, re.I)) == 1
-    assert len(re.findall(r"\bStart-WrapperProcess\b", seam_code, re.I)) == 1
-    assert not re.search(r"\bStart-WrapperProcess\b", outside_code, re.I)
-    assert len(re.findall(r"\bInvoke-SupervisorSpawnStep\b", all_code, re.I)) == 3
-    assert len(
-        re.findall(r"\bInvoke-SupervisorSpawnStep\b", _powershell_code(regular), re.I)
-    ) == 1
-    assert len(
-        re.findall(
-            r"\bInvoke-SupervisorSpawnStep\b", _powershell_code(ephemeral), re.I
+    def direct_calls(source: str, command: str) -> list[str]:
+        return re.findall(
+            rf"(?im)^\s*(?:\$[\w:]+\s*=\s*)?{re.escape(command)}\b",
+            source,
         )
-    ) == 1
 
-    normalized_outside_launcher = " ".join(
-        _powershell_code(text.replace(launcher, "", 1)).split()
+    assert len(re.findall(r"(?im)^\s*function\s+Start-WrapperProcess\b", launcher)) == 1
+    assert len(direct_calls(seam, "Start-WrapperProcess")) == 1
+    assert not direct_calls(outside, "Start-WrapperProcess")
+    assert len(re.findall(r"(?im)^\s*function\s+Invoke-SupervisorSpawnStep\b", seam)) == 1
+    assert len(direct_calls(text, "Invoke-SupervisorSpawnStep")) == 2
+    assert len(direct_calls(regular, "Invoke-SupervisorSpawnStep")) == 1
+    assert len(direct_calls(ephemeral, "Invoke-SupervisorSpawnStep")) == 1
+
+    outside_launcher = text.replace(launcher, "", 1)
+    assert not direct_calls(outside_launcher, "Start-Process")
+    assert not re.search(
+        r"(?im)^\s*(?:\$[\w:]+\s*=\s*)?"
+        r"\[(?:System\.)?Diagnostics\.Process\]\s*::\s*Start\s*\(",
+        outside_launcher,
     )
-    process_creation_patterns = [
-        r"\bStart-Process\b",
-        r"(?:::|\.)\s*Start\s*\(",
-        r"\bNew-Object\b(?:\s+-TypeName)?\s+(?:System\.)?Diagnostics\.Process\b",
-        r"\b(?:Invoke-CimMethod|Invoke-WmiMethod)\b.{0,300}"
-        r"\b(?:Win32_Process|Create)\b",
-        r"\bWin32_Process\b.{0,300}\.\s*Create\s*\(",
-        r"\bCreateProcess(?:A|W)?\s*\(",
-    ]
-    for pattern in process_creation_patterns:
-        assert not re.search(pattern, normalized_outside_launcher, re.I)
 
 
-def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
-    _assert_single_spawn_door(supervisor.PS_TEMPLATE)
+def test_generated_supervisor_spawn_door_regression_tripwire_is_clear() -> None:
+    _assert_spawn_door_regression_tripwire(supervisor.PS_TEMPLATE)
 
 
 @pytest.mark.parametrize(
@@ -179,22 +173,14 @@ def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
         "Start-WrapperProcess -startArgs $startArgs",
         "Start-Process @startArgs",
         "[System.Diagnostics.Process]::Start('candidate.exe')",
-        "$process = New-Object System.Diagnostics.Process; $process.Start()",
-        "Invoke-CimMethod -ClassName Win32_Process -MethodName Create",
-        "Invoke-WmiMethod -Class Win32_Process -Name Create",
-        "CreateProcessW($null, $null)",
     ],
     ids=[
         "named-launcher-call",
         "direct-start-process",
         "dotnet-process-start",
-        "new-process-object",
-        "cim-process-create",
-        "wmi-process-create",
-        "native-create-process",
     ],
 )
-def test_spawn_door_guard_rejects_process_creation_outside_seam(
+def test_spawn_door_tripwire_rejects_common_direct_escape(
     escaped_spawn: str,
 ) -> None:
     anchor = '$launch = Invoke-SupervisorSpawnStep $startArgs ("regular:{0}" -f $name)'
@@ -205,7 +191,44 @@ def test_spawn_door_guard_rejects_process_creation_outside_seam(
     )
 
     with pytest.raises(AssertionError):
-        _assert_single_spawn_door(mutated)
+        _assert_spawn_door_regression_tripwire(mutated)
+
+
+def test_spawn_door_tripwire_allows_unrelated_start_method() -> None:
+    anchor = '$launch = Invoke-SupervisorSpawnStep $startArgs ("regular:{0}" -f $name)'
+    mutated = supervisor.PS_TEMPLATE.replace(
+        anchor,
+        f"$timer.Start()\n    {anchor}",
+        1,
+    )
+
+    _assert_spawn_door_regression_tripwire(mutated)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="task #199: lexical tripwire cannot soundly parse PowerShell invocation",
+)
+@pytest.mark.parametrize(
+    "known_gap",
+    [
+        "& $startArgs.FilePath",
+        "$m='#'; Start-Process @startArgs",
+    ],
+    ids=["call-operator", "quoted-hash"],
+)
+def test_spawn_door_tripwire_known_unsound_invocations(
+    known_gap: str,
+) -> None:
+    anchor = '$launch = Invoke-SupervisorSpawnStep $startArgs ("regular:{0}" -f $name)'
+    mutated = supervisor.PS_TEMPLATE.replace(
+        anchor,
+        f"{known_gap}\n    {anchor}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_spawn_door_regression_tripwire(mutated)
 
 
 def test_exact_launcher_samples_filetime_from_original_handle_before_close() -> None:

--- a/tests/test_supervisor_spawn_seam.py
+++ b/tests/test_supervisor_spawn_seam.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from agenttalk import cli, lifecycle_lock, supervisor, wrapper_runtime
+from agenttalk.store import Store
+
+
+STUB_CLI = Path(__file__).parent / "support" / "stub_cli.py"
+
+
+def _powershell_hosts() -> tuple[str | None, ...]:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("powershell"),
+        str(
+            Path(os.environ.get("SystemRoot", r"C:\Windows"))
+            / "System32"
+            / "WindowsPowerShell"
+            / "v1.0"
+            / "powershell.exe"
+        ),
+    ]
+    hosts: list[str] = []
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and candidate.casefold() not in {
+            host.casefold() for host in hosts
+        }:
+            hosts.append(candidate)
+    return tuple(hosts) or (None,)
+
+
+def _direct_python_executable() -> str:
+    # A copied Windows venv may expose a redirector whose CreateProcess PID is
+    # not the interpreter PID. The seam's identity contract needs the owner.
+    return getattr(sys, "_base_executable", None) or sys.executable
+
+
+def _ps_literal(value: str | Path) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _region(text: str, name: str) -> str:
+    start_marker = f"# region {name}"
+    end_marker = f"# endregion {name}"
+    start = text.index(start_marker)
+    end = text.index(end_marker, start) + len(end_marker)
+    return text[start:end]
+
+
+def _generated_executor(tmp_path: Path) -> tuple[Store, str]:
+    store = Store(tmp_path)
+    store.init(["lead", "worker"])
+    store.set_operator_facing("lead")
+    assert cli.main(["--root", str(tmp_path), "supervise", "--init"]) == 0
+    return store, (store.dir / "supervisor.ps1").read_text(encoding="utf-8-sig")
+
+
+def _runtime_env() -> dict[str, str]:
+    env = os.environ.copy()
+    source = str(Path(__file__).resolve().parents[1] / "src")
+    inherited = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = source if not inherited else source + os.pathsep + inherited
+    env["AGENTTALK_PYTHON"] = _direct_python_executable()
+    return env
+
+
+def _wait_until(predicate, *, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if predicate():
+                return
+        except (OSError, json.JSONDecodeError):
+            pass
+        time.sleep(0.05)
+    pytest.fail("timed out waiting for subprocess evidence")
+
+
+def _wait_identity_gone(pid: int, *, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if lifecycle_lock.process_identity(pid) is None:
+            return True
+        time.sleep(0.05)
+    return lifecycle_lock.process_identity(pid) is None
+
+
+def _stop_exact_process_tree(
+    pid: int | None,
+    identity: lifecycle_lock.ProcessIdentity | None,
+) -> None:
+    if not pid or identity is None:
+        return
+    if lifecycle_lock.process_identity(pid) != identity:
+        return
+    taskkill = shutil.which("taskkill") or str(
+        Path(os.environ.get("SystemRoot", r"C:\Windows"))
+        / "System32"
+        / "taskkill.exe"
+    )
+    subprocess.run(
+        [taskkill, "/PID", str(pid), "/T", "/F"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
+    text = supervisor.PS_TEMPLATE
+    seam = _region(text, "supervisor-spawn-step")
+    outside = text.replace(seam, "", 1)
+    regular = text[
+        text.index("function Launch($name") : text.index("function Launch-Spec")
+    ]
+    ephemeral = text[
+        text.index("function Launch-Spec") : text.index("# Console action log")
+    ]
+
+    assert seam.count("Start-WrapperProcess $startArgs") == 1
+    assert "Start-WrapperProcess $startArgs" not in outside
+    assert regular.count("Invoke-SupervisorSpawnStep $startArgs") == 1
+    assert ephemeral.count("Invoke-SupervisorSpawnStep $startArgs") == 1
+
+
+def test_exact_launcher_samples_filetime_from_original_handle_before_close() -> None:
+    text = supervisor.PS_TEMPLATE
+    launcher = _region(text, "wrapper-log-helpers")
+    created = launcher.index("processCreated = true;")
+    observed = launcher.index("GetProcessTimes(processInfo.hProcess", created)
+    resumed = launcher.index("ResumeThread(processInfo.hThread)", observed)
+    closed = launcher.index("CloseHandle(processInfo.hProcess)", resumed)
+
+    assert created < observed < resumed < closed
+    assert "CreationFiletime" in launcher
+    assert 'scheme = "win32-filetime-v1"' not in launcher
+
+
+@pytest.mark.parametrize(
+    "shell",
+    _powershell_hosts(),
+    ids=lambda value: Path(value).stem if value else "unavailable",
+)
+def test_spawn_seam_refuses_invalid_precreate_input_with_closed_result(
+    tmp_path: Path,
+    shell: str | None,
+) -> None:
+    if shell is None:
+        pytest.skip("Windows PowerShell hosts are unavailable")
+    _, text = _generated_executor(tmp_path)
+    output = tmp_path / "spawn-refused.json"
+    harness = tmp_path / "spawn-refused.ps1"
+    harness.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                "$WrapperLogEnvKeys = @()",
+                _region(text, "exec-helpers"),
+                _region(text, "wrapper-log-helpers"),
+                _region(text, "supervisor-spawn-step"),
+                "$result = Invoke-SupervisorSpawnStep @{} 'test-invalid'",
+                "$result | Select-Object schema,schema_version,outcome,"
+                "reason_code,remedy,cleanup_status,pid,process_identity,"
+                "redirected | ConvertTo-Json -Depth 5 | "
+                f"Set-Content {_ps_literal(output)} -Encoding utf8",
+            ]
+        ),
+        encoding="utf-8-sig",
+    )
+
+    result = subprocess.run(
+        [shell, "-NoProfile", "-File", str(harness)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=_runtime_env(),
+    )
+
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+    payload = json.loads(output.read_text(encoding="utf-8-sig"))
+    assert payload == {
+        "schema": "agenttalk-supervisor-spawn-step",
+        "schema_version": 1,
+        "outcome": "refused",
+        "reason_code": "spawn_args_invalid",
+        "remedy": "regenerate the supervisor script and retry the launch",
+        "cleanup_status": "not_started",
+        "pid": None,
+        "process_identity": None,
+        "redirected": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "shell",
+    _powershell_hosts(),
+    ids=lambda value: Path(value).stem if value else "unavailable",
+)
+@pytest.mark.parametrize(
+    ("failure_mode", "reason_code", "compatibility_disposition"),
+    [
+        ("no-pid", "spawn_pid_unavailable", "no_pid"),
+        ("exception", "spawn_step_exception", "rethrow"),
+    ],
+)
+def test_spawn_seam_reports_unknown_without_a_null_result(
+    tmp_path: Path,
+    shell: str | None,
+    failure_mode: str,
+    reason_code: str,
+    compatibility_disposition: str,
+) -> None:
+    if shell is None:
+        pytest.skip("Windows PowerShell hosts are unavailable")
+    output = tmp_path / f"spawn-unknown-{failure_mode}.json"
+    harness = tmp_path / f"spawn-unknown-{failure_mode}.ps1"
+    fake = (
+        "function Start-WrapperProcess([hashtable]$startArgs) { "
+        "throw 'injected launch-boundary failure' }"
+        if failure_mode == "exception"
+        else "function Start-WrapperProcess([hashtable]$startArgs) { "
+        "return [pscustomobject]@{ Process = $null; "
+        "CreationFiletime = $null; Redirected = $false } }"
+    )
+    harness.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                fake,
+                _region(supervisor.PS_TEMPLATE, "supervisor-spawn-step"),
+                "$result = Invoke-SupervisorSpawnStep "
+                "@{ FilePath = 'candidate.exe' } 'test-unknown'",
+                "$result | Select-Object schema,schema_version,outcome,"
+                "reason_code,remedy,cleanup_status,pid,process_identity,"
+                "redirected,_compatibility_disposition | ConvertTo-Json "
+                f"-Depth 5 | Set-Content {_ps_literal(output)} -Encoding utf8",
+            ]
+        ),
+        encoding="utf-8-sig",
+    )
+
+    result = subprocess.run(
+        [shell, "-NoProfile", "-File", str(harness)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_runtime_env(),
+    )
+
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+    payload = json.loads(output.read_text(encoding="utf-8-sig"))
+    assert payload["schema"] == "agenttalk-supervisor-spawn-step"
+    assert payload["schema_version"] == 1
+    assert payload["outcome"] == "unknown"
+    assert payload["reason_code"] == reason_code
+    assert payload["remedy"]
+    assert payload["cleanup_status"] == "unknown"
+    assert payload["pid"] is None
+    assert payload["process_identity"] is None
+    assert payload["_compatibility_disposition"] == compatibility_disposition
+
+
+@pytest.mark.subprocess
+@pytest.mark.parametrize(
+    "shell",
+    _powershell_hosts(),
+    ids=lambda value: Path(value).stem if value else "unavailable",
+)
+def test_spawn_seam_start_process_path_records_exact_identity(
+    tmp_path: Path,
+    shell: str | None,
+) -> None:
+    if shell is None:
+        pytest.skip("Windows PowerShell hosts are unavailable")
+    _, text = _generated_executor(tmp_path)
+    direct_python = _direct_python_executable()
+    child_record = tmp_path / "start-process-child.json"
+    result_path = tmp_path / "start-process-result.json"
+    child = tmp_path / "start-process-child.py"
+    child.write_text(
+        "\n".join(
+            [
+                "import json, os, sys, time",
+                "from pathlib import Path",
+                "from agenttalk import lifecycle_lock",
+                "identity = lifecycle_lock.process_identity(os.getpid())",
+                "assert identity is not None",
+                "Path(sys.argv[1]).write_text(json.dumps({",
+                "    'pid': os.getpid(),",
+                "    'process_identity': {",
+                "        'scheme': identity.scheme, 'value': identity.value},",
+                "}), encoding='utf-8')",
+                "time.sleep(0.5)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    argument_line = subprocess.list2cmdline(
+        ["-X", "utf8", str(child), str(child_record)]
+    )
+    harness = tmp_path / "start-process-identity.ps1"
+    harness.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                "$WrapperLogEnvKeys = @()",
+                _region(text, "exec-helpers"),
+                _region(text, "wrapper-log-helpers"),
+                _region(text, "supervisor-spawn-step"),
+                "$startArgs = @{",
+                f"  FilePath = {_ps_literal(direct_python)}",
+                f"  ArgumentList = {_ps_literal(argument_line)}",
+                f"  WorkingDirectory = {_ps_literal(tmp_path)}",
+                "  WindowStyle = 'Hidden'",
+                "  PassThru = $true",
+                "}",
+                "$result = Invoke-SupervisorSpawnStep "
+                "$startArgs 'test-start-process'",
+                "$result | Select-Object schema,schema_version,outcome,"
+                "reason_code,remedy,cleanup_status,pid,process_identity,"
+                "redirected | ConvertTo-Json -Depth 5 | "
+                f"Set-Content {_ps_literal(result_path)} -Encoding utf8",
+            ]
+        ),
+        encoding="utf-8-sig",
+    )
+
+    result = subprocess.run(
+        [shell, "-NoProfile", "-File", str(harness)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_runtime_env(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+    _wait_until(child_record.exists, timeout=5)
+    child_payload = json.loads(child_record.read_text(encoding="utf-8"))
+    payload = json.loads(result_path.read_text(encoding="utf-8-sig"))
+    assert payload["outcome"] == "spawned", payload
+    assert payload["pid"] == child_payload["pid"]
+    assert payload["process_identity"] == child_payload["process_identity"]
+    assert payload["redirected"] is False
+    assert _wait_identity_gone(int(payload["pid"]), timeout=5)
+
+
+@pytest.mark.subprocess
+@pytest.mark.parametrize(
+    "shell",
+    _powershell_hosts(),
+    ids=lambda value: Path(value).stem if value else "unavailable",
+)
+def test_spawn_seam_real_wrapper_reaches_readiness_with_one_exact_identity(
+    tmp_path: Path,
+    shell: str | None,
+) -> None:
+    if shell is None:
+        pytest.skip("Windows PowerShell hosts are unavailable")
+    store, text = _generated_executor(tmp_path)
+    direct_python = _direct_python_executable()
+    journal = tmp_path / "spawn-journal.txt"
+    result_path = tmp_path / "spawn-result.json"
+    bootstrap = tmp_path / "wrapper-bootstrap.py"
+    bootstrap.write_text(
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "from agenttalk.cli import console_main",
+                "with Path(os.environ['AGENTTALK_TEST_SPAWN_JOURNAL']).open('a', encoding='utf-8') as stream:",
+                "    stream.write(f'{os.getpid()}\\n')",
+                "raise SystemExit(console_main())",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    wrapper_argv = [
+        "-X",
+        "utf8",
+        str(bootstrap),
+        "--root",
+        str(tmp_path),
+        "wrap",
+        "--for",
+        "worker",
+        "--cli",
+        "claude",
+        "--loop",
+        "--",
+        direct_python,
+        str(STUB_CLI),
+    ]
+    stdout_path = tmp_path / "wrapper-stdout.log"
+    stderr_path = tmp_path / "wrapper-stderr.log"
+    harness = tmp_path / "spawn-real-wrapper.ps1"
+    harness.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                "$WrapperLogEnvKeys = @(",
+                "  'AGENTTALK_WRAPPER_STDOUT_LOG',",
+                "  'AGENTTALK_WRAPPER_STDERR_LOG',",
+                "  'AGENTTALK_WRAPPER_LOG_MAX_BYTES',",
+                "  'AGENTTALK_WRAPPER_LOG_SEGMENTS',",
+                "  'AGENTTALK_WRAPPER_LOG_NONCE')",
+                _region(text, "exec-helpers"),
+                _region(text, "wrapper-log-helpers"),
+                _region(text, "supervisor-spawn-step"),
+                "$startArgs = @{",
+                f"  FilePath = {_ps_literal(direct_python)}",
+                f"  ArgumentList = {_ps_literal(subprocess.list2cmdline(wrapper_argv))}",
+                f"  WorkingDirectory = {_ps_literal(tmp_path)}",
+                "  WindowStyle = 'Hidden'",
+                "  PassThru = $true",
+                f"  RedirectStandardOutput = {_ps_literal(stdout_path)}",
+                f"  RedirectStandardError = {_ps_literal(stderr_path)}",
+                "}",
+                "$result = Invoke-SupervisorSpawnStep $startArgs 'test-real-wrapper'",
+                "$result | Select-Object schema,schema_version,outcome,"
+                "reason_code,remedy,cleanup_status,pid,process_identity,"
+                "redirected | ConvertTo-Json -Depth 5 | "
+                f"Set-Content {_ps_literal(result_path)} -Encoding utf8",
+            ]
+        ),
+        encoding="utf-8-sig",
+    )
+
+    guard_release = tmp_path / "guard.release"
+    guard_ready = tmp_path / "guard.ready"
+    guard_code = (
+        "import os,time; from pathlib import Path; "
+        f"Path({str(guard_ready)!r}).write_text(str(os.getpid()), encoding='utf-8'); "
+        f"release=Path({str(guard_release)!r}); "
+        "\nwhile not release.exists(): time.sleep(0.02)"
+    )
+    env = _runtime_env()
+    env["AGENTTALK_TEST_SPAWN_JOURNAL"] = str(journal)
+    guard = subprocess.Popen(
+        [direct_python, "-X", "utf8", "-c", guard_code],
+        env=env,
+        cwd=str(tmp_path),
+    )
+    target_pid: int | None = None
+    target_identity: lifecycle_lock.ProcessIdentity | None = None
+    guard_identity: lifecycle_lock.ProcessIdentity | None = None
+    try:
+        _wait_until(guard_ready.exists)
+        guard_identity = lifecycle_lock.process_identity(guard.pid)
+        assert guard_identity is not None
+
+        launched = subprocess.run(
+            [shell, "-NoProfile", "-File", str(harness)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            cwd=str(tmp_path),
+        )
+        assert launched.returncode == 0, f"{launched.stdout}{launched.stderr}"
+        payload = json.loads(result_path.read_text(encoding="utf-8-sig"))
+        assert payload["outcome"] == "spawned", payload
+        assert payload["reason_code"] is None
+        assert payload["remedy"] is None
+        assert payload["cleanup_status"] == "not_needed"
+        target_pid = int(payload["pid"])
+        target_identity = lifecycle_lock.process_identity(target_pid)
+        assert target_identity is not None
+        assert payload["process_identity"] == {
+            "scheme": target_identity.scheme,
+            "value": target_identity.value,
+        }
+
+        def _ready() -> bool:
+            waiting = store.read_waiting("worker")
+            runtime = wrapper_runtime.read_runtime(store.state_dir, "worker")
+            return bool(
+                waiting
+                and waiting.get("pid") == target_pid
+                and store.read_heartbeat("worker") is not None
+                and runtime.get("status") == wrapper_runtime.STATUS_VALID
+                and runtime["record"].get("phase") == wrapper_runtime.PHASE_IDLE
+                and runtime["record"].get("wrapper_pid") == target_pid
+            )
+
+        _wait_until(_ready)
+        rows = [line for line in journal.read_text(encoding="utf-8").splitlines() if line]
+        assert rows == [str(target_pid)]
+        assert lifecycle_lock.process_identity(guard.pid) == guard_identity
+
+        store.send(
+            sender="lead",
+            recipient="worker",
+            kind="release",
+            body="increment-1 spawn-seam test complete",
+            meta={
+                "release_authority": "human",
+                "operator_decision": "true",
+                "authority_reason": "targeted spawn-seam cleanup",
+            },
+        )
+        assert _wait_identity_gone(target_pid)
+        assert lifecycle_lock.process_identity(guard.pid) == guard_identity
+    finally:
+        _stop_exact_process_tree(target_pid, target_identity)
+        guard_release.write_text("release", encoding="utf-8")
+        try:
+            guard.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            if lifecycle_lock.process_identity(guard.pid) == guard_identity:
+                guard.terminate()
+            guard.wait(timeout=10)

--- a/tests/test_supervisor_spawn_seam.py
+++ b/tests/test_supervisor_spawn_seam.py
@@ -15,6 +15,10 @@ from agenttalk.store import Store
 
 
 STUB_CLI = Path(__file__).parent / "support" / "stub_cli.py"
+WINDOWS_FILETIME_IDENTITY_ONLY = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="win32-filetime-v1 exact process identity is Windows-only",
+)
 
 
 def _powershell_hosts() -> tuple[str | None, ...]:
@@ -271,6 +275,7 @@ def test_spawn_seam_reports_unknown_without_a_null_result(
 
 
 @pytest.mark.subprocess
+@WINDOWS_FILETIME_IDENTITY_ONLY
 @pytest.mark.parametrize(
     "shell",
     _powershell_hosts(),
@@ -281,7 +286,10 @@ def test_spawn_seam_start_process_path_records_exact_identity(
     shell: str | None,
 ) -> None:
     if shell is None:
-        pytest.skip("Windows PowerShell hosts are unavailable")
+        pytest.fail(
+            "a Windows PowerShell host is required for the "
+            "win32-filetime-v1 exact-identity test"
+        )
     _, text = _generated_executor(tmp_path)
     direct_python = _direct_python_executable()
     child_record = tmp_path / "start-process-child.json"
@@ -357,6 +365,7 @@ def test_spawn_seam_start_process_path_records_exact_identity(
 
 
 @pytest.mark.subprocess
+@WINDOWS_FILETIME_IDENTITY_ONLY
 @pytest.mark.parametrize(
     "shell",
     _powershell_hosts(),
@@ -367,7 +376,10 @@ def test_spawn_seam_real_wrapper_reaches_readiness_with_one_exact_identity(
     shell: str | None,
 ) -> None:
     if shell is None:
-        pytest.skip("Windows PowerShell hosts are unavailable")
+        pytest.fail(
+            "a Windows PowerShell host is required for the "
+            "win32-filetime-v1 exact-identity test"
+        )
     store, text = _generated_executor(tmp_path)
     direct_python = _direct_python_executable()
     journal = tmp_path / "spawn-journal.txt"

--- a/tests/test_supervisor_spawn_seam.py
+++ b/tests/test_supervisor_spawn_seam.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -58,6 +59,10 @@ def _region(text: str, name: str) -> str:
     start = text.index(start_marker)
     end = text.index(end_marker, start) + len(end_marker)
     return text[start:end]
+
+
+def _powershell_code(text: str) -> str:
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
 
 
 def _generated_executor(tmp_path: Path) -> tuple[Store, str]:
@@ -120,10 +125,10 @@ def _stop_exact_process_tree(
     )
 
 
-def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
-    text = supervisor.PS_TEMPLATE
+def _assert_single_spawn_door(text: str) -> None:
+    launcher = _region(text, "wrapper-process-launcher")
     seam = _region(text, "supervisor-spawn-step")
-    outside = text.replace(seam, "", 1)
+    outside = text.replace(launcher, "", 1).replace(seam, "", 1)
     regular = text[
         text.index("function Launch($name") : text.index("function Launch-Spec")
     ]
@@ -131,10 +136,76 @@ def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
         text.index("function Launch-Spec") : text.index("# Console action log")
     ]
 
-    assert seam.count("Start-WrapperProcess $startArgs") == 1
-    assert "Start-WrapperProcess $startArgs" not in outside
-    assert regular.count("Invoke-SupervisorSpawnStep $startArgs") == 1
-    assert ephemeral.count("Invoke-SupervisorSpawnStep $startArgs") == 1
+    launcher_code = _powershell_code(launcher)
+    seam_code = _powershell_code(seam)
+    outside_code = _powershell_code(outside)
+    all_code = _powershell_code(text)
+    assert len(re.findall(r"\bStart-WrapperProcess\b", launcher_code, re.I)) == 1
+    assert len(re.findall(r"\bStart-WrapperProcess\b", seam_code, re.I)) == 1
+    assert not re.search(r"\bStart-WrapperProcess\b", outside_code, re.I)
+    assert len(re.findall(r"\bInvoke-SupervisorSpawnStep\b", all_code, re.I)) == 3
+    assert len(
+        re.findall(r"\bInvoke-SupervisorSpawnStep\b", _powershell_code(regular), re.I)
+    ) == 1
+    assert len(
+        re.findall(
+            r"\bInvoke-SupervisorSpawnStep\b", _powershell_code(ephemeral), re.I
+        )
+    ) == 1
+
+    normalized_outside_launcher = " ".join(
+        _powershell_code(text.replace(launcher, "", 1)).split()
+    )
+    process_creation_patterns = [
+        r"\bStart-Process\b",
+        r"(?:::|\.)\s*Start\s*\(",
+        r"\bNew-Object\b(?:\s+-TypeName)?\s+(?:System\.)?Diagnostics\.Process\b",
+        r"\b(?:Invoke-CimMethod|Invoke-WmiMethod)\b.{0,300}"
+        r"\b(?:Win32_Process|Create)\b",
+        r"\bWin32_Process\b.{0,300}\.\s*Create\s*\(",
+        r"\bCreateProcess(?:A|W)?\s*\(",
+    ]
+    for pattern in process_creation_patterns:
+        assert not re.search(pattern, normalized_outside_launcher, re.I)
+
+
+def test_generated_supervisor_has_one_spawn_door_for_both_populations() -> None:
+    _assert_single_spawn_door(supervisor.PS_TEMPLATE)
+
+
+@pytest.mark.parametrize(
+    "escaped_spawn",
+    [
+        "Start-WrapperProcess -startArgs $startArgs",
+        "Start-Process @startArgs",
+        "[System.Diagnostics.Process]::Start('candidate.exe')",
+        "$process = New-Object System.Diagnostics.Process; $process.Start()",
+        "Invoke-CimMethod -ClassName Win32_Process -MethodName Create",
+        "Invoke-WmiMethod -Class Win32_Process -Name Create",
+        "CreateProcessW($null, $null)",
+    ],
+    ids=[
+        "named-launcher-call",
+        "direct-start-process",
+        "dotnet-process-start",
+        "new-process-object",
+        "cim-process-create",
+        "wmi-process-create",
+        "native-create-process",
+    ],
+)
+def test_spawn_door_guard_rejects_process_creation_outside_seam(
+    escaped_spawn: str,
+) -> None:
+    anchor = '$launch = Invoke-SupervisorSpawnStep $startArgs ("regular:{0}" -f $name)'
+    mutated = supervisor.PS_TEMPLATE.replace(
+        anchor,
+        f"{escaped_spawn}\n    {anchor}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_single_spawn_door(mutated)
 
 
 def test_exact_launcher_samples_filetime_from_original_handle_before_close() -> None:


### PR DESCRIPTION


---
**CI:** this PR also raises the dev-gate pytest per-leg cap 2700\u21923600s (dev-gate.json) so the slow Windows source test leg has honest headroom under runner load — it twice hit the cap here while all tests pass when the leg finishes. Root fix (parallelise the legs) stays booked as #127.
