### PR TITLE
fix(#202,#204,#205): seat reliability — interruption-aware redelivery + loud launch refusals

### DIFF
--- a/docs/DESIGN-202-interruption-aware-redelivery.md
+++ b/docs/DESIGN-202-interruption-aware-redelivery.md
@@ -77,8 +77,20 @@ work complete under an unchanged watchdog budget; that is #206
   remainder). This single site survives relaunch amnesia (fail_sleep is
   in-memory) and covers crash_mid_turn's immediate-redrive-at-relaunch path
   (loop.py:1182 → 1268) with the same code.
-- Backoff: base × 2^(n-1), n = interrupted_consecutive, no separate cap
-  needed (n ≤ k_interrupted by D3).
+- Backoff: base × 2^(n-1), n = interrupted_consecutive, HARD-CAPPED at
+  `INTERRUPTION_BACKOFF_CAP_SECONDS` = 900s (cold-review FIX 1, post-ship: the
+  "no separate cap needed (n ≤ k_interrupted by D3)" claim above was **wrong**.
+  D3's ceiling bounds n only for `turn_watchdog` interruptions; `crash_mid_turn`
+  is excluded from that ceiling by design (its cause is unobserved — see D3)
+  and its own counter is bounded only by k_escalate (default 20), so n can
+  reach 19. Worse, an infra-dominant crash history escapes even the
+  k_escalate backstop (the loop keeps retrying through a sustained outage
+  instead of disposing). Uncapped, n=10 demands 60×2⁹ = 30720s (8.5h) and
+  n=19 demands ~182 DAYS of head-of-line blocking on a single message, all
+  while the chunked stamp reads the wrapper as healthy. The cap makes a
+  runaway counter degrade to "very slow" instead of "effectively never",
+  with no config knob — it is a named module constant next to the failure
+  mode it defends against.)
 
 ### D3. Interruption budget → self-clearing dead-letter (NOT a park)
 

--- a/docs/DESIGN-202-interruption-aware-redelivery.md
+++ b/docs/DESIGN-202-interruption-aware-redelivery.md
@@ -1,0 +1,218 @@
+# DESIGN #202 — Interruption-aware redelivery (rev 3, approved-for-implementation shape)
+
+Status: rev 3 — rev 1 REJECTED (3 blockers, all resolved in rev 2); rev 2
+re-verdict found 3 NEW defects in the rev-2 additions (NEW-1 blocker, NEW-2
+major, NEW-3 minor), fixed here per the reviewer's prescriptions; reviewer
+pre-cleared rev 3 as approve-implement with these deltas. Author:
+claude-agenttalk-lead · 2026-08-25. Field basis: JAWS retro finding 2;
+mechanism investigation 2026-08-25 (anchors verified at master a35297c).
+
+## Verified mechanism (unchanged from rev 1, review-confirmed)
+
+No code path delivers into a live turn. The field case is: the turn watchdog
+(or supervisor stall recovery) kills the child's whole process tree mid-build
+(abrupt TerminateProcess → partial log, no exit file); the kill re-stamps the
+heartbeat so the wrapper stays "healthy"; the turn classifies
+CLASS_AMBIGUOUS; the uncommitted head re-drives in **0.3 s** into the SAME
+resumed session with a byte-identical prompt, the partial draft deleted and
+nothing telling the child it was interrupted; CLASS_AMBIGUOUS only escalates
+at k_escalate=20 ≈ 10 hours of kill/rebuild.
+
+## Contract
+
+**A self-inflicted interruption is a first-class fact with its own persisted
+accounting, its own supervisor-safe backoff, a bounded budget that ends in a
+self-clearing dead-letter with an actionable remedy, and a visible trace to
+the child.**
+
+Stated plainly (review finding 6): v1 converts a silent 10-hour livelock
+into a fast, loud, resumable failure — three attempts (each able to profit
+from resumed session state, e.g. a warm Maven repo), then a dead-letter the
+operator can requeue after raising the budget. It does NOT make oversized
+work complete under an unchanged watchdog budget; that is #206
+(watchdog progress-awareness) and operator budget tuning.
+
+### D1. The interruption fact — DriveOutcome and the attempt ledger
+
+- `DriveOutcome` gains `interrupted: bool = False` and
+  `interruption_kind: str | None = None` ("turn_watchdog"). make_drive sets
+  them wherever `sig["watchdog"]` is true — at ALL FOUR failure-return sites
+  (run.py:2662, 2692, 2700, 2765 — the resume-failure branches rewrite the
+  summary, so summary-sniffing is forbidden by construction).
+- `store.record_attempt_result` gains the two fields and a persisted
+  `interrupted_consecutive` counter: +1 when interrupted, RESET TO 0 on any
+  non-interrupted result — and the fields are ALWAYS written (overwritten to
+  False/None on non-interrupted results, including the commit-gate CAS-miss
+  results at loop.py:1319/1337), so a stale flag can never pollute the
+  rejoin or the ceiling.
+- `store.reconcile_crash_in_progress` marks its reclassified attempt
+  interrupted with kind "crash_mid_turn" and increments the same counter.
+- Failure CLASS stays CLASS_AMBIGUOUS. The counter, not the class, carries
+  the new semantics (this is new disposition state, named as such).
+
+### D2. Supervisor-safe interruption backoff
+
+- Knob `interruption_redrive_seconds` (default 60.0) in **supervisor.json**,
+  resolved per-agent → global → default exactly like
+  resolve_dead_letter_caps (supervisor.py:821+); corrupt values refuse
+  visibly through the launch config-blocked path (the
+  work_heartbeat.interval_violation precedent, cli.py:11200-11214) — never
+  silently clamped.
+- LAUNCH VALIDATION (rev 3, per re-verdict NEW-1: the rev-2 formula refused
+  every wrapped-claude seat at shipped defaults — 60×2² = 240 ≥ 180 — and
+  validated a quantity the chunked stamp makes moot): validate the actually
+  load-bearing invariant instead — `heartbeat_interval <
+  resolve_stuck_after(agent)`; violation refuses at launch with both
+  numbers (interval_violation precedent). No constraint on the backoff
+  length itself: the per-chunk stamp keeps heartbeat age ≤
+  heartbeat_interval regardless of total sleep.
+- The backoff sleep is CHUNKED: sleep in `heartbeat_interval` slices,
+  stamping the heartbeat each slice (blocked-but-alive, the same posture as
+  the holds). A supervisor can therefore never STUCK_RECOVER a wrapper that
+  is deliberately backing off. Control kinds are still delayed for the
+  duration — documented cost, bounded by the launch validation above.
+- WHERE: not only after the failed turn. The backoff is computed at the
+  head-entry site from the PERSISTED record (`interrupted_consecutive` > 0
+  and `now - last_finished_at < required_backoff` → chunked sleep for the
+  remainder). This single site survives relaunch amnesia (fail_sleep is
+  in-memory) and covers crash_mid_turn's immediate-redrive-at-relaunch path
+  (loop.py:1182 → 1268) with the same code.
+- Backoff: base × 2^(n-1), n = interrupted_consecutive, no separate cap
+  needed (n ≤ k_interrupted by D3).
+
+### D3. Interruption budget → self-clearing dead-letter (NOT a park)
+
+Rev 1 parked via the config-blocked path; the review proved that park (a)
+never re-fires under an unchanged class (the durable hold is the ENTRY CHECK
+keyed on last_failure_class, loop.py:1184-1188), (b) never re-drives and has
+no un-park path (#62's re-probe belongs to CLASS_GATEWAY_HELD), and (c)
+head-blocks a healthy seat (#122) — trading a self-clearing 10 h failure for
+a permanent wedge. Rev 2 therefore uses the machinery whose semantics
+actually fit:
+
+- SCOPE OF THE CEILING (rev 3, per re-verdict NEW-2): only
+  `interruption_kind == "turn_watchdog"` attempts count toward
+  `k_interrupted`. crash_mid_turn's cause is UNOBSERVED — the codified codex
+  ruling in `reconcile_crash_in_progress`'s contract (store.py:3994-4002)
+  forbids exactly a DL@3 for it, because three supervisor stale-kills during
+  a host anomaly must not dispose healthy-but-slow work. crash_mid_turn
+  attempts still get the D1 accounting, the D2 backoff, and the D4 rejoin
+  (the mechanisms that make retries cheaper and saner), but their disposal
+  ceiling stays k_escalate. The ruling stands; this design does not overturn
+  it.
+- When the turn_watchdog-only `interrupted_consecutive` reaches
+  `k_interrupted` (default 3, same supervisor.json resolver), the loop
+  DEAD-LETTERS the head via the existing `_dispose` path with failure_class
+  CLASS_AMBIGUOUS and reason `interruption_budget_exhausted`, and escalates
+  once with the remedy:
+  "this message's turns were killed <k> times by <kind> after <budget>s
+  each; raise turn_watchdog.turn_elapsed_seconds for <agent>, split the
+  task, or requeue as-is: `agenttalk dead-letter requeue --agent <a> --id
+  <id>`" (threading the REAL reason into `_escalate_once` — review finding
+  9: today it hardcodes the class into the operator notification).
+- Dead-letter is self-clearing (cursor advances, the seat keeps serving the
+  queue), preserves the original bytes, and ALREADY has the recovery verb:
+  `requeue` mints a fresh message with a fresh attempt ledger — the exact
+  "operator raised the budget, try again" path, no new machinery invented.
+- Check ordering: the k_interrupted ceiling is evaluated with the other
+  post-failure ceilings, BEFORE k_poison/noninfra/k_escalate (it is strictly
+  more specific); AND mirrored at the ENTRY site (rev 3, per re-verdict
+  NEW-3): a head whose persisted counter is already at the ceiling on entry
+  — the relaunch-reconcile path can take it there — is disposed WITHOUT
+  burning another watchdog budget, joining the existing
+  auto-dispose-on-entry block (loop.py:1189+). Note the entry case can only
+  arise from turn_watchdog counts per the scope rule above.
+
+### D4. Tell the child — rejoin from the attempt ledger
+
+- `rejoin_for(record) -> str | None` is built NEXT TO make_drive in the cli
+  wiring (NOT injected by the loop — review finding 7): it reads
+  `store.attempt_record(agent, record["id"])` and, when the previous attempt
+  was interrupted, returns the REJOIN CONTEXT block (kind, elapsed, attempt
+  n of k_interrupted, preserved-draft path if any, "verify state before
+  repeating side-effectful work; prefer resuming over redoing").
+- Keyed per head id, so a rejoin can never leak across heads; the cadence
+  synthetic turn builds its own prompt and is untouched (verified: exactly
+  one assemble_turn_prompt caller). Gate path: verify dispatch_record
+  preserves record["id"] (it copies the record) so keying holds.
+- One-shot path: `_run_one_shot` has no attempt ledger; D4 there uses the
+  in-memory DriveOutcome from the previous scoped attempt (single-head loop,
+  so a local variable suffices); D2's persisted-entry backoff does not apply
+  (bounded by max_wall anyway) — stated, not implied.
+
+### D5. Preserve the interrupted draft
+
+`_with_reply_draft`: when the attempt record shows the previous attempt
+interrupted, RENAME the leftover draft to `<id>.interrupted.md` (single
+suffix; unlink the target first — Windows rename-over-existing throws,
+mirroring preserve_refused_draft) instead of deleting. Otherwise delete as
+today. Delivery reads only the exact declared live path (verified: nothing
+globs the drafts dir), so the preserved copy can never publish; the #201
+stale-draft regression test stays green and gains an interrupted-rename
+sibling.
+
+## Out of v1 (filed)
+
+- #206 watchdog tree-kill selectivity / progress-awareness (the fix that
+  would let a live build FINISH).
+- #57 second-wrapper freeform fence; #87 supervisor thresholds;
+  durable_continuation generalization (#203 adjacency).
+
+## Tests (fixture store + injected drive; force the bound, not the happy path)
+
+1. DriveOutcome contract: all four make_drive failure-return sites set
+   interrupted/kind under sig["watchdog"] (parameterized over the resume
+   branches — the summary-rewrite sites).
+2. Ledger: interrupted result → counter+1; non-interrupted → reset AND flags
+   overwritten to False (the stale-flag bug); crash_mid_turn reconcile
+   increments with its kind; counter survives relaunch (new Store instance).
+3. Backoff: injected sleep records requested durations — chunked at
+   heartbeat_interval with a stamp per chunk (assert heartbeat writes DURING
+   the backoff); entry-site backoff honored after simulated relaunch;
+   non-interrupted ambiguous failure keeps idle_interval backoff.
+4. Launch validation (rev-3 invariant): stuck_after ≤ heartbeat_interval
+   refuses at launch with both numbers; the claude 180 s shipped default is
+   the VALID-launch direction. (Implementation note: two persisted counters
+   — any-kind drives the backoff, watchdog-only drives the ceiling; a
+   non-interrupted result resets both, crash_mid_turn touches only the
+   any-kind counter.)
+5. Ceiling: 3rd consecutive turn_watchdog interruption → dead-letter with
+   reason interruption_budget_exhausted + escalation carries the remedy +
+   cursor ADVANCES (seat unblocked, next message drives); a non-interrupted
+   failure between resets the run; requeue after the ceiling yields a fresh
+   ledger; crash_mid_turn interruptions NEVER trip this ceiling (3+ crash
+   reconciles → still retrying under backoff, per the store.py ruling);
+   entry-site: a head at the ceiling on entry (kill between result-write and
+   dispose, then relaunch) disposes without another drive.
+6. Rejoin: re-drive after interruption carries the block with kind/elapsed/
+   count and the preserved-draft path; first attempts and clean redeliveries
+   carry none; gate-path dispatch keeps head keying.
+7. Draft: interrupted → renamed .interrupted.md (target pre-unlinked), live
+   path clear, preserved copy never publishes; non-interrupted → deleted as
+   today.
+8. One-shot: previous scoped attempt interrupted → next drive carries the
+   rejoin (in-memory path).
+
+## Review disposition (rev 1 → rev 2)
+
+F1/F2 (blockers): park abandoned for dead-letter+requeue; new persisted
+counter named as disposition state. F3 (blocker): chunked stamped sleep +
+launch validation + persisted entry-site backoff (covers relaunch amnesia
+and crash_mid_turn). F4: DriveOutcome fields + four enumerated sites. F5:
+always-write semantics + counter + reconcile increment. F6: honest scope
+statement added. F7: rejoin built in cli wiring; one-shot handled
+in-memory. F8: single suffix + pre-unlink. F9: real reason threaded into
+escalation. F10: supervisor.json + named resolvers + refuse-visibly. F11:
+control-kind delay documented; ceiling ordering pinned. F12: all five gap
+tests included above.
+
+Rev 2 → rev 3 (re-verdict NEW findings): NEW-1 (launch validation refused
+wrapped-claude at shipped defaults; validated a moot quantity) → validate
+heartbeat_interval < stuck_after instead, no constraint on backoff length.
+NEW-2 (k_interrupted@3 silently overturned the codified crash_mid_turn
+ruling, store.py:3994-4002) → ceiling counts turn_watchdog only;
+crash_mid_turn keeps k_escalate disposal but gains backoff + rejoin +
+accounting; ruling explicitly preserved. NEW-3 (counter can reach the
+ceiling at entry via relaunch) → ceiling mirrored at the entry-site
+auto-dispose block. Reviewer pre-cleared this rev as approve-implement
+without a further full pass.

--- a/docs/PROPOSAL-console-client-sellability.md
+++ b/docs/PROPOSAL-console-client-sellability.md
@@ -229,3 +229,49 @@ that don't mean what they look like they mean.
    remote-access mode for the client view only (e.g. a signed, time-boxed,
    read-only export server) — or is static export the permanent answer to
    "the client isn't at the operator's desk"?
+
+---
+
+## 7. Reconciliation with the third-party review (2026-08-25)
+
+An independent reviewer assessed the live console (all seven views, desktop
+and narrow-laptop) against the same question. The two reviews converge on
+every structural call and the external one sharpens ours:
+
+**Where we agree** — keep the Team Console as the engineering/operations
+view and build a program layer above it (their words: "a cosmetic redesign
+alone will not make the present UI compelling"); separate personas over the
+same evidence (we said two, they say three — Executive / Delivery leader /
+Engineer — theirs is better); the Gate & Evidence Wall generalizes into
+their readiness-and-assurance matrix (every green = evidence + independent
+verifier + expiry; missing = HOLD); static signed briefings first, remote
+portal only as a later, explicitly-decided trade-off — both reviews reached
+this independently, which settles open question 5.
+
+**What they add that ours missed:**
+- An evidence-backed *stage vocabulary* (assessment-complete → plan-approved
+  → reimplementation-complete → parity-verified → acceptance-ready →
+  cutover-ready → legacy-decommissioned). This answers our open question 1:
+  the plateau concept should be formalized as these stages — they exist
+  precisely to prevent "complete but not cutover-ready" overstatement.
+- An executive scorecard with named KPIs, and a Decision Center upgrade of
+  the Human Queue (plain-language decision, options, impact, owner,
+  deadline, expiring risk acceptance).
+- Concrete, verified mechanical defects in today's console (header
+  mission-pill overflow, untrustworthy relative timestamps, default scope
+  showing retired agents, endpoint latency vs the 2-second poll, narrow-
+  layout priority) — filed as an immediate fix bundle.
+- The best near-term showcase: a customer-facing static dashboard built
+  from the Papendal pilot — a real migration that is reimplemented and
+  parity-verified but honestly NOT cutover-ready, with clickable evidence.
+  That demo is the differentiator stated exactly: the system proves what
+  was migrated, surfaces what remains unknown, and stops a confident team
+  declaring victory early.
+
+**Where we hold our ground** — nothing in the external review contradicts
+the "what NOT to build" list; it independently endorses the loopback
+posture and static-first stakeholder delivery.
+
+**Disposition:** mechanical fixes = task #207 (immediate, small); the merged
+program layer = task #208 (quarter-scale, built together with the #55
+assessment/comprehension plane, which is its data source).

--- a/docs/PROPOSAL-console-client-sellability.md
+++ b/docs/PROPOSAL-console-client-sellability.md
@@ -1,0 +1,231 @@
+# Proposal: Making the Team Console Client-Sellable
+
+Audience: product/ops decision-makers, not engineers. No code, no file references.
+
+## 1. Today's console, honestly
+
+The Team Console is a read-only, loopback-only dashboard: it only answers to a
+browser on the same machine the tool runs on, only responds to GET requests,
+and refuses to render anything an attacker could smuggle in as script. What it
+already shows, per project: who the agents are and whether they're alive
+(health, last heartbeat, what they're composing), who owns which part of the
+codebase, a traffic graph of who's talking to whom, open and closed
+conversation threads (including review-request/review-result exchanges,
+tagged but not narrated as a story), a ranked "needs a human" queue that
+already blends stalled agents, dead letters, and gate blockers with a
+severity/confidence score, an onboarding ledger for a codebase analysis pass
+(segments inspected, open drift, blocking unknowns), and a lessons-learned
+audit trail (what got taught to which agent and when). An optional
+action-gated mode lets the one loopback operator answer escalations and chat
+with the lead from the browser instead of the CLI.
+
+What it structurally cannot show today: it has no view of lanes or
+deliveries (the isolated-worktree assignments and their reject/fix/re-verdict
+history) even though that data is recorded on disk; it has no view of gates
+or operator waivers beyond a one-line blocker mention buried in the attention
+queue — the actual evidence, status, and severity behind "why is this red"
+is invisible; it has nothing on close/release records (the GO/HOLD verdict
+that aggregates gates, reviews, and sign-offs); and it cannot be reached by
+anyone who isn't sitting at the operator's own machine — no client, however
+trusted, can just open a link.
+
+## 2. The pitch reframe: two personas, two views
+
+**The operator** (today's only user) needs control: can I unstick this agent,
+answer this escalation, see who's composing what right now. That's a live,
+interactive, loopback cockpit — keep it exactly that.
+
+**The client's engineering director** (the buyer) needs something completely
+different: they are not debugging anything, they don't read code, and they
+are not going to SSH-tunnel into anyone's laptop. They need three things a
+sales conversation can point to: (1) *proof of progress* — a plateau-by-plateau
+view of the migration, not a wall of agent chatter; (2) *proof of rigor* — a
+visible wall of gates that stay red until real evidence exists, with waivers
+named and dated rather than silently skipped; and (3) *something they can
+keep* — a snapshot or export they can put in a status deck or an audit
+folder, independent of whether the tool is even running when someone asks
+"how did we know this was safe to ship."
+
+The operator view is a cockpit. The client view is a report. They should be
+visibly different surfaces built from the same store, not the same screen
+with more permissions.
+
+## 3. Ranked feature proposals
+
+Ordered by sellability impact per unit of effort. "Data" = what's already
+recorded on disk vs what needs new plumbing to compute or persist.
+
+**1. Gate & Evidence Wall (the "nothing is green without proof" screen).**
+Shows every gate by scope (a release, a plateau, a lane) as a card: red,
+green, or waived, with the evidence behind a green and the reason/expiry
+behind a waiver, in plain language ("tests: green, verified by CI run on
+[date]" / "security scan: waived, reason: scanner unavailable, expires
+[date]"). This is the single most on-brand, most sellable screen — it's the
+tool's actual differentiator made visible. Data: gate status, severity,
+evidence, and waivers are already fully recorded on disk today; today's
+console only ever surfaces a one-line blocker mention, never the full
+picture. New plumbing needed: a real API view and a UI screen; no new data
+capture. Size: **M**.
+
+**2. Migration Progress Plateaus.**
+A top-level "where are we" bar: plateaus/milestones as steps, each stamped
+delivered/in-progress/blocked, backed by what actually shipped (lane
+deliveries) and what's still open (gate/onboarding findings) for that
+plateau. This is the screen a director opens first. Data: onboarding
+segments and lane deliveries both exist; there is no existing concept that
+ties a delivery to a "plateau" label, so grouping logic and a small new
+aggregation are needed. Size: **L**.
+
+**3. Review-Chain Story ("reject → fix → approved").**
+Instead of a raw thread list, render the review lifecycle of a piece of work
+as a short narrative: reviewer raised issue X, dev fixed it, re-reviewed,
+approved — with dates and named actors. This is proof that scrutiny actually
+happened, not just that a checkbox got ticked. Data: the review-request and
+review-result messages and their thread linkage already exist; today they
+render as tagged chat entries, not a story. New plumbing: a grouping/
+narration layer over existing thread data. Size: **M**.
+
+**4. Lane & Delivery Ledger.**
+A view of every scoped assignment (lane): its worktree isolation, its
+current stage (assigned → checked → delivered → cleaned up), and its
+verdict history including any HOLDs it had to clear. Proves the "isolated,
+reviewed unit of work" promise concretely. Data: lanes and their delivery
+artifacts are fully recorded on disk; there is currently **zero** exposure
+of this data anywhere in the web layer — this is the single biggest gap
+between what's recorded and what's shown. Size: **M**.
+
+**5. Client Audit Export (static snapshot).**
+A one-click export of gates, plateau progress, and the review-chain story as
+a static HTML or PDF file, timestamped, that a client can file away
+independent of whether the tool or the project is still running. This is
+what actually gets attached to an invoice or a compliance folder. Data:
+entirely a reuse of #1–#3's data once built; the only new work is a
+render-to-static-file path. Size: **M/L** (depends on #1–#3 landing first).
+
+**6. Risk Register from Open Findings.**
+Reframe the existing "needs a human" queue as a client-legible risk
+register: each open item (stalled agent, dead letter, gate blocker, open
+onboarding drift/unknown) shown with severity, age, and owner, sorted the
+way a risk log is sorted, not the way an operator triage queue is sorted.
+Data: the ranking, severity, and confidence fields already exist and are
+already computed; this is close to a relabeling exercise with a different
+sort/filter and a client-safe rendering. Size: **S**.
+
+**7. Ownership & Accountability Map.**
+Surface the full domain-ownership registry — which agent/team owns which
+part of the codebase, and which paths require shared sign-off — as its own
+small view, not just a one-line tag buried on each agent card. Answers "who
+is accountable for this part of my codebase" directly. Data: fully recorded;
+today only a thin per-agent slice is shown. Size: **S**.
+
+**8. Decision & Gotcha Log.**
+Surface the general knowledge notes (decisions, gotchas — not just process
+lessons) tied to the part of the codebase they apply to, e.g. "why we chose
+X here." Gives a client a legible "institutional memory" artifact instead of
+having to trust it exists. Data: the note types exist and are already
+recorded; today's Learning view filters down to lessons only, so most notes
+of this kind are invisible. Size: **S/M**.
+
+**9. Deliverable Cycle Time.**
+For each delivered lane: how long from assignment to delivery, how many
+review rounds, how many dead-letter/retry events along the way. A rough
+proxy for "how much did this cost to get right" without exposing raw
+token/dollar spend. Data: timestamps for assignment and delivery exist; dead
+letters are already counted; nothing currently rolls this into a per-
+deliverable figure. Size: **M**.
+
+**10. Before/After Code Health Snapshot.**
+Diff-level metrics (files touched, test coverage delta, lines changed) shown
+per plateau, alongside the gate evidence for that plateau. The most visually
+persuasive "this migration actually improved things" artifact — and the
+weakest-grounded proposal here. Data: **does not exist today** in any
+recorded form beyond whatever a coverage percentage a gate's evidence
+happens to carry; this needs new evidence collection, not just new
+plumbing. Treat as speculative until a gate/evidence convention for code
+metrics is agreed. Size: **L**.
+
+**11. Client Notification Digest.**
+A periodic (e.g. weekly) plain-language summary — "3 plateaus done, 1 gate
+waived and expiring in 5 days, 2 open risks" — sent or exported without the
+client needing to visit anything. Turns the console from "pull" to "push."
+Data: entirely derivable from #1, #2, and #6 once they exist; the new work
+is a summarization/formatting pass and a delivery mechanism (file drop,
+email, etc. — mechanism is an open question, see §6). Size: **M**.
+
+**12. Waiver Watch.**
+A dedicated small view listing every active operator waiver with its
+expiry, so nothing red-turned-green-by-waiver silently outlives its
+justification unnoticed by a client. Data: fully recorded already; today
+waivers are invisible outside the raw gate file. Size: **S**.
+
+## 4. Quick wins vs strategic bets
+
+**Two-week list** (small, mostly reads existing data, highest visible payoff
+per hour): #6 Risk Register relabel, #7 Ownership Map, #12 Waiver Watch, and
+the read side of #1 Gate & Evidence Wall (status + evidence text, without
+export yet). These alone would take the console from "internal ops tool" to
+"here's proof we're rigorous" in a demo.
+
+**Quarter list** (the actual strategic bets): #2 Migration Progress Plateaus
+(needs a plateau/milestone concept that doesn't exist yet — a real design
+decision, not just plumbing), #4 Lane & Delivery Ledger (biggest data-to-UI
+gap in the whole codebase), #3 Review-Chain Story, and #5 Client Audit
+Export once #1–#3 exist under it. #10 Before/After Code Health should be
+explicitly parked until there's a real evidence convention for code
+metrics — building the UI before the data model invites showing numbers
+that don't mean what they look like they mean.
+
+## 5. What NOT to build (and why)
+
+- **Do not give the client's engineering director live remote access to a
+  running console.** The console's entire security model is "one human at
+  their own workstation, loopback only, no opt-in to bind elsewhere." Any
+  path that lets a client browser reach a live server — even authenticated,
+  even read-only — is a new network-facing attack surface this tool has
+  deliberately never had, and it changes the threat model from "protect one
+  operator's laptop" to "protect an internet-reachable service." If remote
+  client access is wanted, the trade-off must be named and decided by the
+  operator explicitly, not solved by quietly loosening the loopback rule.
+  The static-export approach (#5) gets most of the sellability value —
+  "here's proof, dated and yours to keep" — without that exposure.
+- **Do not add client-side write actions.** Actions (answering escalations,
+  restarting agents) are already gated behind an explicit opt-in for the one
+  trusted operator. A client persona has no legitimate reason to write to
+  the store, and adding a write path "for convenience" multiplies the
+  authorization surface for no sellability gain — a client wants to see
+  proof, not operate the tool.
+- **Do not relax the strict Content-Security-Policy or inline-script
+  restrictions to make richer client-facing charts easier to build.** Every
+  proposal above is achievable with the same self-hosted-script, no-inline,
+  textContent-only discipline the console already uses; reaching for a
+  chart library that needs eval or inline styles is a security regression
+  for a cosmetic gain.
+- **Do not fabricate a code-health or cost metric ahead of a real evidence
+  source** (see #10, #9's dollar-cost variant). A client-facing number that
+  looks authoritative but isn't backed by recorded evidence is worse than no
+  number — it's exactly the kind of unverified claim this tool exists to
+  refuse to make about itself.
+- **Do not build a generic multi-tenant/SaaS version of the console.** The
+  buyer is the engineering director of one client at a time using one
+  operator's local tool; multi-tenant hosting is a different product with a
+  different security and ops burden, not a UI feature.
+
+## 6. Open questions for the operator
+
+1. Is a **plateau/milestone** a concept we're willing to formally define and
+   persist (needed for #2 and to make #5's export meaningful), or should
+   progress stay expressed only in terms of lanes and gates as-is?
+2. For client delivery of the audit export (#5) and digest (#11): is a
+   manually-triggered file drop acceptable, or does the sales motion need a
+   push mechanism (email, shared folder), which would need its own trust
+   review?
+3. Should client-facing waivers (#1, #12) show the operator's name/identity,
+   or should they be anonymized to "the operator" — some clients may read a
+   named individual accepting risk differently than an anonymous role?
+4. How far do we want to go on #10 (code health metrics) — is it worth
+   defining a real evidence convention for coverage/diff metrics this
+   quarter, or is it explicitly out of scope until a client asks for it?
+5. Is there appetite to eventually offer a deliberately narrower, harder
+   remote-access mode for the client view only (e.g. a signed, time-boxed,
+   read-only export server) — or is static export the permanent answer to
+   "the client isn't at the operator's desk"?

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -10423,6 +10423,7 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
                     one_shot_request_id: str | None = None,
                     k_poison: int = 3, k_escalate: int = 20,
                     k_interrupted: int = 3,
+                    heartbeat_interval: float | None = None,
                     interruption_redrive_seconds: float = 60.0,
                     infra_exhaust_after_seconds: float = 14400.0,
                     infra_exhaust_min_attempts: int = 100,
@@ -10729,6 +10730,15 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             max_wall=max_wall,
             k_poison=k_poison, k_escalate=k_escalate,
             k_interrupted=k_interrupted,
+            # cold-review FIX 7: pass the SAME value cmd_wrap already validated
+            # against stuck_after (HEARTBEAT_INTERVAL_SECONDS) explicitly, rather
+            # than relying on run_loop's default parameter matching the module
+            # constant by coincidence - the launch invariant and the runtime value
+            # can then never drift apart.
+            heartbeat_interval=(
+                heartbeat_interval if heartbeat_interval is not None
+                else wloop.HEARTBEAT_INTERVAL_SECONDS
+            ),
             interruption_redrive_seconds=interruption_redrive_seconds,
             # for the escalation's remedy text only: the watchdog budget each
             # killed turn burned (None when the watchdog is not live).
@@ -11330,6 +11340,7 @@ def _cmd_wrap_with_logging(args: argparse.Namespace) -> int:
             k_poison=k_poison,
             k_escalate=k_escalate,
             k_interrupted=k_interrupted,
+            heartbeat_interval=_hb_interval,
             interruption_redrive_seconds=interruption_redrive,
             infra_exhaust_after_seconds=infra_ceiling[
                 "infra_exhaust_after_seconds"

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -10379,7 +10379,14 @@ def _interruption_rejoin_for(store, agent: str, k_interrupted: int):
     def rejoin_for(record: dict) -> str | None:
         head_id = record.get("id")
         ctx = record.get("interrupted_redelivery")
-        if isinstance(ctx, dict):
+        # #202 cold-review P2-2: the one-shot path (``ctx`` is the in-memory
+        # decoration) has NO attempt ledger and _run_one_shot never enforces
+        # k_interrupted (bounded by max_wall instead) - the budget clause below
+        # must never be shown for it, or the rejoin promises a dead-letter ceiling
+        # that can never fire.
+        is_one_shot = isinstance(ctx, dict)
+        watchdog_count = 0
+        if is_one_shot:
             kind = ctx.get("kind") or "unknown"
             count = ctx.get("consecutive") or 1
             last_at = ctx.get("last_failure_at")
@@ -10394,16 +10401,36 @@ def _interruption_rejoin_for(store, agent: str, k_interrupted: int):
                 count = max(1, int(rec.get("interrupted_consecutive") or 1))
             except (TypeError, ValueError):
                 count = 1
+            # #202 cold-review P2-5: ``interrupted_consecutive`` counts ANY kind
+            # (crash_mid_turn interruptions included), but the budget is
+            # turn_watchdog-only - showing the any-kind count against it overstates
+            # how close the message is to the ceiling after a mixed crash+watchdog
+            # run. Show the watchdog-only count against k, and name any extra
+            # crash interruptions separately instead of folding them in silently.
+            try:
+                watchdog_count = max(0, int(rec.get("interrupted_watchdog_consecutive") or 0))
+            except (TypeError, ValueError):
+                watchdog_count = 0
             last_at = rec.get("last_failure_at")
         lines = [
             f"Your previous turn on this message was INTERRUPTED ({kind}) "
             f"{_elapsed_text(last_at)} ago - the work was killed mid-turn, "
             "not rejected.",
         ]
-        if kind == "turn_watchdog" and k_interrupted > 0:
+        if is_one_shot:
             lines.append(
-                f"This is interruption {count} of a budget of {k_interrupted}; "
-                "at the budget the message is dead-lettered for the operator.")
+                f"Consecutive interruptions on this message: {count}; no automatic "
+                "budget applies in one-shot mode.")
+        elif kind == "turn_watchdog" and k_interrupted > 0:
+            n_shown = max(1, watchdog_count)
+            crash_extra = max(0, count - watchdog_count)
+            plus_clause = (
+                f" (plus {crash_extra} crash interruption{'s' if crash_extra != 1 else ''})"
+                if crash_extra > 0 else "")
+            lines.append(
+                f"This is interruption {n_shown} of a budget of {k_interrupted}"
+                f"{plus_clause}; at the budget the message is dead-lettered for "
+                "the operator.")
         else:
             lines.append(f"Consecutive interruptions on this message: {count}.")
         if isinstance(head_id, str) and head_id:

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -10041,10 +10041,14 @@ def _dead_letter_notifier(store, agent: str):
                 return True
             request_id = "esc-" + uuid.uuid4().hex[:12]
             verb = "DEAD-LETTERED" if disposed else "repeatedly FAILING (not yet dead-lettered)"
+            # #202 D3 (review finding 9): carry the REAL reason/remedy, not only the
+            # class - e.g. the interruption-budget escalation's concrete remedy.
+            reason = str(info.get("summary") or "")
             body = (f"[dead-letter] agent {ag} {verb} message {mid} from "
                     f"{info.get('from')} (kind={info.get('kind')}, "
                     f"attempts={info.get('attempts')}, class={info.get('failure_class')}). "
-                    f"Inspect: agenttalk dead-letter show --agent {ag} --id {mid}")
+                    + (f"Reason: {reason}  " if reason else "")
+                    + f"Inspect: agenttalk dead-letter show --agent {ag} --id {mid}")
             if disposed:
                 body += f"  Requeue: agenttalk dead-letter requeue --agent {ag} --id {mid}"
             store.send(sender=agent, recipient=target, kind="question",
@@ -10353,10 +10357,73 @@ def _inject_claude_permission_mode(argv: list[str], cli: str,
     return [*argv, "--permission-mode", perm_mode]
 
 
+def _interruption_rejoin_for(store, agent: str, k_interrupted: int):
+    """Build make_drive's #202 D4 rejoin provider (cli wiring, NOT the loop).
+
+    Keyed per head id from the PERSISTED attempt ledger, so a rejoin can never leak
+    across heads and survives relaunch. The one-shot loop has no ledger; it decorates
+    the record in-memory (``interrupted_redelivery``) and is read here first. Returns
+    the REJOIN CONTEXT block, or None on a first attempt / clean redelivery."""
+    from agenttalk import reply_transport as _rt
+
+    def _elapsed_text(last_at: object) -> str:
+        if not isinstance(last_at, str) or not last_at.strip():
+            return "an unknown time"
+        try:
+            at = datetime.fromisoformat(last_at.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return "an unknown time"
+        seconds = max(0.0, datetime.now(timezone.utc).timestamp() - at.timestamp())
+        return f"~{seconds:.0f}s"
+
+    def rejoin_for(record: dict) -> str | None:
+        head_id = record.get("id")
+        ctx = record.get("interrupted_redelivery")
+        if isinstance(ctx, dict):
+            kind = ctx.get("kind") or "unknown"
+            count = ctx.get("consecutive") or 1
+            last_at = ctx.get("last_failure_at")
+        else:
+            if not isinstance(head_id, str) or not head_id:
+                return None
+            rec = store.attempt_record(agent, head_id) or {}
+            if not rec.get("last_interrupted"):
+                return None
+            kind = rec.get("last_interruption_kind") or "unknown"
+            try:
+                count = max(1, int(rec.get("interrupted_consecutive") or 1))
+            except (TypeError, ValueError):
+                count = 1
+            last_at = rec.get("last_failure_at")
+        lines = [
+            f"Your previous turn on this message was INTERRUPTED ({kind}) "
+            f"{_elapsed_text(last_at)} ago - the work was killed mid-turn, "
+            "not rejected.",
+        ]
+        if kind == "turn_watchdog" and k_interrupted > 0:
+            lines.append(
+                f"This is interruption {count} of a budget of {k_interrupted}; "
+                "at the budget the message is dead-lettered for the operator.")
+        else:
+            lines.append(f"Consecutive interruptions on this message: {count}.")
+        if isinstance(head_id, str) and head_id:
+            preserved = _rt.reply_draft_path(store, agent, head_id).with_suffix(
+                ".interrupted.md")
+            if preserved.is_file():
+                lines.append(f"Your interrupted draft was preserved at: {preserved}")
+        lines.append("Verify state before repeating side-effectful work; prefer "
+                     "resuming over redoing.")
+        return "\n".join(lines)
+
+    return rejoin_for
+
+
 def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
                     sender: str, min_interval: float, render: bool,
                     one_shot_request_id: str | None = None,
                     k_poison: int = 3, k_escalate: int = 20,
+                    k_interrupted: int = 3,
+                    interruption_redrive_seconds: float = 60.0,
                     infra_exhaust_after_seconds: float = 14400.0,
                     infra_exhaust_min_attempts: int = 100,
                     noninfra_sub_ceiling: int | None = None,
@@ -10513,6 +10580,9 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             # lost_lease, never a bus heartbeat without the lease), while the
             # pre_commit gate remains the consume-boundary authority.
             lease_lost_exceptions=(_LeadLoopLeaseLost,) if lead_loop else (),
+            # #202 D4: tell the child it was interrupted - built here in the cli
+            # wiring (review finding 7), reading the persisted attempt ledger.
+            rejoin_for=_interruption_rejoin_for(store, agent, k_interrupted),
         )
     except ValueError as e:
         _release()
@@ -10658,6 +10728,13 @@ def _wrap_loop_mode(store, agent: str, *, cli: str, base_argv: list[str],
             only_request_id=one_shot_request_id,
             max_wall=max_wall,
             k_poison=k_poison, k_escalate=k_escalate,
+            k_interrupted=k_interrupted,
+            interruption_redrive_seconds=interruption_redrive_seconds,
+            # for the escalation's remedy text only: the watchdog budget each
+            # killed turn burned (None when the watchdog is not live).
+            interruption_budget_seconds=(
+                getattr(turn_watchdog, "turn_elapsed_seconds", None)
+                if getattr(turn_watchdog, "enabled", False) else None),
             infra_exhaust_after_seconds=infra_exhaust_after_seconds,
             infra_exhaust_min_attempts=infra_exhaust_min_attempts,
             noninfra_sub_ceiling=noninfra_sub_ceiling,
@@ -11212,6 +11289,35 @@ def _cmd_wrap_with_logging(args: argparse.Namespace) -> int:
                 return _handle_launch_config_blocked(
                     store, agent, args.cli, mode=whb_mode,
                     min_interval=args.min_interval, summary=summary)
+        # #202 D2: interruption-aware redelivery knobs. A present-but-corrupt value
+        # refuses visibly through the launch config-blocked path (never silently
+        # clamped) - same discipline as work_heartbeat above.
+        interruption_redrive, k_interrupted, _int_errors = (
+            _sup.resolve_interruption_policy(sup_cfg, cfg_agent))
+        if _int_errors:
+            summary = ("invalid interruption redelivery config (never silently "
+                       "coerced): " + "; ".join(_int_errors))
+            sys.stderr.write(f"agenttalk wrap: {summary}\n")
+            return _handle_launch_config_blocked(
+                store, agent, args.cli, mode=whb_mode,
+                min_interval=args.min_interval, summary=summary)
+        # #202 D2 launch validation (rev 3): the chunked backoff stamps once per
+        # heartbeat_interval slice, keeping heartbeat age <= heartbeat_interval no
+        # matter how long the total backoff - so the ONE load-bearing invariant is
+        # heartbeat_interval < stuck_after. Refuse with both numbers.
+        from agenttalk.wrapper.loop import HEARTBEAT_INTERVAL_SECONDS as _hb_interval
+        _stuck_after = _sup.resolve_stuck_after(sup_cfg, cfg_agent)
+        if _hb_interval >= _stuck_after:
+            summary = (
+                f"wrapper heartbeat_interval {_hb_interval:.0f}s must be below "
+                f"stuck_after {_stuck_after:.0f}s: the interruption backoff stamps "
+                f"the heartbeat once per {_hb_interval:.0f}s chunk, so a stuck_after "
+                "at/below it would let the supervisor kill a deliberately "
+                "backing-off wrapper. Raise stuck_after_seconds.")
+            sys.stderr.write(f"agenttalk wrap: {summary}\n")
+            return _handle_launch_config_blocked(
+                store, agent, args.cli, mode=whb_mode,
+                min_interval=args.min_interval, summary=summary)
         return _wrap_loop_mode(
             store,
             agent,
@@ -11223,6 +11329,8 @@ def _cmd_wrap_with_logging(args: argparse.Namespace) -> int:
             one_shot_request_id=args.to_request if args.one_shot else None,
             k_poison=k_poison,
             k_escalate=k_escalate,
+            k_interrupted=k_interrupted,
+            interruption_redrive_seconds=interruption_redrive,
             infra_exhaust_after_seconds=infra_ceiling[
                 "infra_exhaust_after_seconds"
             ],

--- a/src/agenttalk/launch_admission.py
+++ b/src/agenttalk/launch_admission.py
@@ -548,6 +548,15 @@ def validate_standalone_wrap(args: argparse.Namespace | WrapInvocation) -> WrapP
             "one_shot_without_request",
             "agenttalk wrap: --one-shot requires --to-request <id>",
         )
+    if invocation.to_request and not invocation.one_shot:
+        # #204 refuse-loudly (#166): without --one-shot the request scope was
+        # silently dropped - the invocation ran as an unscoped plain/loop wrap
+        # and never drove the named request.
+        return WrapRefusal(
+            "to_request_without_one_shot",
+            "agenttalk wrap: --to-request only scopes a one-shot turn; use "
+            "--loop --one-shot --to-request <id> to drive that request",
+        )
     if invocation.lead_loop and not invocation.loop:
         return WrapRefusal(
             "lead_loop_without_loop",

--- a/src/agenttalk/reply_transport.py
+++ b/src/agenttalk/reply_transport.py
@@ -166,6 +166,26 @@ def preserve_refused_draft(draft_path: Path) -> Path | None:
     return target
 
 
+def preserve_interrupted_draft(draft_path: Path) -> Path | None:
+    """Rename an interrupted attempt's leftover draft to ``.interrupted.md``.
+
+    #202 D5: a draft cut short by a watchdog kill / crash is the child's
+    recoverable progress, not stale garbage — the next attempt's rejoin context
+    names this path so the child can resume instead of redoing. Single suffix;
+    the target is unlinked first (Windows rename-over-existing throws —
+    mirrors preserve_refused_draft). The LIVE draft path is left clear, and
+    delivery reads only the exact declared live path, so the preserved copy
+    can never publish.
+    """
+    target = draft_path.with_suffix(".interrupted.md")
+    try:
+        target.unlink(missing_ok=True)
+        draft_path.rename(target)
+    except OSError:
+        return None
+    return target
+
+
 def read_reply_draft(draft_path: Path) -> str | None:
     """Read and bound a child-written draft; None means 'no deliverable draft'.
 

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -3967,7 +3967,10 @@ class Store:
     def record_attempt_result(self, agent: str, msg_id: str, *, failure_class: str,
                               summary: str | None, at: str,
                               interrupted: bool = False,
-                              interruption_kind: str | None = None) -> dict | None:
+                              interruption_kind: str | None = None,
+                              never_started_first_at: str | None = None,
+                              never_started_consecutive: int = 0,
+                              promoted_by_generation: str | None = None) -> dict | None:
         """After a FAILED drive: clear ``in_progress``, bump the per-class failure
         counter, record the last class/summary. (Success calls clear_attempt.)
 
@@ -3979,7 +3982,18 @@ class Store:
         ``interrupted_consecutive`` (any kind - drives the D2 backoff) and
         ``interrupted_watchdog_consecutive`` (kind=turn_watchdog only - drives the D3
         ceiling; crash_mid_turn must never count toward it, per the
-        reconcile_crash_in_progress ruling below)."""
+        reconcile_crash_in_progress ruling below).
+
+        #205 cold-review P1-B: ``never_started_first_at``/``never_started_consecutive``
+        are ALSO always written (the caller computes them from the prior record before
+        this call, so they persist across relaunch and are cleared the instant a
+        non-never-started result lands) - the promotion window is measured from the
+        FIRST never-started failure, never a pairwise gap that every fast retry resets.
+
+        #205 cold-review P1-A: ``promoted_by_generation`` is written only when the
+        caller is PROMOTING this result to CLASS_CONFIG_BLOCKED (non-None); it names
+        the wrapper generation active at promotion time so the entry-check park can
+        allow exactly one re-probe drive after a restart (operator intervention)."""
         data = self.dead_letter_attempts(agent)
         rec = data["messages"].get(msg_id)
         if not isinstance(rec, dict):
@@ -3990,6 +4004,10 @@ class Store:
         rec["last_failure_at"] = at
         rec["last_interrupted"] = bool(interrupted)
         rec["last_interruption_kind"] = interruption_kind if interrupted else None
+        rec["never_started_first_at"] = never_started_first_at
+        rec["never_started_consecutive"] = _safe_int(never_started_consecutive)
+        if promoted_by_generation is not None:
+            rec["promoted_by_generation"] = promoted_by_generation
         if interrupted:
             rec["interrupted_consecutive"] = _safe_int(
                 rec.get("interrupted_consecutive")) + 1

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -3965,9 +3965,21 @@ class Store:
         return rec
 
     def record_attempt_result(self, agent: str, msg_id: str, *, failure_class: str,
-                              summary: str | None, at: str) -> dict | None:
+                              summary: str | None, at: str,
+                              interrupted: bool = False,
+                              interruption_kind: str | None = None) -> dict | None:
         """After a FAILED drive: clear ``in_progress``, bump the per-class failure
-        counter, record the last class/summary. (Success calls clear_attempt.)"""
+        counter, record the last class/summary. (Success calls clear_attempt.)
+
+        #202 D1: a SELF-INFLICTED interruption (the turn watchdog killed the child's
+        tree) is a first-class fact with its own persisted accounting. The fields are
+        ALWAYS written - overwritten to False/None on a non-interrupted result
+        (including the loop's commit-gate CAS-miss results) - so a stale flag can
+        never pollute the rejoin context or the k_interrupted ceiling. Two counters:
+        ``interrupted_consecutive`` (any kind - drives the D2 backoff) and
+        ``interrupted_watchdog_consecutive`` (kind=turn_watchdog only - drives the D3
+        ceiling; crash_mid_turn must never count toward it, per the
+        reconcile_crash_in_progress ruling below)."""
         data = self.dead_letter_attempts(agent)
         rec = data["messages"].get(msg_id)
         if not isinstance(rec, dict):
@@ -3976,6 +3988,17 @@ class Store:
         rec["last_failure_class"] = failure_class
         rec["last_failure_summary"] = (summary or "")[:500]
         rec["last_failure_at"] = at
+        rec["last_interrupted"] = bool(interrupted)
+        rec["last_interruption_kind"] = interruption_kind if interrupted else None
+        if interrupted:
+            rec["interrupted_consecutive"] = _safe_int(
+                rec.get("interrupted_consecutive")) + 1
+            if interruption_kind == "turn_watchdog":
+                rec["interrupted_watchdog_consecutive"] = _safe_int(
+                    rec.get("interrupted_watchdog_consecutive")) + 1
+        else:
+            rec["interrupted_consecutive"] = 0
+            rec["interrupted_watchdog_consecutive"] = 0
         key = {"poison_eligible": "poison_eligible_failures",
                "known_global_infra": "infra_failures"}.get(
                    failure_class, "ambiguous_failures")
@@ -4010,6 +4033,12 @@ class Store:
         rec["last_failure_class"] = "ambiguous_or_unknown"
         rec["last_failure_summary"] = "crash_mid_turn"
         rec["last_failure_at"] = at
+        # #202 D1: a crash IS an interruption (it gets the D2 backoff + D4 rejoin), but
+        # its cause is UNOBSERVED, so it must NOT count toward - nor erase the evidence
+        # behind - the turn_watchdog-only k_interrupted ceiling (the ruling above).
+        rec["last_interrupted"] = True
+        rec["last_interruption_kind"] = "crash_mid_turn"
+        rec["interrupted_consecutive"] = _safe_int(rec.get("interrupted_consecutive")) + 1
         data["messages"][msg_id] = rec
         self._write_attempts(agent, data)
         return True

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -4057,6 +4057,14 @@ class Store:
         rec["last_interrupted"] = True
         rec["last_interruption_kind"] = "crash_mid_turn"
         rec["interrupted_consecutive"] = _safe_int(rec.get("interrupted_consecutive")) + 1
+        # #7-fix-4: a crash BREAKS the "consecutive never-started" run by
+        # definition (the process DID start this attempt - it crashed mid-turn,
+        # which is exactly why it is here). Leaving never_started_first_at /
+        # never_started_consecutive intact would let a LATER never-started
+        # failure promote using a window/count that spans across the crash,
+        # not an actually-consecutive run.
+        rec["never_started_first_at"] = None
+        rec["never_started_consecutive"] = 0
         data["messages"][msg_id] = rec
         self._write_attempts(agent, data)
         return True

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -852,7 +852,16 @@ def resolve_interruption_policy(config: dict, cfg_agent: dict) -> tuple[float, i
     Per-agent -> global -> default (60.0s / 3), mirroring resolve_dead_letter_caps'
     chain - but unlike the caps, a PRESENT-and-corrupt value is returned as an ERROR
     the launch path refuses visibly (config-blocked), never a silent clamp or
-    default. ``k_interrupted`` 0 disables the ceiling (debug only)."""
+    default. ``k_interrupted`` 0 disables the ceiling (debug only).
+
+    #202 cold-review P2-4: ``interruption_redrive_seconds`` must be finite AND
+    bounded - a hand-edited (or JSON-extension ``Infinity``) value like ``1e308``
+    is a valid positive number that the D2 backoff's ``base * 2**(n-1)`` overflows
+    toward ``inf``; the runtime hard cap (INTERRUPTION_BACKOFF_CAP_SECONDS) then
+    SILENTLY CLAMPS it to 900s regardless of what the operator configured - exactly
+    the silent-clamp this resolver exists to refuse instead of doing. Values outside
+    (0, 86400] (24h - already far beyond any sane single-turn backoff) are refused
+    as a config error, same as a non-numeric value."""
     config = config if isinstance(config, dict) else {}
     cfg_agent = cfg_agent if isinstance(cfg_agent, dict) else {}
     errors: list[str] = []
@@ -861,12 +870,13 @@ def resolve_interruption_policy(config: dict, cfg_agent: dict) -> tuple[float, i
         if "interruption_redrive_seconds" not in src:
             continue
         v = src.get("interruption_redrive_seconds")
-        if isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0:
+        if (isinstance(v, (int, float)) and not isinstance(v, bool)
+                and math.isfinite(v) and 0 < v <= 86400):
             redrive = float(v)
         else:
             errors.append(
                 f"invalid {source_name} interruption_redrive_seconds={v!r}; "
-                "expected a positive number")
+                "expected a finite positive number no greater than 86400 (24h)")
         break
     k_interrupted = 3
     for source_name, src in (("per-agent", cfg_agent), ("global", config)):

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -845,6 +845,44 @@ def resolve_dead_letter_caps(config: dict, cfg_agent: dict) -> tuple[int, int]:
     return _pick("max_attempts"), _pick("escalate_after_attempts")
 
 
+def resolve_interruption_policy(config: dict, cfg_agent: dict) -> tuple[float, int, list[str]]:
+    """The interruption-aware redelivery knobs (#202, PURE):
+    ``(interruption_redrive_seconds, k_interrupted, errors)``.
+
+    Per-agent -> global -> default (60.0s / 3), mirroring resolve_dead_letter_caps'
+    chain - but unlike the caps, a PRESENT-and-corrupt value is returned as an ERROR
+    the launch path refuses visibly (config-blocked), never a silent clamp or
+    default. ``k_interrupted`` 0 disables the ceiling (debug only)."""
+    config = config if isinstance(config, dict) else {}
+    cfg_agent = cfg_agent if isinstance(cfg_agent, dict) else {}
+    errors: list[str] = []
+    redrive = 60.0
+    for source_name, src in (("per-agent", cfg_agent), ("global", config)):
+        if "interruption_redrive_seconds" not in src:
+            continue
+        v = src.get("interruption_redrive_seconds")
+        if isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0:
+            redrive = float(v)
+        else:
+            errors.append(
+                f"invalid {source_name} interruption_redrive_seconds={v!r}; "
+                "expected a positive number")
+        break
+    k_interrupted = 3
+    for source_name, src in (("per-agent", cfg_agent), ("global", config)):
+        if "k_interrupted" not in src:
+            continue
+        v = src.get("k_interrupted")
+        if isinstance(v, int) and not isinstance(v, bool) and v >= 0:
+            k_interrupted = v
+        else:
+            errors.append(
+                f"invalid {source_name} k_interrupted={v!r}; "
+                "expected a non-negative integer (0 disables)")
+        break
+    return redrive, k_interrupted, errors
+
+
 def resolve_infra_retry_exhaustion(config: dict, cfg_agent: dict,
                                    k_escalate: int) -> dict:
     """Resolve the finite infra-exhaustion ceiling.

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -859,9 +859,15 @@ def resolve_interruption_policy(config: dict, cfg_agent: dict) -> tuple[float, i
     is a valid positive number that the D2 backoff's ``base * 2**(n-1)`` overflows
     toward ``inf``; the runtime hard cap (INTERRUPTION_BACKOFF_CAP_SECONDS) then
     SILENTLY CLAMPS it to 900s regardless of what the operator configured - exactly
-    the silent-clamp this resolver exists to refuse instead of doing. Values outside
-    (0, 86400] (24h - already far beyond any sane single-turn backoff) are refused
-    as a config error, same as a non-numeric value."""
+    the silent-clamp this resolver exists to refuse instead of doing.
+
+    #7-fix-3: the bound here used to be (0, 86400] (24h), but the runtime's D2
+    backoff hard-caps the computed sleep at INTERRUPTION_BACKOFF_CAP_SECONDS
+    (900s) regardless of ``base``. A base above 900 would pass this resolver
+    but still be silently reduced by the runtime cap on the very first
+    interruption (n=1: ``base * 2**0 == base``) - exactly the silent-clamp
+    this resolver exists to refuse. So the resolver's own bound is tightened
+    to (0, 900] to match, and refused loudly (not clamped) if exceeded."""
     config = config if isinstance(config, dict) else {}
     cfg_agent = cfg_agent if isinstance(cfg_agent, dict) else {}
     errors: list[str] = []
@@ -871,12 +877,13 @@ def resolve_interruption_policy(config: dict, cfg_agent: dict) -> tuple[float, i
             continue
         v = src.get("interruption_redrive_seconds")
         if (isinstance(v, (int, float)) and not isinstance(v, bool)
-                and math.isfinite(v) and 0 < v <= 86400):
+                and math.isfinite(v) and 0 < v <= 900):
             redrive = float(v)
         else:
             errors.append(
                 f"invalid {source_name} interruption_redrive_seconds={v!r}; "
-                "expected a finite positive number no greater than 86400 (24h)")
+                "expected a finite positive number no greater than 900 "
+                "(the runtime's interruption backoff cap)")
         break
     k_interrupted = 3
     for source_name, src in (("per-agent", cfg_agent), ("global", config)):

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -1527,13 +1527,14 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 INTERRUPTION_BACKOFF_CAP_SECONDS,
             )
             # #202 cold-review P2-4 belt: the cap above already bounds ordinary
-            # cases, but a NaN/inf base (a corrupt knob that slipped past the
-            # resolver, or a direct run_loop() caller that bypasses it) must never
-            # reach `sleep()` as a non-finite duration - fail loud, not an endless
-            # chunked backoff.
-            assert math.isfinite(required), (
-                f"interruption backoff computed a non-finite duration ({required!r}); "
-                "interruption_redrive_seconds must be a finite, bounded config value")
+            # cases, but a NaN/inf value (a corrupt knob past the resolver, a
+            # bypassing run_loop() caller, or the CAP constant itself corrupted
+            # by a future refactor) must never reach `sleep()` as a non-finite
+            # duration. Not an assert (stripped under -O; bandit B101), and a
+            # LITERAL fallback on purpose: falling back to the module constant
+            # would re-feed the corruption when the constant is the bad value.
+            if not math.isfinite(required):
+                required = 900.0
             last_at = _iso_epoch(rec.get("last_failure_at"))
             now_at = _iso_epoch(now_iso())
             remaining = (required if last_at is None or now_at is None

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -1367,6 +1367,16 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 continue
 
         # ---- dead-letter: bound the at-least-once retry of a POISON head message ----
+        # #7-fix-5: set below (non-None) only when this turn's drive() is the ONE
+        # re-probe allowed by the generation-mismatch fall-through further down -
+        # threaded through to the result-recording block so a re-probe that fails
+        # (whether via direct config_blocked or via re-promotion) re-parks with THE
+        # CURRENT generation, not the stale one that granted the re-probe. Without
+        # this, a re-probe failing DIRECTLY as config_blocked (never_started False,
+        # so the promotion path below never runs) would leave the old generation on
+        # the record forever, granting every later generation a further free
+        # re-probe.
+        reprobe_generation_consumed: str | None = None
         head_id = record.get("id")
         # A stale in_progress on this head means the process crashed mid-turn last run ->
         # reconcile it as an AMBIGUOUS crash_mid_turn failure (unobserved cause, NOT poison),
@@ -1401,7 +1411,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             if (wrapper_generation is not None
                     and isinstance(promoted_gen, str) and promoted_gen
                     and promoted_gen != wrapper_generation):
-                pass
+                reprobe_generation_consumed = wrapper_generation
             else:
                 _park_config_blocked(record)
                 continue
@@ -1522,8 +1532,16 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # validation (cli).
         interrupted_n = _safe_int(rec.get("interrupted_consecutive"))
         if interrupted_n > 0 and interruption_redrive_seconds > 0:
+            # #7-fix-1: cap the EXPONENT before evaluating 2.0 ** x. A huge
+            # persisted counter (repeated reconciled crashes in an
+            # infra-dominant history) can push interrupted_n past ~1025,
+            # where CPython's 2.0 ** 1025 raises OverflowError instead of
+            # returning inf - crashing the loop before the cap below ever
+            # applies. 2**32 seconds is already many orders past the 900s
+            # cap, so clamping the exponent there changes no real behavior.
             required = min(
-                float(interruption_redrive_seconds) * (2.0 ** (interrupted_n - 1)),
+                float(interruption_redrive_seconds)
+                * (2.0 ** min(interrupted_n - 1, 32)),
                 INTERRUPTION_BACKOFF_CAP_SECONDS,
             )
             # #202 cold-review P2-4 belt: the cap above already bounds ordinary
@@ -1539,6 +1557,11 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             now_at = _iso_epoch(now_iso())
             remaining = (required if last_at is None or now_at is None
                          else required - (now_at - last_at))
+            # #7-fix-2: a backwards wall clock (last_failure_at recorded in
+            # the future, or a clock step-back) can make elapsed negative,
+            # pushing remaining above required. Clamp into [0, required] so
+            # a clock anomaly can neither skip the backoff nor extend it.
+            remaining = min(max(remaining, 0.0), required)
             while remaining > 0:
                 stamp()
                 last_hb = clock()
@@ -1631,6 +1654,18 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 continue
             store.clear_attempt(agent, head_id)
             store.gc_attempts_below(agent, store.cursor(agent))
+            # #7-fix-7: a clean retry that writes no live draft and sends no
+            # direct reply (so neither _deliver_reply_draft branch above GC'd
+            # it) would otherwise leave an earlier attempt's preserved
+            # <id>.interrupted.md on disk FOREVER - nothing else ever revisits
+            # a head once it commits clean. GC it here, unconditionally, once
+            # the record has actually committed.
+            preserved = _interrupted_draft_path(store, agent, head_id)
+            if preserved is not None:
+                try:
+                    preserved.unlink(missing_ok=True)
+                except OSError:
+                    pass
             last_hb = clock()                           # drive already stamped on success
             _maybe_refresh_capacity(last_hb)
             fail_sleep = idle_interval                  # reset failure backoff
@@ -1694,6 +1729,16 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 promoted_by_generation = wrapper_generation
             # else: window not yet elapsed (or timestamps unavailable) - keep
             # retrying ambiguous instead of permanently parking the head.
+        if (outcome.failure_class == CLASS_CONFIG_BLOCKED
+                and promoted_by_generation is None
+                and reprobe_generation_consumed is not None):
+            # #7-fix-5: this turn consumed the one allowed re-probe (entry-check
+            # above), and it failed directly as config_blocked (not through the
+            # never-started promotion above, so promoted_by_generation is still
+            # unset). Record the CURRENT generation now, so the next generation's
+            # entry-check sees a matching (not stale) value and re-parks instead
+            # of granting yet another free re-probe.
+            promoted_by_generation = reprobe_generation_consumed
         # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,
                                     summary=outcome.summary, at=failure_now,
@@ -1718,6 +1763,18 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # wedge the seat with no un-park path (rev 1 F1/F2).
         if (k_interrupted > 0 and _safe_int(
                 rec.get("interrupted_watchdog_consecutive")) >= k_interrupted):
+            # #7-fix-6: THIS turn's drive() just ran (and was interrupted, so
+            # _deliver_reply_draft above never published it) - if it left a LIVE
+            # draft (<id>.md), that is the child's NEWEST recoverable progress,
+            # newer than whatever older <id>.interrupted.md an earlier interrupted
+            # attempt may have preserved. Move it over that older copy (pre-unlink
+            # for Windows, via preserve_interrupted_draft) BEFORE the dispose below
+            # keeps the interrupted.md sibling - so the remedy names the freshest
+            # partial work, not a stale one, and the live copy is never orphaned.
+            if isinstance(head_id, str) and head_id:
+                live_draft = reply_transport.reply_draft_path(store, agent, head_id)
+                if live_draft.is_file():
+                    reply_transport.preserve_interrupted_draft(live_draft)
             # P2-3: name the preserved draft (if any) in the remedy, then keep it
             # through the dispose below instead of GC'ing it.
             preserved_for_remedy = _interrupted_draft_path(store, agent, head_id)

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -18,7 +18,7 @@ import os
 import time
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -46,6 +46,46 @@ CLASS_INFRA_RETRY_EXHAUSTED = "infra_retry_exhausted"
 # instant the operator clears the hold. See _hold_park + the failed-turn branch below (#62).
 CLASS_GATEWAY_HELD = "gateway_held"
 
+# #205: the classifier summary prefix for a child that produced NO turn-start and NO
+# model output before exiting (run._classify_drive_failure's last-resort branch, e.g. a
+# codex child refusing a non-git/untrusted workspace before it emits a single stream
+# event). ONE such result stays AMBIGUOUS (a transient host hiccup must not park a
+# healthy seat), but the SECOND CONSECUTIVE one on the same head is deterministic: the
+# loop promotes it to CLASS_CONFIG_BLOCKED (escalate once + durable park + safe
+# re-probe, #62) instead of burning the K_escalate ceiling on 20 ambiguous retries.
+NEVER_STARTED_SUMMARY_PREFIX = "turn never started"
+NEVER_STARTED_REMEDY = (
+    "child CLI never started; check: workspace is a git repo / trusted directory, "
+    "CLI auth, executable path")
+
+
+def _is_never_started_failure(failure_class: object, summary: object) -> bool:
+    """True iff a failure result carries the never-started AMBIGUOUS signature."""
+    return (failure_class == CLASS_AMBIGUOUS and isinstance(summary, str)
+            and NEVER_STARTED_SUMMARY_PREFIX in summary)
+
+
+# The continuous loop's idle-heartbeat cadence AND the #202 D2 backoff chunk size.
+# Named so the launch validation (cli) can enforce the load-bearing invariant
+# heartbeat_interval < stuck_after: the chunked backoff stamps once per chunk, so
+# a wrapper deliberately backing off can never look stale to the supervisor.
+HEARTBEAT_INTERVAL_SECONDS = 10.0
+
+# #202 D3: dead-letter reason for a head whose turns were repeatedly killed by the
+# turn watchdog (k_interrupted consecutive turn_watchdog interruptions).
+INTERRUPTION_BUDGET_EXHAUSTED = "interruption_budget_exhausted"
+
+
+def _interruption_remedy(agent: str, head_id: object, *, k: int, kind: str,
+                         budget_seconds: float | None) -> str:
+    """The operator remedy carried by the k_interrupted escalation (#202 D3)."""
+    budget = (f" after {budget_seconds:.0f}s each"
+              if isinstance(budget_seconds, (int, float)) else "")
+    return (f"this message's turns were killed {k} times by {kind}{budget}; "
+            f"raise turn_watchdog.turn_elapsed_seconds for {agent}, split the task, "
+            f"or requeue as-is: `agenttalk dead-letter requeue --agent {agent} "
+            f"--id {head_id}`")
+
 
 @dataclass(frozen=True)
 class DriveOutcome:
@@ -61,6 +101,12 @@ class DriveOutcome:
     bus_action_attempted: bool = False
     bus_action_infra: bool = False
     bus_action_rejected: bool = False
+    # #202 D1: a SELF-INFLICTED interruption (the per-turn watchdog killed the
+    # child's tree) is a first-class fact - set structurally at every make_drive
+    # failure-return site under sig["watchdog"], never sniffed from the summary
+    # (the resume branches rewrite summaries). Kind: "turn_watchdog".
+    interrupted: bool = False
+    interruption_kind: str | None = None
 
 
 def _as_outcome(ret: object) -> DriveOutcome:
@@ -115,6 +161,13 @@ def _with_reply_draft(store, agent: str, record: dict) -> dict:
         # a partial draft at the same deterministic path, and a later clean
         # turn that never overwrites it must not publish those stale bytes as
         # the authoritative answer (PR #127 connector P1).
+        # #202 D5: when the PREVIOUS attempt was interrupted, that leftover is the
+        # child's recoverable progress - preserve it as <id>.interrupted.md (the
+        # rejoin names it; a failed rename falls through to today's delete). The
+        # live path is cleared either way, so the preserved copy never publishes.
+        prev = store.attempt_record(agent, inbound_id) or {}
+        if prev.get("last_interrupted") and path.is_file():
+            reply_transport.preserve_interrupted_draft(path)
         path.unlink(missing_ok=True)
     except OSError:
         return record
@@ -296,13 +349,16 @@ def classify_loop_control(store, record: dict) -> str:
 
 def run_loop(store, agent: str, drive: Callable[[dict], object], *,
              idle_interval: float = 0.3, max_idle_interval: float = 2.0,
-             heartbeat_interval: float = 10.0,
+             heartbeat_interval: float = HEARTBEAT_INTERVAL_SECONDS,
              clock: Callable[[], float] = time.monotonic,
              sleep: Callable[[float], None] = time.sleep,
              max_turns: int | None = None, max_polls: int | None = None,
              only_request_id: str | None = None,
              max_wall: float | None = None,
              k_poison: int = 3, k_escalate: int = 20,
+             k_interrupted: int = 3,
+             interruption_redrive_seconds: float = 60.0,
+             interruption_budget_seconds: float | None = None,
              infra_exhaust_after_seconds: float = 14400.0,
              infra_exhaust_min_attempts: int = 100,
              noninfra_sub_ceiling: int | None = None,
@@ -393,6 +449,9 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
             max_idle_interval=max_idle_interval, heartbeat_interval=heartbeat_interval,
             clock=clock, sleep=sleep, max_turns=max_turns, max_polls=max_polls,
             max_wall=max_wall, k_poison=k_poison, k_escalate=k_escalate,
+            k_interrupted=k_interrupted,
+            interruption_redrive_seconds=interruption_redrive_seconds,
+            interruption_budget_seconds=interruption_budget_seconds,
             infra_exhaust_after_seconds=infra_exhaust_after_seconds,
             infra_exhaust_min_attempts=infra_exhaust_min_attempts,
             noninfra_sub_ceiling=noninfra_sub_ceiling,
@@ -416,6 +475,9 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     sleep: Callable[[float], None], max_turns: int | None,
                     max_polls: int | None, max_wall: float | None,
                     k_poison: int, k_escalate: int,
+                    k_interrupted: int,
+                    interruption_redrive_seconds: float,
+                    interruption_budget_seconds: float | None,
                     infra_exhaust_after_seconds: float,
                     infra_exhaust_min_attempts: int,
                     noninfra_sub_ceiling: int | None,
@@ -539,7 +601,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             return
 
     def _info(record: dict, rec: dict, failure_class: str, *,
-              infra_exhausted: bool = False, quarantined: bool = False) -> dict:
+              infra_exhausted: bool = False, quarantined: bool = False,
+              summary: str | None = None) -> dict:
         attempts = _safe_int((rec or {}).get("attempts_started"))
         bucket = "below_backstop"
         if quarantined:
@@ -558,7 +621,10 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 "infra_exhausted": infra_exhausted,
                 "quarantined": quarantined,
                 "failure_class": failure_class,
-                "summary": (rec or {}).get("last_failure_summary") or ""}
+                # #202 D3 (review finding 9): an explicit summary carries the REAL
+                # reason/remedy to the operator instead of only the ledger's last line.
+                "summary": (summary if summary is not None
+                            else (rec or {}).get("last_failure_summary") or "")}
 
     def _dispose(record: dict, *, failure_class: str, reason: str | None,
                  infra_exhausted: bool = False,
@@ -625,7 +691,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             except Exception:  # noqa: BLE001 - a notification must never crash the loop
                 return
 
-    def _escalate_once(record: dict, failure_class: str, *, retry_unrouted: bool = True) -> None:
+    def _escalate_once(record: dict, failure_class: str, *, retry_unrouted: bool = True,
+                       summary: str | None = None) -> None:
         """Class-agnostic K_escalate backstop: emit an operator escalation, DEDUPED on
         successful ROUTING - not merely on having attempted. An UNROUTED notice (no
         liaison/lead resolved) is retried on subsequent polls so it fires once the operator
@@ -635,7 +702,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         if rec.get("escalation_routed") or (rec.get("escalated") and not retry_unrouted):
             return                                    # already routed -> done (deduped)
         try:
-            routed = bool(on_escalate(_info(record, rec, failure_class))) \
+            routed = bool(on_escalate(_info(record, rec, failure_class, summary=summary))) \
                 if on_escalate is not None else False
         except Exception:  # noqa: BLE001 - a notification must never crash the loop
             routed = False                            # unrouted -> retried + doctor LOUD
@@ -1190,6 +1257,22 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # relaunch/crash-accumulation path - test #3).
         if rec.get("last_failure_class") != CLASS_CONFIG_BLOCKED:
             cap_now = now_iso()
+            # #202 D3 (rev 3 NEW-3, entry mirror): a head whose persisted
+            # turn_watchdog-only counter is already AT the k_interrupted ceiling
+            # (the process died between the result-write and the dispose, then
+            # relaunched) is disposed WITHOUT burning another watchdog budget.
+            # Strictly more specific than the caps below, so it is checked first.
+            # Only turn_watchdog counts reach this counter - crash_mid_turn's
+            # reconcile never increments it (the store.py ruling stands).
+            if (k_interrupted > 0 and _safe_int(
+                    rec.get("interrupted_watchdog_consecutive")) >= k_interrupted):
+                remedy = _interruption_remedy(
+                    agent, head_id, k=k_interrupted, kind="turn_watchdog",
+                    budget_seconds=interruption_budget_seconds)
+                _escalate_once(record, CLASS_AMBIGUOUS, summary=remedy)
+                _dispose(record, failure_class=CLASS_AMBIGUOUS,
+                         reason=INTERRUPTION_BUDGET_EXHAUSTED)
+                continue
             if k_poison > 0 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison:
                 _dispose(record, failure_class=CLASS_POISON,
                          reason=rec.get("last_failure_summary"))
@@ -1260,6 +1343,30 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 continue
             legacy_gate_resolution = authorized
 
+        # #202 D2: supervisor-safe interruption backoff, computed HERE (head entry)
+        # from the PERSISTED record - never from in-memory fail_sleep, which relaunch
+        # amnesia resets. This single site therefore also covers crash_mid_turn's
+        # immediate-redrive-at-relaunch path (the reconcile above just incremented
+        # the counter). base x 2^(n-1), n = interrupted_consecutive (any kind); no
+        # separate cap needed (n is bounded by the k_interrupted dispose above for
+        # watchdog kills and by k_escalate for crashes). The sleep is CHUNKED at
+        # heartbeat_interval with a stamp per chunk (blocked-but-alive, the same
+        # posture as the holds), so the supervisor can never STUCK_RECOVER a wrapper
+        # that is deliberately backing off. Control kinds are delayed for the
+        # duration - documented cost, bounded by the launch validation (cli).
+        interrupted_n = _safe_int(rec.get("interrupted_consecutive"))
+        if interrupted_n > 0 and interruption_redrive_seconds > 0:
+            required = float(interruption_redrive_seconds) * (2.0 ** (interrupted_n - 1))
+            last_at = _iso_epoch(rec.get("last_failure_at"))
+            now_at = _iso_epoch(now_iso())
+            remaining = (required if last_at is None or now_at is None
+                         else required - (now_at - last_at))
+            while remaining > 0:
+                stamp()
+                last_hb = clock()
+                chunk = min(max(0.1, float(heartbeat_interval)), remaining)
+                sleep(chunk)
+                remaining -= chunk
         # WRITE-AHEAD: count + mark in_progress BEFORE drive() so a crash mid-turn
         # still costs a durable attempt on relaunch. EXACTLY one attempt per drive().
         record = _with_reply_draft(store, agent, record)
@@ -1363,14 +1470,46 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             # ledger (and so it can never reach a dispose ceiling). See _hold_park.
             _hold_park(record)
             continue
+        # #205: a SECOND consecutive never-started result on the same head (the attempt
+        # record still holds the previous failure - record_attempt_start preserves it)
+        # is a deterministic launch/config denial, not an ambiguous hiccup. Promote it
+        # to CLASS_CONFIG_BLOCKED with the concrete remedies so the existing branch
+        # below escalates once + parks durably instead of retrying blind to K_escalate.
+        if _is_never_started_failure(outcome.failure_class, outcome.summary):
+            prev = store.attempt_record(agent, head_id) or {}
+            if _is_never_started_failure(prev.get("last_failure_class"),
+                                         prev.get("last_failure_summary")):
+                outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
+                                  summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
         # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,
-                                    summary=outcome.summary, at=now_iso())
+                                    summary=outcome.summary, at=now_iso(),
+                                    interrupted=outcome.interrupted,
+                                    interruption_kind=outcome.interruption_kind)
         rec = store.attempt_record(agent, head_id) or {}
         if outcome.failure_class == CLASS_CONFIG_BLOCKED:
             if isinstance(head_id, str):
                 config_blocked_ids.add(head_id)
             _park_config_blocked(record)
+            continue
+        # #202 D3: the interruption budget. Counts ONLY kind=turn_watchdog results
+        # (crash_mid_turn's cause is unobserved - its disposal ceiling stays
+        # k_escalate, per the codified store.py ruling). Checked BEFORE
+        # k_poison/noninfra/k_escalate: strictly more specific. At the ceiling the
+        # head DEAD-LETTERS (self-clearing: cursor advances, the seat keeps serving
+        # the queue; `dead-letter requeue` is the operator's raised-budget retry)
+        # and the escalation carries the concrete remedy - NOT a park, which would
+        # wedge the seat with no un-park path (rev 1 F1/F2).
+        if (k_interrupted > 0 and _safe_int(
+                rec.get("interrupted_watchdog_consecutive")) >= k_interrupted):
+            remedy = _interruption_remedy(
+                agent, head_id, k=k_interrupted, kind="turn_watchdog",
+                budget_seconds=interruption_budget_seconds)
+            _escalate_once(record, outcome.failure_class or CLASS_AMBIGUOUS,
+                           summary=remedy)
+            _dispose(record, failure_class=CLASS_AMBIGUOUS,
+                     reason=INTERRUPTION_BUDGET_EXHAUSTED,
+                     child_output_tail=outcome.child_output_tail)
             continue
         if (k_poison > 0 and outcome.failure_class == CLASS_POISON
                 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison):
@@ -1428,6 +1567,32 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
     fail_sleep = idle_interval
     start = clock()
     _stamp = stamp if stamp is not None else (lambda: store.write_heartbeat(agent))
+
+    # #202 D4 (one-shot): this scoped loop has NO attempt ledger, so the previous
+    # attempt's interruption is carried IN-MEMORY (single head by construction - a
+    # local run suffices) and handed to the drive as a record decoration the cli's
+    # rejoin_for consumes. D2's persisted-entry backoff deliberately does not apply
+    # here (the one-shot is bounded by max_wall anyway).
+    interrupted_run: dict = {"count": 0, "kind": None, "at": None}
+
+    def _with_interruption_context(rec: dict) -> dict:
+        if interrupted_run["count"] <= 0:
+            return rec
+        decorated = dict(rec)
+        decorated["interrupted_redelivery"] = {
+            "kind": interrupted_run["kind"],
+            "consecutive": interrupted_run["count"],
+            "last_failure_at": interrupted_run["at"],
+        }
+        return decorated
+
+    def _note_interruption(outcome: DriveOutcome) -> None:
+        if outcome.interrupted:
+            interrupted_run["count"] += 1
+            interrupted_run["kind"] = outcome.interruption_kind
+            interrupted_run["at"] = _iso_now()
+        else:
+            interrupted_run.update({"count": 0, "kind": None, "at": None})
 
     def _runtime_idle() -> None:
         if on_runtime_idle is not None:
@@ -1664,7 +1829,9 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
                     sleep(fail_sleep)
                     fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
                     continue
-                outcome = _as_outcome(drive(dispatch_record))
+                outcome = _as_outcome(
+                    drive(_with_interruption_context(dispatch_record)))
+                _note_interruption(outcome)
                 action_infra = (
                     outcome.bus_action_infra or outcome.failure_class == CLASS_INFRA
                 )
@@ -1829,7 +1996,8 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
                 continue
             legacy_gate_resolution = authorized
         record = _with_reply_draft(store, agent, record)
-        outcome = _as_outcome(drive(record))
+        outcome = _as_outcome(drive(_with_interruption_context(record)))
+        _note_interruption(outcome)
         # #201: same wrapper-owned draft delivery as _run_continuous — the
         # one-shot path must not strand a sandbox-blocked child's answer.
         if outcome.ok:

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -73,9 +73,17 @@ NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS = 60.0
 
 
 def _is_never_started_failure(failure_class: object, summary: object) -> bool:
-    """True iff a failure result carries the never-started AMBIGUOUS signature."""
+    """True iff a failure result carries the never-started AMBIGUOUS signature.
+
+    connector P2 (final head): the canonical signature is only ever produced at
+    the START of the summary (run.py's _classify_drive_failure). An ambiguous
+    diagnostic that merely EMBEDS the words (e.g. child stderr echoed into
+    "terminal failure, unrecognized cause: ...") must not count - repeated, it
+    would promote to a sticky config_blocked park with the WRONG remedy for a
+    child that did start and failed for an unrelated reason.
+    """
     return (failure_class == CLASS_AMBIGUOUS and isinstance(summary, str)
-            and NEVER_STARTED_SUMMARY_PREFIX in summary)
+            and summary.startswith(NEVER_STARTED_SUMMARY_PREFIX))
 
 
 # The continuous loop's idle-heartbeat cadence AND the #202 D2 backoff chunk size.

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -1720,7 +1720,20 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 and (now_at_epoch - first_at_epoch)
                     >= NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS
             )
-            if never_started_consecutive >= 2 and elapsed_ok:
+            # connector P1 (final head): fail_sleep retries land 0.3-2.0s apart,
+            # so a FAST deterministic refusal reaches the k_escalate attempt
+            # ceiling (default 20, disposed below as ambiguous) in well under
+            # the 60s window - the promotion would never fire exactly for the
+            # fastest, most clearly deterministic refusals. An UNBROKEN run of
+            # never-started results as long as the ceiling is deterministic
+            # evidence regardless of wall time: promote it here, preempting the
+            # generic ceiling dispose this same iteration. A mixed history
+            # (count resets on any non-never-started result) still disposes
+            # ambiguous at the ceiling - that run is not deterministic.
+            ceiling_run_ok = (
+                k_escalate > 0 and never_started_consecutive >= k_escalate
+            )
+            if never_started_consecutive >= 2 and (elapsed_ok or ceiling_run_ok):
                 outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
                                   summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
                 # #205 cold-review P1-A: name the wrapper generation active at THIS
@@ -2282,6 +2295,22 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
         record = _with_reply_draft(store, agent, _with_interruption_context(record))
         outcome = _as_outcome(drive(record))
         _note_interruption(outcome)
+        # connector P2 (final head): one-shot is LEDGER-LESS, so the FIX 5
+        # decoration above is the only carrier of "previously interrupted" -
+        # and it only helps if THIS invocation gets another iteration. If the
+        # bound (max_wall/max_polls) expires first, the killed attempt's
+        # partial draft stays at the LIVE path, and a LATER invocation (fresh
+        # memory, empty ledger) deletes it as ordinary stale residue. Preserve
+        # it NOW, at the interrupted outcome itself; the next attempt's
+        # preservation gate then finds no live file (a no-op) and the
+        # preserved copy survives the exit either way.
+        if outcome.interrupted:
+            inbound_id = record.get("id")
+            if isinstance(inbound_id, str) and inbound_id:
+                live_draft = reply_transport.reply_draft_path(
+                    store, agent, inbound_id)
+                if live_draft.is_file():
+                    reply_transport.preserve_interrupted_draft(live_draft)
         # #201: same wrapper-owned draft delivery as _run_continuous — the
         # one-shot path must not strand a sandbox-blocked child's answer.
         if outcome.ok:

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -50,13 +50,25 @@ CLASS_GATEWAY_HELD = "gateway_held"
 # model output before exiting (run._classify_drive_failure's last-resort branch, e.g. a
 # codex child refusing a non-git/untrusted workspace before it emits a single stream
 # event). ONE such result stays AMBIGUOUS (a transient host hiccup must not park a
-# healthy seat), but the SECOND CONSECUTIVE one on the same head is deterministic: the
-# loop promotes it to CLASS_CONFIG_BLOCKED (escalate once + durable park + safe
-# re-probe, #62) instead of burning the K_escalate ceiling on 20 ambiguous retries.
+# healthy seat). A SECOND CONSECUTIVE one on the same head, at least
+# NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS after the first (cold-review FIX 2: two
+# 0.3-2.0s-apart fail_sleep samples are NOT evidence of determinism - a transient auth
+# refresh / CLI update banner / AV lock must not permanently park a healthy seat), is
+# deterministic: the loop promotes it to CLASS_CONFIG_BLOCKED and escalates once via
+# _park_config_blocked. Unlike CLASS_GATEWAY_HELD/_hold_park's #62 self-healing
+# re-probe (which clears its attempt and re-drives every poll), a config_blocked park
+# is STICKY - the entry-mirror check below re-parks WITHOUT ever driving again, so
+# there is no automatic re-probe here; an operator must clear the underlying denial
+# (and the attempt ledger) before this head can proceed. This avoids burning the
+# K_escalate ceiling on 20 ambiguous retries for a deterministic denial.
 NEVER_STARTED_SUMMARY_PREFIX = "turn never started"
 NEVER_STARTED_REMEDY = (
     "child CLI never started; check: workspace is a git repo / trusted directory, "
     "CLI auth, executable path")
+# #205 (cold-review FIX 2): the minimum time that must have elapsed since the FIRST
+# never-started failure before a second consecutive one is trusted as deterministic
+# rather than a transient hiccup landing ~seconds apart under fail_sleep (0.3-2.0s).
+NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS = 60.0
 
 
 def _is_never_started_failure(failure_class: object, summary: object) -> bool:
@@ -74,6 +86,18 @@ HEARTBEAT_INTERVAL_SECONDS = 10.0
 # #202 D3: dead-letter reason for a head whose turns were repeatedly killed by the
 # turn watchdog (k_interrupted consecutive turn_watchdog interruptions).
 INTERRUPTION_BUDGET_EXHAUSTED = "interruption_budget_exhausted"
+
+# #202 D2 (cold-review FIX 1): hard cap on the ANY-KIND interruption backoff
+# (base x 2^(n-1)). n = interrupted_consecutive is bounded by k_interrupted ONLY
+# for turn_watchdog kills; crash_mid_turn's cause is unobserved, so its disposal
+# ceiling stays k_escalate (default 20) - and an infra-dominant crash history
+# evades even THAT ceiling (_infra_dominant keeps retrying through a sustained
+# outage instead of disposing). Left uncapped, n=10 demands an 8.5h sleep and
+# n=19 demands ~182 DAYS, all while the chunked stamp reads the wrapper as
+# healthy - a single interrupted head would head-of-line block the whole seat's
+# queue for that long. Capped, a runaway counter degrades to "very slow"
+# instead of "effectively never".
+INTERRUPTION_BACKOFF_CAP_SECONDS = 900.0
 
 
 def _interruption_remedy(agent: str, head_id: object, *, k: int, kind: str,
@@ -128,6 +152,17 @@ def _as_outcome(ret: object) -> DriveOutcome:
 _REPLY_DRAFT_KINDS = frozenset({"question", "message", "wake"})
 
 
+def _interrupted_draft_path(store, agent: str, msg_id: object) -> Path | None:
+    """The preserved-progress sibling #202 D5 writes for an interrupted attempt's
+    draft, or None when ``msg_id`` cannot name one. Shared by the write side
+    (_with_reply_draft), the GC-on-deliver side (_deliver_reply_draft), and the
+    GC-on-dispose side (_run_continuous._dispose) so a stale preserved copy never
+    outlives the head it was recovered for (cold-review FIX 6)."""
+    if not isinstance(msg_id, str) or not msg_id:
+        return None
+    return reply_transport.reply_draft_path(store, agent, msg_id).with_suffix(".interrupted.md")
+
+
 def _with_reply_draft(store, agent: str, record: dict) -> dict:
     """Decorate a freeform (no-admission) record with its declared draft path."""
     if record.get("kind") not in _REPLY_DRAFT_KINDS:
@@ -165,8 +200,16 @@ def _with_reply_draft(store, agent: str, record: dict) -> dict:
         # child's recoverable progress - preserve it as <id>.interrupted.md (the
         # rejoin names it; a failed rename falls through to today's delete). The
         # live path is cleared either way, so the preserved copy never publishes.
+        # cold-review FIX 5: _run_continuous has a persisted ledger (last_interrupted
+        # on the attempt record), but _run_one_shot is LEDGER-LESS - its previous
+        # interruption rides ONLY the in-memory ``interrupted_redelivery`` decoration
+        # the one-shot loop places on the record before calling here. Without this
+        # second gate the ledger read is always empty for one-shot and the draft is
+        # unconditionally deleted, even while the rejoin still says "prefer resuming".
         prev = store.attempt_record(agent, inbound_id) or {}
-        if prev.get("last_interrupted") and path.is_file():
+        previously_interrupted = bool(prev.get("last_interrupted")) or isinstance(
+            record.get("interrupted_redelivery"), dict)
+        if previously_interrupted and path.is_file():
             reply_transport.preserve_interrupted_draft(path)
         path.unlink(missing_ok=True)
     except OSError:
@@ -207,6 +250,17 @@ def _deliver_reply_draft(store, agent: str, record: dict) -> None:
             # a trace the answer would vanish exactly like the dead-letter
             # dotfiles #201 exists to fix. Preserve the bytes observably.
             reply_transport.preserve_refused_draft(draft)
+        elif published is not None:
+            # cold-review FIX 6: a real reply just landed for this head, so any
+            # earlier <id>.interrupted.md leftover (recovered progress from a
+            # PRIOR interrupted attempt on the same id) is now moot - GC it so it
+            # cannot linger on disk / be misread as still-pending by a later probe.
+            preserved = _interrupted_draft_path(store, agent, record.get("id"))
+            if preserved is not None:
+                try:
+                    preserved.unlink(missing_ok=True)
+                except OSError:
+                    pass
     except Exception:  # noqa: BLE001, S110 - must never change disposition  # nosec B110
         return
 
@@ -628,10 +682,18 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
 
     def _dispose(record: dict, *, failure_class: str, reason: str | None,
                  infra_exhausted: bool = False,
-                 child_output_tail: dict | None = None) -> None:
+                 child_output_tail: dict | None = None,
+                 summary: str | None = None) -> None:
         """Dead-letter the head record (store advances the cursor past it), then stamp
         progress: DL is PROGRESS, not a failed turn, so the heartbeat goes FRESH and
-        the failure backoff resets - the supervisor sees progress + never restarts."""
+        the failure backoff resets - the supervisor sees progress + never restarts.
+
+        ``summary`` (cold-review FIX 3) overrides the operator-facing notice text
+        (default: the ledger's ``last_failure_summary``, via ``_info``). Needed
+        because ``_escalate_once``'s remedy no-ops when escalation is already
+        latched (a prior, unrelated escalation on this head routed already) - the
+        dead-letter notification must still carry the REAL remedy (e.g. the #202 D3
+        interruption-budget-exhausted remedy) regardless of that dedupe."""
         nonlocal last_hb, fail_sleep
         rec = store.attempt_record(agent, record.get("id")) or {}
         _guard_advance()                      # dead-letter ADVANCES the cursor - verify
@@ -672,6 +734,15 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             sleep(fail_sleep)
             fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
             return
+        # cold-review FIX 6: the head is durably disposed - GC any <id>.interrupted.md
+        # preserved-progress sibling now, so it cannot outlive the head it was
+        # recovered for (nothing else ever removes it once a head is dead-lettered).
+        preserved = _interrupted_draft_path(store, agent, record.get("id"))
+        if preserved is not None:
+            try:
+                preserved.unlink(missing_ok=True)
+            except OSError:
+                pass
         if on_runtime_dead_letter is not None:
             on_runtime_dead_letter(record)
         _runtime_idle()
@@ -687,7 +758,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             try:
                 on_dead_letter(_info(
                     record, rec, failure_class,
-                    infra_exhausted=infra_exhausted, quarantined=True))
+                    infra_exhausted=infra_exhausted, quarantined=True,
+                    summary=summary))
             except Exception:  # noqa: BLE001 - a notification must never crash the loop
                 return
 
@@ -1271,7 +1343,7 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     budget_seconds=interruption_budget_seconds)
                 _escalate_once(record, CLASS_AMBIGUOUS, summary=remedy)
                 _dispose(record, failure_class=CLASS_AMBIGUOUS,
-                         reason=INTERRUPTION_BUDGET_EXHAUSTED)
+                         reason=INTERRUPTION_BUDGET_EXHAUSTED, summary=remedy)
                 continue
             if k_poison > 0 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison:
                 _dispose(record, failure_class=CLASS_POISON,
@@ -1347,16 +1419,26 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # from the PERSISTED record - never from in-memory fail_sleep, which relaunch
         # amnesia resets. This single site therefore also covers crash_mid_turn's
         # immediate-redrive-at-relaunch path (the reconcile above just incremented
-        # the counter). base x 2^(n-1), n = interrupted_consecutive (any kind); no
-        # separate cap needed (n is bounded by the k_interrupted dispose above for
-        # watchdog kills and by k_escalate for crashes). The sleep is CHUNKED at
-        # heartbeat_interval with a stamp per chunk (blocked-but-alive, the same
-        # posture as the holds), so the supervisor can never STUCK_RECOVER a wrapper
-        # that is deliberately backing off. Control kinds are delayed for the
-        # duration - documented cost, bounded by the launch validation (cli).
+        # the counter). base x 2^(n-1), n = interrupted_consecutive (ANY kind -
+        # turn_watchdog AND crash_mid_turn), HARD-CAPPED at
+        # INTERRUPTION_BACKOFF_CAP_SECONDS (cold-review FIX 1: the earlier "no separate
+        # cap needed" claim was wrong - n is bounded by k_interrupted ONLY for
+        # turn_watchdog; crash_mid_turn's counter is bounded only by k_escalate
+        # (default 20, so n=19 is reachable), and an infra-dominant crash history
+        # evades even that ceiling (_infra_dominant keeps retrying through a sustained
+        # outage instead of disposing) - so an uncapped exponent reaches hours (n=10)
+        # to months (n=19) of head-of-line blocking while heartbeat-stamped healthy).
+        # The sleep is CHUNKED at heartbeat_interval with a stamp per chunk
+        # (blocked-but-alive, the same posture as the holds), so the supervisor can
+        # never STUCK_RECOVER a wrapper that is deliberately backing off. Control
+        # kinds are delayed for the duration - documented cost, bounded by the launch
+        # validation (cli).
         interrupted_n = _safe_int(rec.get("interrupted_consecutive"))
         if interrupted_n > 0 and interruption_redrive_seconds > 0:
-            required = float(interruption_redrive_seconds) * (2.0 ** (interrupted_n - 1))
+            required = min(
+                float(interruption_redrive_seconds) * (2.0 ** (interrupted_n - 1)),
+                INTERRUPTION_BACKOFF_CAP_SECONDS,
+            )
             last_at = _iso_epoch(rec.get("last_failure_at"))
             now_at = _iso_epoch(now_iso())
             remaining = (required if last_at is None or now_at is None
@@ -1472,18 +1554,35 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             continue
         # #205: a SECOND consecutive never-started result on the same head (the attempt
         # record still holds the previous failure - record_attempt_start preserves it)
-        # is a deterministic launch/config denial, not an ambiguous hiccup. Promote it
-        # to CLASS_CONFIG_BLOCKED with the concrete remedies so the existing branch
-        # below escalates once + parks durably instead of retrying blind to K_escalate.
+        # is a deterministic launch/config denial, not an ambiguous hiccup - PROVIDED
+        # it is actually separated in time from the first one. cold-review FIX 2: with
+        # fail_sleep 0.3-2.0s, two samples can land ~seconds apart - that is NOT
+        # evidence of determinism, just an unlucky pair of retries during a transient
+        # hiccup (auth refresh, CLI update banner, AV lock). Require BOTH the
+        # never-started signature AND at least
+        # NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS since the previous failure's
+        # recorded time before promoting to CLASS_CONFIG_BLOCKED (escalate once + durable
+        # park below); missing/unparseable timestamps fail CLOSED (keep retrying
+        # ambiguous) rather than promote on unproven elapsed time.
+        failure_now = now_iso()
         if _is_never_started_failure(outcome.failure_class, outcome.summary):
             prev = store.attempt_record(agent, head_id) or {}
             if _is_never_started_failure(prev.get("last_failure_class"),
                                          prev.get("last_failure_summary")):
-                outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
-                                  summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
+                prev_at = _iso_epoch(prev.get("last_failure_at"))
+                now_at = _iso_epoch(failure_now)
+                elapsed_ok = (
+                    prev_at is not None and now_at is not None
+                    and (now_at - prev_at) >= NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS
+                )
+                if elapsed_ok:
+                    outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
+                                      summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
+                # else: too soon after the first sample (or timestamps unavailable) -
+                # keep retrying ambiguous instead of permanently parking the head.
         # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,
-                                    summary=outcome.summary, at=now_iso(),
+                                    summary=outcome.summary, at=failure_now,
                                     interrupted=outcome.interrupted,
                                     interruption_kind=outcome.interruption_kind)
         rec = store.attempt_record(agent, head_id) or {}
@@ -1509,7 +1608,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                            summary=remedy)
             _dispose(record, failure_class=CLASS_AMBIGUOUS,
                      reason=INTERRUPTION_BUDGET_EXHAUSTED,
-                     child_output_tail=outcome.child_output_tail)
+                     child_output_tail=outcome.child_output_tail,
+                     summary=remedy)
             continue
         if (k_poison > 0 and outcome.failure_class == CLASS_POISON
                 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison):
@@ -1995,8 +2095,11 @@ def _run_one_shot(store, agent: str, drive: Callable[[dict], bool], *, rid: str,
                 fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
                 continue
             legacy_gate_resolution = authorized
-        record = _with_reply_draft(store, agent, record)
-        outcome = _as_outcome(drive(_with_interruption_context(record)))
+        # cold-review FIX 5: decorate with the in-memory interruption context BEFORE
+        # _with_reply_draft, so its ledger-less preservation gate (see there) can see
+        # THIS attempt's "previously interrupted" fact on the record itself.
+        record = _with_reply_draft(store, agent, _with_interruption_context(record))
+        outcome = _as_outcome(drive(record))
         _note_interruption(outcome)
         # #201: same wrapper-owned draft delivery as _run_continuous — the
         # one-shot path must not strand a sandbox-blocked child's answer.

--- a/src/agenttalk/wrapper/loop.py
+++ b/src/agenttalk/wrapper/loop.py
@@ -14,6 +14,7 @@ injected, so the loop is unit-testable with a fixture Store and NO real CLI.
 
 from __future__ import annotations
 
+import math
 import os
 import time
 import uuid
@@ -101,14 +102,24 @@ INTERRUPTION_BACKOFF_CAP_SECONDS = 900.0
 
 
 def _interruption_remedy(agent: str, head_id: object, *, k: int, kind: str,
-                         budget_seconds: float | None) -> str:
-    """The operator remedy carried by the k_interrupted escalation (#202 D3)."""
+                         budget_seconds: float | None,
+                         preserved_draft: Path | None = None) -> str:
+    """The operator remedy carried by the k_interrupted escalation (#202 D3).
+
+    #202 cold-review P2-3: when a preserved ``<id>.interrupted.md`` sibling exists
+    for this head (the last thing the child managed to write before the FINAL kill
+    that exhausted the budget), name its path here - the dead-letter dispose that
+    follows now KEEPS that file (see ``_dispose``) specifically so the operator has
+    something to inspect/requeue with context, and the remedy must say where."""
     budget = (f" after {budget_seconds:.0f}s each"
               if isinstance(budget_seconds, (int, float)) else "")
-    return (f"this message's turns were killed {k} times by {kind}{budget}; "
-            f"raise turn_watchdog.turn_elapsed_seconds for {agent}, split the task, "
-            f"or requeue as-is: `agenttalk dead-letter requeue --agent {agent} "
-            f"--id {head_id}`")
+    remedy = (f"this message's turns were killed {k} times by {kind}{budget}; "
+              f"raise turn_watchdog.turn_elapsed_seconds for {agent}, split the task, "
+              f"or requeue as-is: `agenttalk dead-letter requeue --agent {agent} "
+              f"--id {head_id}`")
+    if preserved_draft is not None:
+        remedy += f"; the last preserved partial progress is at: {preserved_draft}"
+    return remedy
 
 
 @dataclass(frozen=True)
@@ -234,12 +245,36 @@ def _deliver_reply_draft(store, agent: str, record: dict) -> None:
     draft = Path(str(declared["path"]))
     try:
         if not draft.is_file():
-            return          # most turns: no draft written, no scan paid
+            # P2-6: no LIVE draft this turn - the child may have answered directly
+            # via the CLI/bus channel instead. Most turns have no preserved
+            # <id>.interrupted.md sibling either, so check that CHEAP is_file()
+            # first (no store scan paid on a plain clean turn with no interruption
+            # history); only when one exists is the landed-reply scan worth its
+            # cost, to GC it - otherwise a successful direct reply left it on disk
+            # FOREVER (nothing else ever revisits a head once it commits clean).
+            preserved = _interrupted_draft_path(store, agent, record.get("id"))
+            if (preserved is not None and preserved.is_file()
+                    and reply_transport.landed_reply_exists(
+                        store, agent=agent, record=record)):
+                try:
+                    preserved.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            return
         if reply_transport.landed_reply_exists(store, agent=agent, record=record):
             try:
                 draft.unlink(missing_ok=True)
             except OSError:
                 pass
+            # P2-6: the reply already landed via the direct channel - GC the
+            # <id>.interrupted.md sibling here too (previously only done on the
+            # deliver_draft_reply success path below), or it survives forever.
+            preserved = _interrupted_draft_path(store, agent, record.get("id"))
+            if preserved is not None:
+                try:
+                    preserved.unlink(missing_ok=True)
+                except OSError:
+                    pass
             return
         published = reply_transport.deliver_draft_reply(
             store, agent=agent, record=record, draft_path=draft,
@@ -504,6 +539,10 @@ def run_loop(store, agent: str, drive: Callable[[dict], object], *,
             clock=clock, sleep=sleep, max_turns=max_turns, max_polls=max_polls,
             max_wall=max_wall, k_poison=k_poison, k_escalate=k_escalate,
             k_interrupted=k_interrupted,
+            # #205 cold-review P1-A: the SAME token this run wrote to .waiting (the
+            # explicit param, else the commit-gate fence, else a fresh uuid) - the
+            # entry-check park's "did the operator restart the wrapper" signal.
+            wrapper_generation=wait_token,
             interruption_redrive_seconds=interruption_redrive_seconds,
             interruption_budget_seconds=interruption_budget_seconds,
             infra_exhaust_after_seconds=infra_exhaust_after_seconds,
@@ -547,7 +586,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     capacity_refresh: Callable[[], None] | None,
                     capacity_interval_seconds: float,
                     commit_gate,
-                    now_iso: Callable[[], str]) -> int:
+                    now_iso: Callable[[], str],
+                    wrapper_generation: str | None = None) -> int:
     turns = 0
 
     def _guard_advance() -> None:
@@ -683,7 +723,8 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
     def _dispose(record: dict, *, failure_class: str, reason: str | None,
                  infra_exhausted: bool = False,
                  child_output_tail: dict | None = None,
-                 summary: str | None = None) -> None:
+                 summary: str | None = None,
+                 preserve_interrupted_draft: bool = False) -> None:
         """Dead-letter the head record (store advances the cursor past it), then stamp
         progress: DL is PROGRESS, not a failed turn, so the heartbeat goes FRESH and
         the failure backoff resets - the supervisor sees progress + never restarts.
@@ -693,7 +734,14 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         because ``_escalate_once``'s remedy no-ops when escalation is already
         latched (a prior, unrelated escalation on this head routed already) - the
         dead-letter notification must still carry the REAL remedy (e.g. the #202 D3
-        interruption-budget-exhausted remedy) regardless of that dedupe."""
+        interruption-budget-exhausted remedy) regardless of that dedupe.
+
+        ``preserve_interrupted_draft`` (cold-review P2-3): the interruption-budget-
+        exhausted dispose is the ONE case where the ``<id>.interrupted.md`` sibling
+        IS the final progress evidence for the very interruptions that exhausted the
+        budget - GC'ing it here (as every other dispose does) destroys it exactly
+        when the operator most needs it to inspect/requeue with context. The remedy
+        (built by the caller) already names its path."""
         nonlocal last_hb, fail_sleep
         rec = store.attempt_record(agent, record.get("id")) or {}
         _guard_advance()                      # dead-letter ADVANCES the cursor - verify
@@ -737,12 +785,15 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # cold-review FIX 6: the head is durably disposed - GC any <id>.interrupted.md
         # preserved-progress sibling now, so it cannot outlive the head it was
         # recovered for (nothing else ever removes it once a head is dead-lettered).
-        preserved = _interrupted_draft_path(store, agent, record.get("id"))
-        if preserved is not None:
-            try:
-                preserved.unlink(missing_ok=True)
-            except OSError:
-                pass
+        # P2-3: EXCEPT the interruption-budget-exhausted dispose, which keeps it
+        # (see the docstring above) - ordinary disposes still unlink as today.
+        if not preserve_interrupted_draft:
+            preserved = _interrupted_draft_path(store, agent, record.get("id"))
+            if preserved is not None:
+                try:
+                    preserved.unlink(missing_ok=True)
+                except OSError:
+                    pass
         if on_runtime_dead_letter is not None:
             on_runtime_dead_letter(record)
         _runtime_idle()
@@ -1091,6 +1142,9 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                     sleep(fail_sleep)
                     fail_sleep = min(max_idle_interval, fail_sleep * 2.0)
                     continue
+                # interruption accounting deliberately not wired for admitted
+                # dispatches - commit-gate integration is the #201 PR-2 work; see
+                # connector P1 2026-08-25
                 outcome = _as_outcome(drive(dispatch_record))
                 action_infra = (
                     outcome.bus_action_infra or outcome.failure_class == CLASS_INFRA
@@ -1323,8 +1377,34 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         if rec.get("last_failure_class") == CLASS_CONFIG_BLOCKED:
             if isinstance(head_id, str):
                 config_blocked_ids.add(head_id)
-            _park_config_blocked(record)
-            continue
+            # #205 cold-review P1-A: a sticky config_blocked park never re-fires under
+            # an unchanged class - but the operator CAN fix the underlying denial
+            # (workspace trust, git, auth) and RESTART the wrapper. A restart mints a
+            # NEW wrapper_generation (cli.py, once per process); when it differs from
+            # the generation that PROMOTED this head, that is exactly "operator
+            # intervention implies restart" - allow ONE re-probe drive instead of
+            # re-parking blind. Fall through (no continue) WITHOUT calling
+            # _park_config_blocked: the entry cap block below is gated on
+            # last_failure_class != CLASS_CONFIG_BLOCKED, so it stays skipped too -
+            # the re-probe reaches drive() untouched by the other ceilings. If the
+            # workspace is still broken, the never-started counting (below) re-
+            # promotes and re-parks recording the NEW generation, so a same-generation
+            # entry after that re-parks immediately again (no re-probe storm).
+            #
+            # Scoped to #205's never-started promotion ONLY: a config_blocked
+            # classification reached DIRECTLY from drive() (e.g. #58's sandbox/
+            # workspace denials) never writes ``promoted_by_generation`` - it stays
+            # sticky-forever exactly as before (that mechanism's own contract, not
+            # changed here). Only a present, non-empty recorded generation that
+            # DIFFERS from the current one triggers the re-probe.
+            promoted_gen = rec.get("promoted_by_generation")
+            if (wrapper_generation is not None
+                    and isinstance(promoted_gen, str) and promoted_gen
+                    and promoted_gen != wrapper_generation):
+                pass
+            else:
+                _park_config_blocked(record)
+                continue
         # AUTO-DISPOSE WITHOUT DRIVE if a cap is already reached on entry (covers the
         # relaunch/crash-accumulation path - test #3).
         if rec.get("last_failure_class") != CLASS_CONFIG_BLOCKED:
@@ -1338,12 +1418,19 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             # reconcile never increments it (the store.py ruling stands).
             if (k_interrupted > 0 and _safe_int(
                     rec.get("interrupted_watchdog_consecutive")) >= k_interrupted):
+                # P2-3: name the preserved draft (if any) in the remedy, then keep it
+                # through the dispose below instead of GC'ing it.
+                preserved_for_remedy = _interrupted_draft_path(store, agent, head_id)
+                if preserved_for_remedy is not None and not preserved_for_remedy.is_file():
+                    preserved_for_remedy = None
                 remedy = _interruption_remedy(
                     agent, head_id, k=k_interrupted, kind="turn_watchdog",
-                    budget_seconds=interruption_budget_seconds)
+                    budget_seconds=interruption_budget_seconds,
+                    preserved_draft=preserved_for_remedy)
                 _escalate_once(record, CLASS_AMBIGUOUS, summary=remedy)
                 _dispose(record, failure_class=CLASS_AMBIGUOUS,
-                         reason=INTERRUPTION_BUDGET_EXHAUSTED, summary=remedy)
+                         reason=INTERRUPTION_BUDGET_EXHAUSTED, summary=remedy,
+                         preserve_interrupted_draft=True)
                 continue
             if k_poison > 0 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison:
                 _dispose(record, failure_class=CLASS_POISON,
@@ -1439,6 +1526,14 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
                 float(interruption_redrive_seconds) * (2.0 ** (interrupted_n - 1)),
                 INTERRUPTION_BACKOFF_CAP_SECONDS,
             )
+            # #202 cold-review P2-4 belt: the cap above already bounds ordinary
+            # cases, but a NaN/inf base (a corrupt knob that slipped past the
+            # resolver, or a direct run_loop() caller that bypasses it) must never
+            # reach `sleep()` as a non-finite duration - fail loud, not an endless
+            # chunked backoff.
+            assert math.isfinite(required), (
+                f"interruption backoff computed a non-finite duration ({required!r}); "
+                "interruption_redrive_seconds must be a finite, bounded config value")
             last_at = _iso_epoch(rec.get("last_failure_at"))
             now_at = _iso_epoch(now_iso())
             remaining = (required if last_at is None or now_at is None
@@ -1552,39 +1647,60 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
             # ledger (and so it can never reach a dispose ceiling). See _hold_park.
             _hold_park(record)
             continue
-        # #205: a SECOND consecutive never-started result on the same head (the attempt
-        # record still holds the previous failure - record_attempt_start preserves it)
-        # is a deterministic launch/config denial, not an ambiguous hiccup - PROVIDED
-        # it is actually separated in time from the first one. cold-review FIX 2: with
-        # fail_sleep 0.3-2.0s, two samples can land ~seconds apart - that is NOT
-        # evidence of determinism, just an unlucky pair of retries during a transient
-        # hiccup (auth refresh, CLI update banner, AV lock). Require BOTH the
-        # never-started signature AND at least
-        # NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS since the previous failure's
-        # recorded time before promoting to CLASS_CONFIG_BLOCKED (escalate once + durable
-        # park below); missing/unparseable timestamps fail CLOSED (keep retrying
-        # ambiguous) rather than promote on unproven elapsed time.
+        # #205: a run of never-started results on the same head is a deterministic
+        # launch/config denial, not an ambiguous hiccup - PROVIDED it is actually
+        # separated in time from the FIRST one. cold-review P1-B: comparing against
+        # the immediately-PRECEDING failure (as this used to) is wrong - fail_sleep
+        # retries land 0.3-2.0s apart, so a child that ALWAYS fails never-started
+        # (#205's motivating case: codex in a non-git dir) never satisfies a 60s
+        # PAIRWISE gap and burns k_escalate=20 ambiguous retries again. Persist
+        # ``never_started_first_at`` (set once, on the FIRST never-started result)
+        # and ``never_started_consecutive``; promote once count >= 2 AND the window
+        # has elapsed since the FIRST failure - so a fast, ALWAYS-failing loop
+        # promotes at the first failure after ~60s (not never), while a genuine
+        # transient (one or two, then success) never promotes (the fields are reset
+        # to None/0 below whenever a non-never-started result lands). Missing/
+        # unparseable timestamps fail CLOSED (keep retrying ambiguous) rather than
+        # promote on unproven elapsed time.
         failure_now = now_iso()
-        if _is_never_started_failure(outcome.failure_class, outcome.summary):
+        never_started = _is_never_started_failure(outcome.failure_class, outcome.summary)
+        never_started_first_at: str | None = None
+        never_started_consecutive = 0
+        promoted_by_generation: str | None = None
+        if never_started:
             prev = store.attempt_record(agent, head_id) or {}
-            if _is_never_started_failure(prev.get("last_failure_class"),
-                                         prev.get("last_failure_summary")):
-                prev_at = _iso_epoch(prev.get("last_failure_at"))
-                now_at = _iso_epoch(failure_now)
-                elapsed_ok = (
-                    prev_at is not None and now_at is not None
-                    and (now_at - prev_at) >= NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS
-                )
-                if elapsed_ok:
-                    outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
-                                      summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
-                # else: too soon after the first sample (or timestamps unavailable) -
-                # keep retrying ambiguous instead of permanently parking the head.
+            prev_first_at = prev.get("never_started_first_at")
+            prev_count = _safe_int(prev.get("never_started_consecutive"))
+            never_started_first_at = (
+                prev_first_at
+                if prev_count > 0 and isinstance(prev_first_at, str) and prev_first_at
+                else failure_now
+            )
+            never_started_consecutive = prev_count + 1
+            first_at_epoch = _iso_epoch(never_started_first_at)
+            now_at_epoch = _iso_epoch(failure_now)
+            elapsed_ok = (
+                first_at_epoch is not None and now_at_epoch is not None
+                and (now_at_epoch - first_at_epoch)
+                    >= NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS
+            )
+            if never_started_consecutive >= 2 and elapsed_ok:
+                outcome = replace(outcome, failure_class=CLASS_CONFIG_BLOCKED,
+                                  summary=f"{NEVER_STARTED_REMEDY} ({outcome.summary})")
+                # #205 cold-review P1-A: name the wrapper generation active at THIS
+                # promotion, so the entry-check park (above) can allow exactly one
+                # re-probe drive after a restart following operator intervention.
+                promoted_by_generation = wrapper_generation
+            # else: window not yet elapsed (or timestamps unavailable) - keep
+            # retrying ambiguous instead of permanently parking the head.
         # record the classified failure (clears in_progress), then decide.
         store.record_attempt_result(agent, head_id, failure_class=outcome.failure_class,
                                     summary=outcome.summary, at=failure_now,
                                     interrupted=outcome.interrupted,
-                                    interruption_kind=outcome.interruption_kind)
+                                    interruption_kind=outcome.interruption_kind,
+                                    never_started_first_at=never_started_first_at,
+                                    never_started_consecutive=never_started_consecutive,
+                                    promoted_by_generation=promoted_by_generation)
         rec = store.attempt_record(agent, head_id) or {}
         if outcome.failure_class == CLASS_CONFIG_BLOCKED:
             if isinstance(head_id, str):
@@ -1601,15 +1717,22 @@ def _run_continuous(store, agent: str, drive: Callable[[dict], object], *,
         # wedge the seat with no un-park path (rev 1 F1/F2).
         if (k_interrupted > 0 and _safe_int(
                 rec.get("interrupted_watchdog_consecutive")) >= k_interrupted):
+            # P2-3: name the preserved draft (if any) in the remedy, then keep it
+            # through the dispose below instead of GC'ing it.
+            preserved_for_remedy = _interrupted_draft_path(store, agent, head_id)
+            if preserved_for_remedy is not None and not preserved_for_remedy.is_file():
+                preserved_for_remedy = None
             remedy = _interruption_remedy(
                 agent, head_id, k=k_interrupted, kind="turn_watchdog",
-                budget_seconds=interruption_budget_seconds)
+                budget_seconds=interruption_budget_seconds,
+                preserved_draft=preserved_for_remedy)
             _escalate_once(record, outcome.failure_class or CLASS_AMBIGUOUS,
                            summary=remedy)
             _dispose(record, failure_class=CLASS_AMBIGUOUS,
                      reason=INTERRUPTION_BUDGET_EXHAUSTED,
                      child_output_tail=outcome.child_output_tail,
-                     summary=remedy)
+                     summary=remedy,
+                     preserve_interrupted_draft=True)
             continue
         if (k_poison > 0 and outcome.failure_class == CLASS_POISON
                 and _safe_int(rec.get("poison_eligible_failures")) >= k_poison):

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1426,8 +1426,15 @@ def run_wrapper(
         min_interval=min_interval,
     )
 
+    # #204 refuse-loudly (#166): count what the child actually produced. A plain
+    # (non---loop) wrap whose child emits NO parseable structured events did
+    # nothing - no heartbeat stamped, no output rendered, no degraded detection -
+    # and used to exit 0 in total silence (success-shaped no-op).
+    seen = {"events": 0}
+
     def _health_events(events: Iterable[Event]) -> Iterator[Event]:
         for ev in events:
+            seen["events"] += 1
             if health_writer is not None:
                 health_writer.event(ev)
             yield ev
@@ -1485,6 +1492,21 @@ def run_wrapper(
     else:
         _close_pipe_suppressing_benign_pipe_teardown(proc.stdout)
     rc = proc.wait()
+    if seen["events"] == 0:
+        # Zero structured events = no turn driven, whatever the child's rc. Say
+        # so ONCE with the concrete remedy instead of the historical silent
+        # exit-0 no-op (#204): plain wrap only adapts an already-complete
+        # structured-stream command; it never reads the inbox.
+        sys.stderr.write(
+            f"agenttalk wrap: no turn driven - the child (exit {rc}) produced no "
+            "structured events. Plain `wrap` only adapts a complete structured-"
+            "stream command (e.g. `codex ... exec --json \"...\"`); to drive "
+            "inbox messages use --loop, or --loop --one-shot --to-request <id> "
+            "for a single request.\n")
+        sys.stderr.flush()
+        if health_writer is not None:
+            health_writer.crashed_or_exited(reason_code="wrapper_no_turn_driven")
+        return rc if rc != 0 else 1
     if health_writer is not None:
         if rc == 0:
             if health_writer.state != health_model.STATE_DEGRADED_OUTPUT:
@@ -1981,6 +2003,7 @@ def _classify_drive_failure(
         CLASS_GATEWAY_HELD,
         CLASS_INFRA,
         CLASS_POISON,
+        NEVER_STARTED_SUMMARY_PREFIX,
     )
 
     # A TRANSIENT, operator-resolvable gateway HOLD surfaced at mint time (#62): classify
@@ -2071,7 +2094,10 @@ def _classify_drive_failure(
             return CLASS_AMBIGUOUS, ("partial stream: started, never completed "
                                      "(poison or an unrecognized drop after the handshake)")
         return CLASS_AMBIGUOUS, f"nonzero child exit (rc={sig.get('rc')}) after start"
-    return CLASS_AMBIGUOUS, f"turn never started (rc={sig.get('rc')}, no clear signal)"
+    # The loop promotes the SECOND consecutive result carrying this prefix to
+    # CLASS_CONFIG_BLOCKED (#205) - keep the summary bound to the shared constant.
+    return CLASS_AMBIGUOUS, (
+        f"{NEVER_STARTED_SUMMARY_PREFIX} (rc={sig.get('rc')}, no clear signal)")
 
 
 # Event types that prove the resumed turn actually RAN (produced real activity):
@@ -2144,7 +2170,9 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                backend_profile: str | None = None,
                profile_env: dict[str, str] | None = None,
                lifecycle_log=None,
-               lease_lost_exceptions: tuple = ()) -> Callable[[dict], object]:
+               lease_lost_exceptions: tuple = (),
+               rejoin_for: Callable[[dict], str | None] | None = None,
+               ) -> Callable[[dict], object]:
     """Build the per-turn ``drive(record)`` callback for loop.run_loop. Each call
     drives ONE real CLI turn and returns a :class:`loop.DriveOutcome` (ok + a failure
     CLASS on failure, for dead-letter). A turn fails if it produced no progress event or
@@ -2617,8 +2645,17 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 turn_id=lesson_turn_id,
             )
 
+        # #202 D4: the rejoin context is built by the CALLER's rejoin_for (cli
+        # wiring, keyed per head id from the attempt ledger / the one-shot record
+        # decoration) - advisory context that must never kill a turn.
+        rejoin = None
+        if rejoin_for is not None:
+            try:
+                rejoin = rejoin_for(record)
+            except Exception:  # noqa: BLE001, S110 - advisory rejoin only  # nosec B110
+                rejoin = None
         prompt = _prompt.assemble_turn_prompt(
-            record, rules=rules, lessons=lesson_prompt)
+            record, rules=rules, rejoin=rejoin, lessons=lesson_prompt)
         spec = _session.build_turn(session_state, prompt)
         cli = session_state.cli
         # A failed RESUME turn self-heals to a fresh session before we classify (codex:
@@ -2664,6 +2701,8 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                     failure_class=resume_failure_class,
                     summary=resume_summary,
                     child_output_tail=sig.get("child_output_tail"),
+                    interrupted=bool(sig.get("watchdog")),
+                    interruption_kind="turn_watchdog" if sig.get("watchdog") else None,
                 )
             count = _session.record_resume_attempt_result(
                 session_state,
@@ -2694,6 +2733,10 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                     failure_class=CLASS_AMBIGUOUS,
                     summary="resume_unavailable; next attempt will start a fresh session",
                     child_output_tail=sig.get("child_output_tail"),
+                    # #202 D1: the resume branches REWRITE the summary, so the
+                    # interruption fact must ride structurally, never be sniffed.
+                    interrupted=bool(sig.get("watchdog")),
+                    interruption_kind="turn_watchdog" if sig.get("watchdog") else None,
                 )
             health_writer.failure(sig, CLASS_AMBIGUOUS if attributable else resume_failure_class)
             _finish_watchdog_recovery(sig)
@@ -2703,6 +2746,8 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                 summary=("resume attempt failed; retrying resume once before fresh session"
                          if attributable else resume_summary),
                 child_output_tail=sig.get("child_output_tail"),
+                interrupted=bool(sig.get("watchdog")),
+                interruption_kind="turn_watchdog" if sig.get("watchdog") else None,
             )
         if sig["ok"]:
             _session.clear_resume_attempt(session_state)
@@ -2766,7 +2811,10 @@ def make_drive(store, agent: str, cli: str, session_state, base_argv: list[str],
                             child_output_tail=sig.get("child_output_tail"),
                             bus_action_attempted=bool(sig.get("bus_action_attempted")),
                             bus_action_infra=bool(sig.get("bus_action_infra")),
-                            bus_action_rejected=bool(sig.get("bus_action_rejected")))
+                            bus_action_rejected=bool(sig.get("bus_action_rejected")),
+                            interrupted=bool(sig.get("watchdog")),
+                            interruption_kind=("turn_watchdog"
+                                               if sig.get("watchdog") else None))
 
     return drive
 

--- a/src/agenttalk/wrapper/run.py
+++ b/src/agenttalk/wrapper/run.py
@@ -1384,7 +1384,9 @@ def run_wrapper(
     clock: Callable[[], float] = time.monotonic,
 ) -> int:
     """Wrap one CLI run. Returns the child exit code (0 when a line_source is
-    injected, i.e. tests)."""
+    injected AND it produced at least one parseable structured event, i.e.
+    tests; 1 if a line_source produced none - see the zero-events refusal
+    below)."""
     mapper = _ADAPTERS.get(cli)
     if mapper is None:
         raise ValueError(f"no wrapper adapter for cli {cli!r} (Phase 1 = codex)")
@@ -1443,6 +1445,21 @@ def run_wrapper(
         if health_writer is not None:
             health_writer.turn_start(None)
         engine.run(_health_events(parse_lines(line_source, mapper)), clock)
+        if seen["events"] == 0:
+            # cold-review FIX 4: apply the same zero-events refusal as the real
+            # subprocess branch below (never silently return 0) - a caller feeding an
+            # injected line source (tests / an alternate stream adapter) that produces
+            # no parseable structured events drove no turn either.
+            sys.stderr.write(
+                "agenttalk wrap: no turn driven by the wrapper - no parseable "
+                "stream events in the supplied line source. Plain `wrap` only "
+                "adapts a complete structured-stream command (e.g. `codex ... "
+                "exec --json \"...\"`); to drive inbox messages use --loop, or "
+                "--loop --one-shot --to-request <id> for a single request.\n")
+            sys.stderr.flush()
+            if health_writer is not None:
+                health_writer.crashed_or_exited(reason_code="wrapper_no_turn_driven")
+            return 1
         if (health_writer is not None
                 and health_writer.state != health_model.STATE_DEGRADED_OUTPUT):
             health_writer.idle(reason_code="wrapper_completed")
@@ -1493,13 +1510,22 @@ def run_wrapper(
         _close_pipe_suppressing_benign_pipe_teardown(proc.stdout)
     rc = proc.wait()
     if seen["events"] == 0:
-        # Zero structured events = no turn driven, whatever the child's rc. Say
-        # so ONCE with the concrete remedy instead of the historical silent
-        # exit-0 no-op (#204): plain wrap only adapts an already-complete
-        # structured-stream command; it never reads the inbox.
+        # cold-review FIX 4: zero structured events means the WRAPPER drove no turn -
+        # it must NOT claim the child "did nothing": the child process genuinely ran
+        # and exited rc={rc}, and anything it did outside the structured stream (file
+        # writes, side-effectful commands) is real and already happened. Say so ONCE
+        # with the concrete remedy instead of the historical silent exit-0 no-op
+        # (#204): plain wrap only adapts an already-complete structured-stream
+        # command; it never reads the inbox.
+        # rc semantics: PASS THROUGH a nonzero child rc unchanged (it is already an
+        # honest failure signal); promote a clean rc=0 to 1, because "no turn driven"
+        # dressed as a successful exit is exactly the misleading success-shaped no-op
+        # this fix exists to end - a caller checking only the exit code must see a
+        # failure, not a silent success.
         sys.stderr.write(
-            f"agenttalk wrap: no turn driven - the child (exit {rc}) produced no "
-            "structured events. Plain `wrap` only adapts a complete structured-"
+            "agenttalk wrap: no turn driven by the wrapper - no parseable stream "
+            f"events; the child process ran and exited rc={rc} - any side effects "
+            "it made are real. Plain `wrap` only adapts a complete structured-"
             "stream command (e.g. `codex ... exec --json \"...\"`); to drive "
             "inbox messages use --loop, or --loop --one-shot --to-request <id> "
             "for a single request.\n")

--- a/tests/test_dead_letter.py
+++ b/tests/test_dead_letter.py
@@ -748,6 +748,22 @@ def test_interruption_policy_resolver_chain_and_corrupt_values() -> None:
     assert errors and "k_interrupted" in errors[0]
     # corrupt containers degrade to defaults without crashing (resolver-chain parity)
     assert sup.resolve_interruption_policy("junk", 7) == (60.0, 3, [])
+    # #202 cold-review P2-4: a valid-JSON-but-absurd knob (a hand-edited config, or
+    # the JSON extension `Infinity`) that the D2 backoff's base*2**(n-1) would
+    # overflow toward inf must refuse (never silently clamp to the 900s runtime
+    # cap) - same discipline as a non-numeric value.
+    _, _, errors = sup.resolve_interruption_policy(
+        {}, {"interruption_redrive_seconds": 1e308})
+    assert errors and "interruption_redrive_seconds" in errors[0]
+    _, _, errors = sup.resolve_interruption_policy(
+        {}, {"interruption_redrive_seconds": float("inf")})
+    assert errors and "interruption_redrive_seconds" in errors[0]
+    _, _, errors = sup.resolve_interruption_policy(
+        {}, {"interruption_redrive_seconds": 86401})
+    assert errors and "interruption_redrive_seconds" in errors[0]
+    # the upper bound itself is a VALID launch value
+    assert sup.resolve_interruption_policy(
+        {}, {"interruption_redrive_seconds": 86400}) == (86400.0, 3, [])
 
 
 def test_interruption_ledger_counts_always_write_and_survive_relaunch(tmp_path: Path) -> None:

--- a/tests/test_dead_letter.py
+++ b/tests/test_dead_letter.py
@@ -758,12 +758,18 @@ def test_interruption_policy_resolver_chain_and_corrupt_values() -> None:
     _, _, errors = sup.resolve_interruption_policy(
         {}, {"interruption_redrive_seconds": float("inf")})
     assert errors and "interruption_redrive_seconds" in errors[0]
+    # #7-fix-3: the resolver's bound is tightened to (0, 900] to match the
+    # runtime's INTERRUPTION_BACKOFF_CAP_SECONDS - a base above 900 would
+    # otherwise pass here but be silently reduced by the runtime cap on the
+    # very first interruption, exactly the silent-clamp this resolver exists
+    # to refuse instead of doing.
     _, _, errors = sup.resolve_interruption_policy(
-        {}, {"interruption_redrive_seconds": 86401})
+        {}, {"interruption_redrive_seconds": 901})
     assert errors and "interruption_redrive_seconds" in errors[0]
+    assert "900" in errors[0]
     # the upper bound itself is a VALID launch value
     assert sup.resolve_interruption_policy(
-        {}, {"interruption_redrive_seconds": 86400}) == (86400.0, 3, [])
+        {}, {"interruption_redrive_seconds": 900}) == (900.0, 3, [])
 
 
 def test_interruption_ledger_counts_always_write_and_survive_relaunch(tmp_path: Path) -> None:
@@ -1345,6 +1351,27 @@ def test_46_crash_mid_turn_resets_poison_counter(tmp_path: Path) -> None:
     rec2 = s.attempt_record("beta", m.id)
     assert int(rec2["poison_eligible_failures"]) == 0        # crash reset the consecutive run
     assert rec2["last_failure_class"] == "ambiguous_or_unknown"
+
+
+def test_46b_crash_mid_turn_resets_never_started_tracking(tmp_path: Path) -> None:
+    # #7-fix-4: a crash mid-turn breaks the "consecutive never-started" run by
+    # definition (the process DID start this attempt - it crashed, which is why
+    # it's here). Leaving never_started_first_at/never_started_consecutive
+    # intact would let a LATER never-started failure promote using a
+    # window/count that spans across the crash, not an actually-consecutive run.
+    s = _store(tmp_path)
+    m = _send(s, "never-started-then-crash")
+    rec = _rec(s)
+    s.record_attempt_start("beta", rec, attempt_id="a", at="t")
+    data = s.dead_letter_attempts("beta")
+    data["messages"][m.id]["never_started_first_at"] = "t0"
+    data["messages"][m.id]["never_started_consecutive"] = 1
+    data["messages"][m.id]["in_progress"] = True             # crashed mid-turn
+    s._write_attempts("beta", data)
+    assert s.reconcile_crash_in_progress("beta", m.id, at="t2") is True
+    rec2 = s.attempt_record("beta", m.id)
+    assert rec2["never_started_first_at"] is None
+    assert rec2["never_started_consecutive"] == 0
 
 
 def test_47_infra_dominant_crash_at_ceiling_escalates_no_dispose(tmp_path: Path) -> None:

--- a/tests/test_dead_letter.py
+++ b/tests/test_dead_letter.py
@@ -731,6 +731,77 @@ def test_30_f3_supervisor_config_caps_take_effect(tmp_path: Path) -> None:
     assert sup.resolve_dead_letter_caps({"dead_letter": {"max_attempts": 0}}, {}) == (0, 20)  # 0 disables
 
 
+def test_interruption_policy_resolver_chain_and_corrupt_values() -> None:
+    # #202 D2: per-agent -> global -> default, mirroring resolve_dead_letter_caps -
+    # but a PRESENT-and-corrupt value is an ERROR (refuse-visibly), never a clamp.
+    assert sup.resolve_interruption_policy({}, {}) == (60.0, 3, [])              # defaults
+    assert sup.resolve_interruption_policy(
+        {"interruption_redrive_seconds": 30, "k_interrupted": 5}, {}) == (30.0, 5, [])
+    assert sup.resolve_interruption_policy(
+        {"interruption_redrive_seconds": 30},
+        {"interruption_redrive_seconds": 15, "k_interrupted": 2}) == (15.0, 2, [])  # per-agent wins
+    assert sup.resolve_interruption_policy({}, {"k_interrupted": 0}) == (60.0, 0, [])  # 0 disables
+    _, _, errors = sup.resolve_interruption_policy(
+        {}, {"interruption_redrive_seconds": "fast"})
+    assert errors and "interruption_redrive_seconds" in errors[0]
+    _, _, errors = sup.resolve_interruption_policy({"k_interrupted": -1}, {})
+    assert errors and "k_interrupted" in errors[0]
+    # corrupt containers degrade to defaults without crashing (resolver-chain parity)
+    assert sup.resolve_interruption_policy("junk", 7) == (60.0, 3, [])
+
+
+def test_interruption_ledger_counts_always_write_and_survive_relaunch(tmp_path: Path) -> None:
+    # #202 D1: interrupted result -> counter+1 (both counters for turn_watchdog);
+    # non-interrupted -> counters reset AND flags overwritten to False/None (the
+    # stale-flag bug); the ledger is durable across a relaunch (new Store instance).
+    s = _store(tmp_path)
+    m = _send(s, "task")
+    rec = _rec(s)
+    for n in (1, 2):
+        s.record_attempt_start("beta", rec, attempt_id=f"a{n}", at=f"t{n}")
+        s.record_attempt_result("beta", rec["id"], failure_class=CLASS_AMBIGUOUS,
+                                summary="turn watchdog killed hung tool descendant",
+                                at=f"t{n}", interrupted=True,
+                                interruption_kind="turn_watchdog")
+        r = s.attempt_record("beta", rec["id"])
+        assert r["interrupted_consecutive"] == n
+        assert r["interrupted_watchdog_consecutive"] == n
+        assert r["last_interrupted"] is True
+        assert r["last_interruption_kind"] == "turn_watchdog"
+    # relaunch: a NEW Store instance reads the same persisted counters
+    r = Store(tmp_path).attempt_record("beta", rec["id"])
+    assert r["interrupted_consecutive"] == 2
+    # a non-interrupted result RESETS the run and overwrites the flags
+    s.record_attempt_start("beta", rec, attempt_id="a3", at="t3")
+    s.record_attempt_result("beta", rec["id"], failure_class=CLASS_AMBIGUOUS,
+                            summary="ordinary failure", at="t3")
+    r = s.attempt_record("beta", rec["id"])
+    assert r["interrupted_consecutive"] == 0
+    assert r["interrupted_watchdog_consecutive"] == 0
+    assert r["last_interrupted"] is False
+    assert r["last_interruption_kind"] is None
+    assert m.id == rec["id"]
+
+
+def test_crash_reconcile_increments_any_kind_but_never_the_watchdog_counter(
+    tmp_path: Path,
+) -> None:
+    # #202 D1 + NEW-2: crash_mid_turn IS an interruption (backoff + rejoin apply),
+    # but its cause is UNOBSERVED - it must never count toward the turn_watchdog-only
+    # k_interrupted ceiling (the codified store ruling stands).
+    s = _store(tmp_path)
+    _send(s, "task")
+    rec = _rec(s)
+    for n in (1, 2, 3):
+        s.record_attempt_start("beta", rec, attempt_id=f"a{n}", at=f"t{n}")
+        assert s.reconcile_crash_in_progress("beta", rec["id"], at=f"t{n}") is True
+        r = s.attempt_record("beta", rec["id"])
+        assert r["interrupted_consecutive"] == n
+        assert r.get("interrupted_watchdog_consecutive", 0) == 0   # never the ceiling counter
+        assert r["last_interrupted"] is True
+        assert r["last_interruption_kind"] == "crash_mid_turn"
+
+
 def test_31_unrouted_escalation_retries_after_target_configured(tmp_path: Path) -> None:
     # codex re-review P2: an UNROUTED escalation (no liaison/lead) must NOT be permanently
     # deduped - once an operator target is configured, the loop retries and the notice

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -365,6 +365,41 @@ def test_one_shot_path_delivers_the_draft(tmp_path) -> None:
     assert (msg.meta or {}).get("request_id") == "q-oneshot"
 
 
+def test_one_shot_interrupted_draft_is_preserved_across_the_in_memory_redrive(tmp_path) -> None:
+    # cold-review FIX 5: _run_one_shot has NO attempt ledger, so _with_reply_draft's
+    # preservation gate must ALSO trust the in-memory ``interrupted_redelivery``
+    # decoration the one-shot loop places on the record - otherwise the ledger read
+    # is always empty here and the interrupted attempt's draft is unconditionally
+    # deleted even while the rejoin still says "prefer resuming over redoing".
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="scoped q",
+               meta={"request_id": "q-oneshot-interrupted"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            Path(rec["reply_draft"]["path"]).write_text(
+                "scoped partial progress", encoding="utf-8")
+            return loop.DriveOutcome(
+                ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                summary="turn watchdog killed hung tool descendant",
+                interrupted=True, interruption_kind="turn_watchdog")
+        return True                      # clean retry, no draft written
+
+    turns = loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                          max_turns=1, max_polls=6,
+                          only_request_id="q-oneshot-interrupted")
+    assert turns == 1
+    assert attempts["n"] == 2
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    preserved = live.with_suffix(".interrupted.md")
+    assert preserved.is_file()
+    assert preserved.read_text(encoding="utf-8") == "scoped partial progress"
+    assert not live.exists()             # live path clear for the retry
+    assert _reply_inbox(s, "alpha") == []
+
+
 def test_message_on_review_thread_gets_no_draft_channel(tmp_path) -> None:
     # PR #127 connector P2: a kind=message on a review-request thread (e.g.
     # a needs-info answer) owes a TYPED review-result next — the draft
@@ -484,3 +519,63 @@ def test_preserve_interrupted_draft_pre_unlinks_the_target(tmp_path) -> None:
     assert out == stale
     assert stale.read_text(encoding="utf-8") == "new partial"
     assert not live.exists()
+
+
+# ------------------------------------------------------- cold-review FIX 6: GC
+
+def test_dispose_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:
+    # cold-review FIX 6: nothing removed <id>.interrupted.md - a head that is
+    # eventually dead-lettered must GC its preserved-progress sibling too, so it
+    # cannot linger on disk forever.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-gc-dispose"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        Path(rec["reply_draft"]["path"]).write_text(
+            f"partial {attempts['n']}", encoding="utf-8")
+        return loop.DriveOutcome(
+            ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+            summary="turn watchdog killed hung tool descendant",
+            interrupted=True, interruption_kind="turn_watchdog")
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_polls=4, k_poison=0, k_escalate=0, k_interrupted=2,
+                  interruption_redrive_seconds=0.0)
+    assert attempts["n"] == 2                  # 1st preserves attempt 1's draft, 2nd hits k_interrupted
+    assert s.dead_lettered_count("beta") == 1
+    preserved = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".interrupted.md")
+    assert not preserved.exists()              # GC'd on dispose - never outlives the head
+
+
+def test_successful_draft_delivery_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:
+    # cold-review FIX 6 (the other half): once a real reply lands for a head, an
+    # earlier preserved <id>.interrupted.md for that SAME head is moot - GC it so
+    # a stale pre-success draft can never be misread as still-pending progress.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-gc-deliver"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            Path(rec["reply_draft"]["path"]).write_text(
+                "partial progress", encoding="utf-8")
+            return loop.DriveOutcome(
+                ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                summary="turn watchdog killed hung tool descendant",
+                interrupted=True, interruption_kind="turn_watchdog")
+        Path(rec["reply_draft"]["path"]).write_text("the real answer", encoding="utf-8")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=4, k_poison=0, k_escalate=0,
+                  interruption_redrive_seconds=0.0)
+    assert attempts["n"] == 2
+    preserved = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".interrupted.md")
+    assert not preserved.exists()              # GC'd once the real reply landed
+    (msg,) = _reply_inbox(s, "alpha")
+    assert msg.body == "the real answer"

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -499,10 +499,17 @@ def test_publish_exception_preserves_the_draft(tmp_path, monkeypatch) -> None:
 
 # ---------------------------------------- #202 D5: preserve the interrupted draft
 
-def test_interrupted_attempt_draft_is_preserved_and_never_published(tmp_path) -> None:
+def test_interrupted_draft_never_published_and_gcd_on_clean_no_reply_commit(
+    tmp_path,
+) -> None:
     # #202 D5: attempt 1 writes a partial draft and is INTERRUPTED (watchdog kill);
     # the retry preserves it at <id>.interrupted.md (the rejoin names it) while the
     # LIVE path stays clear - so the preserved bytes can never be published.
+    #
+    # #7-fix-7: this clean retry writes no live draft and sends no direct reply
+    # (a freeform message may owe no reply at all) - once it COMMITS, the
+    # preserved sibling is moot (nothing else will ever revisit this head) and
+    # must be GC'd, not left on disk forever.
     s = _store(tmp_path)
     q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
                meta={"request_id": "q-interrupted"})
@@ -525,8 +532,7 @@ def test_interrupted_attempt_draft_is_preserved_and_never_published(tmp_path) ->
     assert attempts["n"] >= 2
     live = reply_transport.reply_draft_path(s, "beta", q.id)
     preserved = live.with_suffix(".interrupted.md")
-    assert preserved.is_file()
-    assert preserved.read_text(encoding="utf-8") == "partial progress"
+    assert not preserved.exists()                # GC'd once the clean retry committed
     assert not live.exists()                     # live path clear for the retry
     assert _reply_inbox(s, "alpha") == []        # preserved copy never publishes
     assert s.cursor("beta") == q.id              # the clean retry still committed
@@ -581,6 +587,11 @@ def test_interruption_budget_exhausted_dispose_keeps_the_preserved_draft(tmp_pat
     # the operator can inspect/requeue with context. See
     # test_ordinary_dispose_still_gcs_the_interrupted_draft (test_wrapper_loop.py)
     # for the still-GC'd ordinary-dispose case.
+    #
+    # #7-fix-6: the KTH (final, budget-ending) attempt's LIVE draft is NEWER than
+    # the sibling preserved from attempt 1 - it must be moved over that older
+    # copy before the dispose, so the remedy/operator sees the NEWEST partial
+    # work, not the first attempt's stale one.
     s = _store(tmp_path)
     q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
                meta={"request_id": "q-gc-dispose"})
@@ -602,9 +613,11 @@ def test_interruption_budget_exhausted_dispose_keeps_the_preserved_draft(tmp_pat
     assert s.dead_lettered_count("beta") == 1
     entry = s.list_dead_letters("beta")[0]
     assert entry["last_reason"] == "interruption_budget_exhausted"
-    preserved = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".interrupted.md")
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    preserved = live.with_suffix(".interrupted.md")
     assert preserved.is_file()                 # KEPT - the operator's final progress evidence
-    assert preserved.read_text(encoding="utf-8") == "partial 1"
+    assert preserved.read_text(encoding="utf-8") == "partial 2"  # NEWEST attempt's content
+    assert not live.exists()                   # the kth attempt's live draft is never left behind
 
 
 def test_successful_draft_delivery_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -410,3 +410,77 @@ def test_publish_exception_preserves_the_draft(tmp_path, monkeypatch) -> None:
     refused = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".refused.md")
     assert refused.exists()
     assert refused.read_text(encoding="utf-8") == "good answer"
+
+
+# ---------------------------------------- #202 D5: preserve the interrupted draft
+
+def test_interrupted_attempt_draft_is_preserved_and_never_published(tmp_path) -> None:
+    # #202 D5: attempt 1 writes a partial draft and is INTERRUPTED (watchdog kill);
+    # the retry preserves it at <id>.interrupted.md (the rejoin names it) while the
+    # LIVE path stays clear - so the preserved bytes can never be published.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-interrupted"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            Path(rec["reply_draft"]["path"]).write_text(
+                "partial progress", encoding="utf-8")
+            return loop.DriveOutcome(
+                ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                summary="turn watchdog killed hung tool descendant",
+                interrupted=True, interruption_kind="turn_watchdog")
+        return True                      # clean retry, no draft written
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=4, k_poison=0, k_escalate=0,
+                  interruption_redrive_seconds=0.0)
+    assert attempts["n"] >= 2
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    preserved = live.with_suffix(".interrupted.md")
+    assert preserved.is_file()
+    assert preserved.read_text(encoding="utf-8") == "partial progress"
+    assert not live.exists()                     # live path clear for the retry
+    assert _reply_inbox(s, "alpha") == []        # preserved copy never publishes
+    assert s.cursor("beta") == q.id              # the clean retry still committed
+
+
+def test_non_interrupted_failed_attempt_draft_is_still_deleted(tmp_path) -> None:
+    # #202 D5 (the other half): an ordinary NON-interrupted failure keeps today's
+    # delete - no .interrupted.md sibling appears (that suffix means "interrupted").
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-ordinary"})
+    attempts = {"n": 0}
+
+    def drive(rec):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            Path(rec["reply_draft"]["path"]).write_text("partial", encoding="utf-8")
+            return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_INFRA,
+                                     summary="killed mid-write")
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=4, k_poison=0, k_escalate=0)
+    assert attempts["n"] >= 2
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    assert not live.exists()
+    assert not live.with_suffix(".interrupted.md").exists()
+
+
+def test_preserve_interrupted_draft_pre_unlinks_the_target(tmp_path) -> None:
+    # Windows rename-over-existing throws: a stale preserved copy from an earlier
+    # interruption must be unlinked first (mirrors preserve_refused_draft).
+    d = tmp_path / "drafts"
+    d.mkdir()
+    live = d / "m-1.md"
+    live.write_text("new partial", encoding="utf-8")
+    stale = d / "m-1.interrupted.md"
+    stale.write_text("old preserved copy", encoding="utf-8")
+    out = reply_transport.preserve_interrupted_draft(live)
+    assert out == stale
+    assert stale.read_text(encoding="utf-8") == "new partial"
+    assert not live.exists()

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -400,6 +400,56 @@ def test_one_shot_interrupted_draft_is_preserved_across_the_in_memory_redrive(tm
     assert _reply_inbox(s, "alpha") == []
 
 
+def test_direct_reply_with_no_draft_this_turn_also_gcs_the_interrupted_draft(
+    tmp_path,
+) -> None:
+    # #202 cold-review P2-6: _deliver_reply_draft used to return EARLY when there
+    # is no LIVE draft this turn (the child answered directly via the CLI/bus
+    # channel instead) - skipping the landed-check entirely, so a preserved
+    # <id>.interrupted.md from an earlier interrupted attempt survived FOREVER
+    # once the retry succeeded via the direct channel (nothing else ever revisits
+    # a head once it commits clean). The landed-check-success path must GC it too.
+    s = _store(tmp_path)
+    q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+               meta={"request_id": "q-direct"})
+    live = reply_transport.reply_draft_path(s, "beta", q.id)
+    preserved = live.with_suffix(".interrupted.md")
+    preserved.parent.mkdir(parents=True, exist_ok=True)
+    preserved.write_text("earlier partial progress", encoding="utf-8")
+
+    def drive(rec):
+        # the child answers directly via the bus, writing NO draft this turn.
+        s.send(sender="beta", recipient="alpha", body="direct answer",
+               meta={"in_reply_to": q.id, "request_id": "q-direct"})
+        return True
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1)
+    assert [m.body for m in _reply_inbox(s, "alpha")] == ["direct answer"]
+    assert not preserved.exists()          # GC'd, not left to linger forever
+
+
+def test_clean_turn_with_no_draft_and_no_interruption_history_never_scans(
+    tmp_path, monkeypatch,
+) -> None:
+    # P2-6 cost guard: a plain clean turn with NO preserved .interrupted.md sibling
+    # must not pay the landed-reply store scan at all (cheap is_file() check first).
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", kind="question", body="q?",
+           meta={"request_id": "q-plain"})
+    scanned = {"n": 0}
+    real_landed = reply_transport.landed_reply_exists
+
+    def counting_landed(*args, **kwargs):
+        scanned["n"] += 1
+        return real_landed(*args, **kwargs)
+
+    monkeypatch.setattr(reply_transport, "landed_reply_exists", counting_landed)
+    loop.run_loop(s, "beta", lambda rec: True, clock=lambda: 0.0,
+                  sleep=lambda d: None, max_turns=1)
+    assert scanned["n"] == 0
+
+
 def test_message_on_review_thread_gets_no_draft_channel(tmp_path) -> None:
     # PR #127 connector P2: a kind=message on a review-request thread (e.g.
     # a needs-info answer) owes a TYPED review-result next — the draft
@@ -523,10 +573,14 @@ def test_preserve_interrupted_draft_pre_unlinks_the_target(tmp_path) -> None:
 
 # ------------------------------------------------------- cold-review FIX 6: GC
 
-def test_dispose_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:
-    # cold-review FIX 6: nothing removed <id>.interrupted.md - a head that is
-    # eventually dead-lettered must GC its preserved-progress sibling too, so it
-    # cannot linger on disk forever.
+def test_interruption_budget_exhausted_dispose_keeps_the_preserved_draft(tmp_path) -> None:
+    # cold-review FIX 6 originally GC'd <id>.interrupted.md on EVERY dispose. #202
+    # cold-review P2-3 narrows that: the interruption-budget-exhausted dispose is
+    # the ONE case where that sibling IS the final progress evidence for the very
+    # interruptions that exhausted the budget - it must be KEPT (not unlinked) so
+    # the operator can inspect/requeue with context. See
+    # test_ordinary_dispose_still_gcs_the_interrupted_draft (test_wrapper_loop.py)
+    # for the still-GC'd ordinary-dispose case.
     s = _store(tmp_path)
     q = s.send(sender="alpha", recipient="beta", kind="question", body="q?",
                meta={"request_id": "q-gc-dispose"})
@@ -546,8 +600,11 @@ def test_dispose_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:
                   interruption_redrive_seconds=0.0)
     assert attempts["n"] == 2                  # 1st preserves attempt 1's draft, 2nd hits k_interrupted
     assert s.dead_lettered_count("beta") == 1
+    entry = s.list_dead_letters("beta")[0]
+    assert entry["last_reason"] == "interruption_budget_exhausted"
     preserved = reply_transport.reply_draft_path(s, "beta", q.id).with_suffix(".interrupted.md")
-    assert not preserved.exists()              # GC'd on dispose - never outlives the head
+    assert preserved.is_file()                 # KEPT - the operator's final progress evidence
+    assert preserved.read_text(encoding="utf-8") == "partial 1"
 
 
 def test_successful_draft_delivery_unlinks_the_preserved_interrupted_draft(tmp_path) -> None:

--- a/tests/test_turn_watchdog.py
+++ b/tests/test_turn_watchdog.py
@@ -560,6 +560,82 @@ def test_make_drive_watchdog_default_path_stamps_store_heartbeat(tmp_path: Path)
     assert s.read_heartbeat("beta") is not None
 
 
+# --------------------- #202 D1: the interruption fact is structural, never sniffed
+
+def test_drive_outcome_marks_watchdog_interruption_on_plain_failure(tmp_path: Path) -> None:
+    # main failure-return site: sig["watchdog"] -> interrupted + kind, structurally.
+    s = _store(tmp_path)
+    st = wsession.load_session(s, "beta", "codex")
+    drive = run.make_drive(s, "beta", "codex", st, ["codex"],
+                           spawn=lambda a, i: _FakeStream(_PARTIAL, returncode=-1,
+                                                          watchdog_result=_WD_RESULT))
+    out = drive({"id": "m1", "body": "x"})
+    assert out.interrupted is True and out.interruption_kind == "turn_watchdog"
+    # and an ORDINARY failure (no watchdog) is overwritten-to-False by construction
+    st2 = wsession.load_session(s, "beta", "codex")
+    drive2 = run.make_drive(s, "beta", "codex", st2, ["codex"],
+                            spawn=lambda a, i: _FakeStream(_PARTIAL, returncode=-1))
+    out2 = drive2({"id": "m1", "body": "x"})
+    assert out2.interrupted is False and out2.interruption_kind is None
+
+
+def test_drive_outcome_marks_interruption_on_resume_rewrite_sites(tmp_path: Path) -> None:
+    # #202 D1: the resume-failure branches REWRITE the outcome summary, so
+    # summary-sniffing is forbidden by construction - the interruption fields must
+    # ride each return structurally. Drive a resumable codex session into a
+    # session-attributable watchdog failure twice: first the "retrying resume"
+    # rewrite, then the "resume_unavailable" rewrite.
+    s = _store(tmp_path)
+    st = wsession.load_session(s, "beta", "codex")
+    st.codex_thread_id = "t-1"                        # build_turn -> exec resume (resume path)
+    # a NON-JSON diagnostic line lands in the discarded tail; with no model output
+    # it makes the failure session-ATTRIBUTABLE ("no session") while the watchdog
+    # still owns the classification.
+    lines = ["No conversation found with session ID: t-1"]
+    drive = run.make_drive(s, "beta", "codex", st, ["codex"],
+                           spawn=lambda a, i: _FakeStream(lines, returncode=1,
+                                                          watchdog_result=_WD_RESULT))
+    out1 = drive({"id": "m1", "body": "x"})
+    assert out1.summary == "resume attempt failed; retrying resume once before fresh session"
+    assert out1.interrupted is True and out1.interruption_kind == "turn_watchdog"
+    out2 = drive({"id": "m1", "body": "x"})
+    assert out2.summary == "resume_unavailable; next attempt will start a fresh session"
+    assert out2.interrupted is True and out2.interruption_kind == "turn_watchdog"
+
+
+def test_make_drive_rejoin_for_reaches_the_child_prompt(tmp_path: Path) -> None:
+    # #202 D4: the injected rejoin_for's block rides assemble_turn_prompt's rejoin
+    # param; a None rejoin (first attempt) leaves the prompt untouched; a raising
+    # provider never kills the turn.
+    s = _store(tmp_path)
+    prompts: list[str] = []
+
+    def spawn(_argv, stdin):
+        prompts.append(stdin)
+        return _FakeStream(_COMPLETED, returncode=0)
+
+    st = wsession.load_session(s, "beta", "codex")
+    drive = run.make_drive(s, "beta", "codex", st, ["codex"], spawn=spawn,
+                           rejoin_for=lambda rec: "previous turn was interrupted")
+    drive({"id": "m1", "body": "x"})
+    assert "== REJOIN CONTEXT ==" in prompts[0]
+    assert "previous turn was interrupted" in prompts[0]
+    st2 = wsession.load_session(s, "beta", "codex")
+    drive2 = run.make_drive(s, "beta", "codex", st2, ["codex"], spawn=spawn,
+                            rejoin_for=lambda rec: None)
+    drive2({"id": "m2", "body": "x"})
+    assert "REJOIN CONTEXT" not in prompts[1]
+
+    def boom(rec):
+        raise RuntimeError("advisory only")
+
+    st3 = wsession.load_session(s, "beta", "codex")
+    drive3 = run.make_drive(s, "beta", "codex", st3, ["codex"], spawn=spawn,
+                            rejoin_for=boom)
+    out = drive3({"id": "m3", "body": "x"})
+    assert out.ok is True and "REJOIN CONTEXT" not in prompts[2]
+
+
 def test_proc_stream_watchdog_enabled_normal_exit_needs_no_wake() -> None:
     stream = run._ProcStream(
         [sys.executable, "-c", "print('done', flush=True)"],

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -599,6 +599,23 @@ def test_run_wrapper_zero_events_refuses_loudly(
     assert "--loop" in err                         # the concrete remedy reaches stderr
 
 
+def test_run_wrapper_injected_line_source_zero_events_refuses_loudly(capsys) -> None:
+    # cold-review FIX 4: the injected-stream branch used to return 0 silently on
+    # zero parseable events. It must refuse the same way the real subprocess
+    # branch does (never a silent success-shaped no-op).
+    rc = run.run_wrapper(
+        cli="codex", agent="worker", argv=["codex"], render=False,
+        line_source=["not json at all\n", "\n"],
+        heartbeat_fn=lambda _event, _now: None,
+        restart_fn=lambda _signal: None,
+        info_fn=lambda _signal: None,
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no turn driven" in err
+    assert "--loop" in err
+
+
 def test_run_wrapper_unknown_cli_raises() -> None:
     import pytest
     # codex + claude are registered (Phase 1 + 2); an unknown CLI has no adapter.

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -562,6 +562,43 @@ def test_run_wrapper_degraded_codex_message_escalates_when_enabled() -> None:
     assert "degraded-output" in restarts[0].reason
 
 
+@pytest.mark.parametrize("child_rc,expected_rc", [(0, 1), (7, 7)])
+def test_run_wrapper_zero_events_refuses_loudly(
+    monkeypatch, capsys, child_rc: int, expected_rc: int,
+) -> None:
+    # #204: a child that produces NO parseable structured events drove nothing - no
+    # heartbeat, no render, no degraded detection. That used to exit 0 (child rc) in
+    # total silence. Now: a one-line stderr diagnostic naming the remedy, and never
+    # exit 0 (a clean child rc becomes 1; a nonzero child rc passes through).
+    class _Stdout:
+        def __iter__(self):
+            return iter(["not json at all\n", "\n"])   # noise only -> zero events
+
+        def close(self):
+            pass
+
+    class _Popen:
+        def __init__(self, argv, **kwargs):
+            _ = argv, kwargs
+            self.stdout = _Stdout()
+
+        def wait(self):
+            return child_rc
+
+    monkeypatch.setattr(run.subprocess, "Popen", _Popen)
+
+    rc = run.run_wrapper(
+        cli="codex", agent="worker", argv=["codex"], render=False,
+        heartbeat_fn=lambda _event, _now: None,
+        restart_fn=lambda _signal: None,
+        info_fn=lambda _signal: None,
+    )
+    assert rc == expected_rc
+    err = capsys.readouterr().err
+    assert "no turn driven" in err
+    assert "--loop" in err                         # the concrete remedy reaches stderr
+
+
 def test_run_wrapper_unknown_cli_raises() -> None:
     import pytest
     # codex + claude are registered (Phase 1 + 2); an unknown CLI has no adapter.

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -761,6 +761,22 @@ def test_never_started_run_at_the_escalate_ceiling_promotes_instead_of_disposing
     assert s.dead_lettered_count("beta") == 0   # the ambiguous dead-letter never fired
 
 
+def test_never_started_signature_matches_only_at_the_start_of_the_summary() -> None:
+    # connector P2 (final head): the canonical signature is only ever PRODUCED at
+    # the start of the summary. An ambiguous diagnostic that merely embeds the
+    # words (child stderr echoed into an unrecognized-cause summary) must not
+    # count - repeated, it would falsely promote to a sticky config_blocked park
+    # with the wrong remedy for a child that DID start.
+    assert loop._is_never_started_failure(
+        loop.CLASS_AMBIGUOUS, "turn never started (rc=1, no clear signal)")
+    assert not loop._is_never_started_failure(
+        loop.CLASS_AMBIGUOUS,
+        "terminal failure, unrecognized cause: child said 'turn never started'")
+    assert not loop._is_never_started_failure(
+        loop.CLASS_INFRA, "turn never started (rc=1, no clear signal)")
+    assert not loop._is_never_started_failure(loop.CLASS_AMBIGUOUS, None)
+
+
 def test_crash_reconcile_resets_never_started_window_for_a_fresh_start(tmp_path) -> None:
     # #7-fix-4: reconcile_crash_in_progress must reset never_started_first_at /
     # never_started_consecutive - a crash breaks the "consecutive never-started"

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -5,6 +5,7 @@ fixture Store + injected drive/spawn - NO real CLI.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import errno
 import gc
 import json
@@ -563,15 +564,43 @@ def test_first_never_started_failure_stays_ambiguous_and_retries(tmp_path) -> No
     assert s.dead_lettered_count("beta") == 0
 
 
+def _now_iso_bumping_after_nth_drive(n: int, delta_seconds: float):
+    """A now_iso() fake whose virtual clock jumps by ``delta_seconds`` the instant the
+    n-th drive() call is made (before it returns) - so everything computed AFTER that
+    call (record_attempt_result, the FIX 2 elapsed-window check) sees the bumped time,
+    while everything up to and including entry to that call still sees the baseline.
+    Returns ``(now_iso, wrap_drive)``; wrap the test's drive callable with ``wrap_drive``."""
+    base = datetime(2026, 8, 25, tzinfo=timezone.utc)
+    clock_box = {"t": 0.0}
+    calls = {"n": 0}
+
+    def now_iso() -> str:
+        return (base + timedelta(seconds=clock_box["t"])).isoformat().replace("+00:00", "Z")
+
+    def wrap_drive(inner):
+        def driven(rec):
+            calls["n"] += 1
+            if calls["n"] == n:
+                clock_box["t"] += delta_seconds
+            return inner(rec)
+        return driven
+
+    return now_iso, wrap_drive
+
+
 def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_path) -> None:
     # #205: the field case - a codex child in a non-git workspace exits rc=1 before any
     # stream output, deterministically. The SECOND consecutive never-started result on
-    # the same head promotes to config_blocked (escalate once + durable park, the
-    # existing #62 machinery) instead of burning 20 ambiguous k_escalate retries.
+    # the same head, ARRIVING AT LEAST NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS after
+    # the first (cold-review FIX 2 - here 90s, well outside the 60s window), promotes to
+    # config_blocked (escalate once + durable park, the existing #62 machinery) instead
+    # of burning 20 ambiguous k_escalate retries.
     s = _store(tmp_path)
     m = s.send(sender="alpha", recipient="beta", body="task")
     drives = {"n": 0}
+    now_iso, wrap_drive = _now_iso_bumping_after_nth_drive(2, 90.0)
 
+    @wrap_drive
     def drive(rec):
         drives["n"] += 1
         return _never_started_drive()
@@ -580,6 +609,7 @@ def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_p
     escalations: list = []
     loop.run_loop(
         s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=now_iso,
         max_polls=4, k_poison=0, k_escalate=20,
         on_escalate=lambda info: escalations.append(info.get("msg_id")) or True,
         on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
@@ -594,6 +624,37 @@ def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_p
     assert len(escalations) == 1                            # escalated exactly once
     assert s.cursor("beta") == ""                           # parked, never committed
     assert s.dead_lettered_count("beta") == 0               # parked, never dead-lettered
+
+
+def test_second_consecutive_never_started_inside_the_window_stays_ambiguous(tmp_path) -> None:
+    # cold-review FIX 2: two never-started samples 0.3-2.0s apart under fail_sleep are NOT
+    # evidence of a deterministic denial - only a transient hiccup (auth refresh, CLI update
+    # banner, AV lock). A second consecutive never-started result arriving WITHIN
+    # NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS (here 30s, inside the 60s window) of the
+    # first must stay ambiguous and keep retrying - never permanently park a healthy seat.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+    now_iso, wrap_drive = _now_iso_bumping_after_nth_drive(2, 30.0)
+
+    @wrap_drive
+    def drive(rec):
+        drives["n"] += 1
+        return _never_started_drive()
+
+    parked: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=now_iso,
+        max_polls=3, k_poison=0, k_escalate=0,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 3                                 # kept retrying - never parked
+    assert parked == []
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_AMBIGUOUS
+    assert s.cursor("beta") == ""
+    assert s.dead_lettered_count("beta") == 0
 
 
 def test_non_never_started_ambiguous_failure_never_promotes(tmp_path) -> None:
@@ -662,6 +723,28 @@ def test_interruption_backoff_is_chunked_and_stamps_during(tmp_path) -> None:
     assert backoff == ["hb", ("sleep", 10.0), "hb", ("sleep", 10.0)]  # 20s remainder, stamped per chunk
 
 
+def test_interruption_backoff_is_hard_capped_for_a_long_crash_chain(tmp_path) -> None:
+    # cold-review FIX 1: base x 2^(n-1) with n=10 and a 60s base UNCAPPED demands
+    # 60 * 2^9 = 30720s (8.5h) - a crash_mid_turn chain is bounded only by k_escalate
+    # (default 20, so n can reach 19 -> ~182 DAYS uncapped), not by k_interrupted.
+    # INTERRUPTION_BACKOFF_CAP_SECONDS (900s) must cap the REQUESTED sleep regardless.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    _seed_interruptions(s, m.id, 10)              # uncapped required = 60 * 2^9 = 30720s
+    events: list = []
+    turns = loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: events.append("drive") or True,
+        clock=lambda: 0.0, sleep=lambda d: events.append(("sleep", d)),
+        heartbeat=lambda: events.append("hb"),
+        now_iso=lambda: _ISO_T0,                  # 0s elapsed since last_failure_at
+        heartbeat_interval=10.0, interruption_redrive_seconds=60.0,
+        k_interrupted=0, max_polls=1, k_poison=0, k_escalate=0)
+    assert turns == 1
+    backoff = events[:events.index("drive")]
+    total_sleep = sum(item[1] for item in backoff if isinstance(item, tuple))
+    assert total_sleep == loop.INTERRUPTION_BACKOFF_CAP_SECONDS  # capped at 900s, not 30720s
+
+
 def test_non_interrupted_failure_keeps_the_ordinary_idle_backoff(tmp_path) -> None:
     # A non-interrupted ambiguous failure must keep today's fail_sleep backoff:
     # no chunked pre-drive sleep, no pre-drive heartbeat stamping.
@@ -720,6 +803,39 @@ def test_third_consecutive_watchdog_interruption_dead_letters_with_remedy(tmp_pa
                      "--agent", "beta", "--id", m.id, "--from", "alpha"]) == 0
     fresh = [msg for msg in s.messages_for("beta") if msg.id not in (m.id, nxt.id)]
     assert fresh and s.attempt_record("beta", fresh[0].id) is None
+
+
+def test_dead_letter_notice_carries_the_remedy_even_when_escalation_already_latched(
+    tmp_path,
+) -> None:
+    # cold-review FIX 3: _escalate_once no-ops when escalation_routed is already
+    # latched (a prior, unrelated escalation on this head routed already) - the
+    # DEAD-LETTER notification (on_dead_letter) must still carry the interruption
+    # remedy, not silently fall back to the ledger's stale last_failure_summary.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="oversized task")
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="pre", at=_ISO_T0)
+    s.record_attempt_result("beta", m.id, failure_class=loop.CLASS_AMBIGUOUS,
+                            summary="an earlier, unrelated failure", at=_ISO_T0)
+    s.mark_attempt_escalated("beta", m.id, routed=True)   # PRE-LATCH: already routed
+
+    escalations: list = []
+    disposals: list = []
+    loop.run_loop(
+        s, "beta", lambda rec: _watchdog_interrupted_outcome(),
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=8, k_poison=0, k_escalate=0, k_interrupted=3,
+        interruption_redrive_seconds=0.0,
+        interruption_budget_seconds=1800.0,
+        on_escalate=lambda info: escalations.append(info) or True,
+        on_dead_letter=lambda info: disposals.append(info),
+    )
+    assert escalations == []                       # already latched - never re-sent
+    assert len(disposals) == 1
+    remedy = disposals[0]["summary"]
+    assert "killed 3 times by turn_watchdog after 1800s each" in remedy
+    assert "turn_watchdog.turn_elapsed_seconds" in remedy
+    assert remedy != "an earlier, unrelated failure"
 
 
 def test_non_interrupted_failure_between_resets_the_interruption_run(tmp_path) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import errno
 import gc
 import json
+import math
 from pathlib import Path
 import re
 import sys
@@ -881,28 +882,32 @@ def test_interruption_backoff_is_hard_capped_for_a_long_crash_chain(tmp_path) ->
     assert total_sleep == loop.INTERRUPTION_BACKOFF_CAP_SECONDS  # capped at 900s, not 30720s
 
 
-def test_interruption_backoff_asserts_finite_if_the_cap_itself_is_corrupted(
+def test_interruption_backoff_bounds_even_a_corrupted_cap_constant(
     tmp_path, monkeypatch,
 ) -> None:
-    # #202 cold-review P2-4 belt: resolve_interruption_policy now refuses a
-    # non-finite/absurd knob before it ever reaches the loop (config error, never a
-    # silent clamp) - the ordinary overflow case (a huge-but-finite base) is
-    # already bounded by INTERRUPTION_BACKOFF_CAP_SECONDS regardless. The residual
-    # risk this assert defends is the CAP itself going bad (e.g. a future
-    # refactor): ``min(inf, nan)`` returns ``inf`` (NaN never wins a comparison),
-    # so a corrupted cap would otherwise sleep an undefined/endless backoff
-    # silently - assert loud instead.
+    # #202 cold-review P2-4 belt (bandit B101 rework: a runtime bound, not an
+    # assert): resolve_interruption_policy refuses non-finite/absurd knobs at
+    # launch, and INTERRUPTION_BACKOFF_CAP_SECONDS bounds ordinary overflow.
+    # The residual risk is the CAP constant itself going bad in a future
+    # refactor: ``min(inf, nan)`` returns ``inf`` (NaN never wins a
+    # comparison). The loop must then degrade to the LITERAL 900s bound —
+    # never an endless chunked sleep, never a non-finite sleep() argument.
     s = _store(tmp_path)
     m = s.send(sender="alpha", recipient="beta", body="task")
     _seed_interruptions(s, m.id, 10)          # base * 2^9 overflows to +inf pre-cap
     monkeypatch.setattr(loop, "INTERRUPTION_BACKOFF_CAP_SECONDS", float("nan"))
-    with pytest.raises(AssertionError):
-        loop.run_loop(
-            Store(tmp_path), "beta", lambda rec: True,
-            clock=lambda: 0.0, sleep=lambda d: None,
-            now_iso=lambda: _ISO_T0,
-            interruption_redrive_seconds=1e308,
-            k_interrupted=0, max_polls=1, k_poison=0, k_escalate=0)
+    sleeps: list = []
+    drove: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta",
+        lambda rec: drove.append(1) or True,
+        clock=lambda: 0.0, sleep=lambda d: sleeps.append(d),
+        now_iso=lambda: _ISO_T0,
+        interruption_redrive_seconds=1e308,
+        k_interrupted=0, max_polls=1, max_turns=1, k_poison=0, k_escalate=0)
+    assert drove, "the head must still drive after the bounded backoff"
+    assert all(math.isfinite(d) for d in sleeps)
+    assert sum(d for d in sleeps) <= 900.0 + 1.0
 
 
 def test_non_interrupted_failure_keeps_the_ordinary_idle_backoff(tmp_path) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -588,6 +588,29 @@ def _now_iso_bumping_after_nth_drive(n: int, delta_seconds: float):
     return now_iso, wrap_drive
 
 
+def _now_iso_bumping_every_drive(delta_seconds: float):
+    """A now_iso() fake whose virtual clock advances by ``delta_seconds`` before
+    EVERY drive() call after the first - simulating a fast, ALWAYS-failing retry
+    loop where each attempt is evenly spaced (unlike ``_now_iso_bumping_after_nth_drive``,
+    which bumps once). Returns ``(now_iso, wrap_drive)``."""
+    base = datetime(2026, 8, 25, tzinfo=timezone.utc)
+    clock_box = {"t": 0.0}
+    calls = {"n": 0}
+
+    def now_iso() -> str:
+        return (base + timedelta(seconds=clock_box["t"])).isoformat().replace("+00:00", "Z")
+
+    def wrap_drive(inner):
+        def driven(rec):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                clock_box["t"] += delta_seconds
+            return inner(rec)
+        return driven
+
+    return now_iso, wrap_drive
+
+
 def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_path) -> None:
     # #205: the field case - a codex child in a non-git workspace exits rc=1 before any
     # stream output, deterministically. The SECOND consecutive never-started result on
@@ -624,6 +647,11 @@ def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_p
     assert len(escalations) == 1                            # escalated exactly once
     assert s.cursor("beta") == ""                           # parked, never committed
     assert s.dead_lettered_count("beta") == 0               # parked, never dead-lettered
+    # #205 cold-review P1-A/P1-B: promotion persists the window state and the
+    # ACTIVE wrapper generation, so a later restart can be told apart from a
+    # same-generation re-poll.
+    assert rec["never_started_consecutive"] == 2
+    assert rec.get("promoted_by_generation")
 
 
 def test_second_consecutive_never_started_inside_the_window_stays_ambiguous(tmp_path) -> None:
@@ -631,7 +659,7 @@ def test_second_consecutive_never_started_inside_the_window_stays_ambiguous(tmp_
     # evidence of a deterministic denial - only a transient hiccup (auth refresh, CLI update
     # banner, AV lock). A second consecutive never-started result arriving WITHIN
     # NEVER_STARTED_PROMOTION_MIN_ELAPSED_SECONDS (here 30s, inside the 60s window) of the
-    # first must stay ambiguous and keep retrying - never permanently park a healthy seat.
+    # FIRST must stay ambiguous and keep retrying - never permanently park a healthy seat.
     s = _store(tmp_path)
     m = s.send(sender="alpha", recipient="beta", body="task")
     drives = {"n": 0}
@@ -655,6 +683,114 @@ def test_second_consecutive_never_started_inside_the_window_stays_ambiguous(tmp_
     assert rec["last_failure_class"] == loop.CLASS_AMBIGUOUS
     assert s.cursor("beta") == ""
     assert s.dead_lettered_count("beta") == 0
+    # #205 cold-review P1-B: the window is measured from the FIRST never-started
+    # failure (not this pairwise gap) - the persisted state proves it.
+    assert rec["never_started_consecutive"] == 3
+    assert rec.get("never_started_first_at") is not None
+
+
+def test_never_started_fast_retry_loop_promotes_once_60s_elapsed_from_first_not_never(
+    tmp_path,
+) -> None:
+    # #205 cold-review P1-B (the actual field bug): a child that ALWAYS fails
+    # never-started, retried at a roughly constant cadence (0.3-2.0s in production;
+    # a fixed 10s here for clean arithmetic), NEVER satisfies a window measured
+    # against the immediately-PRECEDING failure (every gap is 10s < 60s, forever) -
+    # burning k_escalate=20 ambiguous retries again instead of promoting. Measuring
+    # from the FIRST never-started failure promotes at the first result that is
+    # >=60s after it: with a 10s cadence that is the 7th drive (elapsed = 6*10 = 60s).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+    delta = 10.0
+    now_iso, wrap_drive = _now_iso_bumping_every_drive(delta)
+
+    @wrap_drive
+    def drive(rec):
+        drives["n"] += 1
+        return _never_started_drive()
+
+    parked: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=now_iso,
+        max_polls=20, k_poison=0, k_escalate=20,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 7                                 # promotes here, not at 20 (never)
+    assert parked
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_CONFIG_BLOCKED
+    assert rec["never_started_consecutive"] == 7
+    assert s.dead_lettered_count("beta") == 0
+
+
+def test_config_blocked_reprobes_once_on_wrapper_generation_change_and_reparks(
+    tmp_path,
+) -> None:
+    # #205 cold-review P1-A: a sticky config_blocked park never re-fires under an
+    # unchanged class - but the operator CAN fix the underlying denial (workspace
+    # trust, git, auth) and RESTART the wrapper, which mints a NEW wrapper
+    # generation. The entry-check must allow exactly ONE re-probe drive when the
+    # current generation differs from the one that PROMOTED the head - never a
+    # same-generation re-probe (that would be a re-probe storm), and never
+    # unbounded (a still-broken child re-parks recording the NEW generation).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    seed_at = "2026-08-25T00:00:00Z"
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="a0", at=seed_at)
+    s.record_attempt_result(
+        "beta", m.id, failure_class=loop.CLASS_CONFIG_BLOCKED,
+        summary=f"{loop.NEVER_STARTED_REMEDY} (turn never started)", at=seed_at,
+        never_started_first_at=seed_at, never_started_consecutive=2,
+        promoted_by_generation="gen-1")
+
+    # (a) SAME generation on entry: re-parks WITHOUT driving.
+    drives_a: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: drives_a.append(rec["id"]) or True,
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, wrapper_generation="gen-1",
+    )
+    assert drives_a == []
+    assert s.cursor("beta") == ""
+
+    # (b) DIFFERENT generation, still-broken child: drives EXACTLY once, fails
+    # never-started again, and re-promotes recording the NEW generation.
+    drives_b: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta",
+        lambda rec: drives_b.append(rec["id"]) or _never_started_drive(),
+        clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=lambda: "2026-08-25T00:05:00Z",   # well past the 60s window from T0
+        max_polls=2, k_poison=0, k_escalate=20, wrapper_generation="gen-2",
+    )
+    assert drives_b == [m.id]                                # drove exactly once
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_CONFIG_BLOCKED
+    assert rec["promoted_by_generation"] == "gen-2"           # re-parked under the NEW generation
+    assert s.cursor("beta") == ""
+
+    # (c) SAME generation as the re-promotion ("gen-2"): re-parks without driving.
+    drives_c: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: drives_c.append(rec["id"]) or True,
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, wrapper_generation="gen-2",
+    )
+    assert drives_c == []
+
+    # (d) a THIRD generation with the workspace now fixed: drives once and
+    # succeeds, clearing the park entirely.
+    drives_d: list = []
+    turns = loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: drives_d.append(rec["id"]) or True,
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, wrapper_generation="gen-3",
+    )
+    assert drives_d == [m.id]
+    assert turns == 1
+    assert s.cursor("beta") == m.id                           # committed, park cleared
 
 
 def test_non_never_started_ambiguous_failure_never_promotes(tmp_path) -> None:
@@ -745,6 +881,30 @@ def test_interruption_backoff_is_hard_capped_for_a_long_crash_chain(tmp_path) ->
     assert total_sleep == loop.INTERRUPTION_BACKOFF_CAP_SECONDS  # capped at 900s, not 30720s
 
 
+def test_interruption_backoff_asserts_finite_if_the_cap_itself_is_corrupted(
+    tmp_path, monkeypatch,
+) -> None:
+    # #202 cold-review P2-4 belt: resolve_interruption_policy now refuses a
+    # non-finite/absurd knob before it ever reaches the loop (config error, never a
+    # silent clamp) - the ordinary overflow case (a huge-but-finite base) is
+    # already bounded by INTERRUPTION_BACKOFF_CAP_SECONDS regardless. The residual
+    # risk this assert defends is the CAP itself going bad (e.g. a future
+    # refactor): ``min(inf, nan)`` returns ``inf`` (NaN never wins a comparison),
+    # so a corrupted cap would otherwise sleep an undefined/endless backoff
+    # silently - assert loud instead.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    _seed_interruptions(s, m.id, 10)          # base * 2^9 overflows to +inf pre-cap
+    monkeypatch.setattr(loop, "INTERRUPTION_BACKOFF_CAP_SECONDS", float("nan"))
+    with pytest.raises(AssertionError):
+        loop.run_loop(
+            Store(tmp_path), "beta", lambda rec: True,
+            clock=lambda: 0.0, sleep=lambda d: None,
+            now_iso=lambda: _ISO_T0,
+            interruption_redrive_seconds=1e308,
+            k_interrupted=0, max_polls=1, k_poison=0, k_escalate=0)
+
+
 def test_non_interrupted_failure_keeps_the_ordinary_idle_backoff(tmp_path) -> None:
     # A non-interrupted ambiguous failure must keep today's fail_sleep backoff:
     # no chunked pre-drive sleep, no pre-drive heartbeat stamping.
@@ -803,6 +963,59 @@ def test_third_consecutive_watchdog_interruption_dead_letters_with_remedy(tmp_pa
                      "--agent", "beta", "--id", m.id, "--from", "alpha"]) == 0
     fresh = [msg for msg in s.messages_for("beta") if msg.id not in (m.id, nxt.id)]
     assert fresh and s.attempt_record("beta", fresh[0].id) is None
+
+
+def test_interruption_budget_exhausted_dispose_preserves_the_interrupted_draft(
+    tmp_path,
+) -> None:
+    # #202 cold-review P2-3: the interrupted-draft GC-on-dispose (cold-review FIX 6)
+    # must NOT unlink the <id>.interrupted.md sibling when the dispose IS the
+    # interruption-budget-exhausted one - that file is the final progress evidence
+    # for the very interruptions that exhausted the budget, and the operator needs
+    # it most right when the budget trips. The remedy must name its path too.
+    from agenttalk import reply_transport
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="oversized task")
+    preserved = reply_transport.reply_draft_path(s, "beta", m.id).with_suffix(
+        ".interrupted.md")
+    preserved.parent.mkdir(parents=True, exist_ok=True)
+    preserved.write_text("last partial progress before the final kill", encoding="utf-8")
+
+    escalations: list = []
+    loop.run_loop(
+        s, "beta", lambda rec: _watchdog_interrupted_outcome(),
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=3, k_poison=0, k_escalate=0, k_interrupted=3,
+        interruption_redrive_seconds=0.0,
+        on_escalate=lambda info: escalations.append(info) or True,
+    )
+    assert s.dead_lettered_count("beta") == 1
+    assert preserved.is_file()                              # KEPT, not GC'd
+    assert preserved.read_text(encoding="utf-8") == "last partial progress before the final kill"
+    remedy = escalations[0]["summary"]
+    assert "the last preserved partial progress is at:" in remedy
+    assert str(preserved) in remedy
+
+
+def test_ordinary_dispose_still_gcs_the_interrupted_draft(tmp_path) -> None:
+    # P2-3 counterpart: a dispose for any OTHER reason keeps today's GC (cold-review
+    # FIX 6) - only the interruption-budget-exhausted dispose is special-cased.
+    from agenttalk import reply_transport
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    preserved = reply_transport.reply_draft_path(s, "beta", m.id).with_suffix(
+        ".interrupted.md")
+    preserved.parent.mkdir(parents=True, exist_ok=True)
+    preserved.write_text("stale progress", encoding="utf-8")
+
+    def drive(rec):
+        return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_POISON,
+                                 summary="deterministic bad input")
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_polls=1, k_poison=1, k_escalate=0)
+    assert s.dead_lettered_count("beta") == 1
+    assert not preserved.exists()                            # GC'd as today
 
 
 def test_dead_letter_notice_carries_the_remedy_even_when_escalation_already_latched(
@@ -949,10 +1162,42 @@ def test_rejoin_for_builds_block_from_ledger_and_names_the_preserved_draft(tmp_p
     # a DIFFERENT head with no interruption history carries no rejoin (no leak)
     clean = s.send(sender="alpha", recipient="beta", body="other")
     assert rejoin_for({"id": clean.id}) is None
-    # the one-shot in-memory decoration is consumed by the same provider
+    # the one-shot in-memory decoration is consumed by the same provider - #202
+    # cold-review P2-2: _run_one_shot never enforces k_interrupted (bounded by
+    # max_wall instead), so the rejoin must NOT promise a dead-letter budget it
+    # can never reach.
     block2 = rejoin_for({"id": m.id, "interrupted_redelivery": {
         "kind": "turn_watchdog", "consecutive": 1, "last_failure_at": None}})
-    assert "interruption 1 of a budget of 3" in block2
+    assert "no automatic budget applies in one-shot mode" in block2
+    assert "budget of 3" not in block2
+
+
+def test_rejoin_shows_watchdog_only_count_against_the_budget_not_any_kind(
+    tmp_path,
+) -> None:
+    # #202 cold-review P2-5: interrupted_consecutive counts ANY kind (including
+    # crash_mid_turn, which never counts toward k_interrupted); showing it against
+    # the watchdog-only budget OVERSTATES how close the message is to the ceiling
+    # after one crash + one watchdog kill. The budget line must show the
+    # watchdog-only count, and name any extra crash interruptions separately.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    # one crash_mid_turn reconcile, then one turn_watchdog kill (last kind on the
+    # ledger is turn_watchdog, so the budget line applies).
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="c0", at=_ISO_T0)
+    assert s.reconcile_crash_in_progress("beta", m.id, at=_ISO_T0)
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="w0", at=_ISO_T0)
+    s.record_attempt_result("beta", m.id, failure_class=loop.CLASS_AMBIGUOUS,
+                            summary="turn watchdog killed hung tool descendant",
+                            at=_ISO_T0, interrupted=True,
+                            interruption_kind="turn_watchdog")
+    rec = s.attempt_record("beta", m.id)
+    assert rec["interrupted_consecutive"] == 2               # any-kind: crash + watchdog
+    assert rec["interrupted_watchdog_consecutive"] == 1       # watchdog-only
+    rejoin_for = cli._interruption_rejoin_for(s, "beta", 3)
+    block = rejoin_for({"id": m.id})
+    assert "interruption 1 of a budget of 3" in block         # watchdog-only count, not 2
+    assert "plus 1 crash interruption" in block                # crash named separately
 
 
 def test_cmd_wrap_refuses_when_heartbeat_interval_not_below_stuck_after(tmp_path) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -726,6 +726,60 @@ def test_never_started_fast_retry_loop_promotes_once_60s_elapsed_from_first_not_
     assert s.dead_lettered_count("beta") == 0
 
 
+def test_crash_reconcile_resets_never_started_window_for_a_fresh_start(tmp_path) -> None:
+    # #7-fix-4: reconcile_crash_in_progress must reset never_started_first_at /
+    # never_started_consecutive - a crash breaks the "consecutive never-started"
+    # run by definition (the process DID start this attempt; it crashed mid-turn,
+    # which is why it's here). Without the reset, a never-started failure
+    # recorded long BEFORE a crash would let the very next post-crash
+    # never-started failure "inherit" an already-elapsed window and promote
+    # immediately - using a run that was never actually consecutive.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+
+    # A pre-crash never-started failure, long enough ago that its window is
+    # trivially "elapsed" by the time of the crash below.
+    t0 = "2026-08-25T00:00:00Z"
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="a0", at=t0)
+    s.record_attempt_result(
+        "beta", m.id, failure_class=loop.CLASS_AMBIGUOUS,
+        summary="turn never started (rc=1, no clear signal)", at=t0,
+        never_started_first_at=t0, never_started_consecutive=1)
+
+    # A crash mid-turn, long after t0 (in_progress left True == the process died).
+    t1 = "2026-08-25T01:00:00Z"
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="a1", at=t1)
+
+    # Two post-crash never-started drives, only 10s apart - well INSIDE a fresh
+    # 60s window measured from the first POST-CRASH failure.
+    base = datetime(2026, 8, 25, 1, 0, 5, tzinfo=timezone.utc)
+    clock_box = {"t": 0.0}
+    calls = {"n": 0}
+
+    def now_iso() -> str:
+        return (base + timedelta(seconds=clock_box["t"])).isoformat().replace("+00:00", "Z")
+
+    def drive(rec):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            clock_box["t"] += 10.0
+        return _never_started_drive()
+
+    parked: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=now_iso, interruption_redrive_seconds=0.0,
+        max_polls=2, k_poison=0, k_escalate=20,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert calls["n"] == 2
+    assert parked == []                                     # NOT promoted - the window is fresh
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_AMBIGUOUS
+    assert rec["never_started_consecutive"] == 2
+    assert rec["never_started_first_at"] != t0              # window restarted post-crash, not at t0
+
+
 def test_config_blocked_reprobes_once_on_wrapper_generation_change_and_reparks(
     tmp_path,
 ) -> None:
@@ -792,6 +846,55 @@ def test_config_blocked_reprobes_once_on_wrapper_generation_change_and_reparks(
     assert drives_d == [m.id]
     assert turns == 1
     assert s.cursor("beta") == m.id                           # committed, park cleared
+
+
+def test_config_blocked_reprobe_failing_directly_records_current_generation(
+    tmp_path,
+) -> None:
+    # #7-fix-5: the re-probe's failure can land as config_blocked DIRECTLY from
+    # drive() (e.g. #58's gateway-held/sandbox-denial shape), never through the
+    # #205 never-started promotion path - so promoted_by_generation is never set
+    # by that path's own write. Before the fix this left the STALE generation
+    # ("gen-1") on the record forever: a second poll in the SAME "gen-2" process
+    # would then see promoted_gen ("gen-1") != wrapper_generation ("gen-2") and
+    # grant ANOTHER re-probe - a same-generation re-probe storm. The fix threads
+    # the generation the entry-check just consumed through to the re-park write.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    seed_at = "2026-08-25T00:00:00Z"
+    s.record_attempt_start("beta", {"id": m.id}, attempt_id="a0", at=seed_at)
+    s.record_attempt_result(
+        "beta", m.id, failure_class=loop.CLASS_CONFIG_BLOCKED,
+        summary=f"{loop.NEVER_STARTED_REMEDY} (turn never started)", at=seed_at,
+        never_started_first_at=seed_at, never_started_consecutive=2,
+        promoted_by_generation="gen-1")
+
+    # (a) DIFFERENT generation, still-broken child: drives EXACTLY once, fails
+    # DIRECTLY as config_blocked (not never-started), and re-parks recording the
+    # NEW generation instead of leaving "gen-1" stuck on the record.
+    drives_a: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta",
+        lambda rec: drives_a.append(rec["id"]) or _config_blocked_drive(),
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, wrapper_generation="gen-2",
+    )
+    assert drives_a == [m.id]                                # drove exactly once
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_CONFIG_BLOCKED
+    assert rec["promoted_by_generation"] == "gen-2"           # updated, not stuck at "gen-1"
+
+    # (b) a SECOND poll still under "gen-2" (no restart): must re-park WITHOUT
+    # driving again - proving the stale generation no longer grants a
+    # same-generation re-probe storm.
+    drives_b: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: drives_b.append(rec["id"]) or True,
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, wrapper_generation="gen-2",
+    )
+    assert drives_b == []
+    assert s.cursor("beta") == ""
 
 
 def test_non_never_started_ambiguous_failure_never_promotes(tmp_path) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -726,6 +726,41 @@ def test_never_started_fast_retry_loop_promotes_once_60s_elapsed_from_first_not_
     assert s.dead_lettered_count("beta") == 0
 
 
+def test_never_started_run_at_the_escalate_ceiling_promotes_instead_of_disposing(
+    tmp_path,
+) -> None:
+    # connector P1 (final head): fail_sleep retries land 0.3-2.0s apart, so a FAST
+    # deterministic refusal reaches k_escalate=20 attempts in well under the 60s
+    # promotion window (a 1s cadence here: 19s elapsed at attempt 20). Without the
+    # ceiling clause the head dead-letters CLASS_AMBIGUOUS at the ceiling BEFORE
+    # the window can ever elapse - killing the promotion exactly for the fastest,
+    # most clearly deterministic refusals. An unbroken never-started run as long
+    # as the ceiling is deterministic evidence regardless of wall time: promote.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+    now_iso, wrap_drive = _now_iso_bumping_every_drive(1.0)
+
+    @wrap_drive
+    def drive(rec):
+        drives["n"] += 1
+        return _never_started_drive()
+
+    parked: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        now_iso=now_iso,
+        max_polls=25, k_poison=0, k_escalate=20,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 20                    # promoted AT the ceiling, not disposed
+    assert parked
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_CONFIG_BLOCKED
+    assert rec["never_started_consecutive"] == 20
+    assert s.dead_lettered_count("beta") == 0   # the ambiguous dead-letter never fired
+
+
 def test_crash_reconcile_resets_never_started_window_for_a_fresh_start(tmp_path) -> None:
     # #7-fix-4: reconcile_crash_in_progress must reset never_started_first_at /
     # never_started_consecutive - a crash breaks the "consecutive never-started"
@@ -1248,6 +1283,44 @@ def test_one_shot_interrupted_redrive_carries_in_memory_context(tmp_path) -> Non
     assert seen[0] is None                                  # first attempt: no context
     assert seen[1]["kind"] == "turn_watchdog"               # re-drive: in-memory context
     assert seen[1]["consecutive"] == 1
+
+
+def test_one_shot_bound_expiry_preserves_the_interrupted_draft_for_a_later_run(
+    tmp_path,
+) -> None:
+    # connector P2 (final head): one-shot is LEDGER-LESS, so the in-memory
+    # interruption decoration only helps if the SAME invocation gets another
+    # iteration. When the bound (max_polls/max_wall) expires right after a
+    # killed attempt, the partial draft used to stay at the LIVE path - and a
+    # LATER invocation (fresh memory, empty ledger) deleted it as ordinary
+    # stale residue. The interrupted outcome itself must preserve it.
+    from agenttalk import reply_transport
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="the task",
+               meta={"request_id": "rq-1"})
+    live = reply_transport.reply_draft_path(s, "beta", m.id)
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        live.parent.mkdir(parents=True, exist_ok=True)
+        live.write_text("partial progress", encoding="utf-8")
+        return _watchdog_interrupted_outcome()
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=1, only_request_id="rq-1")
+    assert drives["n"] == 1                     # the bound expired before a re-drive
+    preserved = live.with_suffix(".interrupted.md")
+    assert not live.is_file()                   # nothing recoverable left as live residue
+    assert preserved.is_file()                  # the killed attempt's progress survived
+    assert preserved.read_text(encoding="utf-8") == "partial progress"
+
+    # A LATER invocation (fresh memory, still no ledger) must not GC it either.
+    loop.run_loop(s, "beta", lambda rec: loop.DriveOutcome(ok=True),
+                  clock=lambda: 0.0, sleep=lambda d: None,
+                  max_turns=1, max_polls=2, only_request_id="rq-1")
+    assert preserved.is_file()
+    assert preserved.read_text(encoding="utf-8") == "partial progress"
 
 
 def test_rejoin_for_builds_block_from_ledger_and_names_the_preserved_draft(tmp_path) -> None:

--- a/tests/test_wrapper_loop.py
+++ b/tests/test_wrapper_loop.py
@@ -537,6 +537,365 @@ def test_gateway_held_escalates_exactly_once_across_a_long_hold(tmp_path) -> Non
     assert len(escalations) == 1                  # one-shot, not once-per-poll
 
 
+# ------------------- #205: repeated never-started child promotes to config_blocked
+
+def _never_started_drive():
+    return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                             summary="turn never started (rc=1, no clear signal)")
+
+
+def test_first_never_started_failure_stays_ambiguous_and_retries(tmp_path) -> None:
+    # #205 guard: ONE never-started result may be a transient host hiccup - it must NOT
+    # park a healthy seat. It stays ambiguous and the uncommitted head re-drives.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    parked: list = []
+    loop.run_loop(
+        s, "beta", lambda rec: _never_started_drive(),
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=1, k_poison=0, k_escalate=0,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert parked == []                                     # not parked on first sight
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_AMBIGUOUS
+    assert s.cursor("beta") == ""                           # uncommitted -> re-drives
+    assert s.dead_lettered_count("beta") == 0
+
+
+def test_second_consecutive_never_started_parks_config_blocked_with_remedy(tmp_path) -> None:
+    # #205: the field case - a codex child in a non-git workspace exits rc=1 before any
+    # stream output, deterministically. The SECOND consecutive never-started result on
+    # the same head promotes to config_blocked (escalate once + durable park, the
+    # existing #62 machinery) instead of burning 20 ambiguous k_escalate retries.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return _never_started_drive()
+
+    parked: list = []
+    escalations: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=4, k_poison=0, k_escalate=20,
+        on_escalate=lambda info: escalations.append(info.get("msg_id")) or True,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 2                       # one honest retry, then parked - never 20
+    assert parked                                 # visibly parked, not silently retried
+    assert all(pid == m.id and reason == "config_blocked" for pid, reason in parked)
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_CONFIG_BLOCKED
+    assert "child CLI never started" in rec["last_failure_summary"]
+    assert "git repo" in rec["last_failure_summary"]        # names the concrete remedies
+    assert len(escalations) == 1                            # escalated exactly once
+    assert s.cursor("beta") == ""                           # parked, never committed
+    assert s.dead_lettered_count("beta") == 0               # parked, never dead-lettered
+
+
+def test_non_never_started_ambiguous_failure_never_promotes(tmp_path) -> None:
+    # An ambiguous failure WITHOUT the never-started signature (the child started, then
+    # exited nonzero) keeps today's semantics: retry toward the ceiling, never a
+    # config_blocked park.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    drives = {"n": 0}
+
+    def drive(rec):
+        drives["n"] += 1
+        return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                                 summary="nonzero child exit (rc=1) after start")
+
+    parked: list = []
+    loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=4, k_poison=0, k_escalate=0,
+        on_health_parked=lambda rec, reason: parked.append((rec.get("id"), reason)),
+    )
+    assert drives["n"] == 4                                 # re-drove every poll
+    assert parked == []                                     # never promoted/parked
+    rec = s.attempt_record("beta", m.id)
+    assert rec["last_failure_class"] == loop.CLASS_AMBIGUOUS
+
+
+# ------------------- #202: interruption-aware redelivery (backoff, budget, rejoin)
+
+_ISO_T0 = "2026-08-25T00:00:00Z"
+
+
+def _watchdog_interrupted_outcome():
+    return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                             summary="turn watchdog killed hung tool descendant",
+                             interrupted=True, interruption_kind="turn_watchdog")
+
+
+def _seed_interruptions(s, msg_id: str, n: int, *, at: str = _ISO_T0) -> None:
+    for i in range(n):
+        s.record_attempt_start("beta", {"id": msg_id}, attempt_id=f"a{i}", at=at)
+        s.record_attempt_result("beta", msg_id, failure_class=loop.CLASS_AMBIGUOUS,
+                                summary="turn watchdog killed hung tool descendant",
+                                at=at, interrupted=True,
+                                interruption_kind="turn_watchdog")
+
+
+def test_interruption_backoff_is_chunked_and_stamps_during(tmp_path) -> None:
+    # #202 D2: the backoff is computed at HEAD ENTRY from the PERSISTED record (a
+    # NEW Store instance here = simulated relaunch, so in-memory fail_sleep amnesia
+    # cannot skip it) and slept in heartbeat_interval chunks WITH a stamp per chunk
+    # - a deliberately backing-off wrapper never looks stale to the supervisor.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    _seed_interruptions(s, m.id, 1)              # required = 25 * 2^0 = 25s, 5s already elapsed
+    events: list = []
+    turns = loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: events.append("drive") or True,
+        clock=lambda: 0.0, sleep=lambda d: events.append(("sleep", d)),
+        heartbeat=lambda: events.append("hb"),
+        now_iso=lambda: "2026-08-25T00:00:05Z",
+        heartbeat_interval=10.0, interruption_redrive_seconds=25.0,
+        k_interrupted=3, max_polls=1, k_poison=0, k_escalate=0)
+    assert turns == 1
+    backoff = events[:events.index("drive")]
+    assert backoff == ["hb", ("sleep", 10.0), "hb", ("sleep", 10.0)]  # 20s remainder, stamped per chunk
+
+
+def test_non_interrupted_failure_keeps_the_ordinary_idle_backoff(tmp_path) -> None:
+    # A non-interrupted ambiguous failure must keep today's fail_sleep backoff:
+    # no chunked pre-drive sleep, no pre-drive heartbeat stamping.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="task")
+    events: list = []
+    loop.run_loop(
+        s, "beta",
+        lambda rec: events.append("drive") or loop.DriveOutcome(
+            ok=False, failure_class=loop.CLASS_AMBIGUOUS, summary="plain failure"),
+        clock=lambda: 0.0, sleep=lambda d: events.append(("sleep", d)),
+        heartbeat=lambda: events.append("hb"),
+        heartbeat_interval=10.0, interruption_redrive_seconds=60.0,
+        max_polls=2, k_poison=0, k_escalate=0)
+    assert events[0] == "drive"                             # no backoff before the first drive
+    assert events.count("drive") == 2                       # and none before the retry either
+    assert all(d <= 2.0 for kind, d in
+               [e for e in events if isinstance(e, tuple)])  # fail_sleep only, never 10s chunks
+
+
+def test_third_consecutive_watchdog_interruption_dead_letters_with_remedy(tmp_path) -> None:
+    # #202 D3: at k_interrupted the head DEAD-LETTERS (reason
+    # interruption_budget_exhausted), the escalation carries the concrete remedy,
+    # and the cursor ADVANCES - the seat keeps serving the queue (never a park).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="oversized task")
+    nxt = s.send(sender="alpha", recipient="beta", body="next task")
+    driven: list = []
+
+    def drive(rec):
+        driven.append(rec["id"])
+        if rec["id"] == m.id:
+            return _watchdog_interrupted_outcome()
+        return loop.DriveOutcome(ok=True)
+
+    escalations: list = []
+    turns = loop.run_loop(
+        s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=8, k_poison=0, k_escalate=0, k_interrupted=3,
+        interruption_redrive_seconds=0.0,        # backoff off: this test forces the CEILING
+        interruption_budget_seconds=1800.0,
+        on_escalate=lambda info: escalations.append(info) or True)
+    assert driven.count(m.id) == 3                          # three attempts, never 20
+    assert s.dead_lettered_count("beta") == 1
+    entry = s.list_dead_letters("beta")[0]
+    assert entry["last_reason"] == "interruption_budget_exhausted"
+    assert len(escalations) == 1
+    remedy = escalations[0]["summary"]
+    assert "killed 3 times by turn_watchdog after 1800s each" in remedy
+    assert "turn_watchdog.turn_elapsed_seconds" in remedy
+    assert f"agenttalk dead-letter requeue --agent beta --id {m.id}" in remedy
+    assert turns == 1 and driven[-1] == nxt.id              # cursor advanced; seat kept serving
+    assert s.cursor("beta") == nxt.id
+    # requeue after the ceiling yields a FRESH message with a FRESH attempt ledger
+    assert cli.main(["--root", str(tmp_path), "dead-letter", "requeue",
+                     "--agent", "beta", "--id", m.id, "--from", "alpha"]) == 0
+    fresh = [msg for msg in s.messages_for("beta") if msg.id not in (m.id, nxt.id)]
+    assert fresh and s.attempt_record("beta", fresh[0].id) is None
+
+
+def test_non_interrupted_failure_between_resets_the_interruption_run(tmp_path) -> None:
+    # #202 D3: consecutiveness is real - an ordinary failure between watchdog kills
+    # resets the run, so an alternating pattern never reaches the ceiling.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    pattern = [True, True, False, True, True, False]        # never 3 consecutive
+    driven = {"n": 0}
+
+    def drive(rec):
+        interrupted = pattern[driven["n"] % len(pattern)]
+        driven["n"] += 1
+        if interrupted:
+            return _watchdog_interrupted_outcome()
+        return loop.DriveOutcome(ok=False, failure_class=loop.CLASS_AMBIGUOUS,
+                                 summary="plain failure")
+
+    loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                  max_polls=6, k_poison=0, k_escalate=0, k_interrupted=3,
+                  interruption_redrive_seconds=0.0)
+    assert driven["n"] == 6                                  # kept retrying
+    assert s.dead_lettered_count("beta") == 0                # ceiling never tripped
+    rec = s.attempt_record("beta", m.id)
+    assert rec["interrupted_watchdog_consecutive"] < 3
+
+
+def test_crash_mid_turn_interruptions_never_trip_the_interruption_ceiling(tmp_path) -> None:
+    # #202 NEW-2: 3+ crash reconciles leave the head RETRYING UNDER BACKOFF, never
+    # dead-lettered at k_interrupted (the store.py crash_mid_turn ruling stands).
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    for i in range(4):
+        s.record_attempt_start("beta", {"id": m.id}, attempt_id=f"c{i}", at=_ISO_T0)
+        assert s.reconcile_crash_in_progress("beta", m.id, at=_ISO_T0)
+    events: list = []
+    turns = loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: events.append("drive") or True,
+        clock=lambda: 0.0, sleep=lambda d: events.append(("sleep", d)),
+        heartbeat=lambda: events.append("hb"),
+        now_iso=lambda: _ISO_T0,
+        heartbeat_interval=10.0, interruption_redrive_seconds=5.0,
+        k_interrupted=3, max_polls=1, k_poison=0, k_escalate=0)
+    assert s.dead_lettered_count("beta") == 0               # never disposed at the ceiling
+    assert turns == 1 and "drive" in events                 # it DROVE (after backing off)
+    assert events[:2] == ["hb", ("sleep", 10.0)]            # ...under the stamped backoff
+    #                                                         (5 * 2^3 = 40s, chunked at 10s)
+
+
+def test_head_at_interruption_ceiling_on_entry_disposes_without_a_drive(tmp_path) -> None:
+    # #202 NEW-3 (entry mirror): a head already AT the ceiling on entry (killed
+    # between the result-write and the dispose, then relaunched) is disposed
+    # WITHOUT burning another watchdog budget.
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    _seed_interruptions(s, m.id, 3)
+    driven: list = []
+    escalations: list = []
+    loop.run_loop(
+        Store(tmp_path), "beta", lambda rec: driven.append(rec["id"]) or True,
+        clock=lambda: 0.0, sleep=lambda d: None,
+        max_polls=2, k_poison=0, k_escalate=0, k_interrupted=3,
+        interruption_redrive_seconds=0.0,
+        on_escalate=lambda info: escalations.append(info) or True)
+    assert driven == []                                     # disposed WITHOUT another drive
+    assert s.dead_lettered_count("beta") == 1
+    assert s.list_dead_letters("beta")[0]["last_reason"] == "interruption_budget_exhausted"
+    assert escalations and "dead-letter requeue" in escalations[0]["summary"]
+    assert s.cursor("beta") == m.id                         # cursor advanced (self-clearing)
+
+
+def test_one_shot_interrupted_redrive_carries_in_memory_context(tmp_path) -> None:
+    # #202 D4 (one-shot): no attempt ledger - the previous scoped attempt's
+    # interruption rides the record IN-MEMORY so the re-drive still gets a rejoin.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="the task",
+           meta={"request_id": "rq-1"})
+    seen: list = []
+
+    def drive(rec):
+        seen.append(rec.get("interrupted_redelivery"))
+        if len(seen) == 1:
+            return _watchdog_interrupted_outcome()
+        return loop.DriveOutcome(ok=True)
+
+    turns = loop.run_loop(s, "beta", drive, clock=lambda: 0.0, sleep=lambda d: None,
+                          max_turns=1, max_polls=6, only_request_id="rq-1")
+    assert turns == 1
+    assert seen[0] is None                                  # first attempt: no context
+    assert seen[1]["kind"] == "turn_watchdog"               # re-drive: in-memory context
+    assert seen[1]["consecutive"] == 1
+
+
+def test_rejoin_for_builds_block_from_ledger_and_names_the_preserved_draft(tmp_path) -> None:
+    # #202 D4: the cli-built provider reads the PERSISTED ledger per head id (never
+    # leaking across heads), names the preserved draft, and counts attempt n of k.
+    from agenttalk import reply_transport
+    s = _store(tmp_path)
+    m = s.send(sender="alpha", recipient="beta", body="task")
+    _seed_interruptions(s, m.id, 2)
+    preserved = reply_transport.reply_draft_path(s, "beta", m.id).with_suffix(
+        ".interrupted.md")
+    preserved.parent.mkdir(parents=True, exist_ok=True)
+    preserved.write_text("partial progress", encoding="utf-8")
+    rejoin_for = cli._interruption_rejoin_for(s, "beta", 3)
+    block = rejoin_for({"id": m.id})
+    assert "INTERRUPTED (turn_watchdog)" in block
+    assert "interruption 2 of a budget of 3" in block
+    assert str(preserved) in block
+    assert "prefer resuming over redoing" in block
+    # a DIFFERENT head with no interruption history carries no rejoin (no leak)
+    clean = s.send(sender="alpha", recipient="beta", body="other")
+    assert rejoin_for({"id": clean.id}) is None
+    # the one-shot in-memory decoration is consumed by the same provider
+    block2 = rejoin_for({"id": m.id, "interrupted_redelivery": {
+        "kind": "turn_watchdog", "consecutive": 1, "last_failure_at": None}})
+    assert "interruption 1 of a budget of 3" in block2
+
+
+def test_cmd_wrap_refuses_when_heartbeat_interval_not_below_stuck_after(tmp_path) -> None:
+    # #202 D2 launch validation (rev 3): the load-bearing invariant is
+    # heartbeat_interval < stuck_after (the chunked stamp bounds heartbeat age at
+    # heartbeat_interval); refuse at launch with BOTH numbers, config-blocked.
+    import json as _json
+    s = _store(tmp_path)
+    (s.dir / "supervisor.json").write_text(_json.dumps({
+        "agents": {"beta": {"wrapped": True, "cli": "codex",
+                            "stuck_after_seconds": 5}},
+    }), encoding="utf-8")
+    rc = cli.main(["--root", str(tmp_path), "wrap", "--for", "beta", "--cli", "codex",
+                   "--loop", "--", sys.executable, "-c", "pass"])
+    assert rc == 1
+    hold = s.read_config_blocked_hold("beta")
+    assert hold is not None
+    assert "10" in hold["summary"] and "5" in hold["summary"]   # both numbers named
+
+
+def test_cmd_wrap_corrupt_interruption_knob_refuses_visibly(tmp_path) -> None:
+    # #202 D2: a present-but-corrupt knob refuses through the launch
+    # config-blocked path - never silently clamped or defaulted.
+    import json as _json
+    s = _store(tmp_path)
+    (s.dir / "supervisor.json").write_text(_json.dumps({
+        "agents": {"beta": {"interruption_redrive_seconds": "fast"}},
+    }), encoding="utf-8")
+    rc = cli.main(["--root", str(tmp_path), "wrap", "--for", "beta", "--cli", "codex",
+                   "--loop", "--", sys.executable, "-c", "pass"])
+    assert rc == 1
+    hold = s.read_config_blocked_hold("beta")
+    assert hold is not None and "interruption_redrive_seconds" in hold["summary"]
+
+
+def test_cmd_wrap_valid_interruption_config_reaches_the_loop(tmp_path, monkeypatch) -> None:
+    # valid knobs launch and are threaded into the loop (per-agent values win).
+    import json as _json
+    s = _store(tmp_path)
+    (s.dir / "supervisor.json").write_text(_json.dumps({
+        "agents": {"beta": {"interruption_redrive_seconds": 30, "k_interrupted": 2}},
+    }), encoding="utf-8")
+    seen: dict = {}
+
+    def fake_loop(store, agent, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(cli, "_wrap_loop_mode", fake_loop)
+    monkeypatch.setattr(
+        run, "preflight_launch_runtime",
+        lambda argv, _cli, _root, _env: run.LaunchPreflightResult(list(argv)))
+    rc = cli.main(["--root", str(tmp_path), "wrap", "--for", "beta", "--cli", "codex",
+                   "--loop", "--", "codex.exe"])
+    assert rc == 0
+    assert seen["k_interrupted"] == 2
+    assert seen["interruption_redrive_seconds"] == 30.0
+
+
 # --------------------------------------------- make_drive (run.py, injected spawn)
 
 def _codex_turn_lines(thread_id: str = "t-1", text: str = "done") -> list[str]:
@@ -2594,6 +2953,49 @@ def test_cmd_wrap_preflight_success_clears_config_blocked_hold(
     assert seen["agent"] == "beta"
     assert seen["base_argv"] == [str(native), "exec"]
     assert s.read_config_blocked_hold("beta") is None
+
+
+def test_cmd_wrap_plain_silent_child_refuses_loudly_with_remedy(tmp_path, capsys) -> None:
+    # #204: plain `wrap` (no --loop) is the direct progress-adapter over a COMPLETE
+    # child command - it never reads the inbox. A child that emits no structured
+    # events used to exit 0 in total silence (success-shaped no-op, message left
+    # unread, health 'wrapper_completed'). It must refuse loudly with the remedy.
+    s = _store(tmp_path)
+    msg = s.send(sender="alpha", recipient="beta", body="answer me")
+
+    rc = cli.main([
+        "--root", str(tmp_path),
+        "wrap", "--for", "beta", "--cli", "codex",
+        "--", sys.executable, "-c", "pass",
+    ])
+
+    assert rc == 1                                          # no longer a silent exit 0
+    err = capsys.readouterr().err
+    assert "no turn driven" in err                          # one-line diagnostic...
+    assert "--loop" in err                                  # ...with the concrete remedy
+    assert s.cursor("beta") == ""                           # plain mode never consumed it
+    assert s.messages_for("beta")[0].id == msg.id
+    health = s.read_health("beta", ttl_seconds=999999)
+    assert health["reason_code"] == "wrapper_no_turn_driven"  # not 'wrapper_completed'
+
+
+def test_cmd_wrap_to_request_without_one_shot_refuses_loudly(tmp_path, capsys) -> None:
+    # #204: --to-request without --one-shot used to be silently dropped (the wrap ran
+    # unscoped and never drove the named request). Now a loud usage refusal, with and
+    # without --loop.
+    s = _store(tmp_path)
+    s.send(sender="alpha", recipient="beta", body="answer me")
+    for extra in ([], ["--loop"]):
+        rc = cli.main([
+            "--root", str(tmp_path),
+            "wrap", "--for", "beta", "--cli", "codex", *extra,
+            "--to-request", "q-1",
+            "--", sys.executable, "-c", "pass",
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--to-request" in err and "--one-shot" in err  # names the remedy
+    assert s.cursor("beta") == ""                             # nothing was consumed
 
 
 def test_make_drive_retryable_after_start_needs_structured_infra_signal(tmp_path) -> None:


### PR DESCRIPTION
## Theme: seat reliability (v0.85.0 batch 1)

Three field findings from the dogfood migration's dry run + v0.84.0 release smoke.

**#202 — interruption-aware redelivery.** Mechanism investigation overturned the retro's framing: nothing delivers into a live turn; the real sequence is a watchdog/supervisor tree-kill of a running build followed by 0.3s redelivery of the same message into the same resumed session, byte-identical prompt, partial draft deleted — up to 20 rounds (~10h). Now: interruption is a first-class persisted fact; chunked heartbeat-stamped backoff (computed from the persisted ledger at head entry, relaunch-safe, supervisor-safe); 3-strike watchdog-only ceiling ending in a self-clearing dead-letter with the requeue command in the escalation; REJOIN CONTEXT block in the re-driven prompt; interrupted drafts preserved as .interrupted.md. crash_mid_turn keeps its codified k_escalate protection. Design: docs/DESIGN-202-interruption-aware-redelivery.md rev 3 — adversarial review REJECTED rev 1 (3 blockers: the park mechanism didn't exist under the pledged failure class, no un-park path, supervisor-staleness trap) and found 3 new defects in rev 2 (incl. a launch validation that would have refused every wrapped-claude seat at shipped defaults); rev 3 is the reviewer's pre-cleared shape.

**#204 — no silent success-shaped no-ops.** Plain wrap with a zero-event child reported wrapper_completed with zero output; now refuses loudly with both remedies + honest health. --to-request without --one-shot refused at admission instead of silently dropping the scope.

**#205 — deterministic never-started child.** 2 consecutive 'turn never started' failures → config_blocked park with a remedy (workspace trust/git/auth/path) instead of 20 ambiguous retries; shared summary constant prevents classifier/loop drift.

Also files #206 (watchdog condemns the whole descendant tree — the fix that would let a live build FINISH — deliberately separate blast radius).

**Tests:** 26 new; touched suites green locally (~1,950 across wrapper_loop, dead_letter, turn_watchdog, reply_draft_delivery, owed_action, supervisor wrap/launch/admission, canary batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
