### PR TITLE
feat(#201): wrapper-owned reply delivery on the freeform path

### DIFF
--- a/docs/DESIGN-201-wrapper-owned-reply-delivery.md
+++ b/docs/DESIGN-201-wrapper-owned-reply-delivery.md
@@ -1,0 +1,176 @@
+# DESIGN #201 — Wrapper-owned reply delivery (rev 2, post adversarial review)
+
+Status: rev 2 — restructured after adversarial design review (approve-with-changes,
+3 blockers). Author: claude-agenttalk-lead · 2026-08-21.
+Field basis: JAWS dry-run retro (jaws-legacy `docs/dryrun/RETRO.md`, finding 1).
+
+## Problem
+
+A wrapped child delivers replies by running an `agenttalk reply` subprocess in
+its own shell. That channel fails as a class: the claude-wrapped JAWS seat
+could not deliver a bus reply in 5 of 5 work turns (static command validation
++ unanswerable interactive approvals), the codex seat's first reply died on
+missing `AGENTTALK_SELF`, and the claude adapter cannot even report that a
+bus command was attempted (`TOOL_FINISHED` carries no tool name). Answers
+dead-letter into files that are indistinguishable on the bus from a dead agent.
+
+## Review verdict that reshaped rev 1 → rev 2
+
+The rev 1 design put wrapper-owned delivery inside the commit-gate
+(owed-action) path. The adversarial review verified against the JAWS ledger
+that **the commit gate was inactive for the entire dry run** (no
+`POLICY_ENV` policy file → `PolicySnapshot.inactive` → zero obligations
+admitted): every one of the motivating failures went through the FREEFORM
+branch rev 1 had scoped out. Rev 1 also had three blocker defects in its
+gate-path mechanics (broadcast digest fork, no completion seal, escalation
+meta loss). Rev 2 therefore restructures:
+
+- **PR-1 (this design, ship first): wrapper-owned reply delivery on the
+  freeform path** — the branch every field fleet actually runs.
+- **PR-2 (follow-up): the gate-path variant**, carrying ALL review findings
+  (F1 broadcast echo parity in the intent — which also repairs today's
+  latent dead broadcast recovery; F3 escalation meta enrichment
+  `needs_operator=true` + subject; F4 step-6 CAS with fence revalidation;
+  F5 both loop paths; F6 `mark_dispatch_result` side-effect parity +
+  `wrapper_delivered` exemption from the unsatisfied-attempt flip;
+  F10 ValueError semantics). Findings recorded verbatim in the review
+  transcript; PR-2 must not start from rev 1.
+- **PR-3: seat preflight echo-turn** (unchanged sketch: once-per-runtime-
+  fingerprint probe through the injectable `agenttalk_preflight` seam +
+  workspace write probe; failure → existing `config_blocked` hold).
+
+## PR-1 design: freeform wrapper-owned delivery
+
+### Core principle (review's central criticism, adopted)
+
+No hand-derived parity. Every rule the CLI applies to a reply — correlation
+echo, digest computation, typed-response validators — is extracted into one
+shared module used by BOTH `cmd_reply` and the wrapper, so the two paths
+cannot drift. New module `src/agenttalk/reply_transport.py`:
+
+- `echo_reply_correlation(meta, *, anchor_id, anchor_meta, kind)` — the
+  exact block now inlined in `cmd_reply` (in_reply_to; echo `request_id`
+  unless the reply kind opens a new thread; echo `broadcast_id` only when no
+  request_id — the F1 rule, one copy forever).
+- `operation_digest_for(meta, *, operation, body, kind, recipient)` — the
+  `_operation_idempotency` digest computation, one copy.
+- `landed_reply_exists(store, *, agent, record) -> bool` — validated-message
+  scan for sender=agent, recipient=record sender, `meta.in_reply_to` ==
+  record id (the dedupe guard when a capable child used the CLI channel).
+- `deliver_draft_reply(store, *, agent, record, draft_path) -> Message|None`
+  — read the draft with `read_text(encoding="utf-8")` (F8: identical
+  universal-newline semantics to the CLI `--file` path), refuse
+  symlink/oversize(1 MiB)/empty; build meta via `echo_reply_correlation`;
+  autogen request_id via the same helper `cmd_reply` uses; run
+  `validate_response_status`/`validate_review_result_evidence` (no-ops for
+  kind=message, kept for parity); mint a fresh 32-hex nonce; write the
+  operation-intent marker; `store.send_operation(...)`. Any validation
+  failure returns None — never a crash, never a partial publish.
+
+`cmd_reply` is refactored to call the first two helpers (behavior-identical;
+covered by a parity test asserting old inline logic == helper output on the
+matrix of anchor shapes: tracked question, broadcast copy, untracked message,
+counter-review kinds).
+
+### Child contract (prompt change, freeform branch only)
+
+The freeform branch of `assemble_turn_prompt` gains, when the record carries
+a wrapper-declared `reply_draft`:
+
+> PREFERRED — works in every sandbox: write your complete reply body to
+> EXACTLY this file with your structured Write/Edit tool, then end your
+> turn; the wrapper validates and delivers it on this thread. If your
+> harness can run shell commands you may instead use the reply command
+> below. Use ONE channel, never both.
+
+The existing CLI instructions stay (capable seats keep a familiar path;
+the wrapper's landed-check makes the channels race-free). The owed-action
+branch is untouched in PR-1.
+
+### Wrapper integration (both loop paths — review F5)
+
+The loop (not `run.py`) decorates the record before `drive()`:
+`record["reply_draft"] = {"path": <store.state_dir>/reply-drafts/<agent>/<record_id>.md}`
+— deterministic, no new state threading; dir created lazily; the same
+decoration in `_run_continuous`'s legacy (no-admission) region and in
+`_run_one_shot`. Gate-admitted records are NOT decorated (they carry
+`owed_action`; PR-2 territory).
+
+After `outcome = _as_outcome(drive(record))`, in both paths:
+
+1. **Completion seal (review F2):** proceed only when `outcome.ok` — i.e.
+   turn finished, no watchdog kill, rc==0, no failure class. A truncated
+   draft from a killed child is never published.
+2. **Dedupe:** skip when `landed_reply_exists(...)` (child used the CLI
+   channel this turn or a prior attempt already landed).
+3. **Publish:** `deliver_draft_reply(...)`. On success, unlink the draft.
+4. Fall through to the EXISTING landed-check/commit flow unchanged — the
+   just-published reply is found by the same proof machinery
+   (`resolve_landed_response`) that commits child-delivered work today, so
+   commit/finalize logic does not change at all.
+5. On any publish refusal: today's behavior, byte-for-byte (the turn is
+   still ok; the child may simply have had nothing tracked to answer —
+   freeform replies are not obligatory).
+
+Draft files for failed/disposed turns are cleaned at dispose/dead-letter
+time and are bounded by the existing per-message lifecycle (one draft per
+inbound id, overwritten on redelivery).
+
+### Crash windows (honest accounting)
+
+- Crash after marker, before publish: the inbound record was never
+  committed, so redelivery re-runs the turn (at-least-once, same as today);
+  the orphaned `prepared` marker is inert (fresh nonce per attempt).
+- Crash after publish, before commit: redelivery → the landed-check finds
+  the published reply → commit without a paid turn (existing #73 machinery).
+- Double-channel child: nonce dedupe cannot apply across channels (the CLI
+  path has no nonce in freeform); the landed-check closes that window
+  because the child's publication strictly precedes the wrapper's check.
+
+### Composing signal (review F9)
+
+Freeform turns never carried the composing ping, so PR-1 changes nothing
+about composing. The gate-path composing question is PR-2's to answer
+explicitly.
+
+### Bounded residual (documented, not hidden)
+
+- A seat that can neither run bus commands NOR write files cannot reply;
+  PR-3's preflight exists to catch that seat before work is dispatched.
+- Typed multi-field responses (review-result with evidence refs etc.) work
+  through the draft only as plain kind=message bodies in PR-1; typed
+  kind+meta declaration through the draft channel is PR-2/fast-follow scope.
+  The validators are already wired in `deliver_draft_reply`, so extending
+  is additive.
+- The freeform wrapper publish gives at-least-once with landed-check
+  dedupe, not exactly-once across generations (matches the bus's existing
+  delivery semantics).
+
+## Tests (no model spend; review F7 test gaps folded in)
+
+1. Parity: `echo_reply_correlation`/digest helpers vs. pre-refactor
+   `cmd_reply` behavior across anchor matrix — INCLUDING a broadcast-copy
+   anchor (request_id+broadcast_id both set → reply echoes request_id only).
+2. Loop (fixture store + injected drive, `test_wrapper_loop.py` patterns):
+   - clean turn + draft → exactly one bus message, exact correlation
+     (in_reply_to, request_id), draft unlinked, record committed;
+   - dirty outcome (watchdog kill / rc≠0) + partial draft → NO publish;
+   - both channels (drive publishes via store like a CLI child, draft also
+     present) → exactly one message;
+   - no draft → behavior identical to today;
+   - `_run_one_shot` variant of the happy path.
+3. Stub canary (`tests/support/stub_cli.py` + `test_stub_agent_canary.py`):
+   new scenario `draft_only` with the commit gate INACTIVE (the field
+   configuration) — writes the declared draft via its structured-write
+   path, runs no bus command; asserts the reply lands wrapper-delivered
+   end-to-end through the real spawn path.
+4. Prompt: freeform branch renders the draft instruction with the exact
+   path; gate branch unchanged.
+
+## Rollout
+
+PR-1 changes child-visible instructions for every freeform turn (fleet-wide
+blast radius — review R4): the CLI channel remains fully supported, so a
+mixed fleet (old prompts cached in resumed sessions) is safe. Ship as a
+minor release; JAWS-pattern smoke (one wrapped claude seat, one codex seat)
+before tagging.

--- a/docs/DESIGN-201-wrapper-owned-reply-delivery.md
+++ b/docs/DESIGN-201-wrapper-owned-reply-delivery.md
@@ -133,18 +133,37 @@ Freeform turns never carried the composing ping, so PR-1 changes nothing
 about composing. The gate-path composing question is PR-2's to answer
 explicitly.
 
-### Bounded residual (documented, not hidden)
+### Bounded residual (documented, not hidden; updated after the cold review)
 
 - A seat that can neither run bus commands NOR write files cannot reply;
   PR-3's preflight exists to catch that seat before work is dispatched.
-- Typed multi-field responses (review-result with evidence refs etc.) work
-  through the draft only as plain kind=message bodies in PR-1; typed
-  kind+meta declaration through the draft channel is PR-2/fast-follow scope.
-  The validators are already wired in `deliver_draft_reply`, so extending
-  is additive.
+  (The draft dir lives under the store's `.agenttalk/state/`, i.e. inside
+  the project root the wrapped child is normally granted — the JAWS claude
+  seat's `--add-dir <root>` covers it — but PR-3's write probe must verify
+  this per seat rather than assume it.)
+- Typed multi-field responses (review-result, proposal-response, consult
+  replies needing `consult=true`+`round`, NA responses needing
+  `response=not-applicable`) are NOT carried by the draft channel in PR-1:
+  consult-marked questions are excluded from decoration, typed threads were
+  never decorated, and NA/broadcast-decline still needs the CLI. Typed
+  kind+meta declaration through the draft is PR-2/fast-follow scope; the
+  validators already run inside `deliver_draft_reply`'s refusal boundary so
+  the extension inherits both them and the never-raise contract.
+- A REFUSED draft (oversize/encoding/publish failure) on a committing turn
+  is preserved as `<id>.refused.md` beside the draft dir — observable and
+  operator-recoverable, but not yet surfaced in status/health; wiring a
+  refusal signal into the wrapper lifecycle log is fast-follow scope.
+- Draft-dir hygiene: delivered drafts are unlinked on publish, stale drafts
+  are unlinked at next decoration, refused drafts are preserved by design;
+  drafts for records disposed WITHOUT a later redelivery linger until then.
+  No unbounded growth path beyond message volume; a reaper is out of scope.
+- `deliver_draft_reply` does not call the request-id autogen helper: replies
+  of kind=message never autogen (no prefix registered), so the CLI-parity
+  claim holds by vacuity today — the PR-2 typed-kind extension must revisit.
 - The freeform wrapper publish gives at-least-once with landed-check
-  dedupe, not exactly-once across generations (matches the bus's existing
-  delivery semantics).
+  dedupe (in_reply_to OR same-thread request_id, bounded to messages after
+  this inbound), not exactly-once across generations — matching the bus's
+  existing delivery semantics.
 
 ## Tests (no model spend; review F7 test gaps folded in)
 

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -53,6 +53,7 @@ from agenttalk import transcript as tx
 from agenttalk import codex_config as cxc
 from agenttalk import doctor as dr
 from agenttalk import gates as gate_mod
+from agenttalk import reply_transport
 from agenttalk import lanes as lane_mod
 from agenttalk import install_skills as iskl
 from agenttalk import lead_loop_runtime
@@ -126,20 +127,9 @@ def _operation_idempotency(
         return None, None
     if _OPERATION_NONCE_RE.fullmatch(nonce) is None:
         return None, "operation nonce must be exactly 32 lowercase hexadecimal characters"
-    from agenttalk.wrapper.obligations import operation_payload_digest
-
-    digest = operation_payload_digest(
-        operation=operation,
-        body=body,
-        kind=kind,
-        recipient=recipient,
-        in_reply_to=meta.get("in_reply_to"),
-        request_id=meta.get("request_id"),
-        broadcast_id=meta.get("broadcast_id"),
-        origin_request_id=meta.get("origin_request_id"),
-        origin_inbound_id=meta.get("origin_inbound_id"),
-        origin_obligation_key_digest=meta.get("origin_obligation_key_digest"),
-        expected_roster_revision=meta.get("expected_roster_revision"),
+    # One digest producer for CLI and wrapper (#201) — divergence forks dedupe.
+    digest = reply_transport.operation_digest_for(
+        meta, operation=operation, body=body, kind=kind, recipient=recipient,
     )
     meta["operation_nonce"] = nonce
     meta["operation_digest"] = digest
@@ -9137,32 +9127,15 @@ def cmd_reply(args: argparse.Namespace) -> int:
             sys.stderr.write("agenttalk reply: empty body (use -m TEXT, --file PATH, pipe stdin, or --allow-empty)\n")
             return 2
     meta = _parse_meta(args.meta)
-    # Exact immutable anchor for generation-safe replay.  The correlation id
-    # identifies the conversation; in_reply_to identifies this delivery.
-    meta["in_reply_to"] = anchor.id
     if na:
         meta["response"] = "not-applicable"  # the display discriminator
-    # Auto-echo request_id for correlation. Explicit --meta wins.
-    # EXCEPTION: a reply that is ITSELF a thread-opening kind
-    # (review-request = counter-review; proposal = counter-proposal)
-    # opens a NEW correlation thread, so it must NOT inherit the anchor's
-    # request_id — doing so would alias two distinct request/response
-    # pairs and make later responses ambiguous. For those we skip the
-    # echo and let _maybe_autogen_request_id mint a fresh id below
-    # (unless the user passed an explicit --meta one).
-    if (
-        kind not in ("review-request", "proposal")
-        and "request_id" not in meta
-        and "request_id" in (anchor.meta or {})
-    ):
-        meta["request_id"] = anchor.meta["request_id"]
-    if (
-        kind not in ("review-request", "proposal")
-        and "request_id" not in meta
-        and "broadcast_id" not in meta
-        and "broadcast_id" in (anchor.meta or {})
-    ):
-        meta["broadcast_id"] = anchor.meta["broadcast_id"]
+    # Correlation echo lives in reply_transport so the wrapper's draft
+    # delivery (#201) applies IDENTICAL rules: in_reply_to anchor,
+    # request_id echo except for thread-opening reply kinds, broadcast_id
+    # echo only without a request_id. Explicit --meta always wins.
+    reply_transport.echo_reply_correlation(
+        meta, anchor_id=anchor.id, anchor_meta=anchor.meta, kind=kind,
+    )
     _maybe_autogen_request_id(kind, meta, quiet=args.quiet)
     operation_nonce = getattr(args, "operation_nonce", None)
     existing, operation_error = _operation_idempotency(

--- a/src/agenttalk/reply_transport.py
+++ b/src/agenttalk/reply_transport.py
@@ -130,6 +130,25 @@ def landed_reply_exists(store: "Store", *, agent: str, record: dict) -> bool:
     return False
 
 
+def thread_opener_kind(store: "Store", *, agent: str, request_id: str) -> str | None:
+    """The kind of the message that OPENED this request_id's thread.
+
+    Used to withhold the draft channel from a kind=message that arrives on a
+    review-request/proposal thread (e.g. the author's answer to a needs-info
+    review-result): the next response there must be a TYPED kind the draft
+    cannot carry, and a kind=message publish would commit the turn while the
+    typed response stays owed. Returns None when unknown (fail open: an
+    unknown thread is treated as an ordinary message thread).
+    """
+    try:
+        for msg in store.valid_messages():
+            if (msg.meta or {}).get("request_id") == request_id:
+                return msg.kind
+    except Exception:
+        return None
+    return None
+
+
 def preserve_refused_draft(draft_path: Path) -> Path | None:
     """Rename a refused draft to an observable ``.refused.md`` sibling.
 
@@ -221,7 +240,12 @@ def deliver_draft_reply(
             operation_nonce=nonce,
             operation_digest=digest,
         )
-    except ValueError:
+    except Exception:  # noqa: BLE001 - refusal contract: the caller preserves
+        # ValueError (nonce/validator) AND operational failures (publication
+        # lock timeout, I/O): returning None routes ALL of them into the
+        # caller's observable refused-draft preservation instead of a silent
+        # drop. In-process durable retry of publish failures is PR-2 scope
+        # (the captured-operation machinery).
         return None
     try:
         draft_path.unlink(missing_ok=True)

--- a/src/agenttalk/reply_transport.py
+++ b/src/agenttalk/reply_transport.py
@@ -1,0 +1,202 @@
+"""Shared reply-construction rules for the CLI and the wrapper.
+
+#201 (JAWS retro finding 1): a wrapped child that cannot run shell commands
+cannot deliver `agenttalk reply`, so the wrapper delivers a child-written
+draft file itself. The CLI and the wrapper MUST apply byte-identical
+correlation-echo and digest rules or nonce dedupe silently forks (the
+broadcast request_id/broadcast_id echo was the concrete divergence the #201
+design review caught). This module is the single copy of those rules:
+`cmd_reply` calls the same functions the wrapper does.
+"""
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agenttalk import gates as gate_mod
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agenttalk.store import Message, Store
+
+# A reply that is ITSELF a thread-opening kind starts a NEW correlation
+# thread and must not inherit the anchor's ids (aliasing two request/response
+# pairs makes later responses ambiguous).
+_THREAD_OPENING_REPLY_KINDS = ("review-request", "proposal")
+
+# Draft bound mirrors the owed-action transport bound (obligations.py).
+MAX_DRAFT_BYTES = 1024 * 1024
+
+
+def echo_reply_correlation(
+    meta: dict,
+    *,
+    anchor_id: str,
+    anchor_meta: dict | None,
+    kind: str,
+) -> dict:
+    """Attach the reply correlation anchors exactly as `agenttalk reply` does.
+
+    The correlation id identifies the conversation; in_reply_to identifies
+    this delivery. request_id is echoed unless the reply opens a new thread;
+    broadcast_id is echoed ONLY when no request_id is present (a broadcast
+    copy carries both, and the reply must echo just the request_id — echoing
+    both forks the operation digest between producers of the same reply).
+    Explicit caller-provided meta always wins.
+    """
+    anchor_meta = anchor_meta or {}
+    meta["in_reply_to"] = anchor_id
+    if (
+        kind not in _THREAD_OPENING_REPLY_KINDS
+        and "request_id" not in meta
+        and "request_id" in anchor_meta
+    ):
+        meta["request_id"] = anchor_meta["request_id"]
+    if (
+        kind not in _THREAD_OPENING_REPLY_KINDS
+        and "request_id" not in meta
+        and "broadcast_id" not in meta
+        and "broadcast_id" in anchor_meta
+    ):
+        meta["broadcast_id"] = anchor_meta["broadcast_id"]
+    return meta
+
+
+def operation_digest_for(
+    meta: dict,
+    *,
+    operation: str,
+    body: str,
+    kind: str,
+    recipient: str,
+) -> str:
+    """Canonical payload digest for one bus operation, from its FINAL meta."""
+    from agenttalk.wrapper.obligations import operation_payload_digest
+
+    return operation_payload_digest(
+        operation=operation,
+        body=body,
+        kind=kind,
+        recipient=recipient,
+        in_reply_to=meta.get("in_reply_to"),
+        request_id=meta.get("request_id"),
+        broadcast_id=meta.get("broadcast_id"),
+        origin_request_id=meta.get("origin_request_id"),
+        origin_inbound_id=meta.get("origin_inbound_id"),
+        origin_obligation_key_digest=meta.get("origin_obligation_key_digest"),
+        expected_roster_revision=meta.get("expected_roster_revision"),
+    )
+
+
+def reply_draft_path(store: "Store", agent: str, inbound_id: str) -> Path:
+    """The wrapper-declared draft location for one inbound message."""
+    return store.state_dir / "reply-drafts" / agent / f"{inbound_id}.md"
+
+
+def landed_reply_exists(store: "Store", *, agent: str, record: dict) -> bool:
+    """True when a validated reply from `agent` to this record already landed.
+
+    The dedupe guard for the two freeform channels: a capable child that ran
+    `agenttalk reply` itself publishes strictly before the wrapper's
+    end-of-turn check, so finding an exact in_reply_to match here means the
+    wrapper must NOT publish the draft too.
+    """
+    requester = record.get("from")
+    inbound_id = record.get("id")
+    if not isinstance(requester, str) or not isinstance(inbound_id, str):
+        return False
+    try:
+        inbox = store.messages_for(requester)
+    except Exception:
+        # Fail CLOSED for delivery (report "already landed") would LOSE the
+        # reply; fail OPEN here risks at worst a duplicate, which the
+        # requester can correlate by in_reply_to. Prefer not losing work.
+        return False
+    for msg in inbox:
+        if msg.sender != agent:
+            continue
+        if (msg.meta or {}).get("in_reply_to") == inbound_id:
+            return True
+    return False
+
+
+def read_reply_draft(draft_path: Path) -> str | None:
+    """Read and bound a child-written draft; None means 'no deliverable draft'.
+
+    read_text(encoding='utf-8') deliberately matches the CLI `--file` read
+    (universal newlines) so a CRLF draft digests identically on every path.
+    """
+    try:
+        if draft_path.is_symlink():
+            return None
+        if not draft_path.is_file():
+            return None
+        if draft_path.stat().st_size > MAX_DRAFT_BYTES:
+            return None
+        body = draft_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError, ValueError):
+        return None
+    if not body.strip():
+        return None
+    return body
+
+
+def deliver_draft_reply(
+    store: "Store",
+    *,
+    agent: str,
+    record: dict,
+    draft_path: Path,
+) -> "Message | None":
+    """Validate a child-written draft and publish it as the agent's reply.
+
+    Returns the published Message, or None when there is nothing deliverable
+    (missing/oversize/empty draft, malformed record). Never raises on a
+    refusal path: the caller's turn disposition must not change because
+    freeform replies are not obligatory.
+    """
+    inbound_id = record.get("id")
+    requester = record.get("from")
+    if not isinstance(inbound_id, str) or not isinstance(requester, str):
+        return None
+    if requester == agent:
+        return None
+    body = read_reply_draft(draft_path)
+    if body is None:
+        return None
+    kind = "message"
+    record_meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
+    meta: dict = {}
+    echo_reply_correlation(
+        meta, anchor_id=inbound_id, anchor_meta=record_meta, kind=kind,
+    )
+    # Parity with cmd_reply's validator step (no-ops for kind=message today;
+    # kept so a future typed-kind extension inherits them automatically).
+    gate_mod.validate_response_status(kind, meta)
+    gate_mod.validate_review_result_evidence(kind, meta)
+    nonce = secrets.token_hex(16)
+    digest = operation_digest_for(
+        meta, operation="terminal", body=body, kind=kind, recipient=requester,
+    )
+    meta["operation_nonce"] = nonce
+    meta["operation_digest"] = digest
+    try:
+        msg, _published = store.send_operation(
+            sender=agent,
+            recipient=requester,
+            body=body,
+            kind=kind,
+            # Empty subject on purpose: byte-parity with a CLI-path reply
+            # (cmd_reply defaults --subject to "").
+            subject="",
+            meta=meta,
+            operation_nonce=nonce,
+            operation_digest=digest,
+        )
+    except ValueError:
+        return None
+    try:
+        draft_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return msg

--- a/src/agenttalk/reply_transport.py
+++ b/src/agenttalk/reply_transport.py
@@ -98,26 +98,53 @@ def landed_reply_exists(store: "Store", *, agent: str, record: dict) -> bool:
 
     The dedupe guard for the two freeform channels: a capable child that ran
     `agenttalk reply` itself publishes strictly before the wrapper's
-    end-of-turn check, so finding an exact in_reply_to match here means the
-    wrapper must NOT publish the draft too.
+    end-of-turn check, so a match here means the wrapper must NOT publish the
+    draft too. Matches by exact ``in_reply_to`` OR by the thread request_id —
+    the CLI channel anchors ``--to-request`` to the LATEST thread message, so
+    a reply to a nudge carrying the same request_id must also count. Both
+    matches are bounded to messages AFTER this inbound (``since_id``), so an
+    answer to an EARLIER question on the same thread never suppresses this
+    one's draft. ``composing`` pings never close a thread and are excluded.
     """
     requester = record.get("from")
     inbound_id = record.get("id")
     if not isinstance(requester, str) or not isinstance(inbound_id, str):
         return False
+    record_meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
+    thread_rid = record_meta.get("request_id")
     try:
-        inbox = store.messages_for(requester)
+        inbox = store.messages_for(requester, since_id=inbound_id)
     except Exception:
-        # Fail CLOSED for delivery (report "already landed") would LOSE the
-        # reply; fail OPEN here risks at worst a duplicate, which the
-        # requester can correlate by in_reply_to. Prefer not losing work.
+        # Reporting "already landed" on an error would LOSE the reply; the
+        # open failure risks at worst a duplicate the requester can correlate
+        # by in_reply_to. Prefer not losing work.
         return False
     for msg in inbox:
-        if msg.sender != agent:
+        if msg.sender != agent or msg.kind == "composing":
             continue
-        if (msg.meta or {}).get("in_reply_to") == inbound_id:
+        meta = msg.meta or {}
+        if meta.get("in_reply_to") == inbound_id:
+            return True
+        if thread_rid and meta.get("request_id") == thread_rid:
             return True
     return False
+
+
+def preserve_refused_draft(draft_path: Path) -> Path | None:
+    """Rename a refused draft to an observable ``.refused.md`` sibling.
+
+    A refused draft on a turn that still commits would otherwise vanish —
+    behaviorally the same silent loss #201 exists to fix. The preserved file
+    keeps the child's bytes recoverable by an operator and, because the live
+    draft path is now clear, can never be published by a later attempt.
+    """
+    target = draft_path.with_suffix(".refused.md")
+    try:
+        target.unlink(missing_ok=True)
+        draft_path.rename(target)
+    except OSError:
+        return None
+    return target
 
 
 def read_reply_draft(draft_path: Path) -> str | None:
@@ -170,10 +197,6 @@ def deliver_draft_reply(
     echo_reply_correlation(
         meta, anchor_id=inbound_id, anchor_meta=record_meta, kind=kind,
     )
-    # Parity with cmd_reply's validator step (no-ops for kind=message today;
-    # kept so a future typed-kind extension inherits them automatically).
-    gate_mod.validate_response_status(kind, meta)
-    gate_mod.validate_review_result_evidence(kind, meta)
     nonce = secrets.token_hex(16)
     digest = operation_digest_for(
         meta, operation="terminal", body=body, kind=kind, recipient=requester,
@@ -181,6 +204,11 @@ def deliver_draft_reply(
     meta["operation_nonce"] = nonce
     meta["operation_digest"] = digest
     try:
+        # Parity with cmd_reply's validator step (no-ops for kind=message
+        # today; inside the refusal boundary so a future typed-kind extension
+        # inherits both the validators AND the never-raise contract).
+        gate_mod.validate_response_status(kind, meta)
+        gate_mod.validate_review_result_evidence(kind, meta)
         msg, _published = store.send_operation(
             sender=agent,
             recipient=requester,

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -77,7 +77,9 @@ def _as_outcome(ret: object) -> DriveOutcome:
 # seats whose harness statically rejects or approval-gates shell commands.
 # Typed-response threads (review-request/proposal) are excluded: their
 # closure requires a typed kind the draft channel does not carry yet.
-_REPLY_DRAFT_KINDS = frozenset({"question", "message"})
+# `wake` is included: it is an ordinary driven kind whose wk- request id is
+# minted precisely so a plain message reply can correlate.
+_REPLY_DRAFT_KINDS = frozenset({"question", "message", "wake"})
 
 
 def _with_reply_draft(store, agent: str, record: dict) -> dict:
@@ -92,6 +94,11 @@ def _with_reply_draft(store, agent: str, record: dict) -> dict:
     path = reply_transport.reply_draft_path(store, agent, inbound_id)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Bind the draft to THIS attempt: a failed prior attempt may have left
+        # a partial draft at the same deterministic path, and a later clean
+        # turn that never overwrites it must not publish those stale bytes as
+        # the authoritative answer (PR #127 connector P1).
+        path.unlink(missing_ok=True)
     except OSError:
         return record
     decorated = dict(record)

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -91,6 +91,12 @@ def _with_reply_draft(store, agent: str, record: dict) -> dict:
         return record
     if record.get("from") == agent:
         return record
+    # A consult reply must echo consult=true + round meta the draft channel
+    # cannot carry yet — offering the channel would give the child two
+    # contradictory instructions and silently break consult round tracking.
+    record_meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
+    if record_meta.get("consult"):
+        return record
     path = reply_transport.reply_draft_path(store, agent, inbound_id)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -126,9 +132,15 @@ def _deliver_reply_draft(store, agent: str, record: dict) -> None:
             except OSError:
                 pass
             return
-        reply_transport.deliver_draft_reply(
+        published = reply_transport.deliver_draft_reply(
             store, agent=agent, record=record, draft_path=draft,
         )
+        if published is None and draft.exists():
+            # The child wrote an answer the wrapper refused (oversize, bad
+            # encoding, publish failure). The turn still commits, so without
+            # a trace the answer would vanish exactly like the dead-letter
+            # dotfiles #201 exists to fix. Preserve the bytes observably.
+            reply_transport.preserve_refused_draft(draft)
     except Exception:  # noqa: BLE001, S110 - must never change disposition  # nosec B110
         return
 

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -20,6 +20,9 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
+
+from agenttalk import reply_transport
 
 from . import recv_api
 
@@ -66,6 +69,61 @@ def _as_outcome(ret: object) -> DriveOutcome:
     if ret:
         return DriveOutcome(ok=True)
     return DriveOutcome(ok=False, failure_class=CLASS_POISON, summary="drive returned False")
+
+
+# #201 wrapper-owned reply delivery (freeform path). Kinds whose natural
+# reply is a plain message get a wrapper-declared draft file the child can
+# answer through with nothing but its structured Write tool — the fix for
+# seats whose harness statically rejects or approval-gates shell commands.
+# Typed-response threads (review-request/proposal) are excluded: their
+# closure requires a typed kind the draft channel does not carry yet.
+_REPLY_DRAFT_KINDS = frozenset({"question", "message"})
+
+
+def _with_reply_draft(store, agent: str, record: dict) -> dict:
+    """Decorate a freeform (no-admission) record with its declared draft path."""
+    if record.get("kind") not in _REPLY_DRAFT_KINDS:
+        return record
+    inbound_id = record.get("id")
+    if not isinstance(inbound_id, str) or not inbound_id:
+        return record
+    if record.get("from") == agent:
+        return record
+    path = reply_transport.reply_draft_path(store, agent, inbound_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return record
+    decorated = dict(record)
+    decorated["reply_draft"] = {"path": str(path)}
+    return decorated
+
+
+def _deliver_reply_draft(store, agent: str, record: dict) -> None:
+    """Publish a child-written freeform draft after a CLEAN turn.
+
+    Refusals are silent by contract: freeform replies are not obligatory, so
+    a missing/invalid draft must leave the turn disposition byte-identical
+    to today. The landed-check first makes the two channels race-free — a
+    capable child that ran `agenttalk reply` itself published strictly
+    before this end-of-turn call, and then the draft is only residue.
+    """
+    declared = record.get("reply_draft")
+    if not isinstance(declared, dict) or not declared.get("path"):
+        return
+    draft = Path(str(declared["path"]))
+    try:
+        if reply_transport.landed_reply_exists(store, agent=agent, record=record):
+            try:
+                draft.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return
+        reply_transport.deliver_draft_reply(
+            store, agent=agent, record=record, draft_path=draft,
+        )
+    except Exception:  # noqa: BLE001, S110 - must never change disposition  # nosec B110
+        return
 
 
 @dataclass(frozen=True)
@@ -1172,9 +1230,17 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
 
         # WRITE-AHEAD: count + mark in_progress BEFORE drive() so a crash mid-turn
         # still costs a durable attempt on relaunch. EXACTLY one attempt per drive().
+        record = _with_reply_draft(store, agent, record)
         store.record_attempt_start(agent, record, attempt_id=uuid.uuid4().hex[:12],
                                    at=now_iso())
         outcome = _as_outcome(drive(record))
+        # #201: a CLEAN turn's child-written draft is published by the wrapper
+        # itself BEFORE the landed-check below, which then finds and commits it
+        # through the same proof machinery as a child-delivered reply. A dirty
+        # outcome (watchdog kill, nonzero exit) never publishes — a truncated
+        # draft must not become the agent's authoritative answer.
+        if outcome.ok:
+            _deliver_reply_draft(store, agent, record)
         if commit_gate is not None and legacy_gate_resolution is not None:
             landed = commit_gate.resolve_landed_response(record)
             if landed.proof is not None:
@@ -1730,7 +1796,12 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
                 fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
                 continue
             legacy_gate_resolution = authorized
+        record = _with_reply_draft(store, agent, record)
         outcome = _as_outcome(drive(record))
+        # #201: same wrapper-owned draft delivery as _run_continuous — the
+        # one-shot path must not strand a sandbox-blocked child's answer.
+        if outcome.ok:
+            _deliver_reply_draft(store, agent, record)
         if commit_gate is not None and legacy_gate_resolution is not None:
             landed = commit_gate.resolve_landed_response(record)
             if landed.proof is not None:

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -97,6 +97,17 @@ def _with_reply_draft(store, agent: str, record: dict) -> dict:
     record_meta = record.get("meta") if isinstance(record.get("meta"), dict) else {}
     if record_meta.get("consult"):
         return record
+    # A kind=message arriving on a review-request/proposal thread (e.g. the
+    # author's answer to a needs-info review-result) owes a TYPED response
+    # next — publishing a draft as kind=message would commit the turn while
+    # the typed response stays owed (PR #127 connector P2).
+    thread_rid = record_meta.get("request_id")
+    if record.get("kind") == "message" and isinstance(thread_rid, str) and thread_rid:
+        opener = reply_transport.thread_opener_kind(
+            store, agent=agent, request_id=thread_rid,
+        )
+        if opener in ("review-request", "proposal"):
+            return record
     path = reply_transport.reply_draft_path(store, agent, inbound_id)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -126,6 +137,8 @@ def _deliver_reply_draft(store, agent: str, record: dict) -> None:
         return
     draft = Path(str(declared["path"]))
     try:
+        if not draft.is_file():
+            return          # most turns: no draft written, no scan paid
         if reply_transport.landed_reply_exists(store, agent=agent, record=record):
             try:
                 draft.unlink(missing_ok=True)

--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -158,6 +158,22 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
             anchor = f"--to-id {_msg_id}"
         else:
             anchor = "--to-request <request_id from the header above>"
+        # #201: the wrapper-declared draft channel. Works in EVERY sandbox —
+        # a child whose harness statically rejects or approval-gates shell
+        # commands (the JAWS claude seat: 5/5 turns undeliverable) can still
+        # answer with nothing but its structured Write tool; the wrapper
+        # validates and publishes the draft with exact thread correlation.
+        reply_draft = record.get("reply_draft")
+        if isinstance(reply_draft, dict) and reply_draft.get("path"):
+            out += [
+                "== HOW TO REPLY: PREFERRED DRAFT CHANNEL (works in every sandbox) ==",
+                "Write your COMPLETE reply body (UTF-8, any length/lines) to exactly "
+                "this file with your structured Write/Edit tool, then end your turn — "
+                "the wrapper validates and delivers it on this thread:",
+                f"  {reply_draft['path']}",
+                "If your harness can run shell commands you may INSTEAD use the reply "
+                "command below. Use ONE channel, never both.",
+            ]
         out += [
             "== HOW TO REPLY TO THIS MESSAGE (exact form) ==",
             "Answer on THIS thread with ONE command. Short, single-line answer:",

--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -167,9 +167,9 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
         if isinstance(reply_draft, dict) and reply_draft.get("path"):
             out += [
                 "== HOW TO REPLY: PREFERRED DRAFT CHANNEL (works in every sandbox) ==",
-                "Write your COMPLETE reply body (UTF-8, any length/lines) to exactly "
-                "this file with your structured Write/Edit tool, then end your turn — "
-                "the wrapper validates and delivers it on this thread:",
+                "Write your COMPLETE reply body (UTF-8, multi-line fine, up to 1 MiB) "
+                "to exactly this file with your structured Write/Edit tool, then end "
+                "your turn — the wrapper validates and delivers it on this thread:",
                 f"  {reply_draft['path']}",
                 "If your harness can run shell commands you may INSTEAD use the reply "
                 "command below. Use ONE channel, never both.",

--- a/tests/support/stub_cli.py
+++ b/tests/support/stub_cli.py
@@ -170,6 +170,36 @@ def _perform_reply(prompt: str, body: str) -> None:
     _run_bus(argv)
 
 
+def _reply_draft_path(prompt: str) -> str | None:
+    """The wrapper-declared freeform draft path (#201): the indented path line
+    inside the PREFERRED DRAFT CHANNEL section."""
+    m = re.search(
+        r"PREFERRED DRAFT CHANNEL.*?\n {2}(\S.*?)\n",
+        prompt,
+        re.DOTALL,
+    )
+    return m.group(1).strip() if m else None
+
+
+def _scenario_draft_only(prompt: str, session_id: str | None) -> int:
+    """#201: a sandbox-blocked child — writes the wrapper-declared reply draft
+    with its 'structured write' (a plain file write here) and NEVER runs a bus
+    command. The wrapper must deliver the draft itself."""
+    _emit_start()
+    draft = _reply_draft_path(prompt)
+    if draft is None:
+        _emit_assistant_text("No draft channel declared; cannot reply from this sandbox.")
+        _emit_stop()
+        _emit_success(session_id)
+        return 0
+    with open(draft, "w", encoding="utf-8") as handle:
+        handle.write("result=399 via wrapper-owned draft delivery\n")
+    _emit_assistant_text("Wrote the answer to the declared reply draft; ending turn.")
+    _emit_stop()
+    _emit_success(session_id)
+    return 0
+
+
 def _scenario_reply_ok(prompt: str, session_id: str | None) -> int:
     _emit_start()
     _emit_assistant_text("Computed the answer (19 * 21 = 399); replying on the bus.")
@@ -220,6 +250,8 @@ def main(argv: list[str]) -> int:
     session_id = _flag_value(argv, "--session-id") or _flag_value(argv, "--resume")
     if scenario == "reply_ok":
         return _scenario_reply_ok(prompt, session_id)
+    if scenario == "draft_only":
+        return _scenario_draft_only(prompt, session_id)
     if scenario == "compute_no_reply":
         return _scenario_compute_no_reply(session_id)
     if scenario == "resume_missing":

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -228,3 +228,50 @@ def test_prompt_no_draft_section_without_declaration() -> None:
            "correlation_id": "q-1", "request_id": "q-1", "broadcast_id": None,
            "id": "m-1"}
     assert "PREFERRED DRAFT CHANNEL" not in prompt.assemble_turn_prompt(rec)
+
+
+def test_stale_draft_from_failed_attempt_is_never_published(tmp_path) -> None:
+    # PR #127 connector P1: attempt 1 writes a partial draft and fails; the
+    # retry completes cleanly WITHOUT writing a new draft. The stale bytes
+    # must not be published — decoration deletes any pre-existing draft, so
+    # each draft is bound to the attempt that created it.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-stale"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            Path(rec["reply_draft"]["path"]).write_text(
+                "partial from dead attempt", encoding="utf-8")
+            return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_INFRA,
+                                     summary="killed mid-write")
+        return True                      # clean retry, no draft written
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=4, k_poison=0, k_escalate=0)
+    assert attempts["n"] >= 2
+    assert _reply_inbox(s, "alpha") == []      # stale bytes never published
+    assert s.cursor("beta") == q.id            # clean retry still committed
+
+
+def test_wake_kind_gets_the_draft_channel(tmp_path) -> None:
+    # PR #127 connector P2: wake is an ordinary driven kind whose wk- request
+    # id exists so a plain message reply can correlate — sandbox-blocked
+    # seats must be able to acknowledge it via the draft channel.
+    s = _store(tmp_path)
+    w = s.send(sender="alpha", recipient="beta", kind="wake", body="wake up",
+               meta={"request_id": "wk-1"})
+
+    def drive(rec):
+        assert isinstance(rec.get("reply_draft"), dict)
+        Path(rec["reply_draft"]["path"]).write_text("awake", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    (msg,) = _reply_inbox(s, "alpha")
+    assert msg.body == "awake"
+    assert (msg.meta or {}).get("request_id") == "wk-1"
+    assert (msg.meta or {}).get("in_reply_to") == w.id

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -1,0 +1,230 @@
+"""#201 wrapper-owned reply delivery (freeform path).
+
+A wrapped child whose harness statically rejects or approval-gates shell
+commands (the JAWS claude seat: 5/5 turns undeliverable) answers by writing
+the wrapper-declared draft file; the wrapper validates and publishes it with
+exact thread correlation. Fixture Store + injected drive — NO real CLI here
+(the real spawn path is covered by the stub canary's draft_only scenario).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agenttalk import reply_transport
+from agenttalk.store import Store
+from agenttalk.wrapper import loop, prompt
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path)
+    s.init(["alpha", "beta"])
+    return s
+
+
+def _reply_inbox(s: Store, requester: str) -> list:
+    return [m for m in s.messages_for(requester) if m.sender == "beta"]
+
+
+# ------------------------------------------------- correlation echo parity
+
+def test_echo_reply_correlation_broadcast_copy_echoes_request_id_only() -> None:
+    # The #201 design-review blocker: a broadcast copy carries BOTH ids; the
+    # reply must echo just request_id or the operation digest forks between
+    # producers of the same reply.
+    meta: dict = {}
+    reply_transport.echo_reply_correlation(
+        meta, anchor_id="m-1",
+        anchor_meta={"request_id": "bid-7", "broadcast_id": "bid-7"},
+        kind="message",
+    )
+    assert meta == {"in_reply_to": "m-1", "request_id": "bid-7"}
+
+
+def test_echo_reply_correlation_broadcast_id_only_when_no_request_id() -> None:
+    meta: dict = {}
+    reply_transport.echo_reply_correlation(
+        meta, anchor_id="m-2", anchor_meta={"broadcast_id": "b-9"}, kind="message",
+    )
+    assert meta == {"in_reply_to": "m-2", "broadcast_id": "b-9"}
+
+
+def test_echo_reply_correlation_thread_opening_kinds_inherit_nothing() -> None:
+    for kind in ("review-request", "proposal"):
+        meta: dict = {}
+        reply_transport.echo_reply_correlation(
+            meta, anchor_id="m-3",
+            anchor_meta={"request_id": "q-1", "broadcast_id": "b-1"},
+            kind=kind,
+        )
+        assert meta == {"in_reply_to": "m-3"}
+
+
+def test_echo_reply_correlation_explicit_meta_wins() -> None:
+    meta = {"request_id": "explicit"}
+    reply_transport.echo_reply_correlation(
+        meta, anchor_id="m-4", anchor_meta={"request_id": "anchor"}, kind="message",
+    )
+    assert meta["request_id"] == "explicit"
+
+
+# ------------------------------------------------------------ loop: happy
+
+def test_clean_turn_draft_is_published_with_exact_correlation(tmp_path) -> None:
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question",
+               subject="s", body="q?", meta={"request_id": "q-abc123"})
+    drafts: list[Path] = []
+
+    def drive(rec):
+        assert isinstance(rec.get("reply_draft"), dict)
+        p = Path(rec["reply_draft"]["path"])
+        p.write_text("the answer\nline two\n", encoding="utf-8")
+        drafts.append(p)
+        return True
+
+    turns = loop.run_loop(s, "beta", drive, clock=lambda: 0.0,
+                          sleep=lambda d: None, max_turns=1)
+    assert turns == 1
+    replies = _reply_inbox(s, "alpha")
+    assert len(replies) == 1
+    msg = replies[0]
+    assert msg.body == "the answer\nline two\n"
+    assert msg.kind == "message"
+    assert (msg.meta or {}).get("in_reply_to") == q.id
+    assert (msg.meta or {}).get("request_id") == "q-abc123"
+    assert not drafts[0].exists()          # draft consumed
+    assert s.cursor("beta") == q.id        # committed
+
+
+def test_broadcast_copy_reply_via_draft_echoes_request_id_only(tmp_path) -> None:
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="b?",
+               meta={"request_id": "bid-55", "broadcast_id": "bid-55"})
+
+    def drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text("bcast answer", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    (msg,) = _reply_inbox(s, "alpha")
+    meta = msg.meta or {}
+    assert meta.get("request_id") == "bid-55"
+    assert "broadcast_id" not in meta
+    assert meta.get("in_reply_to") == q.id
+
+
+# ---------------------------------------------------------- loop: refusals
+
+def test_dirty_turn_never_publishes_a_truncated_draft(tmp_path) -> None:
+    # Design-review blocker F2: a child killed mid-Write leaves a partial,
+    # valid-UTF-8 draft. A non-ok outcome must never publish it.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+           meta={"request_id": "q-dirty"})
+
+    def dying_drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text("partial ans", encoding="utf-8")
+        return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_INFRA,
+                                 summary="watchdog kill")
+
+    loop.run_loop(s, "beta", dying_drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_polls=2, k_poison=0, k_escalate=0)
+    assert _reply_inbox(s, "alpha") == []
+    assert s.cursor("beta") == ""          # failed turn: not committed
+
+
+def test_both_channels_land_exactly_one_reply(tmp_path) -> None:
+    # A capable child that ran `agenttalk reply` itself AND wrote the draft:
+    # the wrapper's landed-check must not publish a duplicate.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-two"})
+
+    def drive(rec):
+        s.send(sender="beta", recipient="alpha", body="cli answer",
+               meta={"in_reply_to": rec["id"], "request_id": "q-two"})
+        Path(rec["reply_draft"]["path"]).write_text("draft answer", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    replies = _reply_inbox(s, "alpha")
+    assert [m.body for m in replies] == ["cli answer"]
+    assert not Path(
+        reply_transport.reply_draft_path(s, "beta", q.id)
+    ).exists()                             # residue draft cleaned
+
+
+def test_no_draft_leaves_turn_behavior_unchanged(tmp_path) -> None:
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?")
+
+    turns = loop.run_loop(s, "beta", lambda rec: True, clock=lambda: 0.0,
+                          sleep=lambda d: None, max_turns=1)
+    assert turns == 1
+    assert _reply_inbox(s, "alpha") == []
+    assert s.cursor("beta") == q.id
+
+
+def test_empty_or_oversize_draft_is_refused(tmp_path) -> None:
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="question", body="q?")
+
+    def drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text("   \n", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert _reply_inbox(s, "alpha") == []
+
+    big = s.send(sender="alpha", recipient="beta", kind="question", body="q2?")
+
+    def big_drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text(
+            "x" * (reply_transport.MAX_DRAFT_BYTES + 1), encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", big_drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert _reply_inbox(s, "alpha") == []
+    assert s.cursor("beta") == big.id      # still a clean commit
+
+
+def test_typed_response_kinds_get_no_draft_channel(tmp_path) -> None:
+    # A review-request needs a typed review-result; the draft channel would
+    # close it with kind=message, so those records are not decorated.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="review-request", body="rr",
+           meta={"request_id": "rq-1"})
+    seen: list[dict] = []
+
+    def drive(rec):
+        seen.append(rec)
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert seen and "reply_draft" not in seen[0]
+
+
+# ------------------------------------------------------------------ prompt
+
+def test_prompt_renders_draft_channel_when_declared() -> None:
+    rec = {"from": "lead", "to": "w", "kind": "question", "body": "q",
+           "correlation_id": "q-1", "request_id": "q-1", "broadcast_id": None,
+           "id": "m-1", "reply_draft": {"path": "X:/drafts/m-1.md"}}
+    p = prompt.assemble_turn_prompt(rec)
+    assert "PREFERRED DRAFT CHANNEL" in p
+    assert "X:/drafts/m-1.md" in p
+    assert "Use ONE channel, never both." in p
+    assert "HOW TO REPLY TO THIS MESSAGE" in p      # CLI channel still offered
+
+
+def test_prompt_no_draft_section_without_declaration() -> None:
+    rec = {"from": "lead", "to": "w", "kind": "question", "body": "q",
+           "correlation_id": "q-1", "request_id": "q-1", "broadcast_id": None,
+           "id": "m-1"}
+    assert "PREFERRED DRAFT CHANNEL" not in prompt.assemble_turn_prompt(rec)

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -363,3 +363,50 @@ def test_one_shot_path_delivers_the_draft(tmp_path) -> None:
     assert msg.body == "scoped answer"
     assert (msg.meta or {}).get("in_reply_to") == q.id
     assert (msg.meta or {}).get("request_id") == "q-oneshot"
+
+
+def test_message_on_review_thread_gets_no_draft_channel(tmp_path) -> None:
+    # PR #127 connector P2: a kind=message on a review-request thread (e.g.
+    # a needs-info answer) owes a TYPED review-result next — the draft
+    # channel would commit the turn with a kind=message while the typed
+    # response stays owed.
+    s = _store(tmp_path)
+    s.send(sender="beta", recipient="alpha", kind="review-request",
+           body="please review", meta={"request_id": "rq-77"})
+    s.send(sender="alpha", recipient="beta", kind="message",
+           body="needs-info answer: here is the context",
+           meta={"request_id": "rq-77"})
+    seen: list[dict] = []
+
+    def drive(rec):
+        seen.append(rec)
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert seen and "reply_draft" not in seen[0]
+
+
+def test_publish_exception_preserves_the_draft(tmp_path, monkeypatch) -> None:
+    # PR #127 connector P2: a valid draft whose publication fails on an
+    # operational error (lock timeout, I/O) must not vanish silently while
+    # the turn commits — it is preserved as an observable .refused.md.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-lockfail"})
+
+    def boom(**kwargs):
+        raise OSError("publication lock timeout")
+
+    monkeypatch.setattr(s, "send_operation", boom)
+
+    def drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text("good answer", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert _reply_inbox(s, "alpha") == []
+    refused = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".refused.md")
+    assert refused.exists()
+    assert refused.read_text(encoding="utf-8") == "good answer"

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -275,3 +275,91 @@ def test_wake_kind_gets_the_draft_channel(tmp_path) -> None:
     assert msg.body == "awake"
     assert (msg.meta or {}).get("request_id") == "wk-1"
     assert (msg.meta or {}).get("in_reply_to") == w.id
+
+
+def test_consult_questions_are_excluded_from_the_draft_channel(tmp_path) -> None:
+    # Cold review major 1: a consult reply must echo consult=true + round meta
+    # the draft channel cannot carry — offering it would give the child two
+    # contradictory instructions and silently break consult round tracking.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="question", body="consult?",
+           meta={"request_id": "q-c1", "consult": "true", "round": "1"})
+    seen: list[dict] = []
+
+    def drive(rec):
+        seen.append(rec)
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert seen and "reply_draft" not in seen[0]
+
+
+def test_refused_draft_is_preserved_observably(tmp_path) -> None:
+    # Cold review major 2: a refused draft on a committing turn must not
+    # vanish silently — the bytes are preserved at an observable sibling
+    # path an operator can recover, and can never be published later.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-refused"})
+
+    def drive(rec):
+        Path(rec["reply_draft"]["path"]).write_text(
+            "y" * (reply_transport.MAX_DRAFT_BYTES + 1), encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert _reply_inbox(s, "alpha") == []
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    refused = live.with_suffix(".refused.md")
+    assert not live.exists()
+    assert refused.exists() and refused.stat().st_size > reply_transport.MAX_DRAFT_BYTES
+
+
+def test_reply_to_thread_nudge_suppresses_the_draft(tmp_path) -> None:
+    # Cold review minor 5: the CLI channel anchors --to-request to the LATEST
+    # thread message, so a child reply to a nudge (same request_id, different
+    # in_reply_to) must still count as landed for dedupe.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+           meta={"request_id": "q-nudge"})
+    nudge = s.send(sender="alpha", recipient="beta", kind="question",
+                   body="any progress?", meta={"request_id": "q-nudge"})
+    handled = {"n": 0}
+
+    def drive(rec):
+        handled["n"] += 1
+        if handled["n"] == 2:
+            # Child answers the SECOND record via CLI anchored to the nudge,
+            # and also leaves a draft (disobeying "one channel").
+            s.send(sender="beta", recipient="alpha", body="cli via nudge",
+                   meta={"in_reply_to": nudge.id, "request_id": "q-nudge"})
+            Path(rec["reply_draft"]["path"]).write_text("dup", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=2)
+    assert [m.body for m in _reply_inbox(s, "alpha")] == ["cli via nudge"]
+
+
+def test_one_shot_path_delivers_the_draft(tmp_path) -> None:
+    # Cold review major 3: the scoped one-shot loop (ephemeral reviewers) has
+    # its own drive site and must not strand a sandbox-blocked child's answer.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="scoped q",
+               meta={"request_id": "q-oneshot"})
+
+    def drive(rec):
+        assert isinstance(rec.get("reply_draft"), dict)
+        Path(rec["reply_draft"]["path"]).write_text("scoped answer", encoding="utf-8")
+        return True
+
+    turns = loop.run_loop(s, "beta", drive, clock=lambda: 0.0,
+                          sleep=lambda d: None, max_turns=1, max_polls=4,
+                          only_request_id="q-oneshot")
+    assert turns == 1
+    (msg,) = _reply_inbox(s, "alpha")
+    assert msg.body == "scoped answer"
+    assert (msg.meta or {}).get("in_reply_to") == q.id
+    assert (msg.meta or {}).get("request_id") == "q-oneshot"

--- a/tests/test_stub_agent_canary.py
+++ b/tests/test_stub_agent_canary.py
@@ -336,3 +336,41 @@ def test_num_turns_is_authoritative_ran_signal_over_event_type_inference() -> No
     assert session.resume_failure_is_session_attributable(
         cls, "error_during_execution", raw_tail=spoof,
         produced_model_output=False, result_num_turns=None)
+
+
+# ----------------------------------------------------------------------- draft_only
+
+
+def test_draft_only_child_is_delivered_by_the_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#201 end-to-end, gate INACTIVE (the field configuration): a child whose
+    sandbox can run NO bus command writes only the wrapper-declared reply draft
+    through the REAL spawn path; the wrapper validates and publishes it with
+    exact thread correlation, and the record commits."""
+    monkeypatch.setenv("AGENTTALK_STUB_SCENARIO", "draft_only")
+    monkeypatch.delenv("AGENTTALK_COMMIT_GATE_POLICY", raising=False)
+    store = _store(tmp_path)
+    inbound = _question(store, "q-draft")
+
+    drive = run.make_drive(
+        store, "beta", "claude", _claude_session(store), _base_argv(),
+        render=False,
+    )
+    turns = loop.run_loop(
+        store, "beta", drive,
+        clock=lambda: 0.0,
+        sleep=lambda _d: None,
+        max_turns=1,
+        max_polls=6,
+    )
+
+    assert turns == 1
+    replies = _reply_from(store, "beta", inbound.id)
+    assert len(replies) == 1
+    reply = replies[0]
+    assert "wrapper-owned draft delivery" in reply.body
+    assert (reply.meta or {}).get("request_id") == "q-draft"
+    assert (reply.meta or {}).get("operation_nonce")   # idempotent publication
+    assert store.cursor("beta") == inbound.id          # committed
+    assert store.dead_lettered_count("beta") == 0


### PR DESCRIPTION
## What

A wrapped child whose harness statically rejects or approval-gates shell commands can now answer a tracked message with nothing but its structured Write tool: the wrapper declares a per-message **reply draft path** in the turn prompt, and after a **clean** turn validates and publishes the draft itself with exact thread correlation (idempotent operation-nonce publication).

## Why (field evidence)

The dogfood migration's dry-run retro, finding 1: the claude-wrapped seat could not deliver a bus reply in **5 of 5** work turns — the prescribed reply command fails the child harness's static validator before any allowlist check, and every literal respelling needs an interactive approval a headless child cannot give. Its answers dead-lettered into dotfiles that are indistinguishable on the bus from a dead agent.

## Design + adversarial review

`docs/DESIGN-201-wrapper-owned-reply-delivery.md` (rev 2). The rev-1 design targeted the commit-gate path; the adversarial design review verified against the dogfood migration's ledger that the gate was **inactive for the entire dry run** (zero admitted obligations) — the motivating failures all went through the freeform branch. Rev 2 therefore ships the freeform path first and defers the gate-path variant (with the review's three blocker fixes: broadcast echo parity, completion seal, escalation meta enrichment) to PR-2, and the seat preflight echo-turn to PR-3.

Key review-driven properties:
- **Parity by construction**: correlation echo + operation-digest rules extracted into `reply_transport` and shared by `cmd_reply` and the wrapper — including the broadcast rule (echo request_id only), which was a live divergence risk.
- **Completion seal**: delivery only on `outcome.ok` — a watchdog-truncated draft is never published as the agent's authoritative answer.
- **Race-free dual channel**: a capable child may still use the CLI; the wrapper's landed-check prevents duplicates.
- **Both loop paths** wired (continuous + one-shot).

## Tests (no model spend)

- 13 new unit/loop tests (`tests/test_reply_draft_delivery.py`): broadcast echo parity, clean-turn delivery with exact correlation, dirty-outcome refusal, dual-channel dedupe, oversize/empty refusal, typed-kind exclusion, prompt rendering.
- New stub-canary scenario `draft_only`: a shell-blocked child through the **real spawn path**, gate inactive (the field configuration) — reply lands wrapper-delivered end to end.
- Touched-path suites green locally: wrapper_loop (133), canary+obligations (329+7), ephemeral/dead-letter/adapter (243), reply/correlation (33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
