### PR TITLE
Console: gate & evidence wall, risk register, ownership map + #207 mechanical fixes

### DIFF
--- a/src/agenttalk/attention.py
+++ b/src/agenttalk/attention.py
@@ -1340,11 +1340,29 @@ def process_tree_hold_items(
     return out
 
 
-def dead_letter_items(entries: list[dict]) -> list[dict]:
+def _age_seconds_from_iso(value: Any, now_epoch: float | None) -> float:
+    """Seconds between an ISO-8601 marker and ``now_epoch`` (0.0 if either is
+    missing/unparseable - fail-safe, never raises). PR #129 connector finding
+    (web.py:3022): a source record that carries its own timestamp must not
+    silently present as "0 seconds old" just because the caller didn't wire
+    a clock through."""
+    if now_epoch is None:
+        return 0.0
+    dt = parse_iso_dt(value)
+    if dt is None:
+        return 0.0
+    return max(0.0, now_epoch - dt.timestamp())
+
+
+def dead_letter_items(entries: list[dict], *, now_epoch: float | None = None) -> list[dict]:
     """Build items from canonical dead-letter entries.
 
     Resolution filtering is applied centrally by ``build_queue`` against each
     entry's source snapshot, so callers pass both resolved and unresolved rows.
+    ``now_epoch`` (optional, keyword-only): derives ``age_seconds`` from the
+    entry's own ``deadlettered_at`` instead of leaving the ``_mk_item``
+    default of 0.0 - omit for a pure/deterministic call (defaults to 0.0,
+    unchanged from before).
     """
     out = []
     for e in entries:
@@ -1354,6 +1372,7 @@ def dead_letter_items(entries: list[dict]) -> list[dict]:
                       title=f"dead-letter: {ag}/{mid}",
                       ident_content=ident,
                       human_can_unblock_now=True,
+                      age_seconds=_age_seconds_from_iso(e.get("deadlettered_at"), now_epoch),
                       fields={"why_it_matters": "a required message could not be delivered",
                               "priority": "high"},
                       source_refs=[{"kind": "dead_letter", "agent": ag, "message_id": mid}])
@@ -1362,8 +1381,11 @@ def dead_letter_items(entries: list[dict]) -> list[dict]:
     return out
 
 
-def gate_hold_items(blockers: list[dict], *, scope: str = "release") -> list[dict]:
-    """Each blocker: gates.check_gates()[...] item {name, reason, scope, ...}."""
+def gate_hold_items(blockers: list[dict], *, scope: str = "release",
+                    now_epoch: float | None = None) -> list[dict]:
+    """Each blocker: gates.check_gates()[...] item {name, reason, scope, ...}.
+    ``now_epoch`` (optional, keyword-only): derives ``age_seconds`` from the
+    blocker's own ``updated_at`` - see ``dead_letter_items``."""
     out = []
     for b in blockers:
         name = b.get("name", "")
@@ -1372,6 +1394,7 @@ def gate_hold_items(blockers: list[dict], *, scope: str = "release") -> list[dic
                       title=f"gate HOLD: {name} ({sc})",
                       ident_content={"scope": sc, "name": name, "reason": b.get("reason")},
                       human_can_unblock_now=True,
+                      age_seconds=_age_seconds_from_iso(b.get("updated_at"), now_epoch),
                       fields={"why_it_matters": b.get("reason") or "", "priority": "high"},
                       source_refs=[{"kind": "gate", "scope": sc, "name": name}])
         it["dedupe_key"] = dedupe_key(SOURCE_GATE_HOLD, identity=f"{sc}:{name}")

--- a/src/agenttalk/attention.py
+++ b/src/agenttalk/attention.py
@@ -1340,18 +1340,29 @@ def process_tree_hold_items(
     return out
 
 
-def _age_seconds_from_iso(value: Any, now_epoch: float | None) -> float:
-    """Seconds between an ISO-8601 marker and ``now_epoch`` (0.0 if either is
-    missing/unparseable - fail-safe, never raises). PR #129 connector finding
-    (web.py:3022): a source record that carries its own timestamp must not
-    silently present as "0 seconds old" just because the caller didn't wire
-    a clock through."""
+def _age_seconds_from_iso(value: Any, now_epoch: float | None) -> tuple[float, bool]:
+    """Returns ``(age_seconds, unknown)``. ``age_seconds`` is 0.0 whenever
+    ``unknown`` is True - the CALLER must check ``unknown`` rather than
+    treating a bare 0.0 as a real "just happened" age (review
+    rq-1a23fd25053d F-2: the original version returned a bare float and
+    conflated "genuinely 0 seconds old" with "we don't actually know",
+    which also meant a source record that could not be timed sorted
+    identically to a brand-new one instead of being flagged, same class as
+    the onboarding ``age_unknown`` convention this now matches). A negative
+    result (the timestamp is in the FUTURE relative to ``now_epoch`` - a
+    skewed writer, not a real age) is ALSO reported unknown rather than
+    silently clamped, matching the fail-safe treatment of an unparseable
+    timestamp instead of the opposite (PR #129 connector finding,
+    web.py:3156, applied here too for the same reasoning)."""
     if now_epoch is None:
-        return 0.0
+        return 0.0, True
     dt = parse_iso_dt(value)
     if dt is None:
-        return 0.0
-    return max(0.0, now_epoch - dt.timestamp())
+        return 0.0, True
+    age = now_epoch - dt.timestamp()
+    if age < 0:
+        return 0.0, True
+    return age, False
 
 
 def dead_letter_items(entries: list[dict], *, now_epoch: float | None = None) -> list[dict]:
@@ -1362,19 +1373,21 @@ def dead_letter_items(entries: list[dict], *, now_epoch: float | None = None) ->
     ``now_epoch`` (optional, keyword-only): derives ``age_seconds`` from the
     entry's own ``deadlettered_at`` instead of leaving the ``_mk_item``
     default of 0.0 - omit for a pure/deterministic call (defaults to 0.0,
-    unchanged from before).
+    unchanged from before). Also stamps ``age_unknown`` (see
+    ``_age_seconds_from_iso``).
     """
     out = []
     for e in entries:
         ag, mid = e.get("agent", ""), e.get("message_id", "")
         ident = dead_letter_entry_notice_state(e)
+        age_seconds, age_unknown = _age_seconds_from_iso(e.get("deadlettered_at"), now_epoch)
         it = _mk_item(SOURCE_DEAD_LETTER, item_id(SOURCE_DEAD_LETTER, ag, mid),
                       title=f"dead-letter: {ag}/{mid}",
                       ident_content=ident,
                       human_can_unblock_now=True,
-                      age_seconds=_age_seconds_from_iso(e.get("deadlettered_at"), now_epoch),
+                      age_seconds=age_seconds,
                       fields={"why_it_matters": "a required message could not be delivered",
-                              "priority": "high"},
+                              "priority": "high", "age_unknown": age_unknown},
                       source_refs=[{"kind": "dead_letter", "agent": ag, "message_id": mid}])
         it["dedupe_key"] = dedupe_key(SOURCE_DEAD_LETTER, identity=f"{ag}:{mid}")
         out.append(it)
@@ -1390,12 +1403,14 @@ def gate_hold_items(blockers: list[dict], *, scope: str = "release",
     for b in blockers:
         name = b.get("name", "")
         sc = b.get("scope", scope)
+        age_seconds, age_unknown = _age_seconds_from_iso(b.get("updated_at"), now_epoch)
         it = _mk_item(SOURCE_GATE_HOLD, item_id(SOURCE_GATE_HOLD, sc, name),
                       title=f"gate HOLD: {name} ({sc})",
                       ident_content={"scope": sc, "name": name, "reason": b.get("reason")},
                       human_can_unblock_now=True,
-                      age_seconds=_age_seconds_from_iso(b.get("updated_at"), now_epoch),
-                      fields={"why_it_matters": b.get("reason") or "", "priority": "high"},
+                      age_seconds=age_seconds,
+                      fields={"why_it_matters": b.get("reason") or "", "priority": "high",
+                              "age_unknown": age_unknown},
                       source_refs=[{"kind": "gate", "scope": sc, "name": name}])
         it["dedupe_key"] = dedupe_key(SOURCE_GATE_HOLD, identity=f"{sc}:{name}")
         out.append(it)

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -6287,12 +6287,18 @@ def _collect_attention_items(store: Store, *, for_agent: str | None, roster: lis
         items.append(A.source_error_item("process_tree_hold", str(e)))
     # dead-letter (ALL; build_queue hides resolved via the resolve_dead_letter disposition)
     try:
-        items += A.dead_letter_items(store.list_dead_letters())
+        # now_epoch (review rq-1a23fd25053d F-1): derive real age_seconds
+        # from each entry's own deadlettered_at, so CLI attention ages match
+        # the console's /api/risk-register (web.py's collector already
+        # threads this - PR #129 connector finding, web.py:3088).
+        items += A.dead_letter_items(store.list_dead_letters(), now_epoch=time.time())
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("dead_letter", str(e)))
     # gate HOLDs (cheap state read, no git/lane recompute)
     try:
-        items += A.gate_hold_items(gate_mod.check_gates(store.root).get("blockers", []))
+        # now_epoch: same rationale as dead_letter_items above.
+        items += A.gate_hold_items(gate_mod.check_gates(store.root).get("blockers", []),
+                                   now_epoch=time.time())
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("gate_hold", str(e)))
     # lead-loop unarmed (managed agents; PURE lead_loop_state, not doctor text)

--- a/src/agenttalk/gates.py
+++ b/src/agenttalk/gates.py
@@ -13,6 +13,11 @@ from agenttalk._atomic import write_text as _atomic_write_text
 
 SCHEMA_VERSION = 1
 
+# PR #129 connector round-2 finding (reviewer-3 F-4): web.py derived its own
+# waiver_expired signal by comparing against this exact reason string as a
+# separate literal - a single shared constant means the two can never drift.
+WAIVER_EXPIRED_REASON = "waiver expired or invalid"
+
 VALID_STATUSES = frozenset({"red", "green", "unknown", "skipped", "waived"})
 VALID_SEVERITIES = frozenset({"blocker", "warn", "info"})
 VALID_EVIDENCE_SOURCES = frozenset({"automation_ci", "local_command", "manual_review", "operator_waiver"})
@@ -207,8 +212,17 @@ def waive_gate(
     return gate
 
 
-def check_gates(root: Path, *, scope: str | None = None, now: datetime | None = None) -> dict:
-    state = load_gate_state(root)
+def check_gates(root: Path, *, scope: str | None = None, now: datetime | None = None,
+                state: dict | None = None) -> dict:
+    """``state`` (optional, PR #129 connector finding web.py:2901): pass an
+    already-loaded ``load_gate_state(root)`` result to compute the verdict
+    from that EXACT snapshot instead of re-reading the file. Without it,
+    this loads fresh (unchanged default behavior) - a caller that ALSO
+    needs the raw state (e.g. for evidence) should load once and pass it
+    here, so a concurrent ``set_gate()`` between two reads can't combine a
+    verdict from one snapshot with evidence from another."""
+    if state is None:
+        state = load_gate_state(root)
     gates = state["gates"]
     required = sorted(set(state["required_gates"]))
     now = now or datetime.now(timezone.utc)
@@ -340,7 +354,7 @@ def _gate_verdict(gate: dict, *, now: datetime) -> dict:
             blocks = False
         else:
             blocks = severity == "blocker"
-            reason = "waiver expired or invalid"
+            reason = WAIVER_EXPIRED_REASON
     elif severity == "blocker" and status != "green":
         # A blocker clears ONLY on validated green (load_gate_state enforces the
         # evidence source/refs for a green blocker) or an active waiver (handled

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -1725,8 +1725,15 @@ def build_state(roots: list[RootDescriptor],
                 *, history: "HealthTimelineRing | None" = None) -> dict:
     """The /api/state aggregate (data-model.md, schema v1).
 
-    ``generated_at`` is informational only — message ids remain the
-    bus's sole ordering primitive.
+    ``generated_at`` is NOT purely informational: message ids remain the
+    bus's sole ordering primitive, but the console's ``stampStatePayload``
+    now also uses this field as its client-side clock/freshness anchor
+    (``stateFresh`` et al.). It is stamped BEFORE the ``[_root_state(d,
+    history) for d in roots]`` scan below, so under a slow scan it can lag
+    the payload it's attached to by however long that scan takes - a known,
+    accepted limitation (PR #129 connector round-5, banked as a fast-follow
+    rather than fixed here: moving the stamp after the scan, or per-root
+    stamping, is new machinery out of this round's bounded scope).
 
     PURE by default: ``history`` is None unless the /api/state route handler
     passes the server's in-memory ring, so every unit/perf test that calls
@@ -2524,6 +2531,12 @@ def _derive_stuck_items(agents: list[dict], *, now: datetime) -> list[dict]:
             continue
         name = a.get("name")
         age = a.get("last_seen_age_seconds")
+        # PR #129 connector round-5 (web.py:3166): a missing last_seen used to
+        # be silently reported as age_seconds=0.0 with no signal that the age
+        # was never known - same conflation _age_seconds_from_iso was fixed
+        # for. Route through the same age_unknown convention so the register
+        # sorts this item as MOST urgent (inf) instead of as "just happened".
+        age_known = isinstance(age, (int, float))
         stuck.append({
             "id": f"stuck:{name}",
             "source": "stuck",
@@ -2532,7 +2545,8 @@ def _derive_stuck_items(agents: list[dict], *, now: datetime) -> list[dict]:
             "title": f"{name} {title_suffix}",
             "agent": name,
             "detail": detail,
-            "age_seconds": float(age) if isinstance(age, (int, float)) else 0.0,
+            "age_seconds": float(age) if age_known else 0.0,
+            "age_unknown": not age_known,
             "human_can_unblock_now": True,
         })
     return stuck
@@ -2834,17 +2848,38 @@ def _gate_evidence_entry(entry: Any) -> dict | None:
         out["source"] = _envelope_str(source)
     refs = entry.get("refs")
     if isinstance(refs, list):
-        out["refs"] = [
-            _envelope_str(r) for r in refs[:_GATE_EVIDENCE_REFS_MAX] if isinstance(r, str)
-        ]
+        window = refs[:_GATE_EVIDENCE_REFS_MAX]
         # PR #129 connector round-2 finding (P1, web.py:2832): a green
         # blocker gate's VALIDATING ref could sit past position 20 and be
         # silently cut, presenting the gate as green with only empty/
         # non-validating refs visible. Preserving every ref isn't safe
         # (unbounded), so expose the cut count instead - the wall can no
         # longer imply it received the complete proof without saying so.
-        if len(refs) > _GATE_EVIDENCE_REFS_MAX:
-            out["refs_truncated"] = len(refs) - _GATE_EVIDENCE_REFS_MAX
+        refs_truncated = max(0, len(refs) - _GATE_EVIDENCE_REFS_MAX)
+        ref_strs: list[str] = []
+        ref_text_truncated = 0
+        for r in window:
+            if not isinstance(r, str):
+                # reviewer-3 F-2: a non-str ref inside the window used to be
+                # dropped by the `isinstance` filter without counting toward
+                # refs_truncated - same shape as evidence_truncated's F-3 fix
+                # for parse-failed evidence entries, applied here too.
+                refs_truncated += 1
+                continue
+            # PR #129 connector round-5 (web.py:2839): a >300-char ref (e.g.
+            # a long evidence URL) was silently cut mid-string by
+            # _envelope_str into a different, unusable string with no signal
+            # that it happened - flag it the same way _glob_str flags a
+            # truncated glob instead of hiding it.
+            normalized = r.replace("\r", " ").replace("\n", " ").strip()
+            if len(normalized) > _ENVELOPE_MAX:
+                ref_text_truncated += 1
+            ref_strs.append(_envelope_str(r))
+        out["refs"] = ref_strs
+        if refs_truncated:
+            out["refs_truncated"] = refs_truncated
+        if ref_text_truncated:
+            out["ref_text_truncated"] = ref_text_truncated
     at = entry.get("at")
     if isinstance(at, str):
         out["at"] = _envelope_str(at)
@@ -3084,6 +3119,19 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             for_agent = None
             degraded.append(_envelope_str(f"liaison_resolution: {e}"))
         items = _collect_web_attention_items(store, roster, for_agent)
+        # PR #129 connector round-2 (reviewer-3 F-1 + connector P1,
+        # web.py:3103): scan the RAW collected items for SOURCE_ERROR here,
+        # BEFORE build_queue applies dispositions. source_error's only
+        # allowed disposition is `defer` (dismiss is forbidden for a
+        # blocking-class warning) - a DEFERRED item is excluded from
+        # queue.get("items", []) by default, so scanning the post-queue
+        # list let an operator defer the warning and see partial=false
+        # again while the underlying source was still genuinely broken.
+        # Deferring silences the REMINDER, not the fact that data is missing.
+        for it in items:
+            if it.get("source") == _attention.SOURCE_ERROR:
+                degraded.append(_envelope_str(
+                    it.get("title") or "attention source unavailable"))
         disps, disposition_problems = _attention.read_dispositions(store)
         if disposition_problems:
             # PR #129 connector finding (web.py:2997): read_dispositions
@@ -3100,16 +3148,6 @@ def build_risk_register(desc: RootDescriptor) -> dict:
         risks: list[dict] = []
         for it in queue.get("items", []):
             src = it.get("source", "")
-            if src == _attention.SOURCE_ERROR:
-                # PR #129 connector finding (P1, web.py:3047): a source-read
-                # failure inside _collect_web_attention_items becomes a
-                # visible, DISPOSITIONABLE SOURCE_ERROR item - an operator
-                # can defer/dismiss it away, silently losing the only
-                # signal that the register could not fully enumerate. Mark
-                # the failure into degraded_sources directly so partial
-                # does not depend on that warning item still being present.
-                degraded.append(_envelope_str(
-                    it.get("title") or "attention source unavailable"))
             mapped = _ATTENTION_SOURCE_MAP.get(src)
             if mapped is None:
                 continue  # unknown internal source — skip rather than mislabel
@@ -3154,6 +3192,12 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             degraded.append(_envelope_str(f"stuck_agents: {e}"))
         for stuck in _derive_stuck_items(agents, now=now):
             stuck_age = float(stuck.get("age_seconds") or 0)
+            # PR #129 connector round-5 (web.py:3166): this hardcoded
+            # age_unknown=False regardless of what _derive_stuck_items
+            # reported - a missing last_seen (age_seconds forced to 0.0)
+            # sorted as the LEAST urgent, the opposite of the age_unknown
+            # convention every other risk source follows.
+            stuck_age_unknown = bool(stuck.get("age_unknown"))
             risks.append({
                 "id": stuck["id"],
                 "category": "stuck",
@@ -3163,9 +3207,9 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 "owner": stuck.get("agent"),
                 "detail": _envelope_str(stuck.get("detail") or ""),
                 "age_seconds": stuck_age,
-                "age_unknown": False,
+                "age_unknown": stuck_age_unknown,
                 "human_can_unblock_now": bool(stuck.get("human_can_unblock_now")),
-                "_sort_age": stuck_age,
+                "_sort_age": float("inf") if stuck_age_unknown else stuck_age,
             })
         try:
             # limit=None, NOT build_onboarding(desc) - that helper caps at

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -55,6 +55,12 @@ Routes
 - ``GET  /static/<name>``       — allowlisted console assets (css/js/png; 0.58.0/0.61.0)
 - ``GET  /api/state``           — multi-root obligation aggregate, schema v1 (0.17.0)
 - ``GET  /api/attention``       — ranked "needs a human" queue for a selected root
+- ``GET  /api/gates``           — gate & evidence wall: every gate's status/
+  severity/evidence/waiver for a selected root
+- ``GET  /api/risk-register``   — client-legible relabel of the attention queue,
+  sorted by severity/age
+- ``GET  /api/ownership``       — full domain-ownership registry (owners/
+  reviewers/curators/shared-paths) for a selected root
 - ``GET  /api/learning``        — lesson ledger + pointer-only exposure telemetry
 - ``GET  /api/onboarding``      — project/codebase onboarding runs + evidence pointers
 - ``GET  /api/thread/<rid>``    — one thread's full transcript, CARRIES bodies (0.58.0)
@@ -86,7 +92,8 @@ message-derived HTML server-side and its client builds DOM via
 ``textContent`` only. The console CSS/JS ship as served files, so the console
 CSP drops ``'unsafe-inline'`` entirely (``script-src 'self'; style-src
 'self'``). Routes that render hostile message bodies (``/messages/<id>``) and
-every JSON feed (``/api/state``, ``/api/attention``, ``/api/learning``,
+every JSON feed (``/api/state``, ``/api/attention``, ``/api/gates``,
+``/api/risk-register``, ``/api/ownership``, ``/api/learning``,
 ``/api/onboarding``,
 ``/api/thread/<rid>``) keep the stricter no-script policy byte-identical.
 """
@@ -2765,6 +2772,320 @@ def _attention_prompt_excerpt(value: Any) -> str:
     return s
 
 
+# --------------------------------------------------- /api/gates (§4c)
+#
+# Gate & Evidence Wall, read side (docs/PROPOSAL-console-client-sellability.md
+# #1 - the "nothing is green without proof" screen). Every gate by scope as a
+# red/green/waived card, with the evidence behind a green and the reason/
+# expiry behind a waiver. READ-ONLY: wraps gates.check_gates's already-
+# computed status/severity/blocks/reason and merges each gate's raw evidence
+# list; today web.py only ever reads ``.get("blockers", [])`` for the
+# attention queue (§4a's ``_collect_web_attention_items``), discarding every
+# green/waived gate and the evidence/waiver detail entirely. No new data
+# capture, no writes - export (proposal #5) is explicitly out of scope here.
+
+_GATE_EVIDENCE_MAX_ENTRIES = 50
+_GATE_EVIDENCE_REFS_MAX = 20
+
+
+def _gate_evidence_entry(entry: Any) -> dict | None:
+    """Bound one raw gates.json evidence entry to safe fields (§4c). Evidence
+    entries are operator/CI-authored (``gates.set_gate``), not raw message
+    bodies, but every string is still capped like every other envelope field
+    - belt-and-braces against an oversized/binary value riding a JSON field
+    that was never meant to carry prose."""
+    if not isinstance(entry, dict):
+        return None
+    out: dict[str, Any] = {}
+    source = entry.get("source")
+    if isinstance(source, str):
+        out["source"] = _envelope_str(source)
+    refs = entry.get("refs")
+    if isinstance(refs, list):
+        out["refs"] = [
+            _envelope_str(r) for r in refs[:_GATE_EVIDENCE_REFS_MAX] if isinstance(r, str)
+        ]
+    at = entry.get("at")
+    if isinstance(at, str):
+        out["at"] = _envelope_str(at)
+    by = entry.get("by")
+    if isinstance(by, str):
+        out["by"] = _envelope_str(by)
+    for key, value in entry.items():
+        if key in ("source", "refs", "at", "by") or key in out:
+            continue
+        if isinstance(value, str):
+            out[key] = _envelope_str(value)
+        elif isinstance(value, (int, float, bool)) or value is None:
+            out[key] = value
+    return out
+
+
+def _gate_waiver_entry(waiver: Any) -> dict | None:
+    if not isinstance(waiver, dict):
+        return None
+    return {
+        "operator": _envelope_str(waiver.get("operator")),
+        "date": _envelope_str(waiver.get("date")),
+        "reason": _envelope_str(waiver.get("reason")),
+        "scope": _envelope_str(waiver.get("scope")),
+        "expires": _envelope_str(waiver.get("expires")),
+    }
+
+
+def build_gates(desc: RootDescriptor) -> dict:
+    """The /api/gates payload for one root (§4c). Envelope-only, GET-only,
+    read-only. Errors-as-data (parity with build_attention/build_state): a
+    corrupt or uninitialized root must NOT 500 this JSON route - it degrades
+    to a 200 body ``{"gates": [], "count": 0, "errors": ["<str(e)>"]}``.
+    """
+    store = desc.store
+    try:
+        from agenttalk import gates as _gates
+
+        checked = _gates.check_gates(store.root)
+        raw_state = _gates.load_gate_state(store.root)
+        raw_gates = raw_state.get("gates")
+        if not isinstance(raw_gates, dict):
+            raw_gates = {}
+        wire: list[dict] = []
+        for item in checked.get("gates", []):
+            name = item.get("name", "")
+            raw = raw_gates.get(name) if isinstance(name, str) else None
+            evidence_raw = raw.get("evidence") if isinstance(raw, dict) else None
+            evidence: list[dict] = []
+            if isinstance(evidence_raw, list):
+                for entry in evidence_raw[:_GATE_EVIDENCE_MAX_ENTRIES]:
+                    parsed = _gate_evidence_entry(entry)
+                    if parsed is not None:
+                        evidence.append(parsed)
+            wire.append({
+                "name": _envelope_str(name),
+                "status": _envelope_str(item.get("status") or "unknown"),
+                "severity": _envelope_str(item.get("severity") or "blocker"),
+                "scope": _envelope_str(item.get("scope") or "global"),
+                "blocks": bool(item.get("blocks")),
+                "reason": _envelope_str(item.get("reason") or ""),
+                "updated_at": _envelope_str(item.get("updated_at") or ""),
+                "updated_by": _envelope_str(item.get("updated_by") or ""),
+                "evidence": evidence,
+                "waiver": _gate_waiver_entry(item.get("waiver")),
+            })
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "verdict": checked.get("verdict", "HOLD"),
+            "required_gates": [
+                _envelope_str(n) for n in (checked.get("required_gates") or [])
+            ],
+            "gates": wire,
+            "count": len(wire),
+        }
+    except Exception as e:  # noqa: BLE001 — errors-as-data, never a 500
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "verdict": "HOLD",
+            "required_gates": [],
+            "gates": [],
+            "count": 0,
+            "errors": [str(e)],
+        }
+
+
+# --------------------------------------------------- /api/risk-register (§4e)
+#
+# Risk Register relabel (docs/PROPOSAL-console-client-sellability.md #6): the
+# SAME ranked queue /api/attention already computes (build_attention, §4a),
+# resorted by severity/age and relabeled with client-legible categories and an
+# owner column instead of the operator triage source tags. READ-ONLY, no new
+# data, no writes.
+#
+# v1 scope note: onboarding drift/unknown items are deliberately NOT folded in
+# here - the proposal's own effort note calls #6 "close to a relabeling
+# exercise" over fields the attention queue ALREADY computes; onboarding
+# findings are a distinct source (see /api/onboarding) with no severity/age/
+# owner shape today, so including them is a fast-follow, not this quick win.
+
+_RISK_CATEGORY_LABELS: dict[str, str] = {
+    "escalation": "Decision needed",
+    "supervisor": "Process health",
+    "gate": "Gate blocker",
+    "deadletter": "Delivery failure",
+    "coordination_stall": "Coordination risk",
+    "stuck": "Process health",
+}
+# severity stays the SAME "high"/"med"/"low" vocabulary /api/attention already
+# uses (not remapped to "medium") so the frontend can reuse the existing
+# SEV_COLOR/SEV_LABEL/.sev-<key> convention verbatim - this is a relabel of
+# category/sort, not a new severity vocabulary.
+_RISK_SEVERITY_ORDER = {"high": 0, "med": 1, "low": 2}
+
+
+def build_risk_register(desc: RootDescriptor) -> dict:
+    """The /api/risk-register payload for one root (§4e). Envelope-only,
+    GET-only, read-only. Errors-as-data (parity with build_attention): a
+    corrupt/uninitialized root degrades to a 200 body with ``items: []`` and
+    an ``errors`` list, never a 500."""
+    store = desc.store
+    now = datetime.now(timezone.utc)
+    try:
+        cfg = _safe_load_config(store)
+        roster = cfg.get("agents", []) or []
+        try:
+            for_agent = store.operator_facing() or store.sole_lead()
+        except Exception:  # noqa: BLE001 — a corrupt root can't resolve a liaison
+            for_agent = None
+        items = _collect_web_attention_items(store, roster, for_agent)
+        disps, _problems = _attention.read_dispositions(store)
+        queue = _attention.build_queue(items, disps,
+                                       now_iso=now.isoformat().replace("+00:00", "Z"))
+        risks: list[dict] = []
+        for it in queue.get("items", []):
+            src = it.get("source", "")
+            mapped = _ATTENTION_SOURCE_MAP.get(src)
+            if mapped is None:
+                continue  # unknown internal source — skip rather than mislabel
+            wire_source, _label, coarse_severity = mapped
+            risks.append({
+                "id": it.get("item_id", ""),
+                "category": wire_source,
+                "category_label": _RISK_CATEGORY_LABELS.get(wire_source, "Other"),
+                "severity": coarse_severity,
+                "title": _envelope_str(it.get("title") or "attention needed"),
+                "owner": _attention_agent(it),
+                "detail": _envelope_str(it.get("why_it_matters") or ""),
+                "age_seconds": float(it.get("age_seconds") or 0),
+                "human_can_unblock_now": bool(it.get("human_can_unblock_now")),
+            })
+        try:
+            agents = _agent_entries(store, cfg, _validated_for_state(store, cfg)[0],
+                                    for_agent)
+        except Exception:  # noqa: BLE001 — stuck items are best-effort
+            agents = []
+        for stuck in _derive_stuck_items(agents, now=now):
+            risks.append({
+                "id": stuck["id"],
+                "category": "stuck",
+                "category_label": _RISK_CATEGORY_LABELS["stuck"],
+                "severity": stuck.get("severity") or "low",
+                "title": _envelope_str(stuck.get("title") or ""),
+                "owner": stuck.get("agent"),
+                "detail": _envelope_str(stuck.get("detail") or ""),
+                "age_seconds": float(stuck.get("age_seconds") or 0),
+                "human_can_unblock_now": bool(stuck.get("human_can_unblock_now")),
+            })
+        risks.sort(key=lambda r: (_RISK_SEVERITY_ORDER.get(r["severity"], 3),
+                                  -r["age_seconds"]))
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "items": risks,
+            "count": len(risks),
+        }
+    except Exception as e:  # noqa: BLE001 — errors-as-data, never a 500
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "items": [],
+            "count": 0,
+            "errors": [str(e)],
+        }
+
+
+# --------------------------------------------------- /api/ownership (§4d)
+#
+# Ownership & Accountability Map (docs/PROPOSAL-console-client-sellability.md
+# #7): the full domain-ownership registry - which agent/team owns which part
+# of the codebase, which paths require shared sign-off - as its own view,
+# instead of the thin per-agent ``owned_domains`` slice /api/state already
+# carries (§3a's ``_owned_domains_map``, only names + globs, only visible on
+# a single agent's detail card). READ-ONLY: a straight read of domains.json
+# via the existing ``domains.load_registry``, no new data, no writes.
+
+def build_ownership(desc: RootDescriptor) -> dict:
+    """The /api/ownership payload for one root (§4d). Envelope-only,
+    GET-only, read-only. A missing registry is a valid empty state
+    (``domains.load_registry`` already returns ``empty_registry()``); a
+    MALFORMED registry degrades to a 200 body with ``domains: []`` and an
+    ``errors`` list, matching build_gates/build_attention's errors-as-data
+    contract rather than a 500."""
+    store = desc.store
+    try:
+        cfg = _safe_load_config(store)
+        try:
+            reg = _domains.load_registry(store.dir / _domains.FILENAME, cfg)
+        except _domains.DomainError as e:
+            return {
+                "root": desc.label,
+                "root_path": str(store.root),
+                "root_info": _root_info(desc),
+                "target_root_project_id": store.project_id(),
+                "domains": [],
+                "shared_paths": [],
+                "count": 0,
+                "errors": [str(e)],
+            }
+        data = reg.data
+        domains: list[dict] = []
+        for did, dentry in sorted((data.get("domains") or {}).items()):
+            if not isinstance(dentry, dict):
+                continue
+            domains.append({
+                "id": _envelope_str(did),
+                "title": _envelope_str(dentry.get("title") or did),
+                "owners": _domains.resolve_refset(dentry.get("owners") or {}, cfg),
+                "reviewers": _domains.resolve_refset(dentry.get("reviewers") or {}, cfg),
+                "curators": _domains.resolve_refset(dentry.get("curators") or {}, cfg),
+                "owned_globs": [
+                    _envelope_str(g) for g in (dentry.get("owned_globs") or [])
+                ],
+                "description": _envelope_str(dentry.get("description") or ""),
+            })
+        shared_paths: list[dict] = []
+        for entry in data.get("shared_paths") or []:
+            if not isinstance(entry, dict):
+                continue
+            shared_paths.append({
+                "glob": _envelope_str(entry.get("glob") or ""),
+                "category": _envelope_str(entry.get("category") or ""),
+                "requires": _envelope_str(entry.get("requires") or ""),
+                "default_reviewers": _domains.resolve_refset(
+                    entry.get("default_reviewers") or {}, cfg),
+                "default_approvers": _domains.resolve_refset(
+                    entry.get("default_approvers") or {}, cfg),
+                "description": _envelope_str(entry.get("description") or ""),
+            })
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "domains": domains,
+            "shared_paths": shared_paths,
+            "count": len(domains),
+        }
+    except Exception as e:  # noqa: BLE001 — errors-as-data, never a 500
+        return {
+            "root": desc.label,
+            "root_path": str(store.root),
+            "root_info": _root_info(desc),
+            "target_root_project_id": store.project_id(),
+            "domains": [],
+            "shared_paths": [],
+            "count": 0,
+            "errors": [str(e)],
+        }
+
+
 # ------------------------------------------------ /api/thread/<rid> (§4b)
 
 def _cli_from_prefix(name: str) -> str | None:
@@ -3835,6 +4156,34 @@ def _make_handler(roots: list[RootDescriptor], *, enable_actions: bool = False) 
                 self._send_json(HTTPStatus.OK,
                                 build_attention(root,
                                                 actions_enabled=enable_actions))
+                return
+            if path == "/api/gates":
+                selected = self._root_selection(self._request_params())
+                if selected is None:
+                    self._bad_root()
+                    return
+                _root_index, root = selected
+                # Gate & Evidence Wall, read side (§4c). Envelope-only,
+                # read-only, strict _DEFAULT_CSP (JSON is not executed).
+                self._send_json(HTTPStatus.OK, build_gates(root))
+                return
+            if path == "/api/risk-register":
+                selected = self._root_selection(self._request_params())
+                if selected is None:
+                    self._bad_root()
+                    return
+                _root_index, root = selected
+                # Client-legible relabel of the /api/attention queue (§4e).
+                self._send_json(HTTPStatus.OK, build_risk_register(root))
+                return
+            if path == "/api/ownership":
+                selected = self._root_selection(self._request_params())
+                if selected is None:
+                    self._bad_root()
+                    return
+                _root_index, root = selected
+                # Ownership & Accountability Map (§4d).
+                self._send_json(HTTPStatus.OK, build_ownership(root))
                 return
             if path == "/api/learning":
                 # Lessons + wrapper exposure telemetry for the selected root.

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2902,14 +2902,11 @@ def build_gates(desc: RootDescriptor) -> dict:
 # Risk Register relabel (docs/PROPOSAL-console-client-sellability.md #6): the
 # SAME ranked queue /api/attention already computes (build_attention, §4a),
 # resorted by severity/age and relabeled with client-legible categories and an
-# owner column instead of the operator triage source tags. READ-ONLY, no new
-# data, no writes.
-#
-# v1 scope note: onboarding drift/unknown items are deliberately NOT folded in
-# here - the proposal's own effort note calls #6 "close to a relabeling
-# exercise" over fields the attention queue ALREADY computes; onboarding
-# findings are a distinct source (see /api/onboarding) with no severity/age/
-# owner shape today, so including them is a fast-follow, not this quick win.
+# owner column instead of the operator triage source tags, PLUS open
+# onboarding drift/unknown findings (the proposal's #6 body explicitly lists
+# "open onboarding drift/unknown" alongside stalled agent/dead letter/gate
+# blocker - review rq-a7038d8175f2 finding 3). READ-ONLY, no new data, no
+# writes.
 
 _RISK_CATEGORY_LABELS: dict[str, str] = {
     "escalation": "Decision needed",
@@ -2918,12 +2915,20 @@ _RISK_CATEGORY_LABELS: dict[str, str] = {
     "deadletter": "Delivery failure",
     "coordination_stall": "Coordination risk",
     "stuck": "Process health",
+    "onboarding_drift": "Doc/code drift",
+    "onboarding_unknown": "Open unknown",
 }
 # severity stays the SAME "high"/"med"/"low" vocabulary /api/attention already
 # uses (not remapped to "medium") so the frontend can reuse the existing
 # SEV_COLOR/SEV_LABEL/.sev-<key> convention verbatim - this is a relabel of
 # category/sort, not a new severity vocabulary.
 _RISK_SEVERITY_ORDER = {"high": 0, "med": 1, "low": 2}
+# attention.py's typed meta.attention risk_severity vocabulary is "low" /
+# "medium" / "high" (RISK_LEVELS) - distinct spelling from the wire's "med".
+# "unknown" (the _mk_item default when a source never set it) intentionally
+# has NO entry here, so an untyped item falls through to the coarse
+# per-source severity below rather than silently becoming "low".
+_RISK_SEVERITY_FROM_TYPED = {"high": "high", "medium": "med", "low": "low"}
 
 
 def build_risk_register(desc: RootDescriptor) -> dict:
@@ -2951,11 +2956,18 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             if mapped is None:
                 continue  # unknown internal source — skip rather than mislabel
             wire_source, _label, coarse_severity = mapped
+            # Prefer the item's OWN typed risk assessment (an operator-authored
+            # escalation's meta.attention.risk_severity) over the coarse
+            # per-source default - a low-risk escalation must not be forced to
+            # "high" just because escalations are high-severity on average
+            # (review rq-a7038d8175f2 finding 1).
+            severity = _RISK_SEVERITY_FROM_TYPED.get(
+                it.get("risk_severity"), coarse_severity)
             risks.append({
                 "id": it.get("item_id", ""),
                 "category": wire_source,
                 "category_label": _RISK_CATEGORY_LABELS.get(wire_source, "Other"),
-                "severity": coarse_severity,
+                "severity": severity,
                 "title": _envelope_str(it.get("title") or "attention needed"),
                 "owner": _attention_agent(it),
                 "detail": _envelope_str(it.get("why_it_matters") or ""),
@@ -2979,6 +2991,33 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 "age_seconds": float(stuck.get("age_seconds") or 0),
                 "human_can_unblock_now": bool(stuck.get("human_can_unblock_now")),
             })
+        try:
+            onboarding = build_onboarding(desc)
+            for run in onboarding.get("runs") or []:
+                run_records = run.get("records") or {}
+                for kind, category in (
+                    ("drift", "onboarding_drift"),
+                    ("unknown", "onboarding_unknown"),
+                ):
+                    for rec in run_records.get(kind) or []:
+                        if rec.get("status") != "open":
+                            continue
+                        age = _age_seconds_of(rec.get("updated_at"), now=now)
+                        blocking = bool(rec.get("blocking"))
+                        risks.append({
+                            "id": f"onboarding:{run.get('run_id')}:{kind}:{rec.get('key')}",
+                            "category": category,
+                            "category_label": _RISK_CATEGORY_LABELS[category],
+                            "severity": "high" if blocking else "med",
+                            "title": _envelope_str(
+                                rec.get("summary") or f"{kind}: {rec.get('key')}"),
+                            "owner": (rec.get("owner") or rec.get("actor")) or None,
+                            "detail": _envelope_str(run.get("title") or ""),
+                            "age_seconds": age if age is not None else 0.0,
+                            "human_can_unblock_now": blocking,
+                        })
+        except Exception:  # noqa: BLE001, S110 — onboarding risk items are best-effort  # nosec B110
+            pass
         risks.sort(key=lambda r: (_RISK_SEVERITY_ORDER.get(r["severity"], 3),
                                   -r["age_seconds"]))
         return {

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2819,14 +2819,20 @@ def _gate_evidence_entry(entry: Any) -> dict | None:
     # field list isn't viable here. Bound the KEY the same way every value is
     # already bounded, and cap how many extra keys ride one entry (entries
     # themselves are already capped at _GATE_EVIDENCE_MAX_ENTRIES).
+    #
+    # R-1 (review rq-e05589aa3c80, follow-up on F-2): the reserved-name and
+    # duplicate check MUST run on the bounded key, not the raw one - a raw
+    # key like "source " (trailing space) or two long keys sharing the same
+    # 64-char prefix are DISTINCT raw keys but collide once bounded, and
+    # checking the raw key let a collision silently overwrite an
+    # already-populated field (the canonical "source" in the first case).
+    # Skip on collision (first write wins) rather than overwrite.
     extra_keys = 0
     for key, value in entry.items():
-        if key in ("source", "refs", "at", "by") or key in out:
-            continue
         if not isinstance(key, str) or extra_keys >= _GATE_EVIDENCE_EXTRA_KEYS_MAX:
             continue
         bounded_key = _envelope_str(key)[:_GATE_EVIDENCE_KEY_MAX]
-        if not bounded_key:
+        if not bounded_key or bounded_key in ("source", "refs", "at", "by") or bounded_key in out:
             continue
         if isinstance(value, str):
             out[bounded_key] = _envelope_str(value)

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2992,27 +2992,37 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 "human_can_unblock_now": bool(stuck.get("human_can_unblock_now")),
             })
         try:
-            onboarding = build_onboarding(desc)
-            for run in onboarding.get("runs") or []:
+            # limit=None, NOT build_onboarding(desc) - that helper caps at
+            # _ONBOARDING_DEFAULT_LIMIT (50) newest-first runs for the
+            # Onboarding VIEW's presentation payload. A risk register must
+            # source "each open item" (proposal §3 #6) without that cap: an
+            # older unresolved drift/unknown must not silently vanish once
+            # 50 newer runs exist (review rq-4ecf94c4f814 finding 1).
+            all_runs = _onboarding.list_runs(store, limit=None).get("runs") or []
+            for run in all_runs:
                 run_records = run.get("records") or {}
+                run_id = _onboarding_short(run.get("run_id") or run.get("id"), limit=96)
+                run_title = _onboarding_short(run.get("title"), limit=240)
                 for kind, category in (
-                    ("drift", "onboarding_drift"),
-                    ("unknown", "onboarding_unknown"),
+                    (_onboarding.KIND_DRIFT, "onboarding_drift"),
+                    (_onboarding.KIND_UNKNOWN, "onboarding_unknown"),
                 ):
                     for rec in run_records.get(kind) or []:
-                        if rec.get("status") != "open":
+                        if not isinstance(rec, dict) or rec.get("status") != "open":
                             continue
                         age = _age_seconds_of(rec.get("updated_at"), now=now)
                         blocking = bool(rec.get("blocking"))
+                        owner = rec.get("owner") or rec.get("actor") or None
                         risks.append({
-                            "id": f"onboarding:{run.get('run_id')}:{kind}:{rec.get('key')}",
+                            "id": f"onboarding:{run_id}:{kind}:"
+                                  f"{_onboarding_short(rec.get('key'), limit=128)}",
                             "category": category,
                             "category_label": _RISK_CATEGORY_LABELS[category],
                             "severity": "high" if blocking else "med",
                             "title": _envelope_str(
                                 rec.get("summary") or f"{kind}: {rec.get('key')}"),
-                            "owner": (rec.get("owner") or rec.get("actor")) or None,
-                            "detail": _envelope_str(run.get("title") or ""),
+                            "owner": _onboarding_short(owner, limit=96) if owner else None,
+                            "detail": run_title,
                             "age_seconds": age if age is not None else 0.0,
                             "human_can_unblock_now": blocking,
                         })

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2753,15 +2753,22 @@ def _envelope_str(value: Any) -> str:
 # globs display identically (PR #129 connector finding, web.py:3183). Bound
 # it much more generously - effectively lossless for any realistic
 # repo-relative pattern - while still capping a corrupted/pathological value.
+# PR #129 connector round-2 (web.py:2763, folds in reviewer-3 F-5): raising
+# the cap from _ENVELOPE_MAX to this alone just MOVES the same silent-
+# truncation threshold rather than removing it - a >4096-char glob would
+# still be silently altered. _glob_str now returns whether it truncated so
+# the caller can expose that explicitly instead of claiming losslessness it
+# cannot guarantee.
 _GLOB_MAX = 4096
 
 
-def _glob_str(value: Any) -> str:
+def _glob_str(value: Any) -> tuple[str, bool]:
+    """Returns ``(bounded_glob, truncated)``."""
     s = "" if value is None else str(value)
     s = s.replace("\r", " ").replace("\n", " ").strip()
     if len(s) > _GLOB_MAX:
-        s = s[:_GLOB_MAX]
-    return s
+        return s[:_GLOB_MAX], True
+    return s, False
 
 
 def _operator_command_str(value: Any) -> str:
@@ -2830,6 +2837,14 @@ def _gate_evidence_entry(entry: Any) -> dict | None:
         out["refs"] = [
             _envelope_str(r) for r in refs[:_GATE_EVIDENCE_REFS_MAX] if isinstance(r, str)
         ]
+        # PR #129 connector round-2 finding (P1, web.py:2832): a green
+        # blocker gate's VALIDATING ref could sit past position 20 and be
+        # silently cut, presenting the gate as green with only empty/
+        # non-validating refs visible. Preserving every ref isn't safe
+        # (unbounded), so expose the cut count instead - the wall can no
+        # longer imply it received the complete proof without saying so.
+        if len(refs) > _GATE_EVIDENCE_REFS_MAX:
+            out["refs_truncated"] = len(refs) - _GATE_EVIDENCE_REFS_MAX
     at = entry.get("at")
     if isinstance(at, str):
         out["at"] = _envelope_str(at)
@@ -2897,8 +2912,15 @@ def build_gates(desc: RootDescriptor) -> dict:
     try:
         from agenttalk import gates as _gates
 
-        checked = _gates.check_gates(store.root)
+        # PR #129 connector round-2 finding (P2, web.py:2901): check_gates()
+        # and load_gate_state() used to be TWO separate reads - a set_gate()
+        # commit landing between them could combine the verdict/status from
+        # the FIRST snapshot with evidence/waiver data from the SECOND
+        # (green beside proof that didn't produce it, or green with no
+        # proof at all). Load once, derive the verdict from that exact
+        # snapshot.
         raw_state = _gates.load_gate_state(store.root)
+        checked = _gates.check_gates(store.root, state=raw_state)
         raw_gates = raw_state.get("gates")
         if not isinstance(raw_gates, dict):
             raw_gates = {}
@@ -2917,11 +2939,25 @@ def build_gates(desc: RootDescriptor) -> dict:
                 # current green status/updated_at next to evidence that did
                 # NOT produce it, while the evidence that actually did was
                 # cut. Keep the NEWEST entries and expose the cut count.
-                evidence_truncated = max(0, len(evidence_raw) - _GATE_EVIDENCE_MAX_ENTRIES)
-                for entry in evidence_raw[-_GATE_EVIDENCE_MAX_ENTRIES:]:
+                # L-1 (review rq-1a23fd25053d): guard cap<=0 explicitly -
+                # Python's ``xs[-0:]`` is ``xs[0:]`` (the WHOLE list, not
+                # nothing), so a naive ``evidence_raw[-cap:]`` would silently
+                # return everything if the cap constant were ever 0.
+                cap = _GATE_EVIDENCE_MAX_ENTRIES
+                evidence_truncated = max(0, len(evidence_raw) - cap)
+                newest = evidence_raw[-cap:] if cap > 0 else []
+                for entry in newest:
                     parsed = _gate_evidence_entry(entry)
                     if parsed is not None:
                         evidence.append(parsed)
+                    else:
+                        # F-3 (review rq-1a23fd25053d): an entry that fails
+                        # to parse (not a dict) was silently dropped without
+                        # counting toward evidence_truncated - the wall
+                        # could then show FEWER entries than the cap implied
+                        # with no signal that any were lost to a shape
+                        # problem rather than the cap itself.
+                        evidence_truncated += 1
             reason = _envelope_str(item.get("reason") or "")
             waiver = item.get("waiver")
             wire.append({
@@ -2942,7 +2978,11 @@ def build_gates(desc: RootDescriptor) -> dict:
                 # expired warn/info waiver even though it sets this exact
                 # reason string. A severity-independent signal so the view
                 # doesn't need blocks as a (wrong, for warn/info) proxy.
-                "waiver_expired": bool(waiver) and reason == "waiver expired or invalid",
+                # F-4 (review rq-1a23fd25053d): derived from gates.
+                # WAIVER_EXPIRED_REASON, the SAME constant gates.py:343 sets
+                # this reason to, not a separately-typed literal that could
+                # drift out of sync.
+                "waiver_expired": bool(waiver) and reason == _gates.WAIVER_EXPIRED_REASON,
             })
         return {
             "root": desc.label,
@@ -3060,6 +3100,16 @@ def build_risk_register(desc: RootDescriptor) -> dict:
         risks: list[dict] = []
         for it in queue.get("items", []):
             src = it.get("source", "")
+            if src == _attention.SOURCE_ERROR:
+                # PR #129 connector finding (P1, web.py:3047): a source-read
+                # failure inside _collect_web_attention_items becomes a
+                # visible, DISPOSITIONABLE SOURCE_ERROR item - an operator
+                # can defer/dismiss it away, silently losing the only
+                # signal that the register could not fully enumerate. Mark
+                # the failure into degraded_sources directly so partial
+                # does not depend on that warning item still being present.
+                degraded.append(_envelope_str(
+                    it.get("title") or "attention source unavailable"))
             mapped = _ATTENTION_SOURCE_MAP.get(src)
             if mapped is None:
                 continue  # unknown internal source — skip rather than mislabel
@@ -3071,6 +3121,12 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             # (review rq-a7038d8175f2 finding 1).
             severity = _RISK_SEVERITY_FROM_TYPED.get(
                 it.get("risk_severity"), coarse_severity)
+            # age_unknown (review rq-1a23fd25053d F-2): gate/dead-letter
+            # items now stamp this via attention._age_seconds_from_iso when
+            # their source timestamp was missing/unparseable/future -
+            # every other source leaves it absent, i.e. known.
+            age_unknown = bool(it.get("age_unknown"))
+            age_seconds = float(it.get("age_seconds") or 0)
             risks.append({
                 "id": it.get("item_id", ""),
                 "category": wire_source,
@@ -3085,8 +3141,10 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 # needed" category) don't lose their owner column entirely.
                 "owner": _attention_agent(it) or it.get("requester") or None,
                 "detail": _envelope_str(it.get("why_it_matters") or ""),
-                "age_seconds": float(it.get("age_seconds") or 0),
+                "age_seconds": age_seconds,
+                "age_unknown": age_unknown,
                 "human_can_unblock_now": bool(it.get("human_can_unblock_now")),
+                "_sort_age": float("inf") if age_unknown else age_seconds,
             })
         try:
             agents = _agent_entries(store, cfg, _validated_for_state(store, cfg)[0],
@@ -3095,6 +3153,7 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             agents = []
             degraded.append(_envelope_str(f"stuck_agents: {e}"))
         for stuck in _derive_stuck_items(agents, now=now):
+            stuck_age = float(stuck.get("age_seconds") or 0)
             risks.append({
                 "id": stuck["id"],
                 "category": "stuck",
@@ -3103,8 +3162,10 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 "title": _envelope_str(stuck.get("title") or ""),
                 "owner": stuck.get("agent"),
                 "detail": _envelope_str(stuck.get("detail") or ""),
-                "age_seconds": float(stuck.get("age_seconds") or 0),
+                "age_seconds": stuck_age,
+                "age_unknown": False,
                 "human_can_unblock_now": bool(stuck.get("human_can_unblock_now")),
+                "_sort_age": stuck_age,
             })
         try:
             # limit=None, NOT build_onboarding(desc) - that helper caps at
@@ -3134,6 +3195,17 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                         if not isinstance(rec, dict) or rec.get("status") != "open":
                             continue
                         age = _age_seconds_of(rec.get("updated_at"), now=now)
+                        if age is not None and age < 0:
+                            # PR #129 connector finding (web.py:3156): a
+                            # bounded-but-future updated_at (a skewed
+                            # external writer) parses fine and produces a
+                            # NEGATIVE age - treating that as "known" clamps
+                            # display to 0s and sorts it to the LEAST urgent
+                            # end of its band, the opposite of the fail-safe
+                            # "unknown is not safe" treatment an unparseable
+                            # timestamp already gets. Route it through the
+                            # exact same unknown-age path.
+                            age = None
                         blocking = bool(rec.get("blocking"))
                         owner = rec.get("owner") or rec.get("actor") or None
                         risks.append({
@@ -3238,23 +3310,35 @@ def build_ownership(desc: RootDescriptor) -> dict:
         for did, dentry in sorted((data.get("domains") or {}).items()):
             if not isinstance(dentry, dict):
                 continue
+            owned_globs: list[str] = []
+            owned_globs_truncated = 0
+            for g in (dentry.get("owned_globs") or []):
+                bounded, glob_cut = _glob_str(g)
+                owned_globs.append(bounded)
+                if glob_cut:
+                    owned_globs_truncated += 1
             domains.append({
                 "id": _envelope_str(did),
                 "title": _envelope_str(dentry.get("title") or did),
                 "owners": _domains.resolve_refset(dentry.get("owners") or {}, cfg),
                 "reviewers": _domains.resolve_refset(dentry.get("reviewers") or {}, cfg),
                 "curators": _domains.resolve_refset(dentry.get("curators") or {}, cfg),
-                "owned_globs": [
-                    _glob_str(g) for g in (dentry.get("owned_globs") or [])
-                ],
+                "owned_globs": owned_globs,
+                # PR #129 connector round-2 (web.py:2763 / reviewer-3 F-5): a
+                # count of how many of THIS domain's globs were still cut by
+                # _GLOB_MAX, so a client never has to trust "long enough" -
+                # it can see when it wasn't.
+                "owned_globs_truncated": owned_globs_truncated,
                 "description": _envelope_str(dentry.get("description") or ""),
             })
         shared_paths: list[dict] = []
         for entry in data.get("shared_paths") or []:
             if not isinstance(entry, dict):
                 continue
+            glob_bounded, glob_truncated = _glob_str(entry.get("glob") or "")
             shared_paths.append({
-                "glob": _glob_str(entry.get("glob") or ""),
+                "glob": glob_bounded,
+                "glob_truncated": glob_truncated,
                 "category": _envelope_str(entry.get("category") or ""),
                 "requires": _envelope_str(entry.get("requires") or ""),
                 "default_reviewers": _domains.resolve_refset(

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -2786,6 +2786,8 @@ def _attention_prompt_excerpt(value: Any) -> str:
 
 _GATE_EVIDENCE_MAX_ENTRIES = 50
 _GATE_EVIDENCE_REFS_MAX = 20
+_GATE_EVIDENCE_EXTRA_KEYS_MAX = 20
+_GATE_EVIDENCE_KEY_MAX = 64
 
 
 def _gate_evidence_entry(entry: Any) -> dict | None:
@@ -2811,13 +2813,28 @@ def _gate_evidence_entry(entry: Any) -> dict | None:
     by = entry.get("by")
     if isinstance(by, str):
         out["by"] = _envelope_str(by)
+    # F-2 (review rq-093f956dd595): every OTHER key from gates.json's
+    # operator-defined evidence_details passes through too - gates.py leaves
+    # that schema open by design (coverage_percent, pr_url, ...), so a closed
+    # field list isn't viable here. Bound the KEY the same way every value is
+    # already bounded, and cap how many extra keys ride one entry (entries
+    # themselves are already capped at _GATE_EVIDENCE_MAX_ENTRIES).
+    extra_keys = 0
     for key, value in entry.items():
         if key in ("source", "refs", "at", "by") or key in out:
             continue
+        if not isinstance(key, str) or extra_keys >= _GATE_EVIDENCE_EXTRA_KEYS_MAX:
+            continue
+        bounded_key = _envelope_str(key)[:_GATE_EVIDENCE_KEY_MAX]
+        if not bounded_key:
+            continue
         if isinstance(value, str):
-            out[key] = _envelope_str(value)
+            out[bounded_key] = _envelope_str(value)
         elif isinstance(value, (int, float, bool)) or value is None:
-            out[key] = value
+            out[bounded_key] = value
+        else:
+            continue
+        extra_keys += 1
     return out
 
 
@@ -2929,22 +2946,47 @@ _RISK_SEVERITY_ORDER = {"high": 0, "med": 1, "low": 2}
 # has NO entry here, so an untyped item falls through to the coarse
 # per-source severity below rather than silently becoming "low".
 _RISK_SEVERITY_FROM_TYPED = {"high": "high", "medium": "med", "low": "low"}
+# F-1 (review rq-093f956dd595): every neighboring surface in this diff bounds
+# itself (_ONBOARDING_DEFAULT_LIMIT, _GATE_EVIDENCE_MAX_ENTRIES, ...) - the
+# register itself was left unbounded after removing the 50-run cap. A high
+# cap + an explicit `truncated` count keeps the "an old item must not
+# silently vanish" intent (the point was never "no bound", only "no SILENT
+# bound").
+_RISK_REGISTER_ITEM_CAP = 500
+# B-1/B-2 (review rq-093f956dd595): cap how many degraded-source notes ride
+# the payload, so a pathological number of corrupt onboarding runs can't
+# blow up the response - the COUNT of open items lost is what matters to a
+# human, not an unbounded list of which ones.
+_RISK_DEGRADED_MAX = 50
 
 
 def build_risk_register(desc: RootDescriptor) -> dict:
     """The /api/risk-register payload for one root (§4e). Envelope-only,
     GET-only, read-only. Errors-as-data (parity with build_attention): a
     corrupt/uninitialized root degrades to a 200 body with ``items: []`` and
-    an ``errors`` list, never a 500."""
+    an ``errors`` list, never a 500.
+
+    B-1 (review rq-093f956dd595): a register whose CONTRACT is "each open
+    item" must never let an inner collection failure render as a confident,
+    error-free "0 risks" - that is indistinguishable from a genuine all-clear
+    and is the worst failure mode for a screen whose purpose is letting a
+    client conclude nothing is outstanding. Every inner best-effort fallback
+    below (liaison resolution, stuck-agent derivation, onboarding) now
+    records what it lost into ``degraded``, surfaced as ``partial`` +
+    ``degraded_sources`` even on an otherwise-200 response - never silently
+    swallowed.
+    """
     store = desc.store
     now = datetime.now(timezone.utc)
+    degraded: list[str] = []
     try:
         cfg = _safe_load_config(store)
         roster = cfg.get("agents", []) or []
         try:
             for_agent = store.operator_facing() or store.sole_lead()
-        except Exception:  # noqa: BLE001 — a corrupt root can't resolve a liaison
+        except Exception as e:  # noqa: BLE001 — a corrupt root can't resolve a liaison
             for_agent = None
+            degraded.append(_envelope_str(f"liaison_resolution: {e}"))
         items = _collect_web_attention_items(store, roster, for_agent)
         disps, _problems = _attention.read_dispositions(store)
         queue = _attention.build_queue(items, disps,
@@ -2977,8 +3019,9 @@ def build_risk_register(desc: RootDescriptor) -> dict:
         try:
             agents = _agent_entries(store, cfg, _validated_for_state(store, cfg)[0],
                                     for_agent)
-        except Exception:  # noqa: BLE001 — stuck items are best-effort
+        except Exception as e:  # noqa: BLE001
             agents = []
+            degraded.append(_envelope_str(f"stuck_agents: {e}"))
         for stuck in _derive_stuck_items(agents, now=now):
             risks.append({
                 "id": stuck["id"],
@@ -2998,7 +3041,15 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             # source "each open item" (proposal §3 #6) without that cap: an
             # older unresolved drift/unknown must not silently vanish once
             # 50 newer runs exist (review rq-4ecf94c4f814 finding 1).
-            all_runs = _onboarding.list_runs(store, limit=None).get("runs") or []
+            onboarding_result = _onboarding.list_runs(store, limit=None)
+            all_runs = onboarding_result.get("runs") or []
+            # B-2: a run whose ledger fails to parse is SKIPPED from `runs`
+            # and only ever named in `problems` - discarding that channel
+            # drops the run's open findings with no signal at all, no
+            # exception required. Surface which runs were unreadable.
+            for p in (onboarding_result.get("problems") or [])[:_RISK_DEGRADED_MAX]:
+                degraded.append(_envelope_str(
+                    f"onboarding_run:{_onboarding_short(p.get('run_id'), limit=96)}"))
             for run in all_runs:
                 run_records = run.get("records") or {}
                 run_id = _onboarding_short(run.get("run_id") or run.get("id"), limit=96)
@@ -3023,13 +3074,34 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                                 rec.get("summary") or f"{kind}: {rec.get('key')}"),
                             "owner": _onboarding_short(owner, limit=96) if owner else None,
                             "detail": run_title,
+                            # L-2: an unparseable updated_at must not read as
+                            # "0 seconds old" (misleadingly fresh) AND must
+                            # not silently sort to the bottom of its severity
+                            # band (deprioritized) - "unknown" is flagged
+                            # explicitly and sorted as the MOST urgent within
+                            # its band via the internal-only _sort_age below.
                             "age_seconds": age if age is not None else 0.0,
-                            "human_can_unblock_now": blocking,
+                            "age_unknown": age is None,
+                            # L-1: "blocking" (an onboarding workflow-progress
+                            # claim) is a DIFFERENT claim from "a human can
+                            # clear this right now" (a triage-affordance
+                            # claim the attention pipeline computes
+                            # separately for every other source). Nothing
+                            # external gates a human from acting on an
+                            # onboarding finding, so this is unconditionally
+                            # true here - not copied from `blocking`.
+                            "human_can_unblock_now": True,
+                            "_sort_age": age if age is not None else float("inf"),
                         })
-        except Exception:  # noqa: BLE001, S110 — onboarding risk items are best-effort  # nosec B110
-            pass
+        except Exception as e:  # noqa: BLE001
+            degraded.append(_envelope_str(f"onboarding: {e}"))
         risks.sort(key=lambda r: (_RISK_SEVERITY_ORDER.get(r["severity"], 3),
-                                  -r["age_seconds"]))
+                                  -r.get("_sort_age", r["age_seconds"])))
+        truncated = max(0, len(risks) - _RISK_REGISTER_ITEM_CAP)
+        risks = risks[:_RISK_REGISTER_ITEM_CAP]
+        for r in risks:
+            r.pop("_sort_age", None)
+        degraded = degraded[:_RISK_DEGRADED_MAX]
         return {
             "root": desc.label,
             "root_path": str(store.root),
@@ -3037,6 +3109,9 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             "target_root_project_id": store.project_id(),
             "items": risks,
             "count": len(risks),
+            "truncated": truncated,
+            "partial": bool(degraded),
+            "degraded_sources": degraded,
         }
     except Exception as e:  # noqa: BLE001 — errors-as-data, never a 500
         return {
@@ -3046,6 +3121,9 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             "target_root_project_id": store.project_id(),
             "items": [],
             "count": 0,
+            "truncated": 0,
+            "partial": True,
+            "degraded_sources": degraded[:_RISK_DEGRADED_MAX],
             "errors": [str(e)],
         }
 

--- a/src/agenttalk/web.py
+++ b/src/agenttalk/web.py
@@ -105,6 +105,7 @@ import html
 import hmac
 import ipaddress
 import json
+import math
 import re
 import secrets
 import socket
@@ -2424,12 +2425,18 @@ def _collect_web_attention_items(store: Store, roster: list[str],
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("process_tree_hold", str(e)))
     try:
-        items += A.dead_letter_items(store.list_dead_letters())
+        # now_epoch (PR #129 connector finding): derive real age_seconds
+        # from each entry's own deadlettered_at instead of leaving every
+        # dead letter reading as freshly-created.
+        items += A.dead_letter_items(store.list_dead_letters(), now_epoch=time.time())
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("dead_letter", str(e)))
     try:
         from agenttalk import gates as _gates
-        items += A.gate_hold_items(_gates.check_gates(store.root).get("blockers", []))
+        # now_epoch (PR #129 connector finding): derive real age_seconds
+        # from each blocker's own updated_at, same rationale as above.
+        items += A.gate_hold_items(_gates.check_gates(store.root).get("blockers", []),
+                                   now_epoch=time.time())
     except Exception as e:  # noqa: BLE001
         items.append(A.source_error_item("gate_hold", str(e)))
     try:
@@ -2741,6 +2748,22 @@ def _envelope_str(value: Any) -> str:
     return s
 
 
+# A glob is matching SYNTAX, not prose: truncating one at _ENVELOPE_MAX can
+# silently change which paths it matches, or make two DISTINCT ownership
+# globs display identically (PR #129 connector finding, web.py:3183). Bound
+# it much more generously - effectively lossless for any realistic
+# repo-relative pattern - while still capping a corrupted/pathological value.
+_GLOB_MAX = 4096
+
+
+def _glob_str(value: Any) -> str:
+    s = "" if value is None else str(value)
+    s = s.replace("\r", " ").replace("\n", " ").strip()
+    if len(s) > _GLOB_MAX:
+        s = s[:_GLOB_MAX]
+    return s
+
+
 def _operator_command_str(value: Any) -> str:
     """Return one complete, bounded operator command without body-like text."""
     if not isinstance(value, str):
@@ -2836,6 +2859,14 @@ def _gate_evidence_entry(entry: Any) -> dict | None:
             continue
         if isinstance(value, str):
             out[bounded_key] = _envelope_str(value)
+        elif isinstance(value, float) and not math.isfinite(value):
+            # PR #129 connector finding (P2, web.py:2840): json.dumps
+            # (Python's loader too) accepts NaN/Infinity by default, but
+            # they are not valid per strict JSON - a browser's
+            # response.json() rejects them outright, which would fail the
+            # WHOLE /api/gates payload for one bad field instead of
+            # degrading just this entry. Never forward a non-finite float.
+            continue
         elif isinstance(value, (int, float, bool)) or value is None:
             out[bounded_key] = value
         else:
@@ -2877,22 +2908,41 @@ def build_gates(desc: RootDescriptor) -> dict:
             raw = raw_gates.get(name) if isinstance(name, str) else None
             evidence_raw = raw.get("evidence") if isinstance(raw, dict) else None
             evidence: list[dict] = []
+            evidence_truncated = 0
             if isinstance(evidence_raw, list):
-                for entry in evidence_raw[:_GATE_EVIDENCE_MAX_ENTRIES]:
+                # PR #129 connector finding (P1, web.py:2881): set_gate
+                # APPENDS chronologically, so slicing from the START kept
+                # the OLDEST entries - once a gate passed
+                # _GATE_EVIDENCE_MAX_ENTRIES updates, the wall could show a
+                # current green status/updated_at next to evidence that did
+                # NOT produce it, while the evidence that actually did was
+                # cut. Keep the NEWEST entries and expose the cut count.
+                evidence_truncated = max(0, len(evidence_raw) - _GATE_EVIDENCE_MAX_ENTRIES)
+                for entry in evidence_raw[-_GATE_EVIDENCE_MAX_ENTRIES:]:
                     parsed = _gate_evidence_entry(entry)
                     if parsed is not None:
                         evidence.append(parsed)
+            reason = _envelope_str(item.get("reason") or "")
+            waiver = item.get("waiver")
             wire.append({
                 "name": _envelope_str(name),
                 "status": _envelope_str(item.get("status") or "unknown"),
                 "severity": _envelope_str(item.get("severity") or "blocker"),
                 "scope": _envelope_str(item.get("scope") or "global"),
                 "blocks": bool(item.get("blocks")),
-                "reason": _envelope_str(item.get("reason") or ""),
+                "reason": reason,
                 "updated_at": _envelope_str(item.get("updated_at") or ""),
                 "updated_by": _envelope_str(item.get("updated_by") or ""),
                 "evidence": evidence,
-                "waiver": _gate_waiver_entry(item.get("waiver")),
+                "evidence_truncated": evidence_truncated,
+                "waiver": _gate_waiver_entry(waiver),
+                # PR #129 connector finding (P2, console.js:2277): blocks=True
+                # marks an expired waiver as blocking ONLY for severity=
+                # blocker - gates._gate_verdict leaves blocks=False for an
+                # expired warn/info waiver even though it sets this exact
+                # reason string. A severity-independent signal so the view
+                # doesn't need blocks as a (wrong, for warn/info) proxy.
+                "waiver_expired": bool(waiver) and reason == "waiver expired or invalid",
             })
         return {
             "root": desc.label,
@@ -2994,7 +3044,17 @@ def build_risk_register(desc: RootDescriptor) -> dict:
             for_agent = None
             degraded.append(_envelope_str(f"liaison_resolution: {e}"))
         items = _collect_web_attention_items(store, roster, for_agent)
-        disps, _problems = _attention.read_dispositions(store)
+        disps, disposition_problems = _attention.read_dispositions(store)
+        if disposition_problems:
+            # PR #129 connector finding (web.py:2997): read_dispositions
+            # already reports malformed/torn/unreadable lines through its
+            # second return value - discarding it here is the SAME
+            # silent-partial-read shape as B-2 (onboarding problems), just
+            # for a different source. A damaged defer/resolve record can
+            # leave a risk shown as active while the payload still claimed
+            # partial=false.
+            degraded.append(_envelope_str(
+                f"dispositions: {len(disposition_problems)} unreadable record(s)"))
         queue = _attention.build_queue(items, disps,
                                        now_iso=now.isoformat().replace("+00:00", "Z"))
         risks: list[dict] = []
@@ -3017,7 +3077,13 @@ def build_risk_register(desc: RootDescriptor) -> dict:
                 "category_label": _RISK_CATEGORY_LABELS.get(wire_source, "Other"),
                 "severity": severity,
                 "title": _envelope_str(it.get("title") or "attention needed"),
-                "owner": _attention_agent(it),
+                # PR #129 connector finding (web.py:3020): a needs_operator
+                # escalation's source_refs only carry {kind, request_id} - no
+                # "agent" key - so _attention_agent(it) alone always misses.
+                # needs_operator_items already stamps the requester onto the
+                # item; fall back to it so escalations (the "decision
+                # needed" category) don't lose their owner column entirely.
+                "owner": _attention_agent(it) or it.get("requester") or None,
                 "detail": _envelope_str(it.get("why_it_matters") or ""),
                 "age_seconds": float(it.get("age_seconds") or 0),
                 "human_can_unblock_now": bool(it.get("human_can_unblock_now")),
@@ -3179,7 +3245,7 @@ def build_ownership(desc: RootDescriptor) -> dict:
                 "reviewers": _domains.resolve_refset(dentry.get("reviewers") or {}, cfg),
                 "curators": _domains.resolve_refset(dentry.get("curators") or {}, cfg),
                 "owned_globs": [
-                    _envelope_str(g) for g in (dentry.get("owned_globs") or [])
+                    _glob_str(g) for g in (dentry.get("owned_globs") or [])
                 ],
                 "description": _envelope_str(dentry.get("description") or ""),
             })
@@ -3188,7 +3254,7 @@ def build_ownership(desc: RootDescriptor) -> dict:
             if not isinstance(entry, dict):
                 continue
             shared_paths.append({
-                "glob": _envelope_str(entry.get("glob") or ""),
+                "glob": _glob_str(entry.get("glob") or ""),
                 "category": _envelope_str(entry.get("category") or ""),
                 "requires": _envelope_str(entry.get("requires") or ""),
                 "default_reviewers": _domains.resolve_refset(

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -314,6 +314,9 @@ body {
   background: var(--ok);
   animation: liveDot 1.8s ease-in-out infinite;
 }
+.tc-live.is-stale .tc-live-dot { background: var(--danger); animation: none; }
+.tc-live.is-waiting .tc-live-dot { background: var(--gray); animation: none; }
+.tc-live.is-stale .tc-live-label { color: var(--danger); }
 .tc-live-label { font-weight: 500; }
 .tc-clock { font-family: var(--font-mono); color: var(--ink3); }
 

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -277,6 +277,9 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(40vw, 520px);
   padding: 6px 12px;
   border-radius: 8px;
   background: var(--surface2);
@@ -285,7 +288,13 @@ body {
   color: var(--ink2);
 }
 .tc-mission-pill svg { flex: none; }
-.tc-mission-name { font-weight: 500; }
+.tc-mission-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
 .tc-mission-frac { font-family: var(--font-mono); color: var(--ink3); }
 
 .tc-spacer { flex: 1; }

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -1220,6 +1220,94 @@ body {
 .sev-med  { color: var(--warn); background: var(--warn-soft); }
 .sev-low  { color: var(--chip-neutral); background: var(--chip-neutral-bg); }
 
+/* Secondary section heading (e.g. "Shared paths" under Ownership). */
+.tc-h2 {
+  margin: 22px 0 10px;
+  font-family: var(--font-head);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+/* Gate & Evidence Wall (§4c) + Ownership & Accountability Map (§4d) cards.
+   Both reuse the plain .tc-card shell with their own padding/left-bar accent,
+   the same pattern .tc-attn-card uses for the human queue. */
+.tc-gate-list, .tc-domain-list { display: flex; flex-direction: column; gap: 12px; }
+.tc-gate-card, .tc-domain-card {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tc-gate-card.gate-green  { box-shadow: inset 3px 0 0 var(--ok), 0 1px 2px var(--shadow); }
+.tc-gate-card.gate-red    { box-shadow: inset 3px 0 0 var(--danger), 0 1px 2px var(--shadow); }
+.tc-gate-card.gate-waived { box-shadow: inset 3px 0 0 var(--violet), 0 1px 2px var(--shadow); }
+.tc-gate-card.gate-unknown,
+.tc-gate-card.gate-skipped { box-shadow: inset 3px 0 0 var(--gray), 0 1px 2px var(--shadow); }
+
+.tc-gate-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.tc-gate-name { font-size: 14.5px; font-weight: 500; color: var(--ink); }
+.tc-gate-scope, .tc-gate-severity {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink4);
+  text-transform: uppercase;
+  letter-spacing: .02em;
+}
+.tc-chip.gate-green   { color: var(--ok); background: var(--ok-soft); }
+.tc-chip.gate-red      { color: var(--danger); background: var(--danger-soft); }
+.tc-chip.gate-waived   { color: var(--violet); background: var(--violet-soft); }
+.tc-chip.gate-unknown,
+.tc-chip.gate-skipped  { color: var(--chip-neutral); background: var(--chip-neutral-bg); }
+.tc-gate-verdict { font-family: var(--font-mono); font-weight: 600; }
+
+.tc-gate-reason { font-size: 12px; color: var(--ink3); }
+.tc-gate-updated { font-size: 11px; color: var(--ink4); margin-top: 2px; }
+
+.tc-gate-waiver {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--inset);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.tc-gate-waiver-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--violet);
+}
+.tc-gate-waiver-line { font-size: 12px; color: var(--ink2); }
+
+.tc-gate-evidence { display: flex; flex-direction: column; gap: 3px; }
+.tc-gate-evidence-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--ink4);
+}
+.tc-gate-evidence-row { font-size: 12px; color: var(--ink2); }
+.tc-gate-evidence-refs {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink3);
+  overflow-wrap: anywhere;
+}
+
+.tc-domain-line { font-size: 12.5px; color: var(--ink2); }
+.tc-domain-globs {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink3);
+  overflow-wrap: anywhere;
+}
+
 /* Empty "All clear" state */
 .tc-empty {
   background: var(--surface);

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -2152,6 +2152,13 @@ body {
   to { opacity: 1; transform: none; }
 }
 
+/* Desktop keeps secondary material in its original layout. At phone widths
+   the native details wrapper becomes a visible, keyboard-operable disclosure. */
+.tc-secondary-panel { display: contents; }
+.tc-secondary-summary { display: none; }
+.tc-lead-secondary,
+.tc-session-actions { display: flex; flex-direction: column; gap: 12px; }
+
 @media (max-width: 900px) {
   #topbar {
     height: auto;
@@ -2226,6 +2233,40 @@ body {
 }
 
 @media (max-width: 560px) {
+  .tc-priority-primary {
+    order: -1;
+  }
+  .tc-secondary-panel {
+    display: block;
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .tc-secondary-summary {
+    display: block;
+    padding: 11px 13px;
+    color: var(--ink2);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .tc-secondary-panel[open] > .tc-secondary-summary {
+    border-bottom: 1px solid var(--border);
+  }
+  .tc-secondary-panel > .tc-lead-secondary,
+  .tc-secondary-panel > .tc-session-actions,
+  .tc-secondary-panel > .tc-legend {
+    padding: 12px;
+  }
+  .tc-secondary-panel > .tc-card,
+  .tc-secondary-panel > .tc-rail,
+  .tc-secondary-panel > .tc-stats,
+  .tc-secondary-panel > .tc-learning-stats,
+  .tc-secondary-panel > .tc-onboarding-stats {
+    border: 0;
+    border-radius: 0 0 var(--radius) var(--radius);
+  }
   .tc-project-context {
     flex-basis: calc(100% - 130px);
   }

--- a/src/agenttalk/web_static/console.css
+++ b/src/agenttalk/web_static/console.css
@@ -1240,7 +1240,8 @@ body {
   gap: 6px;
 }
 .tc-gate-card.gate-green  { box-shadow: inset 3px 0 0 var(--ok), 0 1px 2px var(--shadow); }
-.tc-gate-card.gate-red    { box-shadow: inset 3px 0 0 var(--danger), 0 1px 2px var(--shadow); }
+.tc-gate-card.gate-red,
+.tc-gate-card.gate-waived_expired { box-shadow: inset 3px 0 0 var(--danger), 0 1px 2px var(--shadow); }
 .tc-gate-card.gate-waived { box-shadow: inset 3px 0 0 var(--violet), 0 1px 2px var(--shadow); }
 .tc-gate-card.gate-unknown,
 .tc-gate-card.gate-skipped { box-shadow: inset 3px 0 0 var(--gray), 0 1px 2px var(--shadow); }
@@ -1255,7 +1256,8 @@ body {
   letter-spacing: .02em;
 }
 .tc-chip.gate-green   { color: var(--ok); background: var(--ok-soft); }
-.tc-chip.gate-red      { color: var(--danger); background: var(--danger-soft); }
+.tc-chip.gate-red,
+.tc-chip.gate-waived_expired { color: var(--danger); background: var(--danger-soft); }
 .tc-chip.gate-waived   { color: var(--violet); background: var(--violet-soft); }
 .tc-chip.gate-unknown,
 .tc-chip.gate-skipped  { color: var(--chip-neutral); background: var(--chip-neutral-bg); }
@@ -1281,6 +1283,10 @@ body {
   text-transform: uppercase;
   color: var(--violet);
 }
+/* An EXPIRED waiver is back to blocking - it must read as danger, not the
+   calm purple "still covered" waiver color (review rq-a7038d8175f2 #2). */
+.tc-gate-waiver.is-expired { border-color: var(--danger); }
+.tc-gate-waiver.is-expired .tc-gate-waiver-title { color: var(--danger); }
 .tc-gate-waiver-line { font-size: 12px; color: var(--ink2); }
 
 .tc-gate-evidence { display: flex; flex-direction: column; gap: 3px; }

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -121,7 +121,7 @@
     view: 'overview',
     selectedAgent: null,   // agent name
     sessionRid: null,      // thread request_id
-    filter: 'all',         // all | working | idle | attention
+    filter: 'active',      // active run by default; all history remains opt-in
     selectedRootId: initialRootId(),
     now: null,             // server-derived wall time; never the browser clock
   };
@@ -831,13 +831,25 @@
     }
     return c;
   }
+  function agentInActiveRun(agent) {
+    // A supervised seat remains part of the run while recovering/exited; hiding
+    // it would conceal exactly the operator-critical failure state. An
+    // unsupervised seat is current only while its independent heartbeat is fresh.
+    return !!agent && (agent.wrapped === true || freshHeartbeat(agent));
+  }
+  function activeRunCount(root) {
+    var as = agentsOf(root), count = 0;
+    for (var i = 0; i < as.length; i++) if (agentInActiveRun(as[i])) count++;
+    return count;
+  }
   function filterAgents(root) {
     var as = agentsOf(root);
     if (state.filter === 'all') return as.slice();
     var out = [];
     for (var i = 0; i < as.length; i++) {
       var grp = agentStateInfo(as[i]).grp;
-      if (state.filter === 'working' && grp === 'work') out.push(as[i]);
+      if (state.filter === 'active' && agentInActiveRun(as[i])) out.push(as[i]);
+      else if (state.filter === 'working' && grp === 'work') out.push(as[i]);
       else if (state.filter === 'idle' && grp === 'idle') out.push(as[i]);
       else if (state.filter === 'attention' && grp === 'attn') out.push(as[i]);
       else if (state.filter === 'unknown' && grp === 'unknown') out.push(as[i]);
@@ -1540,7 +1552,8 @@
   function filterChips(root, counts) {
     var wrap = el('div', 'tc-filters');
     var defs = [
-      { key: 'all', label: 'All', count: agentsOf(root).length },
+      { key: 'active', label: 'Active run', count: activeRunCount(root) },
+      { key: 'all', label: 'All roster', count: agentsOf(root).length },
       { key: 'working', label: 'Working', count: counts.work },
       { key: 'idle', label: 'Idle', count: counts.idle },
       { key: 'attention', label: 'Health attention', count: counts.attn },

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -193,14 +193,27 @@
   }
   function responsiveSecondary(label, content) {
     var details = el('details', 'tc-secondary-panel');
-    var narrow = typeof window !== 'undefined' && window.matchMedia &&
-      window.matchMedia('(max-width: 560px)').matches;
-    details.open = !narrow || secondaryOpen[label] === true;
+    var mq = (typeof window !== 'undefined' && window.matchMedia)
+      ? window.matchMedia('(max-width: 560px)') : null;
+    function applyNarrow(narrow) {
+      details.open = !narrow || secondaryOpen[label] === true;
+    }
+    applyNarrow(!!(mq && mq.matches));
     details.appendChild(el('summary', 'tc-secondary-summary', label));
     details.appendChild(content);
     on(details, 'toggle', function () {
-      if (narrow) secondaryOpen[label] = !!details.open;
+      if (mq && mq.matches) secondaryOpen[label] = !!details.open;
     });
+    // #207 residual: the ORIGINAL narrow snapshot was taken once, at node
+    // creation, and never re-checked - an existing panel crossing the 560px
+    // boundary (resize, or a narrow-to-wide/wide-to-narrow rotation) never
+    // re-evaluated open/closed. Listen for the live media-query change so an
+    // EXISTING node reacts, not just newly-created ones.
+    if (mq) {
+      var onChange = function (e) { applyNarrow(!!e.matches); };
+      if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onChange);
+      else if (typeof mq.addListener === 'function') mq.addListener(onChange); // legacy Safari
+    }
     return details;
   }
   function svgEl(tag, attrs) {
@@ -219,10 +232,16 @@
   function on(node, ev, fn) { node.addEventListener(ev, fn); return node; }
   function monotonicNow() {
     // performance.now is elapsed-time only: client wall-clock skew cannot enter
-    // server ages, freshness, or the displayed clock. Freezing is safer than
-    // falling back to Date.now in the unlikely event it is unavailable.
+    // server ages, freshness, or the displayed clock - PREFER it. But a frozen
+    // constant (the old `: 0` fallback) is fail-OPEN: every later
+    // (monotonicNow() - receivedAt) delta would then be permanently 0, so
+    // attentionFresh/stateFresh could never age out even after polling stops
+    // (#207 residual, low confidence but fail-open is the worse direction).
+    // Date.now is not perfectly monotonic, but only feeds this fallback when
+    // performance.now itself is unavailable everywhere in this session, so
+    // every delta still compares two Date.now-based samples consistently.
     return (typeof performance !== 'undefined' && performance &&
-      typeof performance.now === 'function') ? performance.now() : 0;
+      typeof performance.now === 'function') ? performance.now() : Date.now();
   }
   function serverNowAt(receivedAt) {
     if (!serverClock) return null;
@@ -913,9 +932,11 @@
   }
   function attentionFresh() { return attentionKnownFrom(attentionData, state.now); }
   // Is the agent-health data (from /api/state) KNOWN-fresh? Same rationale as
-  // attentionFresh: fetchState stamps _fetchedAt on each successful poll and retains
-  // last-good on failure, so a stale lastState means agent health is obsolete and the
-  // verdict must NOT assert green from it (v0.76.0 trust contract).
+  // attentionFresh: fetchState stamps _receivedAt (via stampStatePayload) on each
+  // successful poll and retains last-good on failure, so a stale lastState means
+  // agent health is obsolete and the verdict must NOT assert green from it (v0.76.0
+  // trust contract). _fetchedAt below is only the compatibility fallback for pure
+  // test fixtures predating the monotonic stamp, same as attentionKnownFrom.
   function stateFresh() {
     if (lastState == null) return false;
     var received = lastState._receivedAt;

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -576,7 +576,16 @@
   }
   function freshHeartbeat(agent) {
     var age = Number(agent && agent.last_seen_age_seconds);
-    return Number.isFinite(age) && age >= 0 && age <= UNWRAPPED_LIVE_STALE_AFTER_SECONDS;
+    if (!Number.isFinite(age) || age < 0) return false;
+    // PR #129 connector round-2 finding (P2, console.js:905): last_seen_age_seconds
+    // is a SNAPSHOT from the agent's last successful /api/state poll - if
+    // state polling then fails, this stayed frozen at that value forever,
+    // so an agent could sit in the default "Active" run long after crossing
+    // the freshness boundary. Advance it by the elapsed monotonic time
+    // since that snapshot was received, same pattern as liveAge().
+    var elapsed = agent && typeof agent._receivedAt === 'number'
+      ? Math.max(0, monotonicNow() - agent._receivedAt) / 1000 : 0;
+    return (age + elapsed) <= UNWRAPPED_LIVE_STALE_AFTER_SECONDS;
   }
   function agentStateInfo(agent) {
     var raw = ((agent && agent.health) || {}).state;
@@ -2278,6 +2287,13 @@
   function gateVisualState(gate) {
     var expired = 'waiver_expired' in gate ? gate.waiver_expired : gate.blocks;
     if (gate.status === 'waived' && expired) return 'waived_expired';
+    // PR #129 connector round-2 finding (P1, console.js:2281): a missing
+    // required gate is status=unknown/blocks=true, and a skipped blocker
+    // is status=skipped/blocks=true - both used to render with the neutral
+    // gray unknown/skipped color, understating a real HOLD contributor.
+    // Anything still blocking (and not already red or the waived-expired
+    // case above) reuses the existing danger-red treatment.
+    if (gate.blocks && gate.status !== 'red') return 'red';
     return gate.status || 'unknown';
   }
 
@@ -2332,8 +2348,13 @@
       var w = gate.waiver;
       var expired = visual === 'waived_expired';
       var waiverBox = el('div', 'tc-gate-waiver' + (expired ? ' is-expired' : ''));
+      // PR #129 connector round-2 finding (console.js:2336): the API
+      // intentionally sends waiver_expired=true with blocks=false for an
+      // expired ADVISORY (warn/info) waiver - the unconditional "— blocking"
+      // suffix contradicted the chip tooltip right next to it ("not
+      // currently blocking"). Only say "blocking" when it actually is.
       waiverBox.appendChild(el('div', 'tc-gate-waiver-title',
-        expired ? 'Waiver expired — blocking' : 'Waived'));
+        expired ? ('Waiver expired' + (gate.blocks ? ' — blocking' : '')) : 'Waived'));
       waiverBox.appendChild(el('div', 'tc-gate-waiver-line',
         (w.operator ? w.operator + ' — ' : '') + (w.reason || '')));
       if (w.expires) waiverBox.appendChild(el('div', 'tc-gate-waiver-line', 'Expires ' + w.expires));
@@ -2341,23 +2362,33 @@
     }
 
     var evidence = isArray(gate.evidence) ? gate.evidence : [];
-    if (evidence.length) {
+    // F-3 (review rq-1a23fd25053d): the truncation notice must render even
+    // when EVERY entry was lost (evidence.length === 0 but
+    // evidence_truncated > 0) - it used to sit inside `if (evidence.length)`
+    // and so could never appear in exactly that case.
+    if (evidence.length || gate.evidence_truncated) {
       var evBox = el('div', 'tc-gate-evidence');
-      evBox.appendChild(el('div', 'tc-gate-evidence-title', 'Evidence'));
+      if (evidence.length) evBox.appendChild(el('div', 'tc-gate-evidence-title', 'Evidence'));
       for (var i = 0; i < evidence.length; i++) {
         var e = evidence[i];
         var line = (e.source || 'evidence') + (e.by ? ' by ' + e.by : '') + (e.at ? ' at ' + e.at : '');
         var row = el('div', 'tc-gate-evidence-row', line);
         evBox.appendChild(row);
         if (isArray(e.refs) && e.refs.length) {
-          evBox.appendChild(el('div', 'tc-gate-evidence-refs', e.refs.join(', ')));
+          var refsLine = e.refs.join(', ');
+          if (e.refs_truncated) {
+            refsLine += ' (+' + e.refs_truncated + ' more ref' +
+              (e.refs_truncated === 1 ? '' : 's') + ' not shown)';
+          }
+          evBox.appendChild(el('div', 'tc-gate-evidence-refs', refsLine));
         }
         // PR #129 connector finding: the API forwards every OTHER
         // evidence_details field too (coverage_percent, pr_url, ...) - this
         // used to only ever render source/by/at/refs, hiding the actual
         // proof a gate relied on even though it was present in the payload.
         var extraKeys = Object.keys(e).filter(function (k) {
-          return k !== 'source' && k !== 'refs' && k !== 'at' && k !== 'by';
+          return k !== 'source' && k !== 'refs' && k !== 'at' && k !== 'by' &&
+            k !== 'refs_truncated';
         }).sort();
         for (var j = 0; j < extraKeys.length; j++) {
           var k = extraKeys[j];
@@ -2394,9 +2425,16 @@
     var errs = (data && isArray(data.errors)) ? data.errors : [];
     var items = (data && isArray(data.items)) ? data.items : [];
     var count = data && typeof data.count === 'number' ? data.count : items.length;
+    var truncatedCount = data && typeof data.truncated === 'number' ? data.truncated : 0;
     var partial = !!(data && data.partial);
-    header.appendChild(el('span', 'tc-attn-count',
-      errs.length ? 'status unknown' : count + ' open' + (partial ? ' · incomplete' : '')));
+    // PR #129 connector round-2 finding (console.js:2399): the API's
+    // `count` is only how many items are RETURNED after the cap; the true
+    // open total is count + truncated (e.g. 700 open, 500 shown, 200 more).
+    // Labeling only `count` as "open" understated the real number.
+    var totalOpen = count + truncatedCount;
+    var countLabel = totalOpen + ' open' + (partial ? ' · incomplete' : '') +
+      (truncatedCount ? ' (showing ' + count + ')' : '');
+    header.appendChild(el('span', 'tc-attn-count', errs.length ? 'status unknown' : countLabel));
     wrap.appendChild(header);
 
     if (!data) {
@@ -2525,6 +2563,15 @@
     if (d.owned_globs && d.owned_globs.length) {
       card.appendChild(el('div', 'tc-domain-globs', d.owned_globs.join(', ')));
     }
+    // PR #129 connector round-2 (web.py:2763 / reviewer-3 F-5): the API now
+    // reports when a glob still exceeded the transport cap and was cut - a
+    // truncated glob no longer matches its original pattern, so this must
+    // not stay a silent, invisible difference.
+    if (d.owned_globs_truncated) {
+      card.appendChild(el('div', 'tc-gate-reason',
+        d.owned_globs_truncated + ' glob(s) exceeded the length limit and were cut - ' +
+        'they may no longer match the intended path.'));
+    }
     return card;
   }
 
@@ -2540,6 +2587,11 @@
     if (approvers) card.appendChild(el('div', 'tc-domain-line', 'Default approvers: ' + approvers));
     if (reviewers) card.appendChild(el('div', 'tc-domain-line', 'Default reviewers: ' + reviewers));
     if (s.description) card.appendChild(el('div', 'tc-gate-reason', s.description));
+    if (s.glob_truncated) {
+      card.appendChild(el('div', 'tc-gate-reason',
+        'This glob exceeded the length limit and was cut - it may no longer match ' +
+        'the intended path.'));
+    }
     return card;
   }
 
@@ -4519,6 +4571,16 @@
     startEndpointPoll(fetchAttention);
     startEndpointPoll(fetchLeadChat);
     startEndpointPoll(fetchIntents);
+    // PR #129 connector round-2 finding (P1, console.js:4521): Gates and
+    // Risk Register were fetched only on boot/root-entry or on navigating
+    // to the view, then never again while it stayed open - CI could turn a
+    // gate red, or a new dead letter/blocker could appear, and an operator
+    // watching the screen would keep seeing the stale all-clear/count
+    // indefinitely (displayed ages still advancing, making it LOOK live).
+    // Same completion-driven loop as the other high-cadence feeds (#207 -
+    // never queues a poll behind a slow request).
+    startEndpointPoll(fetchGates);
+    startEndpointPoll(fetchRiskRegister);
     // These payloads are view support, not high-cadence telemetry.
     fetchSession();
     fetchLearning();

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -192,20 +192,37 @@
     return n;
   }
   // Shared narrow-viewport tracker for responsiveSecondary. A per-call
-  // MediaQueryList 'change' listener leaks: renderActiveView tears down and
-  // rebuilds the whole view from scratch on every successful /api/state poll
-  // (every POLL_MS), so a per-node listener registered inside
-  // responsiveSecondary is NEVER unregistered - the browser retains one
-  // MediaQueryList per unique query string, so every discarded panel's
-  // listener (closing over its now-detached details node) piles up without
-  // bound over a long session (review rq-2968d93df2bc). ONE listener,
-  // registered once at module load, replaces every per-panel listener; the
-  // natural ~POLL_MS re-render already propagates a change to every panel.
+  // MediaQueryList 'change' listener used to leak (review rq-2968d93df2bc,
+  // round 1): every rendered panel registered its own listener that was
+  // never unregistered, so a long session accumulated one per panel. A pure
+  // "read a shared flag at creation time" fix (round 2) closed the leak but
+  // broke the ORIGINAL live-node contract: an already-displayed panel only
+  // picked up a viewport crossing on the NEXT successful /api/state poll,
+  // and fetchState keeps last-good state on a failed poll - during an
+  // outage a crossing could go unreflected indefinitely.
+  //
+  // Fix: ONE shared listener (still just one, still no leak) that, on a
+  // real change, ALSO walks the LIVE DOM for every currently-mounted
+  // .tc-secondary-panel and updates its open state directly - no per-panel
+  // registry to grow/leak (querySelectorAll always reflects only what is
+  // CURRENTLY attached), no dependency on the next render/poll.
   var _narrowPanelMq = (typeof window !== 'undefined' && window.matchMedia)
     ? window.matchMedia('(max-width: 560px)') : null;
   var isNarrowViewport = !!(_narrowPanelMq && _narrowPanelMq.matches);
+  function _applyNarrowToLiveSecondaryPanels(narrow) {
+    if (typeof document === 'undefined' || typeof document.querySelectorAll !== 'function') return;
+    var panels = document.querySelectorAll('.tc-secondary-panel');
+    for (var i = 0; i < panels.length; i++) {
+      var panel = panels[i];
+      var label = panel.getAttribute && panel.getAttribute('data-secondary-label');
+      panel.open = !narrow || secondaryOpen[label] === true;
+    }
+  }
   if (_narrowPanelMq) {
-    var _onNarrowPanelMqChange = function (e) { isNarrowViewport = !!e.matches; };
+    var _onNarrowPanelMqChange = function (e) {
+      isNarrowViewport = !!e.matches;
+      _applyNarrowToLiveSecondaryPanels(isNarrowViewport);
+    };
     if (typeof _narrowPanelMq.addEventListener === 'function') {
       _narrowPanelMq.addEventListener('change', _onNarrowPanelMqChange);
     } else if (typeof _narrowPanelMq.addListener === 'function') {
@@ -214,6 +231,7 @@
   }
   function responsiveSecondary(label, content) {
     var details = el('details', 'tc-secondary-panel');
+    details.setAttribute('data-secondary-label', label);
     details.open = !isNarrowViewport || secondaryOpen[label] === true;
     details.appendChild(el('summary', 'tc-secondary-summary', label));
     details.appendChild(content);

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -2098,7 +2098,17 @@
   // waiver}], count, errors?}.
   var GATE_STATUS_LABEL = nullMap({
     green: 'GREEN', red: 'RED', waived: 'WAIVED', unknown: 'UNKNOWN', skipped: 'SKIPPED',
+    waived_expired: 'WAIVED (EXPIRED)',
   });
+  // A waiver that no longer covers the gate (gates._gate_verdict: status stays
+  // "waived" but blocks=true, reason="waiver expired or invalid") must NOT
+  // read as the calm purple "WAIVED" state - it is back to blocking (review
+  // rq-a7038d8175f2 finding 2). This is the one place status alone is not
+  // enough; every other card/chip class keys off gate.status directly.
+  function gateVisualState(gate) {
+    if (gate.status === 'waived' && gate.blocks) return 'waived_expired';
+    return gate.status || 'unknown';
+  }
 
   function renderGates(main, root) {
     var wrap = el('div', 'tc-gates');
@@ -2134,11 +2144,12 @@
   }
 
   function gateCard(gate) {
-    var card = el('div', 'tc-card tc-gate-card gate-' + (gate.status || 'unknown'));
+    var visual = gateVisualState(gate);
+    var card = el('div', 'tc-card tc-gate-card gate-' + visual);
     var head = el('div', 'tc-gate-head');
     head.appendChild(el('span', 'tc-gate-name', gate.name || ''));
-    head.appendChild(titled(el('span', 'tc-chip gate-' + (gate.status || 'unknown'),
-      GATE_STATUS_LABEL[gate.status] || (gate.status || '').toUpperCase()),
+    head.appendChild(titled(el('span', 'tc-chip gate-' + visual,
+      GATE_STATUS_LABEL[visual] || (gate.status || '').toUpperCase()),
       gate.blocks ? 'This gate is blocking' : 'Not currently blocking'));
     head.appendChild(el('span', 'tc-gate-scope', gate.scope || 'global'));
     head.appendChild(el('span', 'tc-gate-severity', gate.severity || ''));
@@ -2148,8 +2159,10 @@
 
     if (gate.waiver) {
       var w = gate.waiver;
-      var waiverBox = el('div', 'tc-gate-waiver');
-      waiverBox.appendChild(el('div', 'tc-gate-waiver-title', 'Waived'));
+      var expired = visual === 'waived_expired';
+      var waiverBox = el('div', 'tc-gate-waiver' + (expired ? ' is-expired' : ''));
+      waiverBox.appendChild(el('div', 'tc-gate-waiver-title',
+        expired ? 'Waiver expired — blocking' : 'Waived'));
       waiverBox.appendChild(el('div', 'tc-gate-waiver-line',
         (w.operator ? w.operator + ' — ' : '') + (w.reason || '')));
       if (w.expires) waiverBox.appendChild(el('div', 'tc-gate-waiver-line', 'Expires ' + w.expires));

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -191,29 +191,35 @@
     if (n && title) n.setAttribute('title', String(title));
     return n;
   }
+  // Shared narrow-viewport tracker for responsiveSecondary. A per-call
+  // MediaQueryList 'change' listener leaks: renderActiveView tears down and
+  // rebuilds the whole view from scratch on every successful /api/state poll
+  // (every POLL_MS), so a per-node listener registered inside
+  // responsiveSecondary is NEVER unregistered - the browser retains one
+  // MediaQueryList per unique query string, so every discarded panel's
+  // listener (closing over its now-detached details node) piles up without
+  // bound over a long session (review rq-2968d93df2bc). ONE listener,
+  // registered once at module load, replaces every per-panel listener; the
+  // natural ~POLL_MS re-render already propagates a change to every panel.
+  var _narrowPanelMq = (typeof window !== 'undefined' && window.matchMedia)
+    ? window.matchMedia('(max-width: 560px)') : null;
+  var isNarrowViewport = !!(_narrowPanelMq && _narrowPanelMq.matches);
+  if (_narrowPanelMq) {
+    var _onNarrowPanelMqChange = function (e) { isNarrowViewport = !!e.matches; };
+    if (typeof _narrowPanelMq.addEventListener === 'function') {
+      _narrowPanelMq.addEventListener('change', _onNarrowPanelMqChange);
+    } else if (typeof _narrowPanelMq.addListener === 'function') {
+      _narrowPanelMq.addListener(_onNarrowPanelMqChange); // legacy Safari
+    }
+  }
   function responsiveSecondary(label, content) {
     var details = el('details', 'tc-secondary-panel');
-    var mq = (typeof window !== 'undefined' && window.matchMedia)
-      ? window.matchMedia('(max-width: 560px)') : null;
-    function applyNarrow(narrow) {
-      details.open = !narrow || secondaryOpen[label] === true;
-    }
-    applyNarrow(!!(mq && mq.matches));
+    details.open = !isNarrowViewport || secondaryOpen[label] === true;
     details.appendChild(el('summary', 'tc-secondary-summary', label));
     details.appendChild(content);
     on(details, 'toggle', function () {
-      if (mq && mq.matches) secondaryOpen[label] = !!details.open;
+      if (isNarrowViewport) secondaryOpen[label] = !!details.open;
     });
-    // #207 residual: the ORIGINAL narrow snapshot was taken once, at node
-    // creation, and never re-checked - an existing panel crossing the 560px
-    // boundary (resize, or a narrow-to-wide/wide-to-narrow rotation) never
-    // re-evaluated open/closed. Listen for the live media-query change so an
-    // EXISTING node reacts, not just newly-created ones.
-    if (mq) {
-      var onChange = function (e) { applyNarrow(!!e.matches); };
-      if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onChange);
-      else if (typeof mq.addListener === 'function') mq.addListener(onChange); // legacy Safari
-    }
     return details;
   }
   function svgEl(tag, attrs) {

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -123,8 +123,9 @@
     sessionRid: null,      // thread request_id
     filter: 'all',         // all | working | idle | attention
     selectedRootId: initialRootId(),
-    now: Date.now(),
+    now: null,             // server-derived wall time; never the browser clock
   };
+  var serverClock = null;  // { epochMs, receivedAt } anchored by /api/state.generated_at
   var rootGeneration = 0;
   // Prefs (persisted). Loaded/validated below.
   var prefs = { theme: 'light', accent: 'blue', density: 'comfortable' };
@@ -203,6 +204,54 @@
   function clear(node) { while (node.firstChild) node.removeChild(node.firstChild); }
   function isArray(x) { return Object.prototype.toString.call(x) === '[object Array]'; }
   function on(node, ev, fn) { node.addEventListener(ev, fn); return node; }
+  function monotonicNow() {
+    // performance.now is elapsed-time only: client wall-clock skew cannot enter
+    // server ages, freshness, or the displayed clock. Freezing is safer than
+    // falling back to Date.now in the unlikely event it is unavailable.
+    return (typeof performance !== 'undefined' && performance &&
+      typeof performance.now === 'function') ? performance.now() : 0;
+  }
+  function serverNowAt(receivedAt) {
+    if (!serverClock) return null;
+    return serverClock.epochMs + Math.max(0, receivedAt - serverClock.receivedAt);
+  }
+  function serverNow() { return serverNowAt(monotonicNow()); }
+  function defineTiming(value, key, timing) {
+    try {
+      Object.defineProperty(value, key, { value: timing, configurable: true });
+    } catch (e) { value[key] = timing; }
+  }
+  function stampPayloadTiming(value, receivedAt, serverAt) {
+    if (!value || typeof value !== 'object') return;
+    defineTiming(value, '_receivedAt', receivedAt);
+    if (typeof serverAt === 'number' && isFinite(serverAt)) {
+      defineTiming(value, '_serverAt', serverAt);
+    }
+    var keys = Object.keys(value);
+    for (var i = 0; i < keys.length; i++) {
+      stampPayloadTiming(value[keys[i]], receivedAt, serverAt);
+    }
+  }
+  function stampStatePayload(data) {
+    var receivedAt = monotonicNow();
+    var generatedAt = data ? Date.parse(data.generated_at) : NaN;
+    if (isFinite(generatedAt)) {
+      serverClock = { epochMs: generatedAt, receivedAt: receivedAt };
+      state.now = generatedAt;
+    } else {
+      serverClock = null;
+      state.now = null;
+    }
+    stampPayloadTiming(data, receivedAt, isFinite(generatedAt) ? generatedAt : null);
+    return data;
+  }
+  function stampAuxPayload(data) {
+    var receivedAt = monotonicNow();
+    var generatedAt = data ? Date.parse(data.generated_at) : NaN;
+    var serverAt = isFinite(generatedAt) ? generatedAt : serverNowAt(receivedAt);
+    stampPayloadTiming(data, receivedAt, serverAt);
+    return data;
+  }
   var LEAD_CHAT_VOLATILE_KEYS = nullMap({
     age_seconds: true,
     heartbeat_age_seconds: true,
@@ -312,16 +361,21 @@
     var h = Math.floor(sec / 3600), mm = Math.floor((sec % 3600) / 60);
     return mm ? (h + 'h ' + mm + 'm') : (h + 'h');
   }
-  // Age of a wire item: prefer a live recompute from `ts`, else fall back to
-  // the server-computed `age_seconds` (adjusted by drift since the poll).
+  // Age of a wire item. Prefer the server-computed age and advance it only by
+  // monotonic elapsed time since THAT payload was received. If the wire carries
+  // only `ts`, compare it with the /api/state `generated_at` clock anchor. The
+  // browser wall clock is deliberately absent from both paths (#207).
   function liveAge(item) {
+    var elapsed = item && typeof item._receivedAt === 'number'
+      ? Math.max(0, monotonicNow() - item._receivedAt) / 1000 : 0;
+    if (item && typeof item.age_seconds === 'number') {
+      return item.age_seconds + elapsed;
+    }
     if (item && item.ts) {
       var t = Date.parse(item.ts);
-      if (!isNaN(t)) return (state.now - t) / 1000;
-    }
-    if (item && typeof item.age_seconds === 'number') {
-      var base = lastState && lastState._fetchedAt ? lastState._fetchedAt : state.now;
-      return item.age_seconds + (state.now - base) / 1000;
+      var now = item && typeof item._serverAt === 'number'
+        ? item._serverAt + elapsed * 1000 : serverNow();
+      if (!isNaN(t) && typeof now === 'number') return (now - t) / 1000;
     }
     return null;
   }
@@ -329,8 +383,8 @@
   // A relative-age span that the 1 Hz clock ticker updates IN PLACE (B2a) —
   // NOT via a DOM rebuild, which would destroy inner-scroll and text selection
   // in the transcript/feed every second. The node is tagged with the raw inputs
-  // (`data-age-ts` / `data-age-sec`) plus formatting opts so `updateAges` can
-  // recompute textContent from the current `state.now` without re-rendering.
+  // (`data-age-ts` / `data-age-sec` plus its server/monotonic receipt anchors)
+  // and formatting opts so `updateAges` can recompute without re-rendering.
   //   opts.suffix   — appended after the formatted age (e.g. ' ago')
   //   opts.prefix   — prepended before it (e.g. 'since ')
   //   opts.nullText — shown when age is null / noHb (e.g. 'no hb', 'missing')
@@ -342,6 +396,12 @@
     if (item && item.ts) n.setAttribute('data-age-ts', String(item.ts));
     if (item && typeof item.age_seconds === 'number') {
       n.setAttribute('data-age-sec', String(item.age_seconds));
+    }
+    if (item && typeof item._receivedAt === 'number') {
+      n.setAttribute('data-age-received', String(item._receivedAt));
+    }
+    if (item && typeof item._serverAt === 'number') {
+      n.setAttribute('data-age-server', String(item._serverAt));
     }
     if (opts.suffix) n.setAttribute('data-age-suffix', opts.suffix);
     if (opts.prefix) n.setAttribute('data-age-prefix', opts.prefix);
@@ -355,9 +415,9 @@
     titled(n, absTimeTitle(item, opts));
     return n;
   }
-  // The absolute local time an age refers to, for the hover tooltip. Prefers the
-  // wire `ts`; else derives from `age_seconds` relative to the last poll (like
-  // liveAge). Returns '' for a no-heartbeat node or an unparseable time.
+  // The absolute UTC time an age refers to, for the hover tooltip. A direct wire
+  // `ts` is authoritative; an age-only item is derived from the server-time
+  // anchor captured with that payload. Never derive it from browser wall time.
   function absTimeTitle(item, opts) {
     opts = opts || {};
     var meaning = opts.title || '';   // optional plain-language prefix (e.g. heartbeat)
@@ -367,18 +427,19 @@
       var t = Date.parse(item.ts);
       if (!isNaN(t)) ms = t;
     }
-    if (ms === null && item && typeof item.age_seconds === 'number') {
-      var base = lastState && lastState._fetchedAt ? lastState._fetchedAt : state.now;
-      ms = base - item.age_seconds * 1000;
+    if (ms === null && item && typeof item.age_seconds === 'number' &&
+      typeof item._serverAt === 'number') {
+      ms = item._serverAt - item.age_seconds * 1000;
     }
     if (ms === null) return meaning;
     var abs;
-    try { abs = new Date(ms).toLocaleString(); } catch (e) { abs = ''; }
+    try { abs = new Date(ms).toISOString(); } catch (e) { abs = ''; }
     if (!abs) return meaning;
     return meaning ? (meaning + ' · ' + abs) : abs;
   }
   // Format the current text for a tagged age node from its data-* inputs + the
-  // live `state.now`. Shared by `ageEl` (initial render) and `updateAges` (tick).
+  // trusted payload timing. Shared by `ageEl` (initial render) and
+  // `updateAges` (tick).
   function ageText(n) {
     var pfx = n.getAttribute('data-age-prefix') || '';
     var sfx = n.getAttribute('data-age-suffix') || '';
@@ -389,6 +450,10 @@
     if (ts) item.ts = ts;
     var sec = n.getAttribute('data-age-sec');
     if (sec !== null && sec !== '') item.age_seconds = Number(sec);
+    var received = n.getAttribute('data-age-received');
+    if (received !== null && received !== '') item._receivedAt = Number(received);
+    var server = n.getAttribute('data-age-server');
+    if (server !== null && server !== '') item._serverAt = Number(server);
     var age = liveAge(item);
     if (age === null) return nullText || '';
     return pfx + fmtAge(age) + sfx;
@@ -801,7 +866,7 @@
   // Is the human-attention queue KNOWN (loaded + fresh)? attentionData is null
   // until the first successful fetch and is retained (not blanked) on a failed
   // poll, so a bare count can't tell "confirmed empty" from "never loaded / stale
-  // during an outage". A stamped _fetchedAt (set on each successful fetchAttention,
+  // during an outage". A stamped _receivedAt (set on each successful fetchAttention,
   // which polls every POLL_MS) ages out during an outage -> unknown. An unstamped
   // non-null payload (e.g. a test harness) is treated as known.
   // PURE (testable without module state): an attention payload counts as KNOWN — safe
@@ -812,6 +877,11 @@
   function attentionKnownFrom(data, now) {
     if (data == null) return false;
     if (Array.isArray(data.errors) && data.errors.length) return false;
+    var received = data._receivedAt;
+    if (typeof received === 'number' && isFinite(received)) {
+      return (monotonicNow() - received) <= ATTENTION_STALE_MS;
+    }
+    // Compatibility for pure test fixtures written before the monotonic stamp.
     var at = data._fetchedAt;
     if (typeof at !== 'number' || !isFinite(at)) return true;
     return (now - at) <= ATTENTION_STALE_MS;
@@ -823,9 +893,29 @@
   // verdict must NOT assert green from it (v0.76.0 trust contract).
   function stateFresh() {
     if (lastState == null) return false;
+    var received = lastState._receivedAt;
+    if (typeof received === 'number' && isFinite(received)) {
+      return (monotonicNow() - received) <= STATE_STALE_MS;
+    }
+    // Compatibility for pure test fixtures written before the monotonic stamp.
     var at = lastState._fetchedAt;
     if (typeof at !== 'number' || !isFinite(at)) return true;
     return (state.now - at) <= STATE_STALE_MS;
+  }
+  function serverClockText() {
+    var now = serverNow();
+    if (typeof now !== 'number' || !isFinite(now)) return 'Server time unavailable';
+    try { return new Date(now).toISOString().slice(11, 19) + ' UTC'; }
+    catch (e) { return 'Server time unavailable'; }
+  }
+  function pollingStatus() {
+    if (!lastState) {
+      return { label: 'Connecting', tone: 'waiting', title: 'Waiting for the first server snapshot' };
+    }
+    if (!stateFresh()) {
+      return { label: 'Stale', tone: 'stale', title: 'The last successful server snapshot is stale' };
+    }
+    return { label: 'Current', tone: 'current', title: 'The latest server snapshot is current' };
   }
   function teamHealthVerdict(root) {
     var c = agentCounts(root);
@@ -1074,9 +1164,8 @@
     }
     var at = capNum(win, 'resets_at');
     if (at !== null) {
-      return 'resets at ' + new Date(at * 1000).toLocaleTimeString('en-US', {
-        hour: '2-digit', minute: '2-digit'
-      });
+      try { return 'resets at ' + new Date(at * 1000).toISOString().slice(11, 16) + ' UTC'; }
+      catch (e) { return '—'; }
     }
     return '—';
   }
@@ -1175,12 +1264,17 @@
 
     bar.appendChild(el('div', 'tc-spacer'));
 
-    // Live indicator + clock (recomputed each tick).
-    var live = el('div', 'tc-live');
+    // Poll freshness + server clock (recomputed each tick). "Current" describes
+    // the last successful server snapshot; it is never inferred from a client
+    // clock or from the mere absence of an error.
+    var poll = pollingStatus();
+    var live = el('div', 'tc-live is-' + poll.tone);
     live.appendChild(el('span', 'tc-live-dot'));
-    titled(live, 'The page is polling the bus live');
-    live.appendChild(el('span', 'tc-live-label', 'Live'));
-    live.appendChild(el('span', 'tc-clock', new Date(state.now).toLocaleTimeString('en-US', { hour12: false })));
+    titled(live, poll.title);
+    live.appendChild(el('span', 'tc-live-label', poll.label));
+    var clock = el('span', 'tc-clock', serverClockText());
+    titled(clock, 'Server-provided UTC time; advanced only by monotonic elapsed time');
+    live.appendChild(clock);
     bar.appendChild(live);
 
     // Overall team-health pill (v0.76.0): the green "Live" dot only means the page
@@ -3532,6 +3626,7 @@
     }).then(function (data) {
       if (sessionPending === requestKey) sessionPending = null;
       if (!rootPayloadMatches(data, projectId, generation)) return;
+      stampAuxPayload(data);
       if (data && data.csrf_token) {
         actionSession.enabled = true;
         actionSession.token = data.csrf_token;
@@ -3562,6 +3657,7 @@
     }).then(function (data) {
       if (intentsPending === requestKey) intentsPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      stampAuxPayload(data);
       intentsData = data;
       if (state.view === 'sessions') renderActiveViewFromPoll();
     }).catch(function () {
@@ -3685,7 +3781,7 @@
       if (!data) return;                       // non-ok — keep last-good
       if (seq < stateCommitted) return;        // stale response — drop (P2-4)
       stateCommitted = seq;
-      data._fetchedAt = Date.now();
+      stampStatePayload(data);
       var hadState = !!lastState;
       lastState = data;
       var projectChanged = reconcileProjectSelection();
@@ -3737,7 +3833,7 @@
     }).then(function (data) {
       if (attentionPending === requestKey) attentionPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
-      data._fetchedAt = Date.now();   // freshness stamp for the team-health verdict (v0.76.0)
+      stampAuxPayload(data);   // monotonic freshness + server-time anchor (#207)
       attentionData = data;
       renderSidebar();  // count badge
       if (state.view === 'attention') renderActiveViewFromPoll();
@@ -3758,6 +3854,7 @@
     }).then(function (data) {
       if (leadChatPending === requestKey) leadChatPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      stampAuxPayload(data);
       var nextHash = leadChatPayloadFingerprint(data);
       var changed = leadChatPayloadHash !== nextHash;
       leadChatPayloadHash = nextHash;
@@ -3782,6 +3879,7 @@
     }).then(function (data) {
       if (learningPending === requestKey) learningPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      stampAuxPayload(data);
       learningData = data;
       renderSidebar();
       if (state.view === 'learning') renderActiveViewFromPoll();
@@ -3803,6 +3901,7 @@
     }).then(function (data) {
       if (onboardingPending === requestKey) onboardingPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      stampAuxPayload(data);
       onboardingData = data;
       renderSidebar();
       if (state.view === 'onboarding') renderActiveViewFromPoll();
@@ -3839,6 +3938,7 @@
         archivedState.items = reset ? [] : archivedState.items;
         archivedState.nextCursor = null;
       } else {
+        stampAuxPayload(data);
         var items = data.items || [];
         archivedState.items = reset ? items : archivedState.items.concat(items);
         archivedState.nextCursor = data.next_cursor || null;
@@ -3885,6 +3985,7 @@
       } else if (!rootPayloadMatches(data, projectId, generation)) {
         return;
       } else {
+        stampAuxPayload(data);
         threadCache[key] = data;
         delete threadNotFound[key];
       }
@@ -3905,10 +4006,18 @@
 
   // ------------------------------------------------------------ loops
   function clockTick() {
-    state.now = Date.now();
-    // Recompute the wall clock + relative ages without a network round-trip.
+    state.now = serverNow();
+    // Recompute server clock + relative ages without a network round-trip.
     var clock = document.querySelector('#topbar .tc-clock');
-    if (clock) clock.textContent = new Date(state.now).toLocaleTimeString('en-US', { hour12: false });
+    if (clock) clock.textContent = serverClockText();
+    var live = document.querySelector('#topbar .tc-live');
+    if (live) {
+      var poll = pollingStatus();
+      live.className = 'tc-live is-' + poll.tone;
+      live.setAttribute('title', poll.title);
+      var label = live.querySelector ? live.querySelector('.tc-live-label') : null;
+      if (label) label.textContent = poll.label;
+    }
     // Advance age counters IN PLACE (B2a) — NEVER rebuild the DOM here, or the
     // transcript inner-scroll and any in-progress text selection are destroyed
     // every second. Only the 2s DATA poll re-renders the view.

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -42,9 +42,11 @@
   var DENSITIES = ['comfortable', 'compact'];
   var PREF_KEYS = { theme: 'tc.theme', accent: 'tc.accent', density: 'tc.density' };
 
-  var VIEWS = ['overview', 'flow', 'attention', 'lead-chat', 'learning', 'onboarding', 'sessions', 'agent'];
+  var VIEWS = ['overview', 'flow', 'attention', 'gates', 'risk-register', 'ownership',
+    'lead-chat', 'learning', 'onboarding', 'sessions', 'agent'];
   var VIEW_LABELS = nullMap({
     overview: 'Overview', flow: 'Flow', attention: 'Attention',
+    gates: 'Gates', 'risk-register': 'Risk register', ownership: 'Ownership',
     'lead-chat': 'Lead chat', learning: 'Learning', onboarding: 'Onboarding',
     sessions: 'Sessions', agent: 'Agent',
   });
@@ -135,12 +137,18 @@
   var leadChatData = null;            // /api/lead-chat (operator<->lead bodies)
   var learningData = null;            // /api/learning (lessons + exposure telemetry)
   var onboardingData = null;          // /api/onboarding (project analysis runs)
+  var gatesData = null;               // /api/gates (gate & evidence wall)
+  var riskRegisterData = null;        // /api/risk-register (attention queue relabel)
+  var ownershipData = null;           // /api/ownership (domain ownership registry)
   var leadChatPayloadHash = null;      // unchanged-payload guard for lead-chat
   var intentsData = null;             // /api/intents (body-free queue state)
   var attentionPending = null;
   var leadChatPending = null;
   var learningPending = null;
   var onboardingPending = null;
+  var gatesPending = null;
+  var riskRegisterPending = null;
+  var ownershipPending = null;
   var intentsPending = null;
   var sessionPending = null;
   var statePending = false;           // /api/state in-flight guard (P2-4)
@@ -653,6 +661,9 @@
     leadChatPayloadHash = null;
     learningData = null;
     onboardingData = null;
+    gatesData = null;
+    riskRegisterData = null;
+    ownershipData = null;
     intentsData = null;
     threadCache = {};
     threadNotFound = {};
@@ -1104,6 +1115,9 @@
     if (view === 'lead-chat') fetchLeadChat();
     if (view === 'learning') fetchLearning();
     if (view === 'onboarding') fetchOnboarding();
+    if (view === 'gates') fetchGates();
+    if (view === 'risk-register') fetchRiskRegister();
+    if (view === 'ownership') fetchOwnership();
     if (view === 'sessions' && state.sessionRid) fetchThread(state.sessionRid);
     renderActiveView();
     renderChrome();
@@ -1282,6 +1296,12 @@
       // is visible in the always-on sidebar, not only after opening the queue view.
       { key: 'attention', label: 'Human queue', icon: navIconAlert, badge: attnCount,
         clearWhenZero: true, title: 'Things that need a human decision (escalations, blocked gates, stuck agents, failed messages)' },
+      { key: 'gates', label: 'Gates', icon: navIconFile,
+        title: 'Every gate by scope: red, green, or waived, with its evidence' },
+      { key: 'risk-register', label: 'Risk register', icon: navIconAlert,
+        title: 'The human queue, reframed as a client-legible risk log (severity, age, owner)' },
+      { key: 'ownership', label: 'Ownership', icon: navIconFile,
+        title: 'Which agent/team owns which part of the codebase, and shared-path sign-off' },
       { key: 'lead-chat', label: 'Lead chat', icon: navIconChat, badge: leadPendingCount },
       { key: 'learning', label: 'Learning', icon: navIconFile, badge: learningCount },
       { key: 'onboarding', label: 'Onboarding', icon: navIconFile, badge: onboardingCount },
@@ -1356,6 +1376,9 @@
       case 'overview': renderOverview(main, root); break;
       case 'flow': renderFlow(main, root); break;
       case 'attention': renderAttention(main, root); break;
+      case 'gates': renderGates(main, root); break;
+      case 'risk-register': renderRiskRegister(main, root); break;
+      case 'ownership': renderOwnership(main, root); break;
       case 'lead-chat': renderLeadChat(main, root); break;
       case 'learning': renderLearning(main, root); break;
       case 'onboarding': renderOnboarding(main, root); break;
@@ -2065,6 +2088,238 @@
     card.appendChild(el('div', 'tc-empty-text',
       'The dashboard hit an error building this list, so it can’t tell you what’s waiting. '
       + 'This is a dashboard problem, not an all-clear. (' + (errs || []).join('; ') + ')'));
+    return card;
+  }
+
+  // ------------------------------------------------------------ VIEW 3b: gates
+  // Gate & Evidence Wall, read side (docs/PROPOSAL-console-client-sellability.md
+  // #1). Wire contract: /api/gates -> {verdict, required_gates, gates: [{name,
+  // status, severity, scope, blocks, reason, updated_at, updated_by, evidence,
+  // waiver}], count, errors?}.
+  var GATE_STATUS_LABEL = nullMap({
+    green: 'GREEN', red: 'RED', waived: 'WAIVED', unknown: 'UNKNOWN', skipped: 'SKIPPED',
+  });
+
+  function renderGates(main, root) {
+    var wrap = el('div', 'tc-gates');
+    var header = viewHead('Gate & evidence wall',
+      'Every gate, by scope — red, green, or waived, with the evidence behind it');
+    header.appendChild(el('div', 'tc-spacer'));
+
+    var data = gatesData;
+    var errs = (data && isArray(data.errors)) ? data.errors : [];
+    if (data && !errs.length) {
+      var verdictChip = el('span', 'tc-chip tc-gate-verdict gate-' +
+        (data.verdict === 'GO' ? 'green' : 'red'), data.verdict || 'HOLD');
+      header.appendChild(verdictChip);
+    }
+    wrap.appendChild(header);
+
+    var gatesList = (data && isArray(data.gates)) ? data.gates : [];
+    if (!data) {
+      wrap.appendChild(el('p', 'tc-recent-empty', 'Loading gates…'));
+    } else if (errs.length) {
+      wrap.appendChild(genericErrorState(
+        'Can’t read gate state right now',
+        'The dashboard hit an error building this list. (' + errs.join('; ') + ')'));
+    } else if (!gatesList.length) {
+      wrap.appendChild(emptyState('No gates recorded',
+        'This project has not recorded any assurance gates yet.'));
+    } else {
+      var list = el('div', 'tc-gate-list');
+      for (var i = 0; i < gatesList.length; i++) list.appendChild(gateCard(gatesList[i]));
+      wrap.appendChild(list);
+    }
+    main.appendChild(wrap);
+  }
+
+  function gateCard(gate) {
+    var card = el('div', 'tc-card tc-gate-card gate-' + (gate.status || 'unknown'));
+    var head = el('div', 'tc-gate-head');
+    head.appendChild(el('span', 'tc-gate-name', gate.name || ''));
+    head.appendChild(titled(el('span', 'tc-chip gate-' + (gate.status || 'unknown'),
+      GATE_STATUS_LABEL[gate.status] || (gate.status || '').toUpperCase()),
+      gate.blocks ? 'This gate is blocking' : 'Not currently blocking'));
+    head.appendChild(el('span', 'tc-gate-scope', gate.scope || 'global'));
+    head.appendChild(el('span', 'tc-gate-severity', gate.severity || ''));
+    card.appendChild(head);
+
+    if (gate.reason) card.appendChild(el('div', 'tc-gate-reason', gate.reason));
+
+    if (gate.waiver) {
+      var w = gate.waiver;
+      var waiverBox = el('div', 'tc-gate-waiver');
+      waiverBox.appendChild(el('div', 'tc-gate-waiver-title', 'Waived'));
+      waiverBox.appendChild(el('div', 'tc-gate-waiver-line',
+        (w.operator ? w.operator + ' — ' : '') + (w.reason || '')));
+      if (w.expires) waiverBox.appendChild(el('div', 'tc-gate-waiver-line', 'Expires ' + w.expires));
+      card.appendChild(waiverBox);
+    }
+
+    var evidence = isArray(gate.evidence) ? gate.evidence : [];
+    if (evidence.length) {
+      var evBox = el('div', 'tc-gate-evidence');
+      evBox.appendChild(el('div', 'tc-gate-evidence-title', 'Evidence'));
+      for (var i = 0; i < evidence.length; i++) {
+        var e = evidence[i];
+        var line = (e.source || 'evidence') + (e.by ? ' by ' + e.by : '') + (e.at ? ' at ' + e.at : '');
+        var row = el('div', 'tc-gate-evidence-row', line);
+        evBox.appendChild(row);
+        if (isArray(e.refs) && e.refs.length) {
+          evBox.appendChild(el('div', 'tc-gate-evidence-refs', e.refs.join(', ')));
+        }
+      }
+      card.appendChild(evBox);
+    }
+    if (gate.updated_at) {
+      card.appendChild(el('div', 'tc-gate-updated',
+        'Updated ' + gate.updated_at + (gate.updated_by ? ' by ' + gate.updated_by : '')));
+    }
+    return card;
+  }
+
+  // ------------------------------------------------------------ VIEW 3c: risk register
+  // Risk Register relabel (docs/PROPOSAL-console-client-sellability.md #6): the
+  // SAME ranked queue /api/attention shows, resorted by severity/age and given
+  // client-legible category labels + an owner column. Reuses the .tc-attn-*
+  // card layout/CSS wholesale — this IS the human queue, relabeled, not a new
+  // visual language.
+  function renderRiskRegister(main, root) {
+    var wrap = el('div', 'tc-attention tc-risk-register');
+    var header = viewHead('Risk register',
+      'Open risks — severity, age, and owner, sorted the way a risk log is sorted');
+    header.appendChild(el('div', 'tc-spacer'));
+
+    var data = riskRegisterData;
+    var errs = (data && isArray(data.errors)) ? data.errors : [];
+    var items = (data && isArray(data.items)) ? data.items : [];
+    var count = data && typeof data.count === 'number' ? data.count : items.length;
+    header.appendChild(el('span', 'tc-attn-count', errs.length ? 'status unknown' : count + ' open'));
+    wrap.appendChild(header);
+
+    if (!data) {
+      wrap.appendChild(el('p', 'tc-recent-empty', 'Loading risk register…'));
+    } else if (errs.length) {
+      wrap.appendChild(genericErrorState(
+        'Can’t read the risk register right now',
+        'The dashboard hit an error building this list. (' + errs.join('; ') + ')'));
+    } else if (!items.length) {
+      wrap.appendChild(emptyState('No open risks', 'Nothing is waiting on you right now.'));
+    } else {
+      var list = el('div', 'tc-attn-list');
+      for (var i = 0; i < items.length; i++) list.appendChild(riskCard(items[i]));
+      wrap.appendChild(list);
+    }
+    main.appendChild(wrap);
+  }
+
+  function riskCard(item) {
+    var card = el('div', 'tc-attn-card');
+    card.style.setProperty('--sev-color', 'var(--' + (SEV_COLOR[item.severity] || 'gray') + ')');
+
+    var body = el('div', 'tc-attn-body');
+    var tagRow = el('div', 'tc-attn-tagrow');
+    tagRow.appendChild(el('span', 'tc-src src-' + item.category, item.category_label || 'Other'));
+    tagRow.appendChild(titled(el('span', 'tc-chip sev-' + item.severity,
+      SEV_LABEL[item.severity] || (item.severity || '').toUpperCase()), SEV_DESC[item.severity]));
+    tagRow.appendChild(el('span', 'tc-spacer'));
+    tagRow.appendChild(ageEl('tc-attn-age', item, { suffix: ' ago' }));
+    body.appendChild(tagRow);
+    body.appendChild(el('div', 'tc-attn-title', item.title || ''));
+    var detailRow = el('div', 'tc-attn-detailrow');
+    if (item.owner) detailRow.appendChild(el('span', 'tc-attn-agent', item.owner));
+    detailRow.appendChild(el('span', 'tc-attn-detail', item.detail || ''));
+    body.appendChild(detailRow);
+    card.appendChild(body);
+    return card;
+  }
+
+  // ------------------------------------------------------------ VIEW 3d: ownership
+  // Ownership & Accountability Map (docs/PROPOSAL-console-client-sellability.md
+  // #7): the full domain registry, not just the thin per-agent slice on the
+  // agent detail card.
+  function renderOwnership(main, root) {
+    var wrap = el('div', 'tc-ownership');
+    var header = viewHead('Ownership & accountability map',
+      'Which agent or team owns which part of the codebase, and where shared sign-off is required');
+    header.appendChild(el('div', 'tc-spacer'));
+
+    var data = ownershipData;
+    var errs = (data && isArray(data.errors)) ? data.errors : [];
+    var domainsList = (data && isArray(data.domains)) ? data.domains : [];
+    header.appendChild(el('span', 'tc-attn-count',
+      errs.length ? 'status unknown' : domainsList.length + ' domains'));
+    wrap.appendChild(header);
+
+    if (!data) {
+      wrap.appendChild(el('p', 'tc-recent-empty', 'Loading ownership map…'));
+    } else if (errs.length) {
+      wrap.appendChild(genericErrorState(
+        'Can’t read the ownership registry right now',
+        'The dashboard hit an error reading it. (' + errs.join('; ') + ')'));
+    } else if (!domainsList.length) {
+      wrap.appendChild(emptyState('No domains declared',
+        'This project has not declared any domain ownership yet.'));
+    } else {
+      var list = el('div', 'tc-domain-list');
+      for (var i = 0; i < domainsList.length; i++) list.appendChild(domainCard(domainsList[i]));
+      wrap.appendChild(list);
+    }
+
+    var sharedList = (data && isArray(data.shared_paths)) ? data.shared_paths : [];
+    if (sharedList.length) {
+      wrap.appendChild(el('h2', 'tc-h2', 'Shared paths requiring sign-off'));
+      var sharedBox = el('div', 'tc-domain-list');
+      for (var j = 0; j < sharedList.length; j++) sharedBox.appendChild(sharedPathCard(sharedList[j]));
+      wrap.appendChild(sharedBox);
+    }
+    main.appendChild(wrap);
+  }
+
+  function domainCard(d) {
+    var card = el('div', 'tc-card tc-domain-card');
+    var head = el('div', 'tc-gate-head');
+    head.appendChild(el('span', 'tc-gate-name', d.title || d.id || ''));
+    card.appendChild(head);
+    if (d.description) card.appendChild(el('div', 'tc-gate-reason', d.description));
+    card.appendChild(el('div', 'tc-domain-line', 'Owners: ' + refsetText(d.owners)));
+    if (d.reviewers && d.reviewers.length) {
+      card.appendChild(el('div', 'tc-domain-line', 'Reviewers: ' + refsetText(d.reviewers)));
+    }
+    if (d.curators && d.curators.length) {
+      card.appendChild(el('div', 'tc-domain-line', 'Curators: ' + refsetText(d.curators)));
+    }
+    if (d.owned_globs && d.owned_globs.length) {
+      card.appendChild(el('div', 'tc-domain-globs', d.owned_globs.join(', ')));
+    }
+    return card;
+  }
+
+  function sharedPathCard(s) {
+    var card = el('div', 'tc-card tc-domain-card');
+    var head = el('div', 'tc-gate-head');
+    head.appendChild(el('span', 'tc-gate-name', s.glob || ''));
+    head.appendChild(el('span', 'tc-gate-scope', s.category || ''));
+    card.appendChild(head);
+    card.appendChild(el('div', 'tc-domain-line', 'Requires: ' + (s.requires || '')));
+    var approvers = refsetText(s.default_approvers);
+    var reviewers = refsetText(s.default_reviewers);
+    if (approvers) card.appendChild(el('div', 'tc-domain-line', 'Default approvers: ' + approvers));
+    if (reviewers) card.appendChild(el('div', 'tc-domain-line', 'Default reviewers: ' + reviewers));
+    if (s.description) card.appendChild(el('div', 'tc-gate-reason', s.description));
+    return card;
+  }
+
+  function refsetText(names) {
+    return (isArray(names) && names.length) ? names.join(', ') : 'none';
+  }
+
+  // Shared error-as-data empty state (§4c/e/d): mirrors attentionError's "this
+  // is a dashboard problem, not an all-clear" contract for the new read views.
+  function genericErrorState(title, text) {
+    var card = el('div', 'tc-empty is-error');
+    card.appendChild(el('div', 'tc-empty-title', title));
+    card.appendChild(el('div', 'tc-empty-text', text));
     return card;
   }
 
@@ -3809,6 +4064,66 @@
     });
   }
 
+  function fetchGates() {
+    var projectId = currentRootId();
+    var generation = rootGeneration;
+    var requestKey = rootRequestKey(projectId, generation);
+    if (gatesPending === requestKey) return;
+    gatesPending = requestKey;
+    fetch(rootUrl('/api/gates', projectId)).then(function (r) {
+      if (!r.ok) return null;
+      return r.json();
+    }).then(function (data) {
+      if (gatesPending === requestKey) gatesPending = null;
+      if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      gatesData = data;
+      renderSidebar();
+      if (state.view === 'gates') renderActiveViewFromPoll();
+    }).catch(function () {
+      if (gatesPending === requestKey) gatesPending = null;
+    });
+  }
+
+  function fetchRiskRegister() {
+    var projectId = currentRootId();
+    var generation = rootGeneration;
+    var requestKey = rootRequestKey(projectId, generation);
+    if (riskRegisterPending === requestKey) return;
+    riskRegisterPending = requestKey;
+    fetch(rootUrl('/api/risk-register', projectId)).then(function (r) {
+      if (!r.ok) return null;
+      return r.json();
+    }).then(function (data) {
+      if (riskRegisterPending === requestKey) riskRegisterPending = null;
+      if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      riskRegisterData = data;
+      renderSidebar();
+      if (state.view === 'risk-register') renderActiveViewFromPoll();
+    }).catch(function () {
+      if (riskRegisterPending === requestKey) riskRegisterPending = null;
+    });
+  }
+
+  function fetchOwnership() {
+    var projectId = currentRootId();
+    var generation = rootGeneration;
+    var requestKey = rootRequestKey(projectId, generation);
+    if (ownershipPending === requestKey) return;
+    ownershipPending = requestKey;
+    fetch(rootUrl('/api/ownership', projectId)).then(function (r) {
+      if (!r.ok) return null;
+      return r.json();
+    }).then(function (data) {
+      if (ownershipPending === requestKey) ownershipPending = null;
+      if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      ownershipData = data;
+      renderSidebar();
+      if (state.view === 'ownership') renderActiveViewFromPoll();
+    }).catch(function () {
+      if (ownershipPending === requestKey) ownershipPending = null;
+    });
+  }
+
   function fetchArchivedThreads(reset) {
     if (archivedState.loading) return;
     var projectId = currentRootId();
@@ -3899,6 +4214,9 @@
     fetchLeadChat();
     fetchLearning();
     fetchOnboarding();
+    fetchGates();
+    fetchRiskRegister();
+    fetchOwnership();
   }
 
   // ------------------------------------------------------------ loops

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -165,6 +165,7 @@
   };
   var answerComposerState = {};       // to_request -> body text
   var leadChatComposerState = { body: '' };
+  var secondaryOpen = {};             // disclosure choices survive 2s re-renders
   var archivedState = {
     root: '',
     open: false,
@@ -189,6 +190,18 @@
   function titled(n, title) {
     if (n && title) n.setAttribute('title', String(title));
     return n;
+  }
+  function responsiveSecondary(label, content) {
+    var details = el('details', 'tc-secondary-panel');
+    var narrow = typeof window !== 'undefined' && window.matchMedia &&
+      window.matchMedia('(max-width: 560px)').matches;
+    details.open = !narrow || secondaryOpen[label] === true;
+    details.appendChild(el('summary', 'tc-secondary-summary', label));
+    details.appendChild(content);
+    on(details, 'toggle', function () {
+      if (narrow) secondaryOpen[label] = !!details.open;
+    });
+    return details;
   }
   function svgEl(tag, attrs) {
     var n = document.createElementNS(SVG_NS, tag);
@@ -1435,7 +1448,7 @@
       legendRows.appendChild(lr);
     }
     legend.appendChild(legendRows);
-    side.appendChild(legend);
+    side.appendChild(responsiveSecondary('Status legend', legend));
   }
 
   // ------------------------------------------------------------ view router
@@ -1511,7 +1524,7 @@
       tile.appendChild(el('div', 'tc-stat-value', tileDefs[i].value));
       tiles.appendChild(tile);
     }
-    main.appendChild(tiles);
+    main.appendChild(responsiveSecondary('Team totals', tiles));
 
     // Two-column body: agent grid + live-activity rail.
     var body = el('div', 'tc-overview-body');
@@ -1545,7 +1558,7 @@
       for (var g = 0; g < shown.length; g++) grid.appendChild(agentCard(root, shown[g]));
     }
     body.appendChild(grid);
-    body.appendChild(activityRail(root));
+    body.appendChild(responsiveSecondary('Recent activity', activityRail(root)));
     main.appendChild(body);
   }
 
@@ -1701,10 +1714,10 @@
     var graphCard = el('div', 'tc-card tc-graph-card');
     graphCard.appendChild(buildGraph(root));
     graphCard.appendChild(flowLegend(root));
-    body.appendChild(graphCard);
+    body.appendChild(responsiveSecondary('Relationship graph', graphCard));
 
     // Right: Active-threads list.
-    var listCard = el('div', 'tc-card tc-card-clip');
+    var listCard = el('div', 'tc-card tc-card-clip tc-priority-primary');
     var listHead = el('div', 'tc-card-head');
     listHead.appendChild(el('span', 'tc-card-title', 'Active threads'));
     listCard.appendChild(listHead);
@@ -2332,10 +2345,12 @@
   }
 
   function leadChatSide(data) {
-    var side = el('div', 'tc-lead-side');
-    side.appendChild(leadChatLivenessCard(data));
+    var side = el('div', 'tc-lead-side tc-priority-primary');
     side.appendChild(leadChatDecisionsCard(data));
-    side.appendChild(intentSummaryStrip());
+    var secondary = el('div', 'tc-lead-secondary');
+    secondary.appendChild(leadChatLivenessCard(data));
+    secondary.appendChild(intentSummaryStrip());
+    side.appendChild(responsiveSecondary('Lead status and queued actions', secondary));
     return side;
   }
 
@@ -2506,12 +2521,12 @@
       return;
     }
 
-    wrap.appendChild(learningSummary(data));
+    wrap.appendChild(responsiveSecondary('Learning totals', learningSummary(data)));
     var body = el('div', 'tc-learning-layout');
     body.appendChild(learningLessons(data));
-    var side = el('div', 'tc-learning-side');
-    side.appendChild(learningExposurePanel(data));
+    var side = el('div', 'tc-learning-side tc-priority-primary');
     side.appendChild(learningProblemsPanel(data));
+    side.appendChild(responsiveSecondary('Recent surfaced lessons', learningExposurePanel(data)));
     body.appendChild(side);
     wrap.appendChild(body);
     main.appendChild(wrap);
@@ -2696,12 +2711,12 @@
       return;
     }
 
-    wrap.appendChild(onboardingSummary(data));
+    wrap.appendChild(responsiveSecondary('Onboarding totals', onboardingSummary(data)));
     var body = el('div', 'tc-onboarding-layout');
     body.appendChild(onboardingRuns(data));
-    var side = el('div', 'tc-onboarding-side');
+    var side = el('div', 'tc-onboarding-side tc-priority-primary');
     side.appendChild(onboardingBlockersPanel(data));
-    side.appendChild(onboardingProblemsPanel(data));
+    side.appendChild(responsiveSecondary('Ledger health', onboardingProblemsPanel(data)));
     body.appendChild(side);
     wrap.appendChild(body);
     main.appendChild(wrap);
@@ -3003,8 +3018,10 @@
     var body = el('div', 'tc-sessions-body');
 
     var left = el('div', 'tc-session-left');
-    left.appendChild(actionComposer(root));
-    left.appendChild(intentSummaryStrip());
+    var actions = el('div', 'tc-session-actions');
+    actions.appendChild(actionComposer(root));
+    actions.appendChild(intentSummaryStrip());
+    left.appendChild(responsiveSecondary('Compose and queued actions', actions));
     left.appendChild(activeThreadsCard(root));
     left.appendChild(archivedThreadsCard(root));
     body.appendChild(left);
@@ -3015,7 +3032,7 @@
   }
 
   function activeThreadsCard(root) {
-    var listCard = el('div', 'tc-card tc-card-clip');
+    var listCard = el('div', 'tc-card tc-card-clip tc-priority-primary');
     var head = el('div', 'tc-session-list-title tc-session-section-head');
     head.appendChild(el('span', null, 'Active'));
     head.appendChild(el('span', 'tc-spacer'));

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -2268,12 +2268,16 @@
     waived_expired: 'WAIVED (EXPIRED)',
   });
   // A waiver that no longer covers the gate (gates._gate_verdict: status stays
-  // "waived" but blocks=true, reason="waiver expired or invalid") must NOT
-  // read as the calm purple "WAIVED" state - it is back to blocking (review
-  // rq-a7038d8175f2 finding 2). This is the one place status alone is not
-  // enough; every other card/chip class keys off gate.status directly.
+  // "waived" but reason="waiver expired or invalid") must NOT read as the
+  // calm purple "WAIVED" state (review rq-a7038d8175f2 finding 2). PR #129
+  // connector finding: `blocks` alone under-detects this - _gate_verdict
+  // only sets blocks=true for severity=blocker; an expired warn/info waiver
+  // stays blocks=false. The server now derives `waiver_expired`
+  // severity-independently; prefer it, with `blocks` as a fallback for an
+  // older payload shape.
   function gateVisualState(gate) {
-    if (gate.status === 'waived' && gate.blocks) return 'waived_expired';
+    var expired = 'waiver_expired' in gate ? gate.waiver_expired : gate.blocks;
+    if (gate.status === 'waived' && expired) return 'waived_expired';
     return gate.status || 'unknown';
   }
 
@@ -2348,6 +2352,22 @@
         if (isArray(e.refs) && e.refs.length) {
           evBox.appendChild(el('div', 'tc-gate-evidence-refs', e.refs.join(', ')));
         }
+        // PR #129 connector finding: the API forwards every OTHER
+        // evidence_details field too (coverage_percent, pr_url, ...) - this
+        // used to only ever render source/by/at/refs, hiding the actual
+        // proof a gate relied on even though it was present in the payload.
+        var extraKeys = Object.keys(e).filter(function (k) {
+          return k !== 'source' && k !== 'refs' && k !== 'at' && k !== 'by';
+        }).sort();
+        for (var j = 0; j < extraKeys.length; j++) {
+          var k = extraKeys[j];
+          evBox.appendChild(el('div', 'tc-gate-evidence-row', k + ': ' + e[k]));
+        }
+      }
+      if (gate.evidence_truncated) {
+        evBox.appendChild(el('div', 'tc-gate-evidence-refs',
+          gate.evidence_truncated + ' older evidence entr' +
+          (gate.evidence_truncated === 1 ? 'y' : 'ies') + ' not shown.'));
       }
       card.appendChild(evBox);
     }
@@ -4318,6 +4338,11 @@
     }).then(function (data) {
       if (riskRegisterPending === requestKey) riskRegisterPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      // PR #129 connector finding: unlike every other payload with relative
+      // ages, this fetch skipped stampAuxPayload, so risk items never got
+      // _receivedAt and the 1s updateAges loop kept reconstructing the same
+      // (zero-elapsed) age - every displayed age froze at fetch time.
+      stampAuxPayload(data);
       riskRegisterData = data;
       renderSidebar();
       if (state.view === 'risk-register') renderActiveViewFromPoll();

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -975,6 +975,19 @@
     return (now - at) <= ATTENTION_STALE_MS;
   }
   function attentionFresh() { return attentionKnownFrom(attentionData, state.now); }
+  // PR #129 connector round-5 (P1, console.js:4377, judgment call - fixed
+  // within the ~30-line budget by reusing stampAuxPayload/_receivedAt
+  // exactly as attentionKnownFrom does): the Gates and Risk Register views
+  // silently keep rendering their last-good payload through a poll outage,
+  // with nothing on the view itself signalling that it stopped updating -
+  // only the global topbar tracks /api/state freshness. This is scoped to
+  // those two views only; the topbar "Live" indicator is untouched.
+  function auxPayloadFresh(data) {
+    if (data == null) return false;
+    var received = data._receivedAt;
+    if (typeof received !== 'number' || !isFinite(received)) return true;
+    return (monotonicNow() - received) <= ATTENTION_STALE_MS;
+  }
   // Is the agent-health data (from /api/state) KNOWN-fresh? Same rationale as
   // attentionFresh: fetchState stamps _receivedAt (via stampStatePayload) on each
   // successful poll and retains last-good on failure, so a stale lastState means
@@ -2284,9 +2297,12 @@
   // stays blocks=false. The server now derives `waiver_expired`
   // severity-independently; prefer it, with `blocks` as a fallback for an
   // older payload shape.
+  function gateWaiverExpired(gate) {
+    return 'waiver_expired' in gate ? gate.waiver_expired : gate.blocks;
+  }
+
   function gateVisualState(gate) {
-    var expired = 'waiver_expired' in gate ? gate.waiver_expired : gate.blocks;
-    if (gate.status === 'waived' && expired) return 'waived_expired';
+    if (gate.status === 'waived' && gateWaiverExpired(gate)) return 'waived_expired';
     // PR #129 connector round-2 finding (P1, console.js:2281): a missing
     // required gate is status=unknown/blocks=true, and a skipped blocker
     // is status=skipped/blocks=true - both used to render with the neutral
@@ -2295,6 +2311,20 @@
     // case above) reuses the existing danger-red treatment.
     if (gate.blocks && gate.status !== 'red') return 'red';
     return gate.status || 'unknown';
+  }
+
+  // PR #129 connector round-5 (reviewer-3 F-3 + connector P2, console.js:2339):
+  // the chip TEXT must come from gate.status, not the visual/class value -
+  // gateVisualState forces a blocking unknown/skipped gate into the red
+  // CLASS for color, but a "RED" label on it falsely claims a run actually
+  // FAILED rather than never ran / was skipped. waived_expired is the one
+  // real status+text override (a bare "WAIVED" reads calm once the waiver
+  // stopped covering the gate), so it is kept here too.
+  function gateStatusLabel(gate) {
+    if (gate.status === 'waived' && gateWaiverExpired(gate)) {
+      return GATE_STATUS_LABEL.waived_expired;
+    }
+    return GATE_STATUS_LABEL[gate.status] || (gate.status || '').toUpperCase();
   }
 
   function renderGates(main, root) {
@@ -2309,6 +2339,11 @@
       var verdictChip = el('span', 'tc-chip tc-gate-verdict gate-' +
         (data.verdict === 'GO' ? 'green' : 'red'), data.verdict || 'HOLD');
       header.appendChild(verdictChip);
+      if (!auxPayloadFresh(data)) {
+        header.appendChild(titled(
+          el('span', 'tc-chip tc-cap-confidence is-stale', 'STALE'),
+          'A poll to refresh this view has been failing - this may not reflect the current gate state'));
+      }
     }
     wrap.appendChild(header);
 
@@ -2336,7 +2371,7 @@
     var head = el('div', 'tc-gate-head');
     head.appendChild(el('span', 'tc-gate-name', gate.name || ''));
     head.appendChild(titled(el('span', 'tc-chip gate-' + visual,
-      GATE_STATUS_LABEL[visual] || (gate.status || '').toUpperCase()),
+      gateStatusLabel(gate)),
       gate.blocks ? 'This gate is blocking' : 'Not currently blocking'));
     head.appendChild(el('span', 'tc-gate-scope', gate.scope || 'global'));
     head.appendChild(el('span', 'tc-gate-severity', gate.severity || ''));
@@ -2435,6 +2470,11 @@
     var countLabel = totalOpen + ' open' + (partial ? ' · incomplete' : '') +
       (truncatedCount ? ' (showing ' + count + ')' : '');
     header.appendChild(el('span', 'tc-attn-count', errs.length ? 'status unknown' : countLabel));
+    if (data && !errs.length && !auxPayloadFresh(data)) {
+      header.appendChild(titled(
+        el('span', 'tc-chip tc-cap-confidence is-stale', 'STALE'),
+        'A poll to refresh this view has been failing - this may not reflect the current risk register'));
+    }
     wrap.appendChild(header);
 
     if (!data) {
@@ -4364,12 +4404,22 @@
     var requestKey = rootRequestKey(projectId, generation);
     if (gatesPending === requestKey) return;
     gatesPending = requestKey;
-    fetch(rootUrl('/api/gates', projectId)).then(function (r) {
+    // PR #129 connector round-5 (console.js:4387): startEndpointPoll's `run`
+    // does `Promise.resolve(request).then(scheduleNext, scheduleNext)` -
+    // without this `return`, `request` is undefined and the NEXT poll is
+    // scheduled immediately instead of after this fetch settles.
+    return fetch(rootUrl('/api/gates', projectId)).then(function (r) {
       if (!r.ok) return null;
       return r.json();
     }).then(function (data) {
       if (gatesPending === requestKey) gatesPending = null;
       if (!data || !rootPayloadMatches(data, projectId, generation)) return;
+      // PR #129 connector round-5 (P1, console.js:4377, judgment call): a
+      // failing poll keeps this last-good payload forever with no
+      // _receivedAt to age it out - stamp it like every other polled
+      // payload so auxPayloadFresh() below can tell a live gate list from
+      // one an outage froze indefinitely.
+      stampAuxPayload(data);
       gatesData = data;
       renderSidebar();
       if (state.view === 'gates') renderActiveViewFromPoll();
@@ -4384,7 +4434,9 @@
     var requestKey = rootRequestKey(projectId, generation);
     if (riskRegisterPending === requestKey) return;
     riskRegisterPending = requestKey;
-    fetch(rootUrl('/api/risk-register', projectId)).then(function (r) {
+    // PR #129 connector round-5 (console.js:4387): same missing-return as
+    // fetchGates - startEndpointPoll needs this promise back to wait for it.
+    return fetch(rootUrl('/api/risk-register', projectId)).then(function (r) {
       if (!r.ok) return null;
       return r.json();
     }).then(function (data) {

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -1166,8 +1166,10 @@
     // Mission pill (from root.spec_kitty.missions — name only, no x/y).
     if (root && root.spec_kitty && isArray(root.spec_kitty.missions) && root.spec_kitty.missions.length) {
       var pill = el('div', 'tc-mission-pill');
+      var missionText = root.spec_kitty.missions.join(' · ');
       pill.appendChild(missionIcon());
-      pill.appendChild(el('span', 'tc-mission-name', root.spec_kitty.missions.join(' · ')));
+      pill.appendChild(el('span', 'tc-mission-name', missionText));
+      titled(pill, missionText);
       bar.appendChild(pill);
     }
 

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -3662,9 +3662,9 @@
     var projectId = currentRootId();
     var generation = rootGeneration;
     var requestKey = rootRequestKey(projectId, generation);
-    if (intentsPending === requestKey) return;
+    if (intentsPending === requestKey) return null;
     intentsPending = requestKey;
-    fetch(rootUrl('/api/intents', projectId)).then(function (r) {
+    return fetch(rootUrl('/api/intents', projectId)).then(function (r) {
       if (!r.ok) return null;
       return r.json();
     }).then(function (data) {
@@ -3781,10 +3781,10 @@
     // >2s, stacked requests could commit out of arrival order and move the
     // console backwards; the guard + the per-response sequence check below
     // (drop anything older than the newest committed) prevent that.
-    if (statePending) return;
+    if (statePending) return null;
     statePending = true;
     var seq = ++stateSeq;
-    fetch('/api/state').then(function (r) {
+    return fetch('/api/state').then(function (r) {
       // r.ok guard (P3): on a non-2xx, keep the last-good lastState rather than
       // blanking the view to an error object / "Loading…".
       if (!r.ok) return null;
@@ -3838,9 +3838,9 @@
     var projectId = currentRootId();
     var generation = rootGeneration;
     var requestKey = rootRequestKey(projectId, generation);
-    if (attentionPending === requestKey) return;
+    if (attentionPending === requestKey) return null;
     attentionPending = requestKey;
-    fetch(rootUrl('/api/attention', projectId)).then(function (r) {
+    return fetch(rootUrl('/api/attention', projectId)).then(function (r) {
       if (!r.ok) return null;
       return r.json();
     }).then(function (data) {
@@ -3859,9 +3859,9 @@
     var projectId = currentRootId();
     var generation = rootGeneration;
     var requestKey = rootRequestKey(projectId, generation);
-    if (leadChatPending === requestKey) return;
+    if (leadChatPending === requestKey) return null;
     leadChatPending = requestKey;
-    fetch(rootUrl('/api/lead-chat', projectId)).then(function (r) {
+    return fetch(rootUrl('/api/lead-chat', projectId)).then(function (r) {
       if (!r.ok) return null;
       return r.json();
     }).then(function (data) {
@@ -4042,20 +4042,36 @@
     refreshHealthIfChanged();
   }
 
+  function startEndpointPoll(fetcher) {
+    // One independent completion-driven loop per endpoint. A 9-second scan
+    // therefore produces one request, then waits POLL_MS before the next; it
+    // never queues four interval ticks behind the slow request (#207).
+    function scheduleNext() { setTimeout(run, POLL_MS); }
+    function run() {
+      var request;
+      try { request = fetcher(); }
+      catch (e) { scheduleNext(); return; }
+      Promise.resolve(request).then(scheduleNext, scheduleNext);
+    }
+    run();
+  }
+
   // ------------------------------------------------------------ boot
   function boot() {
     loadPrefs();
     applyPrefs();
     renderChrome();
-    fetchState();
     // Fetch attention at boot AND poll it (P2-3), regardless of the initial
     // view: the sidebar count badge is the open-attention count and must be
     // current from the start, not blank until the Attention view is opened.
-    fetchRootPayloads();
-    setInterval(fetchState, POLL_MS);
-    setInterval(fetchAttention, POLL_MS);
-    setInterval(fetchLeadChat, POLL_MS);
-    setInterval(fetchIntents, POLL_MS);
+    startEndpointPoll(fetchState);
+    startEndpointPoll(fetchAttention);
+    startEndpointPoll(fetchLeadChat);
+    startEndpointPoll(fetchIntents);
+    // These payloads are view support, not high-cadence telemetry.
+    fetchSession();
+    fetchLearning();
+    fetchOnboarding();
     setInterval(clockTick, CLOCK_MS);
   }
 

--- a/src/agenttalk/web_static/console.js
+++ b/src/agenttalk/web_static/console.js
@@ -2207,7 +2207,9 @@
     var errs = (data && isArray(data.errors)) ? data.errors : [];
     var items = (data && isArray(data.items)) ? data.items : [];
     var count = data && typeof data.count === 'number' ? data.count : items.length;
-    header.appendChild(el('span', 'tc-attn-count', errs.length ? 'status unknown' : count + ' open'));
+    var partial = !!(data && data.partial);
+    header.appendChild(el('span', 'tc-attn-count',
+      errs.length ? 'status unknown' : count + ' open' + (partial ? ' · incomplete' : '')));
     wrap.appendChild(header);
 
     if (!data) {
@@ -2216,14 +2218,41 @@
       wrap.appendChild(genericErrorState(
         'Can’t read the risk register right now',
         'The dashboard hit an error building this list. (' + errs.join('; ') + ')'));
-    } else if (!items.length) {
-      wrap.appendChild(emptyState('No open risks', 'Nothing is waiting on you right now.'));
     } else {
-      var list = el('div', 'tc-attn-list');
-      for (var i = 0; i < items.length; i++) list.appendChild(riskCard(items[i]));
-      wrap.appendChild(list);
+      // B-1 (review rq-093f956dd595): a register whose contract is "each
+      // open item" must say so out loud when it could NOT enumerate
+      // everything - showing the items it DID get without this banner would
+      // read as a confident, complete list, indistinguishable from a
+      // genuine all-clear.
+      if (partial) wrap.appendChild(riskRegisterPartialBanner(data));
+      if (!items.length) {
+        wrap.appendChild(partial
+          ? genericErrorState('Risk register is incomplete',
+              'No risks could be read from the sources below - this is NOT a confirmed all-clear.')
+          : emptyState('No open risks', 'Nothing is waiting on you right now.'));
+      } else {
+        var list = el('div', 'tc-attn-list');
+        for (var i = 0; i < items.length; i++) list.appendChild(riskCard(items[i]));
+        wrap.appendChild(list);
+        if (typeof data.truncated === 'number' && data.truncated > 0) {
+          wrap.appendChild(el('p', 'tc-recent-empty',
+            data.truncated + ' more open risk(s) not shown (list capped).'));
+        }
+      }
     }
     main.appendChild(wrap);
+  }
+
+  // "Some of this list could not be read" banner - distinct from
+  // attentionError/genericErrorState because the register is NOT empty here;
+  // it's a confirmed-incomplete list, not a confirmed-failed one.
+  function riskRegisterPartialBanner(data) {
+    var sources = isArray(data.degraded_sources) ? data.degraded_sources : [];
+    var b = el('div', 'tc-attn-stale-banner');
+    b.appendChild(el('span', null,
+      'This list is INCOMPLETE - some sources could not be read, so open risks may be missing.'
+      + (sources.length ? ' (' + sources.join('; ') + ')' : '')));
+    return b;
   }
 
   function riskCard(item) {
@@ -2236,7 +2265,11 @@
     tagRow.appendChild(titled(el('span', 'tc-chip sev-' + item.severity,
       SEV_LABEL[item.severity] || (item.severity || '').toUpperCase()), SEV_DESC[item.severity]));
     tagRow.appendChild(el('span', 'tc-spacer'));
-    tagRow.appendChild(ageEl('tc-attn-age', item, { suffix: ' ago' }));
+    // L-2: an item flagged age_unknown must read as "age unknown", never as
+    // "0s ago" (which looks freshly-created, the opposite of the truth).
+    tagRow.appendChild(item.age_unknown
+      ? ageEl('tc-attn-age', item, { noHb: true, nullText: 'age unknown' })
+      : ageEl('tc-attn-age', item, { suffix: ' ago' }));
     body.appendChild(tagRow);
     body.appendChild(el('div', 'tc-attn-title', item.title || ''));
     var detailRow = el('div', 'tc-attn-detailrow');

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -305,3 +305,48 @@ def test_missing_file_is_empty_go(tmp_path: Path) -> None:
     root = _root(tmp_path)
     res = gates.check_gates(root, scope="release")
     assert res["verdict"] == "GO" and res["required_gates"] == []
+
+
+def test_check_gates_uses_provided_state_snapshot_not_a_fresh_read(tmp_path: Path) -> None:
+    """PR #129 connector round-2 finding (P2, web.py:2901): web.py's
+    build_gates used to call check_gates() and load_gate_state() as TWO
+    separate reads - a set_gate() commit landing between them could combine
+    a verdict from the first snapshot with evidence from the second (green
+    beside proof that did not produce it, or green with no proof at all).
+    check_gates(state=...) must derive the verdict from the EXACT snapshot
+    passed in, never re-reading the file itself."""
+    root = _root(tmp_path)
+    gates.set_gate(root, name="ci", status="green", severity="blocker",
+                   scope="release", actor="alpha", evidence_source="automation_ci",
+                   evidence=["ref"], reason="ok", required=True)
+    snapshot = gates.load_gate_state(root)
+    # Simulate a concurrent write landing AFTER the snapshot was taken.
+    gates.set_gate(root, name="ci", status="red", severity="blocker",
+                   scope="release", actor="alpha", evidence_source="local_command",
+                   reason="broke")
+    from_snapshot = gates.check_gates(root, state=snapshot)
+    assert from_snapshot["gates"][0]["status"] == "green", (
+        "check_gates(state=snapshot) must reflect the SNAPSHOT, not the live file")
+    # Sanity: a fresh (no state=) read still sees the newer write - the
+    # default behavior is unchanged for every OTHER caller.
+    fresh = gates.check_gates(root)
+    assert fresh["gates"][0]["status"] == "red"
+
+
+def test_waiver_expired_reason_constant_matches_gate_verdict(tmp_path: Path) -> None:
+    """PR #129 connector round-2 (reviewer-3 F-4): web.py derives its
+    waiver_expired signal by comparing a gate's verdict reason against
+    gates.WAIVER_EXPIRED_REASON. Link the two directly so they can never
+    silently drift apart - this is the exact reason _gate_verdict sets for
+    an inactive waiver."""
+    root = _root(tmp_path)
+    gates.set_gate(root, name="ci", status="red", severity="warn",
+                   scope="release", actor="alpha", evidence_source="local_command",
+                   reason="stale")
+    gates.waive_gate(root, name="ci", operator="alpha", reason="tracked separately",
+                     scope="release", expires="2020-01-01T00:00:00Z")
+    checked = gates.check_gates(root)
+    (gate,) = checked["gates"]
+    assert gate["reason"] == gates.WAIVER_EXPIRED_REASON, (
+        "an expired waiver's verdict reason must be the shared constant, "
+        f"not a separately-typed literal: {gate['reason']!r}")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8545,7 +8545,7 @@ main.children = [];
 hooks.setup(root, 'gates', gatesFresh, riskFresh);
 hooks.renderActiveView();
 const gateStale = findAllByClass(main, 'is-stale', []);
-assert(gateStale.length === 1, `expected exactly one STALE badge on an outage-aged gates view, got ${gateStale.length}`);
+assert(gateStale.length === 1, `expected one STALE badge on an outage-aged gates view, got ${gateStale.length}`);
 assert(gateStale[0].textContent === 'STALE', `expected the badge text to read STALE, got: ${gateStale[0].textContent}`);
 
 main.children = [];

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4052,7 +4052,7 @@ const hooks = ctx.__agenttalkHistoryTestHooks;
   assert(historyWrites.at(-1).method === 'push' &&
     history.entries[1].includes('root=project-b'),
     `user selection was not a project-B push: ${JSON.stringify(historyWrites)}`);
-  assert(calls.length === 6 && calls.every((call) => call.url.includes('root=project-b')),
+  assert(calls.length === 9 && calls.every((call) => call.url.includes('root=project-b')),
     `project-B selection did not refetch B: ${JSON.stringify(calls)}`);
   const staleB = calls.find((call) => call.url.startsWith('/api/attention'));
   hooks.seedRootContext('project B');
@@ -4071,8 +4071,8 @@ const hooks = ctx.__agenttalkHistoryTestHooks;
   assert(history.entries.length === 2 && history.index === 0 &&
     historyWrites.length === writesBeforeBack,
     `Back wrote history: ${JSON.stringify(historyWrites)}`);
-  const aCalls = calls.slice(6);
-  assert(aCalls.length === 6 && aCalls.every((call) => call.url.includes('root=project-a')),
+  const aCalls = calls.slice(9);
+  assert(aCalls.length === 9 && aCalls.every((call) => call.url.includes('root=project-a')),
     `Back did not refetch A: ${JSON.stringify(aCalls)}`);
 
   const currentA = aCalls.find((call) => call.url.startsWith('/api/attention'));
@@ -4080,7 +4080,7 @@ const hooks = ctx.__agenttalkHistoryTestHooks;
     root_info: {project_id: rootA.project_id}, count: 3, items: [],
   }));
   for (const call of aCalls) if (call !== currentA) call.resolve(response(false, {}));
-  for (const call of calls.slice(0, 6)) {
+  for (const call of calls.slice(0, 9)) {
     if (call !== staleB) call.resolve(response(false, {}));
   }
   await flush();
@@ -4104,8 +4104,8 @@ const hooks = ctx.__agenttalkHistoryTestHooks;
   assert(history.entries.length === 2 && history.index === 1 &&
     historyWrites.length === writesBeforeForward,
     `Forward wrote history: ${JSON.stringify(historyWrites)}`);
-  const forwardCalls = calls.slice(12);
-  assert(forwardCalls.length === 6 &&
+  const forwardCalls = calls.slice(18);
+  assert(forwardCalls.length === 9 &&
     forwardCalls.every((call) => call.url.includes('root=project-b')),
     `Forward did not refetch B: ${JSON.stringify(forwardCalls)}`);
 })().catch((err) => {
@@ -6249,6 +6249,289 @@ def test_api_state_thread_carries_opener(tmp_path: Path) -> None:
         (row,) = root["threads"]
         assert row["opener"] == "alpha"
         assert row["opener_peer"] == "beta"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# ------------------------------------------------------- /api/gates (§4c)
+#
+# Gate & Evidence Wall, read side (docs/PROPOSAL-console-client-sellability.md
+# #1). Quick-win selection: 20260825-215757-153513-ljQ3.
+
+def _gates(base: str) -> dict:
+    with _get(f"{base}/api/gates") as resp:
+        assert resp.status == 200
+        assert resp.headers["Content-Type"].startswith("application/json")
+        return json.loads(resp.read())
+
+
+def test_api_gates_shape_evidence_and_waiver(tmp_path: Path) -> None:
+    """A green blocker gate carries its evidence; a waived gate carries its
+    waiver reason/expiry; a missing required gate blocks with a reason. The
+    envelope carries the full picture /api/attention only ever summarizes as
+    one blocker line."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    gmod.set_gate(s.root, name="tests", status="green", severity="blocker",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  evidence=["ci-run-42"], reason="all green", required=True)
+    gmod.waive_gate(s.root, name="security-scan", operator="alpha",
+                    reason="scanner unavailable", scope="release",
+                    expires="2099-01-01T00:00:00Z")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        assert set(payload) == {
+            "root", "root_path", "root_info", "target_root_project_id",
+            "verdict", "required_gates", "gates", "count",
+        }
+        assert payload["count"] == len(payload["gates"])
+        assert payload["required_gates"] == ["tests"]
+        by_name = {g["name"]: g for g in payload["gates"]}
+
+        tests_gate = by_name["tests"]
+        assert tests_gate["status"] == "green"
+        assert tests_gate["severity"] == "blocker"
+        assert tests_gate["scope"] == "release"
+        assert tests_gate["blocks"] is False
+        assert tests_gate["waiver"] is None
+        (evidence_entry,) = tests_gate["evidence"]
+        assert evidence_entry["source"] == "automation_ci"
+        assert evidence_entry["refs"] == ["ci-run-42"]
+        assert evidence_entry["by"] == "alpha"
+        assert "at" in evidence_entry
+
+        scan_gate = by_name["security-scan"]
+        assert scan_gate["status"] == "waived"
+        assert scan_gate["blocks"] is False
+        assert scan_gate["waiver"] == {
+            "operator": "alpha",
+            "date": scan_gate["waiver"]["date"],
+            "reason": "scanner unavailable",
+            "scope": "release",
+            "expires": "2099-01-01T00:00:00Z",
+        }
+
+        # every required blocker gate is green -> GO
+        assert payload["verdict"] == "GO"
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_missing_required_gate_blocks(tmp_path: Path) -> None:
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    state = gmod.load_gate_state(s.root)
+    state["required_gates"] = ["never-run"]
+    gmod.write_gate_state(s.root, state)
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        assert payload["verdict"] == "HOLD"
+        (gate,) = payload["gates"]
+        assert gate["name"] == "never-run"
+        assert gate["status"] == "unknown"
+        assert gate["blocks"] is True
+        assert gate["reason"]
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_degrades_on_corrupt_root(tmp_path: Path) -> None:
+    """Parity with /api/attention's errors-as-data (B1): a corrupt gates.json
+    must NOT 500 the route. gates.check_gates already fails closed for a
+    corrupt state file with a single synthetic ``__gate_state__`` blocker
+    (mirrored by attention.gate_hold_items) - build_gates must pass that
+    through, not crash trying to read a non-existent evidence list for it."""
+    s = _make_store(tmp_path)
+    (s.dir / "gates.json").write_text("{not json", encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        assert set(payload) >= {"root", "gates", "count", "verdict"}
+        assert payload["count"] == len(payload["gates"])
+        assert payload["verdict"] == "HOLD"
+        (gate,) = payload["gates"]
+        assert gate["name"] == "__gate_state__"
+        assert gate["blocks"] is True
+        assert gate["evidence"] == []
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# --------------------------------------------------- /api/risk-register (§4e)
+#
+# Risk Register relabel (docs/PROPOSAL-console-client-sellability.md #6).
+
+def _risk_register(base: str) -> dict:
+    with _get(f"{base}/api/risk-register") as resp:
+        assert resp.status == 200
+        assert resp.headers["Content-Type"].startswith("application/json")
+        return json.loads(resp.read())
+
+
+def test_api_risk_register_shape_and_sorted_by_severity_then_age(
+    tmp_path: Path,
+) -> None:
+    from agenttalk import gates as gmod
+    from agenttalk.wrapper import recv_api
+
+    s = _make_store(tmp_path)
+    # A high-severity gate-hold risk (blocker gate, red).
+    gmod.set_gate(s.root, name="ci", status="red", severity="blocker",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  reason="pipeline red", required=True)
+    # A dead letter -> med severity risk with an owning agent.
+    message = s.send(sender="alpha", recipient="beta", body="poison",
+                     kind="message", meta={})
+    record = recv_api.next_record(s, "beta")
+    assert record["id"] == message.id
+    s.dead_letter("beta", record, reason="deterministic",
+                  failure_class="poison_eligible", at="2026-07-02T00:00:00Z")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert set(payload) == {
+            "root", "root_path", "root_info", "target_root_project_id",
+            "items", "count",
+        }
+        assert payload["count"] == len(payload["items"])
+        for it in payload["items"]:
+            assert set(it) == {
+                "id", "category", "category_label", "severity", "title",
+                "owner", "detail", "age_seconds", "human_can_unblock_now",
+            }
+            assert it["severity"] in ("high", "med", "low")
+        # severity-desc, then age-desc within a severity band
+        order = [("high", 0), ("med", 1), ("low", 2)]
+        rank = dict(order)
+        ranks = [rank[it["severity"]] for it in payload["items"]]
+        assert ranks == sorted(ranks)
+        gate_items = [it for it in payload["items"] if it["category"] == "gate"]
+        assert gate_items and gate_items[0]["category_label"] == "Gate blocker"
+        deadletter_items = [it for it in payload["items"] if it["category"] == "deadletter"]
+        assert deadletter_items and deadletter_items[0]["category_label"] == "Delivery failure"
+        assert deadletter_items[0]["owner"] == "beta"
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
+    s = _make_store(tmp_path)
+    cfg_path = s.dir / "config.json"
+    cfg_path.write_text("{not json", encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert set(payload) >= {"root", "items", "count"}
+        assert payload["count"] == len(payload["items"])
+        _assert_no_body_keys(payload)
+        assert payload["items"] == [] or all(
+            it["category"] in ("escalation", "supervisor", "gate", "deadletter",
+                               "coordination_stall", "stuck")
+            for it in payload["items"]
+        )
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# ----------------------------------------------------- /api/ownership (§4d)
+#
+# Ownership & Accountability Map (docs/PROPOSAL-console-client-sellability.md
+# #7).
+
+def _ownership(base: str) -> dict:
+    with _get(f"{base}/api/ownership") as resp:
+        assert resp.status == 200
+        assert resp.headers["Content-Type"].startswith("application/json")
+        return json.loads(resp.read())
+
+
+def test_api_ownership_full_registry_shape(tmp_path: Path) -> None:
+    """The full registry - domains with resolved owners/reviewers/curators plus
+    shared_paths - not just the thin per-agent slice /api/state carries."""
+    s = _make_store(tmp_path)
+    (s.dir / "domains.json").write_text(json.dumps({
+        "schema_version": 1,
+        "domains": {
+            "web": {
+                "title": "Web layer",
+                "owners": {"agents": ["alpha"]},
+                "reviewers": {"agents": ["beta"]},
+                "owned_globs": ["src/agenttalk/web.py"],
+                "description": "the dashboard server",
+            },
+        },
+        "shared_paths": [{
+            "glob": "**/pyproject.toml",
+            "category": "package-metadata",
+            "requires": "lead-approval",
+            "default_approvers": {"agents": ["alpha"]},
+        }],
+    }), encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _ownership(base)
+        assert set(payload) == {
+            "root", "root_path", "root_info", "target_root_project_id",
+            "domains", "shared_paths", "count",
+        }
+        assert payload["count"] == len(payload["domains"])
+        (domain,) = payload["domains"]
+        assert domain["id"] == "web"
+        assert domain["title"] == "Web layer"
+        assert domain["owners"] == ["alpha"]
+        assert domain["reviewers"] == ["beta"]
+        assert domain["curators"] == []
+        assert domain["owned_globs"] == ["src/agenttalk/web.py"]
+        assert domain["description"] == "the dashboard server"
+        (shared,) = payload["shared_paths"]
+        assert shared["glob"] == "**/pyproject.toml"
+        assert shared["category"] == "package-metadata"
+        assert shared["requires"] == "lead-approval"
+        assert shared["default_approvers"] == ["alpha"]
+        assert shared["default_reviewers"] == []
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_ownership_missing_registry_is_empty_not_error(tmp_path: Path) -> None:
+    s = _make_store(tmp_path)
+    srv, _t, base = _serve(s)
+    try:
+        payload = _ownership(base)
+        assert payload["domains"] == []
+        assert payload["shared_paths"] == []
+        assert payload["count"] == 0
+        assert "errors" not in payload
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_ownership_degrades_on_malformed_registry(tmp_path: Path) -> None:
+    s = _make_store(tmp_path)
+    (s.dir / "domains.json").write_text("{not json", encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _ownership(base)
+        assert payload["domains"] == []
+        assert payload["count"] == 0
+        assert payload["errors"]
+        _assert_no_body_keys(payload)
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6589,6 +6589,42 @@ def test_api_gates_shape_evidence_and_waiver(tmp_path: Path) -> None:
         srv.server_close()
 
 
+def test_api_gates_evidence_key_bounding_does_not_collide(tmp_path: Path) -> None:
+    """review rq-e05589aa3c80 R-1: a bounded evidence key must not silently
+    overwrite an already-populated field (a whitespace-padded "source "
+    collapsing onto the canonical "source" once _envelope_str strips it),
+    and two distinct long keys that share the same 64-char prefix must not
+    silently merge - first write wins, neither overwrites the other."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    long_prefix = "x" * 64
+    gmod.set_gate(
+        s.root, name="ci", status="green", severity="blocker", scope="release",
+        actor="alpha", evidence_source="automation_ci", evidence=["ref1"],
+        evidence_details={
+            "source ": "SHADOWED",
+            f"{long_prefix}-one": "first",
+            f"{long_prefix}-two": "second",
+        },
+        required=True,
+    )
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        (entry,) = gate["evidence"]
+        assert entry["source"] == "automation_ci", (
+            f"the canonical 'source' field must survive a whitespace-padded "
+            f"colliding key: {entry}")
+        assert entry.get(long_prefix) == "first", (
+            f"two keys sharing a 64-char prefix must not silently merge "
+            f"(first write should win): {entry}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
 def test_api_gates_missing_required_gate_blocks(tmp_path: Path) -> None:
     from agenttalk import gates as gmod
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6640,6 +6640,47 @@ def test_api_risk_register_includes_open_onboarding_drift_and_unknown(
         srv.server_close()
 
 
+def test_api_risk_register_onboarding_not_truncated_by_dashboard_run_limit(
+    tmp_path: Path,
+) -> None:
+    """review rq-4ecf94c4f814 finding 1: build_onboarding's dashboard
+    presentation cap (_ONBOARDING_DEFAULT_LIMIT=50 newest-first runs) must
+    NOT silently drop an older run's open finding from the risk register -
+    "each open item" (proposal §3 #6) has no recency cutoff. Reproduces the
+    reviewer's 51-run repro: the OLDEST run carries the one open, blocking
+    drift; 50 strictly newer runs carry nothing open, so a naive 50-run cap
+    would push the victim run's open finding out of the window."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    victim_run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=victim_run_id, title="oldest scan", objective="map it",
+        base_ref="main", lead="alpha", state="scanning",
+        at="2020-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=victim_run_id, kind=ob.KIND_DRIFT, key="old-drift", status="open",
+        summary="an old unresolved drift", actor="alpha", owner="beta",
+        blocking=True, at="2020-01-01T00:05:00Z"))
+    for i in range(50):
+        run_id = ob.new_run_id()
+        ob.create_run(s, ob.new_create_event(
+            run_id=run_id, title=f"newer scan {i}", objective="map it",
+            base_ref="main", lead="alpha", state="scanning",
+            at=f"2026-01-{(i % 28) + 1:02d}T00:00:00Z"))
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        drift_items = [it for it in payload["items"] if it["category"] == "onboarding_drift"]
+        assert len(drift_items) == 1, (
+            "the older run's open drift must not be truncated by the dashboard's "
+            f"50-run presentation cap: {payload['items']}")
+        assert drift_items[0]["title"] == "an old unresolved drift"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
 def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
     s = _make_store(tmp_path)
     cfg_path = s.dir / "config.json"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2752,6 +2752,29 @@ def test_console_renderer_safety(tmp_path: Path) -> None:
     assert "sessionStorage" not in js
 
 
+def test_console_mission_pill_bounds_long_text(tmp_path: Path) -> None:
+    """#207: long mission labels stay inside the header and retain a full-text
+    tooltip when the visible label is truncated."""
+    s = _make_store(tmp_path)
+    srv, _t, base = _serve(s)
+    try:
+        with _get(f"{base}/static/console.css") as resp:
+            css = resp.read().decode("utf-8")
+        with _get(f"{base}/static/console.js") as resp:
+            js = resp.read().decode("utf-8")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+    pill = re.search(r"\.tc-mission-pill\s*\{([^}]*)\}", css, re.S)
+    label = re.search(r"\.tc-mission-name\s*\{([^}]*)\}", css, re.S)
+    assert pill is not None and "min-width: 0" in pill.group(1)
+    assert pill is not None and "max-width:" in pill.group(1)
+    assert label is not None and "overflow: hidden" in label.group(1)
+    assert label is not None and "text-overflow: ellipsis" in label.group(1)
+    assert "titled(pill, missionText)" in js
+
+
 def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path) -> None:
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3561,6 +3561,17 @@ assert(hasClass(skippedCard, 'gate-red'),
   `a blocking status=skipped gate must render danger (gate-red), got class=${skippedCard.className}`);
 assert(!hasClass(skippedCard, 'gate-skipped'),
   'a blocking gate must not keep the neutral gray skipped class');
+
+// PR #129 connector round-5 (reviewer-3 F-3 + connector P2, console.js:2339):
+// the forced-red CLASS above is a color-only visual escalation - the chip
+// TEXT must still say what the gate's real status is, not "RED" (which
+// falsely claims a run actually FAILED rather than never ran / was skipped).
+const missingChip = findAllByClass(missingCard, 'tc-chip', [])[0];
+assert(missingChip.textContent === 'UNKNOWN',
+  `a blocking status=unknown gate must show the UNKNOWN label text, not RED, got: ${missingChip.textContent}`);
+const skippedChip = findAllByClass(skippedCard, 'tc-chip', [])[0];
+assert(skippedChip.textContent === 'SKIPPED',
+  `a blocking status=skipped gate must show the SKIPPED label text, not RED, got: ${skippedChip.textContent}`);
 """, encoding="utf-8")
     subprocess.run(["node", str(runner), str(instrumented)], check=True,
                    capture_output=True, text=True)
@@ -6614,6 +6625,30 @@ def test_api_attention_derived_stuck_item(tmp_path: Path) -> None:
         srv.server_close()
 
 
+def test_api_risk_register_stuck_item_with_no_heartbeat_is_age_unknown(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector round-5 (web.py:3166): an agent with no heartbeat at
+    all (a genuinely never-seen or long-vanished agent) used to surface as a
+    STUCK risk item with age_seconds=0.0 and no age_unknown flag - the same
+    "just happened" conflation _age_seconds_from_iso was already fixed for
+    everywhere else. It must route through the same age_unknown convention:
+    _sort_age = inf, so it sorts as MOST urgent, never least."""
+    s = _make_store(tmp_path)
+    _write_health(s, "alpha", _hm.STATE_STUCK_SUSPECTED, cli="claude", mode="wrapper-loop")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        stuck = [it for it in payload["items"] if it["category"] == "stuck"]
+        assert len(stuck) == 1, payload
+        assert stuck[0]["age_seconds"] == 0.0, stuck[0]
+        assert stuck[0]["age_unknown"] is True, (
+            f"a stuck agent with no heartbeat must be age_unknown, not a bare 0.0: {stuck[0]}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
 def test_api_attention_derived_worktree_stall_item(tmp_path: Path) -> None:
     s = _make_store(tmp_path)
     s.write_heartbeat("alpha")
@@ -8093,6 +8128,66 @@ def test_api_gates_evidence_refs_truncation_is_flagged(tmp_path: Path) -> None:
         srv.server_close()
 
 
+def test_api_gates_evidence_ref_text_truncation_is_flagged(tmp_path: Path) -> None:
+    """PR #129 connector round-5 (web.py:2839): per-reference envelope
+    truncation (300 chars) was silent - a long evidence URL could be cut
+    into a different, unusable string with no signal it happened. Flag it
+    the same way _glob_str flags a truncated glob."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    long_ref = "https://example.invalid/" + ("x" * 400)
+    gmod.set_gate(s.root, name="ci", status="green", severity="warn",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  evidence=["short-ref", long_ref], reason="ok")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        (entry,) = gate["evidence"]
+        assert entry["refs"][0] == "short-ref"
+        assert entry["refs"][1] != long_ref, "a truncated ref must not be presented as complete"
+        assert entry["refs"][1].endswith("…")
+        assert entry["ref_text_truncated"] == 1, entry
+        assert "refs_truncated" not in entry, (
+            f"refs_truncated must not fire for a text-only truncation within the window: {entry}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_evidence_refs_truncated_counts_non_str_refs_in_window(tmp_path: Path) -> None:
+    """PR #129 connector round-5 (reviewer-3 F-2): a non-str ref inside the
+    (first 20) window used to be dropped by the `isinstance(r, str)` filter
+    without counting toward refs_truncated - the exact counting fix already
+    made for unparseable evidence entries (evidence_truncated), applied here
+    to refs."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    gmod.set_gate(s.root, name="ci", status="green", severity="warn",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  evidence=["ref-a", "ref-b"], reason="ok")
+    gates_path = gmod.gates_path(s.root)
+    raw = json.loads(gates_path.read_text(encoding="utf-8"))
+    # Two of the (now 4) refs are non-str and must be dropped from `refs` -
+    # but still counted, same shape as F-3's evidence_truncated fix.
+    raw["gates"]["ci"]["evidence"][0]["refs"] = ["ref-a", 42, "ref-b", None]
+    gates_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        (entry,) = gate["evidence"]
+        assert entry["refs"] == ["ref-a", "ref-b"]
+        assert entry["refs_truncated"] == 2, (
+            f"2 non-str refs inside the window must count toward refs_truncated: {entry}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
 def test_api_gates_evidence_truncated_counts_unparseable_entries(tmp_path: Path) -> None:
     """PR #129 connector round-2 finding (reviewer-3 F-3): an evidence entry
     that fails to parse (not a JSON object) was silently dropped without
@@ -8144,6 +8239,51 @@ def test_api_risk_register_surfaces_source_error_items_as_partial(
         payload = _risk_register(base)
         assert payload["partial"] is True, (
             f"a SOURCE_ERROR item must mark the register partial: {payload}")
+        assert any("dead_letter" in d for d in payload["degraded_sources"]), payload
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_stays_partial_when_source_error_is_deferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #129 connector round-5 (reviewer-3 F-1 + connector P1, web.py:3103):
+    the degraded-source scan used to iterate queue.get("items", []), which is
+    POST-disposition - build_queue excludes DEFERRED items by default, and
+    defer is the ONLY disposition source_error is allowed to have
+    (allowed_action_for_source). So an operator deferring the warning (the
+    only action available to them) made partial flip back to False while the
+    dead-letter source was still genuinely unreadable. The scan must inspect
+    the raw collected items, before dispositions are applied."""
+    from agenttalk import attention as att
+
+    s = _make_store(tmp_path)
+
+    error_text = "simulated dead-letter read failure"
+
+    def boom(*_args, **_kwargs):
+        raise OSError(error_text)
+    monkeypatch.setattr(s, "list_dead_letters", boom)
+
+    item_id = att.item_id(att.SOURCE_ERROR, "dead_letter")
+    src_hash = att.source_hash({"source": "dead_letter", "error": error_text[:200]})
+    att.append_disposition(s, {
+        "schema_version": 1, "event_id": "att-defer-1", "item_id": item_id,
+        "source": att.SOURCE_ERROR, "action": att.ACTION_DEFER, "actor": "claude",
+        "reason": "operator deferred while investigating", "at": "2026-01-01T00:00:00Z",
+        "until": "2099-01-01T00:00:00Z",
+        "source_snapshot": {"source_hash": src_hash, "refs": []},
+    })
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert not any(it["id"].startswith("source_error:") for it in payload["items"]), (
+            f"the deferred source_error item must NOT still be a visible queue item: {payload}")
+        assert payload["partial"] is True, (
+            f"a DEFERRED source_error must still mark the register partial - the source "
+            f"is still genuinely unreadable even though the warning item is hidden: {payload}")
         assert any("dead_letter" in d for d in payload["degraded_sources"]), payload
     finally:
         srv.shutdown()
@@ -8203,3 +8343,217 @@ def test_console_boot_polls_gates_and_risk_register(tmp_path: Path) -> None:
     boot_body = src[boot_start:boot_end]
     assert "startEndpointPoll(fetchGates)" in boot_body, boot_body
     assert "startEndpointPoll(fetchRiskRegister)" in boot_body, boot_body
+
+
+def test_console_fetch_gates_and_risk_register_return_their_promise_to_the_poller(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector round-5 (console.js:4387): fetchGates and
+    fetchRiskRegister built their fetch().then(...) chain but never
+    RETURNED it. startEndpointPoll's run() does
+    `Promise.resolve(request).then(scheduleNext, scheduleNext)` - with
+    `request` left undefined, that resolves immediately, so the next poll
+    was scheduled right away instead of after the in-flight request
+    settled (the exact stacking bug #207/test_console_poll_waits_for_slow_
+    endpoint_before_rescheduling proved the generic mechanism prevents,
+    but only if the fetcher cooperates by returning its promise)."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for console polling test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ boot\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    startEndpointPoll: startEndpointPoll,\n"
+        "    fetchGates: fetchGates,\n"
+        "    fetchRiskRegister: fetchRiskRegister,\n"
+        "    setup: function (root) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "    }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console-poll-gates-risk.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-poll-gates-risk.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+async function run(fetcherName, urlFragment, jsonBody) {
+  const timers = [];
+  const resolvers = [];
+  let fetchCalls = 0;
+  const ctx = {
+    console,
+    document: { readyState: 'loading', addEventListener() {} },
+    localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    performance: { now() { return 0; } },
+    setTimeout(fn, delay) { timers.push({ fn, delay }); },
+    setInterval() { throw new Error('data polling must not use setInterval'); },
+    clearInterval() {},
+    fetch(url) {
+      if (!String(url).includes(urlFragment)) {
+        throw new Error(`unexpected fetch url for ${fetcherName}: ${url}`);
+      }
+      fetchCalls += 1;
+      return new Promise((resolve) => resolvers.push(resolve));
+    },
+    __agenttalkConsoleTestHooks: null,
+  };
+  ctx.globalThis = ctx;
+  ctx.window = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
+  const hooks = ctx.__agenttalkConsoleTestHooks;
+  hooks.setup({ label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] });
+
+  async function flush() { for (let i = 0; i < 8; i += 1) await Promise.resolve(); }
+
+  hooks.startEndpointPoll(hooks[fetcherName]);
+  if (fetchCalls !== 1 || timers.length !== 0) {
+    throw new Error(`${fetcherName}: poll stacked before settlement: calls=${fetchCalls}, timers=${timers.length}`);
+  }
+  await flush();
+  if (fetchCalls !== 1 || timers.length !== 0) {
+    throw new Error(`${fetcherName} did not return its fetch promise to startEndpointPoll - the next poll ` +
+      `was scheduled before the in-flight request settled: calls=${fetchCalls}, timers=${timers.length}`);
+  }
+  resolvers.shift()({ ok: true, json: () => Promise.resolve(jsonBody) });
+  await flush();
+  if (timers.length !== 1 || timers[0].delay !== 2000) {
+    throw new Error(`${fetcherName}: next poll was not delayed after settlement: ${JSON.stringify(timers)}`);
+  }
+}
+
+(async () => {
+  await run('fetchGates', '/api/gates',
+    { target_root_project_id: 'project-demo', verdict: 'GO', required_gates: [], gates: [], count: 0 });
+  await run('fetchRiskRegister', '/api/risk-register',
+    { target_root_project_id: 'project-demo', items: [], count: 0, truncated: 0, partial: false,
+      degraded_sources: [] });
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
+def test_console_gates_and_risk_register_show_stale_badge_on_outage(tmp_path: Path) -> None:
+    """PR #129 connector round-5 (P1, console.js:4377, judgment call): a
+    failing gates/risk-register poll silently keeps rendering the last-good
+    payload with nothing on those views themselves signalling that it
+    stopped updating (only the global topbar tracks /api/state freshness).
+    Bounded fix: reuse stampAuxPayload/_receivedAt (already added to
+    fetchGates/fetchRiskRegister this round) plus the same freshness-window
+    check attentionKnownFrom uses, surfaced as a STALE chip on each view."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the stale-badge render test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkStaleBadgeHooks = {\n"
+        "    renderActiveView: renderActiveView,\n"
+        "    setup: function (root, view, gates, riskRegister) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "      gatesData = gates;\n"
+        "      riskRegisterData = riskRegister;\n"
+        "      state.view = view;\n"
+        "    }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-stale-badge.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag).toUpperCase(), children: [], parentNode: null,
+    className: '', textContent: '', attributes: {},
+    style: { setProperty(name, value) { this[name] = String(value); } },
+    appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+      if (name === 'class') this.className = String(value);
+    },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+    },
+    addEventListener() {},
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  return node;
+}
+function hasClass(node, cls) { return String(node.className || '').split(/\s+/).includes(cls); }
+function findAllByClass(node, cls, out) {
+  if (hasClass(node, cls)) out.push(node);
+  for (const child of node.children || []) findAllByClass(child, cls, out);
+  return out;
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+const main = makeNode('main');
+const document = {
+  readyState: 'loading', createElement: makeNode,
+  createElementNS(_ns, tag) { return makeNode(tag); },
+  addEventListener() {}, getElementById(id) { return id === 'main' ? main : null; },
+  querySelector() { return null; }, querySelectorAll() { return []; },
+};
+let clock = 0;
+const ctx = {
+  console, document,
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return clock; } },
+  setInterval() {}, clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkStaleBadgeHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx, { filename: 'console.instrumented.js' });
+const hooks = ctx.__agenttalkStaleBadgeHooks;
+
+const root = { label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] };
+const gatesFresh = { verdict: 'GO', required_gates: [], gates: [], count: 0, _receivedAt: 0 };
+const riskFresh = { items: [], count: 0, truncated: 0, partial: false, degraded_sources: [], _receivedAt: 0 };
+
+// Just-received payload (clock === _receivedAt): no stale badge.
+clock = 0;
+main.children = [];  // this mock's clear() needs firstChild/removeChild it doesn't implement
+hooks.setup(root, 'gates', gatesFresh, riskFresh);
+hooks.renderActiveView();
+assert(findAllByClass(main, 'is-stale', []).length === 0,
+  'a freshly-received gates payload must not render the STALE badge');
+
+// Poll has been failing for well past the freshness window (4 * POLL_MS = 8000ms).
+clock = 60000;
+main.children = [];
+hooks.setup(root, 'gates', gatesFresh, riskFresh);
+hooks.renderActiveView();
+const gateStale = findAllByClass(main, 'is-stale', []);
+assert(gateStale.length === 1, `expected exactly one STALE badge on an outage-aged gates view, got ${gateStale.length}`);
+assert(gateStale[0].textContent === 'STALE', `expected the badge text to read STALE, got: ${gateStale[0].textContent}`);
+
+main.children = [];
+hooks.setup(root, 'risk-register', gatesFresh, riskFresh);
+hooks.renderActiveView();
+const riskStale = findAllByClass(main, 'is-stale', []);
+assert(riskStale.length === 1,
+  `expected exactly one STALE badge on an outage-aged risk register view, got ${riskStale.length}`);
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3506,14 +3506,26 @@ hooks.setup(
         },
         waiver_expired: true,
       },
+      {
+        name: 'missing-required', status: 'unknown', severity: 'blocker', scope: 'release',
+        blocks: true, reason: 'required gate is missing',
+        updated_at: '', updated_by: '',
+        evidence: [], evidence_truncated: 0, waiver: null, waiver_expired: false,
+      },
+      {
+        name: 'skipped-blocker', status: 'skipped', severity: 'blocker', scope: 'release',
+        blocks: true, reason: 'required evidence not run (skipped); use a waiver for not-applicable',
+        updated_at: '2026-01-01T00:00:00Z', updated_by: 'alpha',
+        evidence: [], evidence_truncated: 0, waiver: null, waiver_expired: false,
+      },
     ],
-    count: 2,
+    count: 4,
   },
 );
 hooks.renderActiveView();
 
 const cards = findAllByClass(main, 'tc-gate-card', []);
-assert(cards.length === 2, `expected two gate cards, got ${cards.length}`);
+assert(cards.length === 4, `expected four gate cards, got ${cards.length}`);
 
 const coverageText = collectText(cards[0]);
 assert(coverageText.includes('coverage_percent: 91.5'),
@@ -3529,6 +3541,26 @@ assert(!hasClass(docsCard, 'gate-waived'),
   'expired non-blocker waiver must NOT carry the calm gate-waived class');
 const docsText = collectText(docsCard);
 assert(docsText.includes('WAIVED (EXPIRED)'), `expected the expired label, got: ${docsText}`);
+// PR #129 connector round-2 finding (console.js:2336): blocks=false here,
+// so the waiver box must NOT claim it is blocking.
+assert(!docsText.includes('blocking'),
+  `an advisory (non-blocking) expired waiver must not say "blocking", got: ${docsText}`);
+
+// PR #129 connector round-2 finding (P1, console.js:2281): a missing
+// required gate (status=unknown, blocks=true) and a skipped blocker
+// (status=skipped, blocks=true) must render danger (reuse gate-red), not
+// the neutral gray unknown/skipped color - both are real HOLD contributors.
+const missingCard = cards[2];
+assert(hasClass(missingCard, 'gate-red'),
+  `a blocking status=unknown gate must render danger (gate-red), got class=${missingCard.className}`);
+assert(!hasClass(missingCard, 'gate-unknown'),
+  'a blocking gate must not keep the neutral gray unknown class');
+
+const skippedCard = cards[3];
+assert(hasClass(skippedCard, 'gate-red'),
+  `a blocking status=skipped gate must render danger (gate-red), got class=${skippedCard.className}`);
+assert(!hasClass(skippedCard, 'gate-skipped'),
+  'a blocking gate must not keep the neutral gray skipped class');
 """, encoding="utf-8")
     subprocess.run(["node", str(runner), str(instrumented)], check=True,
                    capture_output=True, text=True)
@@ -7369,9 +7401,17 @@ def test_api_risk_register_shape_and_sorted_by_severity_then_age(
         for it in payload["items"]:
             assert set(it) == {
                 "id", "category", "category_label", "severity", "title",
-                "owner", "detail", "age_seconds", "human_can_unblock_now",
+                "owner", "detail", "age_seconds", "age_unknown",
+                "human_can_unblock_now",
             }
             assert it["severity"] in ("high", "med", "low")
+            # both gate and dead-letter sources have a real updated_at/
+            # deadlettered_at here, so age is known (PR #129 connector
+            # round-2 finding, web.py:3088 - age derivation - and
+            # reviewer-3 F-2 - flag unknown rather than defaulting to 0.0).
+            assert it["age_unknown"] is False
+            assert it["age_seconds"] >= 0, (
+                f"gate/dead-letter age must reflect a real elapsed time: {it}")
         # severity-desc, then age-desc within a severity band
         order = [("high", 0), ("med", 1), ("low", 2)]
         rank = dict(order)
@@ -7986,9 +8026,180 @@ def test_api_ownership_preserves_long_globs_losslessly(tmp_path: Path) -> None:
         (domain,) = payload["domains"]
         assert domain["owned_globs"] == [long_glob], (
             "a long owned_globs entry must not be silently truncated")
+        assert domain["owned_globs_truncated"] == 0
         (shared,) = payload["shared_paths"]
         assert shared["glob"] == long_glob, (
             "a long shared_paths glob must not be silently truncated")
+        assert shared["glob_truncated"] is False
     finally:
         srv.shutdown()
         srv.server_close()
+
+
+def test_api_ownership_flags_globs_still_cut_beyond_the_cap(tmp_path: Path) -> None:
+    """PR #129 connector round-2 finding (web.py:2763 / reviewer-3 F-5):
+    raising the cap to 4096 just MOVES the same silent-truncation threshold
+    - a glob longer than THAT still gets silently altered unless the
+    response says so explicitly."""
+    s = _make_store(tmp_path)
+    huge_glob = "src/" + "x" * 5000 + "/*.py"
+    assert len(huge_glob) > 4096
+    (s.dir / "domains.json").write_text(json.dumps({
+        "schema_version": 1,
+        "domains": {
+            "gen": {"title": "Generated code", "owners": {"agents": ["alpha"]},
+                    "owned_globs": [huge_glob]},
+        },
+        "shared_paths": [{
+            "glob": huge_glob, "category": "generated", "requires": "lead-approval",
+        }],
+    }), encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _ownership(base)
+        (domain,) = payload["domains"]
+        assert domain["owned_globs"][0] != huge_glob, "sanity: this glob IS still cut"
+        assert domain["owned_globs_truncated"] == 1, (
+            f"a glob still cut past the 4096 cap must be flagged, not silent: {domain}")
+        (shared,) = payload["shared_paths"]
+        assert shared["glob_truncated"] is True
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_evidence_refs_truncation_is_flagged(tmp_path: Path) -> None:
+    """PR #129 connector round-2 finding (P1, web.py:2832): a green blocker
+    gate's validating ref could sit past position 20 in a single evidence
+    entry's refs list and be silently cut - the wall could then present the
+    gate as green with only empty/non-validating refs. Expose the cut count
+    rather than preserving or silently dropping."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    refs = [f"ref-{i}" for i in range(25)]
+    gmod.set_gate(s.root, name="ci", status="green", severity="blocker",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  evidence=refs, reason="ok", required=True)
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        (entry,) = gate["evidence"]
+        assert entry["refs"] == refs[:20]
+        assert entry["refs_truncated"] == 5, entry
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_evidence_truncated_counts_unparseable_entries(tmp_path: Path) -> None:
+    """PR #129 connector round-2 finding (reviewer-3 F-3): an evidence entry
+    that fails to parse (not a JSON object) was silently dropped without
+    counting toward evidence_truncated - the wall could show fewer entries
+    than the cap implied with no signal that any were lost to a shape
+    problem rather than the cap itself. Also: the truncation notice must
+    still be reachable in the view even when EVERY entry is lost (covered
+    by the console render test)."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    gmod.set_gate(s.root, name="ci", status="green", severity="warn",
+                  scope="release", actor="alpha", evidence_source="local_command",
+                  evidence=["ref"], reason="ok")
+    gates_path = gmod.gates_path(s.root)
+    raw = json.loads(gates_path.read_text(encoding="utf-8"))
+    # 5 of the (now 6) entries are not objects and must fail to parse.
+    raw["gates"]["ci"]["evidence"] = ["not-a-dict"] * 5 + raw["gates"]["ci"]["evidence"]
+    gates_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        assert len(gate["evidence"]) == 1
+        assert gate["evidence_truncated"] == 5, (
+            f"5 unparseable entries must count toward evidence_truncated: {gate}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_surfaces_source_error_items_as_partial(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #129 connector round-2 finding (P1, web.py:3047): a failure inside
+    _collect_web_attention_items becomes a visible, DISPOSITIONABLE
+    SOURCE_ERROR queue item, but that alone didn't mark the register
+    partial - an operator could disposition the warning item away and lose
+    the only signal that a source could not be fully read."""
+    s = _make_store(tmp_path)
+
+    def boom(*_args, **_kwargs):
+        raise OSError("simulated dead-letter read failure")
+    monkeypatch.setattr(s, "list_dead_letters", boom)
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert payload["partial"] is True, (
+            f"a SOURCE_ERROR item must mark the register partial: {payload}")
+        assert any("dead_letter" in d for d in payload["degraded_sources"]), payload
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_treats_future_onboarding_timestamp_as_unknown(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector round-2 finding (P2, web.py:3156): a bounded but
+    parseable FUTURE updated_at (a skewed external writer) produced a
+    negative age, which read as "known" - clamped to 0s on the wire and
+    sorted to the LEAST urgent end of its severity band, the opposite of
+    the fail-safe "unknown is not safe" treatment an unparseable timestamp
+    already gets."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=run_id, title="scan", objective="map it", base_ref="main",
+        lead="alpha", state="scanning", at="2026-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="future-drift", status="open",
+        summary="from a clock-skewed writer", actor="alpha", blocking=True,
+        at="2030-01-01T00:00:00Z"))
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        drift_items = [it for it in payload["items"] if it["category"] == "onboarding_drift"]
+        (item,) = drift_items
+        assert item["age_unknown"] is True, (
+            f"a future timestamp must be treated as unknown, not a negative-then-clamped "
+            f"age: {item}")
+        assert item["age_seconds"] == 0.0
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_console_boot_polls_gates_and_risk_register(tmp_path: Path) -> None:
+    """PR #129 connector round-2 finding (P1, console.js:4521): Gates and
+    Risk Register used to be fetched once (boot/root-entry/navigation) and
+    never again while the view stayed open, so an operator watching either
+    screen kept seeing a stale all-clear/count indefinitely. boot() must
+    wire both through the SAME completion-driven startEndpointPoll loop as
+    state/attention/lead-chat/intents - that generic mechanism is already
+    behaviorally proven by
+    test_console_poll_waits_for_slow_endpoint_before_rescheduling; this
+    guards the wiring itself landing (and staying) inside boot()."""
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    boot_marker = "  function boot() {\n"
+    assert boot_marker in src
+    boot_start = src.index(boot_marker)
+    boot_end = src.index("\n  }\n", boot_start)
+    boot_body = src[boot_start:boot_end]
+    assert "startEndpointPoll(fetchGates)" in boot_body, boot_body
+    assert "startEndpointPoll(fetchRiskRegister)" in boot_body, boot_body

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2914,6 +2914,81 @@ if (JSON.stringify(names) !== JSON.stringify(expected)) {
                    capture_output=True, text=True)
 
 
+def test_console_poll_waits_for_slow_endpoint_before_rescheduling(tmp_path: Path) -> None:
+    """#207: each endpoint gets one in-flight request and its next cadence starts
+    after settlement, so a response slower than POLL_MS cannot stack requests."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for console polling test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ boot\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    startEndpointPoll: startEndpointPoll\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console-poll.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-poll.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const timers = [];
+const ctx = {
+  console,
+  document: { readyState: 'loading', addEventListener() {} },
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return 0; } },
+  setTimeout(fn, delay) { timers.push({ fn, delay }); },
+  setInterval() { throw new Error('data polling must not use setInterval'); },
+  clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkConsoleTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
+
+let calls = 0;
+const resolvers = [];
+function slowEndpoint() {
+  calls += 1;
+  return new Promise((resolve) => resolvers.push(resolve));
+}
+async function flush() {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+}
+(async () => {
+  ctx.__agenttalkConsoleTestHooks.startEndpointPoll(slowEndpoint);
+  if (calls !== 1 || timers.length !== 0) {
+    throw new Error(`poll stacked before settlement: calls=${calls}, timers=${timers.length}`);
+  }
+  await flush();
+  if (calls !== 1 || timers.length !== 0) {
+    throw new Error(`pending endpoint was rescheduled: calls=${calls}, timers=${timers.length}`);
+  }
+  resolvers.shift()();
+  await flush();
+  if (timers.length !== 1 || timers[0].delay !== 2000) {
+    throw new Error(`next poll was not delayed after settlement: ${JSON.stringify(timers)}`);
+  }
+  const next = timers.shift();
+  next.fn();
+  if (calls !== 2 || timers.length !== 0) {
+    throw new Error(`second slow request stacked: calls=${calls}, timers=${timers.length}`);
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path) -> None:
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2854,6 +2854,66 @@ if (hooks.pollingStatus().label !== 'Stale') {
                    capture_output=True, text=True)
 
 
+def test_console_defaults_agent_grid_to_active_run(tmp_path: Path) -> None:
+    """#207: stale unwrapped roster history is opt-in via All; supervised
+    recovery targets and live unwrapped agents remain in the default scope."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for console active-run test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    defaultFilter: state.filter,\n"
+        "    filterAgents: filterAgents\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console-active-run.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-active-run.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+const ctx = {
+  console,
+  document: { readyState: 'loading', addEventListener() {} },
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return 0; } },
+  setInterval() {},
+  clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkConsoleTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
+const hooks = ctx.__agenttalkConsoleTestHooks;
+if (hooks.defaultFilter !== 'active') {
+  throw new Error(`default filter is ${hooks.defaultFilter}, not active run`);
+}
+const root = { agents: [
+  { name: 'supervised-idle', wrapped: true, health: { state: 'idle_waiting' } },
+  { name: 'supervised-exited', wrapped: true, health: { state: 'crashed_or_exited' } },
+  { name: 'live-unwrapped', wrapped: false, last_seen_age_seconds: 5,
+    health: { state: 'unknown' } },
+  { name: 'historical-unwrapped', wrapped: false, last_seen_age_seconds: 500,
+    health: { state: 'unknown' } },
+] };
+const names = hooks.filterAgents(root).map((item) => item.name);
+const expected = ['supervised-idle', 'supervised-exited', 'live-unwrapped'];
+if (JSON.stringify(names) !== JSON.stringify(expected)) {
+  throw new Error(`active-run scope mismatch: ${JSON.stringify(names)}`);
+}
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path) -> None:
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2822,6 +2822,139 @@ assert(hooks.freshHeartbeat({ last_seen_age_seconds: -1 }) === false, 'negative 
                    capture_output=True, text=True)
 
 
+def test_console_gate_card_expired_waiver_renders_as_blocking(tmp_path: Path) -> None:
+    """review rq-a7038d8175f2 finding 2: gates.check_gates keeps
+    status='waived' for an EXPIRED blocker waiver but sets blocks=True (reason
+    'waiver expired or invalid'). A populated Gates view render must show that
+    as blocking (red/expired), not the calm purple 'WAIVED' card a still-valid
+    waiver gets - a shape-only JSON test cannot catch a frontend styling bug,
+    so this actually renders renderGates()/gateCard() and inspects the DOM."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the gate-card render test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkGatesTestHooks = {\n"
+        "    renderActiveView: renderActiveView,\n"
+        "    setup: function (root, gates) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "      gatesData = gates;\n"
+        "      state.view = 'gates';\n"
+        "    }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-gates.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag).toUpperCase(),
+    children: [],
+    parentNode: null,
+    className: '',
+    textContent: '',
+    attributes: {},
+    style: { setProperty(name, value) { this[name] = String(value); } },
+    appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+      if (name === 'class') this.className = String(value);
+    },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+    },
+    addEventListener() {},
+    // renderActiveView() unconditionally calls snapshotScroll/restoreScroll,
+    // which do root.querySelector(<inner-scroller selector>) - a no-match
+    // stub is enough, this test does not exercise scroll preservation.
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  return node;
+}
+function hasClass(node, cls) { return String(node.className || '').split(/\s+/).includes(cls); }
+function findAllByClass(node, cls, out) {
+  if (hasClass(node, cls)) out.push(node);
+  for (const child of node.children || []) findAllByClass(child, cls, out);
+  return out;
+}
+function collectText(node) {
+  let out = node.textContent || '';
+  for (const child of node.children || []) out += ' ' + collectText(child);
+  return out;
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+const main = makeNode('main');
+const document = {
+  readyState: 'loading',
+  createElement: makeNode,
+  createElementNS(_ns, tag) { return makeNode(tag); },
+  addEventListener() {},
+  getElementById(id) { return id === 'main' ? main : null; },
+  querySelector() { return null; },
+  querySelectorAll() { return []; },
+};
+const ctx = {
+  console, document,
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  setInterval() {}, clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkGatesTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx, { filename: 'console.instrumented.js' });
+const hooks = ctx.__agenttalkGatesTestHooks;
+
+hooks.setup(
+  { label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] },
+  {
+    root: 'demo', verdict: 'HOLD', required_gates: ['security-scan'],
+    gates: [{
+      name: 'security-scan', status: 'waived', severity: 'blocker', scope: 'release',
+      blocks: true, reason: 'waiver expired or invalid',
+      updated_at: '2026-01-01T00:00:00Z', updated_by: 'alpha',
+      evidence: [],
+      waiver: {
+        operator: 'alpha', date: '2025-01-01T00:00:00Z',
+        reason: 'scanner unavailable', scope: 'release',
+        expires: '2025-06-01T00:00:00Z',
+      },
+    }],
+    count: 1,
+  },
+);
+hooks.renderActiveView();
+
+const cards = findAllByClass(main, 'tc-gate-card', []);
+assert(cards.length === 1, 'expected exactly one gate card');
+const card = cards[0];
+assert(hasClass(card, 'gate-waived_expired'),
+  `expired blocker waiver must render gate-waived_expired, got class=${card.className}`);
+assert(!hasClass(card, 'gate-waived'),
+  'expired blocker waiver must NOT carry the calm gate-waived class');
+const text = collectText(card);
+assert(text.includes('WAIVED (EXPIRED)'),
+  `expected the expired-waiver label in the card, got: ${text}`);
+assert(text.includes('Waiver expired'),
+  `expected the waiver box to say it is expired, got: ${text}`);
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_all_dashboard_views_render_smoke_non_empty_main(tmp_path: Path) -> None:
     if shutil.which("node") is None:
         pytest.skip("node is required for console all-views render smoke test")
@@ -6426,6 +6559,87 @@ def test_api_risk_register_shape_and_sorted_by_severity_then_age(
         srv.server_close()
 
 
+def test_api_risk_register_uses_typed_risk_severity_over_source_default(
+    tmp_path: Path,
+) -> None:
+    """review rq-a7038d8175f2 finding 1: an escalation's OWN typed
+    risk_severity must win over the coarse per-source default. The shape test
+    above only covers a gate + dead letter, where source and risk happen to
+    align (both land on the coarse default because neither source sets a
+    typed risk_severity) - this test forces them to DIVERGE."""
+    s = _make_store(tmp_path)
+    s.set_operator_facing("beta")
+    s.send(sender="alpha", recipient="beta", kind="question", body="?",
+           subject="operator input needed",
+           meta={"request_id": "esc-low-risk", "needs_operator": "true",
+                 "attention": {"decision": "Pick a font",
+                               "risk_severity": "low", "confidence": "high"}})
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        item = next(it for it in payload["items"] if it["category"] == "escalation")
+        assert item["severity"] == "low", (
+            "typed risk_severity=low must not be overridden by the coarse "
+            f"escalation source default (high): {item}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_includes_open_onboarding_drift_and_unknown(
+    tmp_path: Path,
+) -> None:
+    """review rq-a7038d8175f2 finding 3: docs/PROPOSAL-console-client-sellability.md:105-112
+    defines item #6's risk register as covering "stalled agent, dead letter,
+    gate blocker, open onboarding drift/unknown" - onboarding findings were
+    omitted. A RESOLVED drift/unknown record must NOT surface (only open
+    ones are risks)."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=run_id, title="repo scan", objective="map the codebase",
+        base_ref="main", lead="alpha", state="scanning",
+        at="2026-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="drift-1", status="open",
+        summary="docs say X, code does Y", actor="alpha", owner="beta",
+        blocking=True, at="2026-01-01T00:05:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_UNKNOWN, key="unknown-1", status="open",
+        summary="unclear retry policy", actor="alpha", blocking=False,
+        at="2026-01-01T00:10:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="drift-resolved", status="resolved",
+        summary="already fixed", actor="alpha", blocking=True,
+        at="2026-01-01T00:15:00Z"))
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        by_category = {}
+        for it in payload["items"]:
+            by_category.setdefault(it["category"], []).append(it)
+
+        drift_items = by_category.get("onboarding_drift", [])
+        assert len(drift_items) == 1, (
+            f"expected exactly the OPEN drift record, not the resolved one: {payload['items']}")
+        assert drift_items[0]["category_label"] == "Doc/code drift"
+        assert drift_items[0]["severity"] == "high"  # blocking=True
+        assert drift_items[0]["owner"] == "beta"
+        assert drift_items[0]["title"] == "docs say X, code does Y"
+
+        unknown_items = by_category.get("onboarding_unknown", [])
+        assert len(unknown_items) == 1
+        assert unknown_items[0]["category_label"] == "Open unknown"
+        assert unknown_items[0]["severity"] == "med"  # blocking=False
+        assert unknown_items[0]["owner"] == "alpha"  # falls back to actor
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
 def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
     s = _make_store(tmp_path)
     cfg_path = s.dir / "config.json"
@@ -6438,7 +6652,8 @@ def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
         _assert_no_body_keys(payload)
         assert payload["items"] == [] or all(
             it["category"] in ("escalation", "supervisor", "gate", "deadletter",
-                               "coordination_stall", "stuck")
+                               "coordination_stall", "stuck", "onboarding_drift",
+                               "onboarding_unknown")
             for it in payload["items"]
         )
     finally:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3016,10 +3016,15 @@ const fs = require('node:fs');
 const vm = require('node:vm');
 
 function node(tag) {
+  const attrs = {};
   return {
     tagName: String(tag).toUpperCase(), className: '', textContent: '', children: [], open: false,
     appendChild(child) { this.children.push(child); return child; },
-    setAttribute() {}, addEventListener() {},
+    setAttribute(name, value) { attrs[name] = String(value); },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+    },
+    addEventListener() {},
   };
 }
 // A live MediaQueryList mock: ONE shared object (like the real
@@ -3033,10 +3038,35 @@ function fireMediaChange(matches) {
   mq.matches = matches;
   for (const cb of mq._listeners) cb({ matches });
 }
+// A minimal "mounted DOM" root, separate from panels that are merely
+// CREATED: round 2 of this review (rq-2968d93df2bc) showed that reacting on
+// the next RENDER isn't equivalent to reacting on the live DOM when a poll
+// is delayed/failed. The fix walks document.querySelectorAll('.tc-secondary-panel')
+// on every real media-query change, so this harness must model "currently
+// attached to the page" vs "created but discarded" to prove it only ever
+// touches what's actually mounted (never a registry that could leak).
+const mountRoot = node('main');
+function mount(panel) { mountRoot.children.push(panel); return panel; }
+function unmount(panel) {
+  const idx = mountRoot.children.indexOf(panel);
+  if (idx !== -1) mountRoot.children.splice(idx, 1);
+}
+function hasClass(n, cls) { return String(n.className || '').split(/\s+/).includes(cls); }
+function queryAllByClass(root, cls) {
+  const out = [];
+  (function walk(n) {
+    if (hasClass(n, cls)) out.push(n);
+    for (const c of n.children || []) walk(c);
+  })(root);
+  return out;
+}
 const document = {
   readyState: 'loading', addEventListener() {},
   createElement: node,
   createElementNS(_ns, tag) { return node(tag); },
+  querySelectorAll(selector) {
+    return queryAllByClass(mountRoot, selector.replace(/^\./, ''));
+  },
 };
 const ctx = {
   console, document,
@@ -3066,35 +3096,51 @@ if (mq._listeners.length !== 1) {
   throw new Error(`expected exactly one shared change listener at module load, got ${mq._listeners.length}`);
 }
 
-// Created narrow: closed, per the existing contract.
+// Created narrow: closed, per the existing contract. Mount it - this is the
+// panel a real page would currently be displaying.
 const mobileContent = node('div');
-const panel = hooks.responsiveSecondary('Recent activity', mobileContent);
+const panel = mount(hooks.responsiveSecondary('Recent activity', mobileContent));
 if (panel.tagName !== 'DETAILS' || panel.open || panel.children[0].tagName !== 'SUMMARY' ||
     panel.children[1] !== mobileContent) {
   throw new Error(`narrow secondary panel did not collapse safely: ${JSON.stringify(panel)}`);
 }
 
-// Direct regression for the reviewer's repro: render (and, in a real DOM,
-// discard) 1000 panels. The listener count must stay at exactly one -
-// nothing accumulates per panel.
+// Direct regression for the reviewer's leak repro: render 1000 panels,
+// mount-then-immediately-unmount each (simulating 1000 view rebuilds). The
+// listener count must stay at exactly one - nothing accumulates per panel,
+// and nothing is retained for a panel that is no longer mounted.
 for (let i = 0; i < 1000; i++) {
-  hooks.responsiveSecondary('Recent activity', node('div'));
+  unmount(mount(hooks.responsiveSecondary('Recent activity', node('div'))));
 }
 if (mq._listeners.length !== 1) {
   throw new Error(`1000 rendered panels must not accumulate listeners, got ${mq._listeners.length}`);
 }
 
-// The fix is RENDER-TIME state (the reviewer's own suggested design), not a
-// live per-node listener: renderActiveView already rebuilds the whole view
-// every poll, so the NEXT panel rendered after a viewport crossing must
-// reflect it, in both directions.
+// review rq-2968d93df2bc round 2: the SAME still-mounted node ("panel" from
+// above) must react to a live viewport crossing WITHOUT any render/poll in
+// between - fetchState keeps last-good state on a failed poll, so depending
+// on the next render is not equivalent to the original live-node contract.
 fireMediaChange(false);
-const wide = hooks.responsiveSecondary('Recent activity', node('div'));
-if (!wide.open) throw new Error('a panel rendered after crossing narrow -> wide was not open');
-
+if (!panel.open) {
+  throw new Error('the SAME mounted panel did not reopen on narrow -> wide with no poll in between');
+}
 fireMediaChange(true);
-const narrowAgain = hooks.responsiveSecondary('Recent activity', node('div'));
-if (narrowAgain.open) throw new Error('a panel rendered after crossing wide -> narrow was not collapsed');
+if (panel.open) {
+  throw new Error('the SAME mounted panel did not re-collapse on wide -> narrow with no poll in between');
+}
+
+// A panel that was mounted and then discarded (unmounted, as a real view
+// teardown would do) must NOT be touched by a later change - proves the fix
+// walks the LIVE DOM (querySelectorAll), not a leak-prone registry of every
+// panel ever created.
+const discardedContent = node('div');
+const discarded = mount(hooks.responsiveSecondary('Recent activity', discardedContent));
+unmount(discarded);
+const discardedOpenBefore = discarded.open;
+fireMediaChange(false);
+if (discarded.open !== discardedOpenBefore) {
+  throw new Error('an unmounted/discarded panel must not be mutated by a later media-query change');
+}
 
 // Still exactly one listener after all of the above.
 if (mq._listeners.length !== 1) {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2775,6 +2775,85 @@ def test_console_mission_pill_bounds_long_text(tmp_path: Path) -> None:
     assert "titled(pill, missionText)" in js
 
 
+def test_console_ages_and_staleness_use_server_time_anchor(tmp_path: Path) -> None:
+    """#207: wall-clock skew on the browser cannot make a server-timestamped
+    event newer/older or keep a failed poll labelled current."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for console timestamp test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    acceptState: function (payload) {\n"
+        "      stampStatePayload(payload);\n"
+        "      lastState = payload;\n"
+        "      return payload;\n"
+        "    },\n"
+        "    liveAge: liveAge,\n"
+        "    serverClockText: serverClockText,\n"
+        "    pollingStatus: pollingStatus,\n"
+        "    resetText: resetText\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console-time.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-time.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+let monotonic = 1000;
+const ctx = {
+  console,
+  document: { readyState: 'loading', addEventListener() {} },
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return monotonic; } },
+  setInterval() {},
+  clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkConsoleTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
+vm.runInContext('Date.now = () => Date.parse("2100-01-01T00:00:00Z")', ctx);
+
+const hooks = ctx.__agenttalkConsoleTestHooks;
+const payload = {
+  generated_at: '2026-08-25T20:00:00Z',
+  roots: [],
+  sample: { ts: '2026-08-25T19:59:50Z', age_seconds: 10 },
+};
+hooks.acceptState(payload);
+monotonic = 6000;
+if (hooks.liveAge(payload.sample) !== 15) {
+  throw new Error(`server-relative age mixed in client clock: ${hooks.liveAge(payload.sample)}`);
+}
+if (hooks.serverClockText() !== '20:00:05 UTC') {
+  throw new Error(`server clock was not rendered in UTC: ${hooks.serverClockText()}`);
+}
+const resetAt = Date.parse('2026-08-25T20:30:00Z') / 1000;
+if (hooks.resetText({ resets_at: resetAt }) !== 'resets at 20:30 UTC') {
+  throw new Error(`server reset timestamp was not rendered in UTC: ${hooks.resetText({ resets_at: resetAt })}`);
+}
+if (hooks.pollingStatus().label !== 'Current') {
+  throw new Error(`fresh server snapshot was not labelled current: ${hooks.pollingStatus().label}`);
+}
+monotonic = 10000;
+if (hooks.pollingStatus().label !== 'Stale') {
+  throw new Error(`aged server snapshot was not labelled stale: ${hooks.pollingStatus().label}`);
+}
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path) -> None:
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2989,6 +2989,79 @@ async function flush() {
                    capture_output=True, text=True)
 
 
+def test_console_narrow_layout_collapses_secondary_panels(tmp_path: Path) -> None:
+    """#207: secondary material is a closed native details panel at narrow
+    widths, while the same panel stays open on desktop and primary panels sort
+    ahead of it."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for console narrow-layout test")
+
+    static_dir = Path(web.__file__).with_name("web_static")
+    src = (static_dir / "console.js").read_text(encoding="utf-8")
+    css = (static_dir / "console.css").read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkConsoleTestHooks = {\n"
+        "    responsiveSecondary: responsiveSecondary\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console-narrow.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-narrow.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+let narrow = true;
+function node(tag) {
+  return {
+    tagName: String(tag).toUpperCase(), className: '', textContent: '', children: [], open: false,
+    appendChild(child) { this.children.push(child); return child; },
+    setAttribute() {}, addEventListener() {},
+  };
+}
+const document = {
+  readyState: 'loading', addEventListener() {},
+  createElement: node,
+  createElementNS(_ns, tag) { return node(tag); },
+};
+const ctx = {
+  console, document,
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return 0; } },
+  setInterval() {}, clearInterval() {},
+  matchMedia() { return { matches: narrow }; },
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkConsoleTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
+const hooks = ctx.__agenttalkConsoleTestHooks;
+const mobileContent = node('div');
+const mobile = hooks.responsiveSecondary('Recent activity', mobileContent);
+if (mobile.tagName !== 'DETAILS' || mobile.open || mobile.children[0].tagName !== 'SUMMARY' ||
+    mobile.children[1] !== mobileContent) {
+  throw new Error(`narrow secondary panel did not collapse safely: ${JSON.stringify(mobile)}`);
+}
+narrow = false;
+const desktop = hooks.responsiveSecondary('Recent activity', node('div'));
+if (!desktop.open) throw new Error('desktop secondary panel was not open');
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+    narrow_css = css[css.index("@media (max-width: 560px)"):]
+    assert ".tc-priority-primary" in narrow_css and "order: -1" in narrow_css
+    assert ".tc-secondary-summary" in narrow_css
+    assert "responsiveSecondary('Team totals', tiles)" in src
+    assert "responsiveSecondary('Recent activity', activityRail(root))" in src
+
+
 def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path) -> None:
     console_js = Path(web.__file__).with_name("web_static") / "console.js"
     src = console_js.read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1258,6 +1258,9 @@ def test_multi_root_explicit_project_id_routes_every_console_get(
             "/api/intents",
             "/api/preflight",
             "/api/attention",
+            "/api/gates",
+            "/api/risk-register",
+            "/api/ownership",
             "/api/learning",
             "/api/onboarding",
             "/api/lead-chat",
@@ -1537,6 +1540,9 @@ def test_duplicate_project_id_descriptors_are_rejected(tmp_path: Path) -> None:
         "/api/intents",
         "/api/preflight",
         "/api/attention",
+        "/api/gates",
+        "/api/risk-register",
+        "/api/ownership",
         "/api/learning",
         "/api/onboarding",
         "/api/lead-chat",
@@ -1971,7 +1977,8 @@ def test_csp_split_per_route(tmp_path: Path) -> None:
     srv, _t, base = _serve(s)
     try:
         for path in (f"/messages/{mid}", "/api/status", "/api/state",
-                     "/api/attention", "/api/learning", "/api/onboarding",
+                     "/api/attention", "/api/gates", "/api/risk-register",
+                     "/api/ownership", "/api/learning", "/api/onboarding",
                      "/api/thread/rid-c"):
             with _get(f"{base}{path}") as resp:
                 assert resp.headers["Content-Security-Policy"] == _LEGACY_CSP, path
@@ -1995,6 +2002,7 @@ def test_new_routes_reject_write_methods(tmp_path: Path) -> None:
     srv, _t, base = _serve(s)
     try:
         for path in ("/api/state", "/api/threads", "/dashboard", "/api/attention",
+                     "/api/gates", "/api/risk-register", "/api/ownership",
                      "/api/learning", "/api/onboarding", "/api/thread/rid-w", "/static/console.js",
                      "/static/console.css", "/static/avatars/claude-dev.png"):
             req = urllib.request.Request(  # noqa: S310  # nosemgrep
@@ -2508,7 +2516,8 @@ def test_no_mutation_full_tree_hash(tmp_path: Path) -> None:
         for _ in range(3):
             _state(base)
         for path in ("/dashboard", "/static/console.js", "/static/console.css",
-                     "/", f"/messages/{mid}", "/api/attention", "/api/learning",
+                     "/", f"/messages/{mid}", "/api/attention", "/api/gates",
+                     "/api/risk-register", "/api/ownership", "/api/learning",
                      "/api/onboarding", "/api/thread/r1"):
             with _get(f"{base}{path}") as resp:
                 resp.read()
@@ -2950,6 +2959,131 @@ assert(text.includes('WAIVED (EXPIRED)'),
   `expected the expired-waiver label in the card, got: ${text}`);
 assert(text.includes('Waiver expired'),
   `expected the waiver box to say it is expired, got: ${text}`);
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
+def test_console_risk_register_partial_state_renders_incomplete_banner(
+    tmp_path: Path,
+) -> None:
+    """review rq-093f956dd595 B-1: "surface partial/degraded state in
+    payload AND view" - a payload-shape assertion alone cannot catch a
+    frontend that silently drops the partial/degraded_sources fields. This
+    actually renders renderRiskRegister() and inspects the DOM for the
+    incomplete-list banner and the truncated-count note."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the risk-register render test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkRiskRegisterTestHooks = {\n"
+        "    renderActiveView: renderActiveView,\n"
+        "    setup: function (root, riskRegister) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "      riskRegisterData = riskRegister;\n"
+        "      state.view = 'risk-register';\n"
+        "    }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-risk-register.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag).toUpperCase(),
+    children: [],
+    parentNode: null,
+    className: '',
+    textContent: '',
+    attributes: {},
+    style: { setProperty(name, value) { this[name] = String(value); } },
+    appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+      if (name === 'class') this.className = String(value);
+    },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+    },
+    addEventListener() {},
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  return node;
+}
+function hasClass(node, cls) { return String(node.className || '').split(/\s+/).includes(cls); }
+function collectText(node) {
+  let out = node.textContent || '';
+  for (const child of node.children || []) out += ' ' + collectText(child);
+  return out;
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+const main = makeNode('main');
+const document = {
+  readyState: 'loading',
+  createElement: makeNode,
+  createElementNS(_ns, tag) { return makeNode(tag); },
+  addEventListener() {},
+  getElementById(id) { return id === 'main' ? main : null; },
+  querySelector() { return null; },
+  querySelectorAll() { return []; },
+};
+const ctx = {
+  console, document,
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  setInterval() {}, clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkRiskRegisterTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx, { filename: 'console.instrumented.js' });
+const hooks = ctx.__agenttalkRiskRegisterTestHooks;
+
+hooks.setup(
+  { label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] },
+  {
+    root: 'demo', root_path: 'D:\\work\\demo',
+    root_info: { project_id: 'project-demo', label: 'demo', path: 'D:\\work\\demo' },
+    target_root_project_id: 'project-demo',
+    items: [{
+      id: 'onboarding:run-1:drift:d1', category: 'onboarding_drift',
+      category_label: 'Doc/code drift', severity: 'high', title: 'a real open risk',
+      owner: 'beta', detail: 'scan run', age_seconds: 30, age_unknown: false,
+      human_can_unblock_now: true,
+    }],
+    count: 1,
+    truncated: 2,
+    partial: true,
+    degraded_sources: ['onboarding_run:corrupt-run-1'],
+  },
+);
+hooks.renderActiveView();
+
+const text = collectText(main);
+assert(text.includes('incomplete'),
+  `expected the header to flag the count as incomplete, got: ${text}`);
+assert(text.includes('INCOMPLETE') || text.includes('could not be read'),
+  `expected an incomplete-list banner naming the degraded source, got: ${text}`);
+assert(text.includes('corrupt-run-1'),
+  `expected the degraded source name in the banner, got: ${text}`);
+assert(text.includes('a real open risk'),
+  `the item that WAS read must still render alongside the partial banner: ${text}`);
+assert(text.includes('2') && text.includes('not shown'),
+  `expected the truncated-count note, got: ${text}`);
 """, encoding="utf-8")
     subprocess.run(["node", str(runner), str(instrumented)], check=True,
                    capture_output=True, text=True)
@@ -6534,9 +6668,12 @@ def test_api_risk_register_shape_and_sorted_by_severity_then_age(
         payload = _risk_register(base)
         assert set(payload) == {
             "root", "root_path", "root_info", "target_root_project_id",
-            "items", "count",
+            "items", "count", "truncated", "partial", "degraded_sources",
         }
         assert payload["count"] == len(payload["items"])
+        assert payload["partial"] is False
+        assert payload["degraded_sources"] == []
+        assert payload["truncated"] == 0
         for it in payload["items"]:
             assert set(it) == {
                 "id", "category", "category_label", "severity", "title",
@@ -6628,12 +6765,21 @@ def test_api_risk_register_includes_open_onboarding_drift_and_unknown(
         assert drift_items[0]["severity"] == "high"  # blocking=True
         assert drift_items[0]["owner"] == "beta"
         assert drift_items[0]["title"] == "docs say X, code does Y"
+        # review rq-093f956dd595 L-1: "human_can_unblock_now" is a triage
+        # affordance claim, not a copy of the onboarding "blocking" flag.
+        assert drift_items[0]["human_can_unblock_now"] is True
+        assert drift_items[0]["age_unknown"] is False
 
         unknown_items = by_category.get("onboarding_unknown", [])
         assert len(unknown_items) == 1
         assert unknown_items[0]["category_label"] == "Open unknown"
         assert unknown_items[0]["severity"] == "med"  # blocking=False
         assert unknown_items[0]["owner"] == "alpha"  # falls back to actor
+        # L-1: still True even though blocking=False here - nothing external
+        # gates a human from acting on this finding.
+        assert unknown_items[0]["human_can_unblock_now"] is True
+        assert unknown_items[0]["age_unknown"] is False
+        assert payload["partial"] is False
         _assert_no_body_keys(payload)
     finally:
         srv.shutdown()
@@ -6682,13 +6828,18 @@ def test_api_risk_register_onboarding_not_truncated_by_dashboard_run_limit(
 
 
 def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
+    """review rq-093f956dd595 B-1/B-3: a corrupt config.json makes
+    store.operator_facing() raise, caught by the liaison-resolution
+    fallback. This must be VISIBLE (partial=True, a degraded_sources entry)
+    - a prior version of this test accepted a silent empty-and-clean 200 as
+    passing, which is the exact defect B-1 closes."""
     s = _make_store(tmp_path)
     cfg_path = s.dir / "config.json"
     cfg_path.write_text("{not json", encoding="utf-8")
     srv, _t, base = _serve(s)
     try:
         payload = _risk_register(base)
-        assert set(payload) >= {"root", "items", "count"}
+        assert set(payload) >= {"root", "items", "count", "partial", "degraded_sources"}
         assert payload["count"] == len(payload["items"])
         _assert_no_body_keys(payload)
         assert payload["items"] == [] or all(
@@ -6697,6 +6848,161 @@ def test_api_risk_register_degrades_on_corrupt_root(tmp_path: Path) -> None:
                                "onboarding_unknown")
             for it in payload["items"]
         )
+        assert payload["partial"] is True, (
+            f"a corrupt config that breaks liaison resolution must be surfaced, "
+            f"not silently absorbed into a clean-looking response: {payload}")
+        assert payload["degraded_sources"], "must name at least one degraded source"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_surfaces_partial_when_onboarding_read_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """review rq-093f956dd595 B-1: reproduces the reviewer's exact repro -
+    one open blocking drift, then onboarding.list_runs raising. Before the
+    fix this returned a clean HTTP 200 with count=0 and no errors key,
+    indistinguishable from a genuine all-clear. Must now surface partial."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=run_id, title="scan", objective="map it", base_ref="main",
+        lead="alpha", state="scanning", at="2026-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="drift-1", status="open",
+        summary="a blocking drift that must not silently vanish", actor="alpha",
+        blocking=True, at="2026-01-01T00:05:00Z"))
+
+    srv, _t, base = _serve(s)
+    try:
+        baseline = _risk_register(base)
+        assert baseline["count"] == 1
+        assert baseline["partial"] is False
+
+        def boom(*_args, **_kwargs):
+            raise OSError("simulated onboarding read failure")
+        monkeypatch.setattr(ob, "list_runs", boom)
+
+        payload = _risk_register(base)
+        assert payload["items"] == []
+        assert payload["count"] == 0
+        assert payload["partial"] is True, (
+            f"an inner collection failure must not render as a silent all-clear: {payload}")
+        assert any("onboarding" in d for d in payload["degraded_sources"]), payload
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_corrupt_onboarding_run_is_flagged_not_dropped(
+    tmp_path: Path,
+) -> None:
+    """review rq-093f956dd595 B-2: onboarding.list_runs SKIPS a run whose
+    ledger fails to parse (view=None) and only names it in `problems` - a
+    silent drop reachable with NO exception at all. The risk register must
+    surface that instead of discarding the `problems` channel."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=run_id, title="scan", objective="map it", base_ref="main",
+        lead="alpha", state="scanning", at="2026-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="drift-1", status="open",
+        summary="an open drift in a run that will be corrupted", actor="alpha",
+        blocking=True, at="2026-01-01T00:05:00Z"))
+    events_file = ob.events_path(s, run_id)
+    lines = events_file.read_text(encoding="utf-8").splitlines()
+    lines[0] = "{not valid json"  # corrupt the create event -> run_view() is None
+    events_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert payload["items"] == [], (
+            f"the corrupt run's open drift must not silently appear: {payload}")
+        assert payload["partial"] is True, (
+            f"a corrupt onboarding run must be surfaced, not silently dropped: {payload}")
+        assert any("onboarding_run" in d for d in payload["degraded_sources"]), payload
+        _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_caps_items_with_explicit_truncated_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """review rq-093f956dd595 F-1: every neighboring surface in this diff
+    bounds itself; the register must too - a high cap, never a silent one.
+    The point was never "no bound", only "no SILENT bound"."""
+    from agenttalk import gates as gmod
+
+    monkeypatch.setattr(web, "_RISK_REGISTER_ITEM_CAP", 3)
+    s = _make_store(tmp_path)
+    for i in range(5):
+        gmod.set_gate(s.root, name=f"gate-{i}", status="red", severity="blocker",
+                      scope="release", actor="alpha", evidence_source="automation_ci",
+                      reason="red", required=True)
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert payload["count"] == 3
+        assert len(payload["items"]) == 3
+        assert payload["truncated"] == 2
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_unknown_age_flagged_and_not_deprioritized(
+    tmp_path: Path,
+) -> None:
+    """review rq-093f956dd595 L-2: an onboarding record whose updated_at
+    cannot parse must be flagged age_unknown (never silently read as "0s
+    old", which looks freshly-created - the opposite of the truth) and must
+    NOT be silently pushed to the bottom of its severity band."""
+    from agenttalk import onboarding as ob
+
+    s = _make_store(tmp_path)
+    run_id = ob.new_run_id()
+    ob.create_run(s, ob.new_create_event(
+        run_id=run_id, title="scan", objective="map it", base_ref="main",
+        lead="alpha", state="scanning", at="2026-01-01T00:00:00Z"))
+    ob.append_event(s, ob.new_record_event(
+        run_id=run_id, kind=ob.KIND_DRIFT, key="known-drift", status="open",
+        summary="known-age drift", actor="alpha", blocking=True,
+        at="2026-01-01T00:05:00Z"))
+    # Hand-written record: new_record_event's `at` is never format-validated
+    # by onboarding.event_problem (only byte-bounded), so this is a legal
+    # on-disk event with an unparseable timestamp - simulates a foreign/
+    # legacy writer, not a fabricated test-only shape.
+    events_file = ob.events_path(s, run_id)
+    bad_event = {
+        "schema_version": ob.SCHEMA_VERSION, "event": ob.EVENT_RECORD,
+        "run_id": run_id, "kind": ob.KIND_DRIFT, "key": "bad-drift",
+        "status": "open", "summary": "unparseable timestamp drift",
+        "actor": "alpha", "blocking": True, "updated_at": "not-a-timestamp",
+    }
+    with events_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(bad_event) + "\n")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        drift_items = [it for it in payload["items"] if it["category"] == "onboarding_drift"]
+        by_key = {it["id"].rsplit(":", 1)[-1]: it for it in drift_items}
+        assert by_key["bad-drift"]["age_unknown"] is True
+        assert by_key["known-drift"]["age_unknown"] is False
+        # both are severity=high (blocking=True) - unknown age must sort
+        # FIRST within that band, not last.
+        assert drift_items[0]["id"] == by_key["bad-drift"]["id"], (
+            f"unknown-age item was deprioritized instead of surfaced: {drift_items}")
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3381,6 +3381,245 @@ assert(text.includes('Waiver expired'),
                    capture_output=True, text=True)
 
 
+def test_console_gate_card_renders_evidence_details_and_nonblocker_waiver_expiry(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector findings (P2 x2):
+    1. gateCard only ever rendered evidence.source/by/at/refs, hiding any
+       evidence_details field the API deliberately forwards (coverage_percent,
+       pr_url, ...) even though it is present in the response.
+    2. gateVisualState used `blocks` as the sole expiry test, but
+       gates._gate_verdict only sets blocks=true for an expired waiver when
+       severity=blocker - a warn/info gate's expired waiver stayed blocks=false
+       and rendered as the calm WAIVED state. The server-derived
+       `waiver_expired` field is severity-independent; this renders a WARN
+       gate with an expired waiver and blocks=false."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the gate-card render test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkGatesTestHooks = {\n"
+        "    renderActiveView: renderActiveView,\n"
+        "    setup: function (root, gates) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "      gatesData = gates;\n"
+        "      state.view = 'gates';\n"
+        "    }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-gates-2.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag).toUpperCase(),
+    children: [],
+    parentNode: null,
+    className: '',
+    textContent: '',
+    attributes: {},
+    style: { setProperty(name, value) { this[name] = String(value); } },
+    appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+      if (name === 'class') this.className = String(value);
+    },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+    },
+    addEventListener() {},
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  return node;
+}
+function hasClass(node, cls) { return String(node.className || '').split(/\s+/).includes(cls); }
+function findAllByClass(node, cls, out) {
+  if (hasClass(node, cls)) out.push(node);
+  for (const child of node.children || []) findAllByClass(child, cls, out);
+  return out;
+}
+function collectText(node) {
+  let out = node.textContent || '';
+  for (const child of node.children || []) out += ' ' + collectText(child);
+  return out;
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+const main = makeNode('main');
+const document = {
+  readyState: 'loading',
+  createElement: makeNode,
+  createElementNS(_ns, tag) { return makeNode(tag); },
+  addEventListener() {},
+  getElementById(id) { return id === 'main' ? main : null; },
+  querySelector() { return null; },
+  querySelectorAll() { return []; },
+};
+const ctx = {
+  console, document,
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  setInterval() {}, clearInterval() {},
+  fetch() { throw new Error('fetch should not run'); },
+  __agenttalkGatesTestHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx, { filename: 'console.instrumented.js' });
+const hooks = ctx.__agenttalkGatesTestHooks;
+
+hooks.setup(
+  { label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] },
+  {
+    root: 'demo', verdict: 'HOLD', required_gates: [],
+    gates: [
+      {
+        name: 'coverage', status: 'green', severity: 'blocker', scope: 'release',
+        blocks: false, reason: '', updated_at: '2026-01-01T00:00:00Z', updated_by: 'alpha',
+        evidence: [{
+          source: 'automation_ci', by: 'alpha', at: '2026-01-01T00:00:00Z',
+          refs: ['ci-run-1'], coverage_percent: 91.5, pr_url: 'https://example.invalid/pr/1',
+        }],
+        evidence_truncated: 0, waiver: null, waiver_expired: false,
+      },
+      {
+        name: 'docs-freshness', status: 'waived', severity: 'warn', scope: 'release',
+        blocks: false, reason: 'waiver expired or invalid',
+        updated_at: '2026-01-01T00:00:00Z', updated_by: 'alpha',
+        evidence: [], evidence_truncated: 0,
+        waiver: {
+          operator: 'alpha', date: '2025-01-01T00:00:00Z',
+          reason: 'known stale, tracked separately', scope: 'release',
+          expires: '2020-01-01T00:00:00Z',
+        },
+        waiver_expired: true,
+      },
+    ],
+    count: 2,
+  },
+);
+hooks.renderActiveView();
+
+const cards = findAllByClass(main, 'tc-gate-card', []);
+assert(cards.length === 2, `expected two gate cards, got ${cards.length}`);
+
+const coverageText = collectText(cards[0]);
+assert(coverageText.includes('coverage_percent: 91.5'),
+  `expected the forwarded coverage_percent evidence detail, got: ${coverageText}`);
+assert(coverageText.includes('pr_url: https://example.invalid/pr/1'),
+  `expected the forwarded pr_url evidence detail, got: ${coverageText}`);
+
+const docsCard = cards[1];
+assert(hasClass(docsCard, 'gate-waived_expired'),
+  `a WARN-severity gate with an expired (blocks=false) waiver must still render ` +
+  `gate-waived_expired, got class=${docsCard.className}`);
+assert(!hasClass(docsCard, 'gate-waived'),
+  'expired non-blocker waiver must NOT carry the calm gate-waived class');
+const docsText = collectText(docsCard);
+assert(docsText.includes('WAIVED (EXPIRED)'), `expected the expired label, got: ${docsText}`);
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
+def test_console_fetch_risk_register_stamps_payload_timing(tmp_path: Path) -> None:
+    """PR #129 connector finding (P2, console.js:4321): unlike every other
+    payload carrying relative ages, fetchRiskRegister skipped
+    stampAuxPayload, so items never received _receivedAt - liveAge()'s
+    elapsed-time term (monotonicNow() - item._receivedAt) always fell back
+    to 0, so the 1s updateAges loop kept reconstructing the SAME age
+    forever. Assert every fetched item now carries a numeric _receivedAt."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for the risk-register fetch-stamp test")
+
+    console_js = Path(web.__file__).with_name("web_static") / "console.js"
+    src = console_js.read_text(encoding="utf-8")
+    marker = "  // ------------------------------------------------------------ loops\n"
+    assert marker in src
+    src = src.replace(
+        marker,
+        "  globalThis.__agenttalkRiskRegisterFetchHooks = {\n"
+        "    setup: function (root) {\n"
+        "      lastState = { roots: [root] };\n"
+        "      state.selectedRootId = root.project_id;\n"
+        "    },\n"
+        "    fetchRiskRegister: fetchRiskRegister,\n"
+        "    snapshot: function () { return riskRegisterData; }\n"
+        "  };\n\n" + marker,
+        1,
+    )
+    instrumented = tmp_path / "console.instrumented.js"
+    instrumented.write_text(src, encoding="utf-8")
+    runner = tmp_path / "console-risk-register-fetch.js"
+    runner.write_text(r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+const ctx = {
+  console,
+  document: { readyState: 'loading', addEventListener() {} },
+  localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  performance: { now() { return 1000; } },
+  setInterval() {}, clearInterval() {},
+  fetch(_url) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        root_info: { project_id: 'project-demo' },
+        target_root_project_id: 'project-demo',
+        items: [{
+          id: 'gate:release:ci', category: 'gate', category_label: 'Gate blocker',
+          severity: 'high', title: 'ci', owner: null, detail: '',
+          age_seconds: 30, human_can_unblock_now: true,
+        }],
+        count: 1, truncated: 0, partial: false, degraded_sources: [],
+      }),
+    });
+  },
+  __agenttalkRiskRegisterFetchHooks: null,
+};
+ctx.globalThis = ctx;
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx, { filename: 'console.instrumented.js' });
+const hooks = ctx.__agenttalkRiskRegisterFetchHooks;
+
+hooks.setup({ label: 'demo', path: 'D:\\work\\demo', project_id: 'project-demo', agents: [] });
+
+(async () => {
+  hooks.fetchRiskRegister();
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+  const data = hooks.snapshot();
+  assert(data, 'riskRegisterData was never set');
+  assert(typeof data._receivedAt === 'number',
+    `expected the payload itself to carry _receivedAt, got: ${JSON.stringify(data)}`);
+  const item = data.items[0];
+  assert(typeof item._receivedAt === 'number',
+    `expected each risk item to carry _receivedAt (stampAuxPayload recurses into ` +
+    `arrays), got: ${JSON.stringify(item)}`);
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exitCode = 1;
+});
+""", encoding="utf-8")
+    subprocess.run(["node", str(runner), str(instrumented)], check=True,
+                   capture_output=True, text=True)
+
+
 def test_console_risk_register_partial_state_renders_incomplete_banner(
     tmp_path: Path,
 ) -> None:
@@ -7171,6 +7410,12 @@ def test_api_risk_register_uses_typed_risk_severity_over_source_default(
         assert item["severity"] == "low", (
             "typed risk_severity=low must not be overridden by the coarse "
             f"escalation source default (high): {item}")
+        # PR #129 connector finding (web.py:3020): a needs_operator item's
+        # source_refs carry only {kind, request_id} - no "agent" key - so
+        # _attention_agent(it) alone always returns None for escalations.
+        # Falls back to the stamped requester (the sender, "alpha" here).
+        assert item["owner"] == "alpha", (
+            f"escalation owner must fall back to the requester, not be null: {item}")
     finally:
         srv.shutdown()
         srv.server_close()
@@ -7547,6 +7792,203 @@ def test_api_ownership_degrades_on_malformed_registry(tmp_path: Path) -> None:
         assert payload["count"] == 0
         assert payload["errors"]
         _assert_no_body_keys(payload)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# --------------------------------------------- PR #129 connector findings
+
+def test_api_gates_evidence_cap_keeps_newest_entries(tmp_path: Path) -> None:
+    """PR #129 connector finding (P1, web.py:2881): set_gate APPENDS
+    evidence chronologically, so slicing the cap from the START kept the
+    OLDEST entries - once a gate passed the cap, the wall could show a
+    current green status/updated_at next to evidence that did NOT produce
+    it, while the evidence that DID was cut. Keep the NEWEST and expose
+    the truncated count."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    total = 55
+    for i in range(total):
+        gmod.set_gate(s.root, name="ci", status="green", severity="blocker",
+                      scope="release", actor="alpha", evidence_source="automation_ci",
+                      evidence=[f"ref-{i}"], reason="ok", required=True)
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        assert gate["evidence_truncated"] == total - 50, gate["evidence_truncated"]
+        refs = [e["refs"][0] for e in gate["evidence"]]
+        assert refs == [f"ref-{i}" for i in range(total - 50, total)], (
+            f"expected the NEWEST 50 refs, oldest-to-newest within that window: {refs}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_evidence_rejects_non_finite_floats(tmp_path: Path) -> None:
+    """PR #129 connector finding (P2, web.py:2840): json.dumps (and Python's
+    loader) accept NaN/Infinity by default, but they are not valid per
+    strict JSON - response.json() in a real browser rejects them outright,
+    failing the WHOLE Gates view for one bad field instead of degrading
+    just that field. Simulates a hand-authored/corrupted gates.json (the
+    public set_gate API already rejects non-finite values, so this can only
+    be reached by writing the file directly)."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    gmod.set_gate(s.root, name="ci", status="green", severity="warn",
+                  scope="release", actor="alpha", evidence_source="local_command",
+                  evidence=["ref"], reason="ok")
+    gates_path = gmod.gates_path(s.root)
+    raw = json.loads(gates_path.read_text(encoding="utf-8"))
+    raw["gates"]["ci"]["evidence"][0]["coverage_percent"] = float("nan")
+    raw["gates"]["ci"]["evidence"][0]["weird_metric"] = float("inf")
+    gates_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        with _get(f"{base}/api/gates") as resp:
+            raw_body = resp.read()
+        assert b"NaN" not in raw_body, "a non-finite float leaked into the JSON response"
+        assert b"Infinity" not in raw_body
+        payload = json.loads(raw_body)
+        (gate,) = payload["gates"]
+        (entry,) = gate["evidence"]
+        assert "coverage_percent" not in entry
+        assert "weird_metric" not in entry
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_gates_expired_non_blocker_waiver_flagged_expired(tmp_path: Path) -> None:
+    """PR #129 connector finding (P2, console.js:2277 - backend half):
+    gates._gate_verdict only sets blocks=true for an expired waiver when
+    severity=blocker; a warn/info gate's expired waiver leaves blocks=false
+    even though reason says "waiver expired or invalid". The server must
+    expose a severity-independent signal for the view to key off."""
+    from agenttalk import gates as gmod
+
+    s = _make_store(tmp_path)
+    gmod.set_gate(s.root, name="docs-freshness", status="red", severity="warn",
+                  scope="release", actor="alpha", evidence_source="local_command",
+                  reason="stale")
+    gmod.waive_gate(s.root, name="docs-freshness", operator="alpha",
+                    reason="known stale, tracked separately", scope="release",
+                    expires="2020-01-01T00:00:00Z")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _gates(base)
+        (gate,) = payload["gates"]
+        assert gate["severity"] == "warn"
+        assert gate["blocks"] is False, "warn severity never blocks by design"
+        assert gate["waiver_expired"] is True, (
+            f"an expired waiver on a non-blocker gate must still be flagged: {gate}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_derives_real_age_for_gate_and_deadletter(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector finding (P1, web.py:3022): gate_hold_items/
+    dead_letter_items left age_seconds at the _mk_item default (0.0) even
+    though their source records carry updated_at/deadlettered_at - every
+    such risk sorted as newly-created regardless of how long it had been
+    open, materially wrong for two of the register's principal categories."""
+    from agenttalk import gates as gmod
+    from agenttalk.wrapper import recv_api
+
+    s = _make_store(tmp_path)
+    old_iso = "2020-01-01T00:00:00Z"
+    gmod.set_gate(s.root, name="ci", status="red", severity="blocker",
+                  scope="release", actor="alpha", evidence_source="automation_ci",
+                  reason="pipeline red", required=True)
+    gates_path = gmod.gates_path(s.root)
+    raw = json.loads(gates_path.read_text(encoding="utf-8"))
+    raw["gates"]["ci"]["updated_at"] = old_iso
+    gates_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    message = s.send(sender="alpha", recipient="beta", body="poison",
+                     kind="message", meta={})
+    record = recv_api.next_record(s, "beta")
+    assert record["id"] == message.id
+    s.dead_letter("beta", record, reason="deterministic",
+                  failure_class="poison_eligible", at=old_iso)
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        gate_items = [it for it in payload["items"] if it["category"] == "gate"]
+        deadletter_items = [it for it in payload["items"] if it["category"] == "deadletter"]
+        six_years = 86400 * 365 * 3
+        assert gate_items and gate_items[0]["age_seconds"] > six_years, (
+            f"gate blocker age must reflect its real updated_at, not 0: {gate_items}")
+        assert deadletter_items and deadletter_items[0]["age_seconds"] > six_years, (
+            f"dead letter age must reflect its real deadlettered_at, not 0: {deadletter_items}")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_risk_register_surfaces_disposition_read_problems_as_partial(
+    tmp_path: Path,
+) -> None:
+    """PR #129 connector finding (P2, web.py:2997): read_dispositions
+    already reports malformed/torn/unreadable lines through its second
+    return value - the exact silent-partial-read shape already closed for
+    onboarding (review rq-093f956dd595 B-2). Apply the same pattern here:
+    a damaged defer/resolve record must not leave the register looking
+    authoritative (partial=false) despite known corruption."""
+    from agenttalk import attention as attn_mod
+
+    s = _make_store(tmp_path)
+    disp_path = attn_mod.dispositions_path(s)
+    disp_path.parent.mkdir(parents=True, exist_ok=True)
+    disp_path.write_text("{not valid json\n", encoding="utf-8")
+
+    srv, _t, base = _serve(s)
+    try:
+        payload = _risk_register(base)
+        assert payload["partial"] is True, (
+            f"a corrupt dispositions log must be surfaced, not silently dropped: {payload}")
+        assert any("disposition" in d for d in payload["degraded_sources"]), payload
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_api_ownership_preserves_long_globs_losslessly(tmp_path: Path) -> None:
+    """PR #129 connector finding (P2, web.py:3183): _envelope_str's 300-char
+    cap silently replaced a long glob's tail with an ellipsis - two DISTINCT
+    long globs could then display identically, and neither would match the
+    path it was meant to. Globs need (near-)lossless transport, not prose
+    truncation."""
+    s = _make_store(tmp_path)
+    long_glob = "src/" + "generated/nested/" * 20 + "*.py"
+    assert len(long_glob) > 300
+    (s.dir / "domains.json").write_text(json.dumps({
+        "schema_version": 1,
+        "domains": {
+            "gen": {"title": "Generated code", "owners": {"agents": ["alpha"]},
+                    "owned_globs": [long_glob]},
+        },
+        "shared_paths": [{
+            "glob": long_glob, "category": "generated", "requires": "lead-approval",
+        }],
+    }), encoding="utf-8")
+    srv, _t, base = _serve(s)
+    try:
+        payload = _ownership(base)
+        (domain,) = payload["domains"]
+        assert domain["owned_globs"] == [long_glob], (
+            "a long owned_globs entry must not be silently truncated")
+        (shared,) = payload["shared_paths"]
+        assert shared["glob"] == long_glob, (
+            "a long shared_paths glob must not be silently truncated")
     finally:
         srv.shutdown()
         srv.server_close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3024,9 +3024,10 @@ function node(tag) {
 }
 // A live MediaQueryList mock: ONE shared object (like the real
 // `window.matchMedia(query)` returning an equivalent list for a repeated
-// query), so a listener registered against it can be fired later to
-// simulate an EXISTING node's viewport crossing the boundary - not just a
-// freshly created node reading a new snapshot (#207 residual, finding 1).
+// query), so the module-level listener registered against it (once, at
+// script load - review rq-2968d93df2bc) can be fired to simulate a real
+// viewport crossing the boundary, and so this test can assert exactly how
+// many listeners ever accumulate on it.
 const mq = { matches: true, _listeners: [] };
 function fireMediaChange(matches) {
   mq.matches = matches;
@@ -3057,6 +3058,14 @@ vm.createContext(ctx);
 vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
 const hooks = ctx.__agenttalkConsoleTestHooks;
 
+// review rq-2968d93df2bc: a per-panel change listener leaked (1000 rendered
+// panels left 1000 live listeners, each closing over a detached node). The
+// fix is ONE shared listener registered at module load, not one per panel -
+// assert that up front, before creating anything.
+if (mq._listeners.length !== 1) {
+  throw new Error(`expected exactly one shared change listener at module load, got ${mq._listeners.length}`);
+}
+
 // Created narrow: closed, per the existing contract.
 const mobileContent = node('div');
 const panel = hooks.responsiveSecondary('Recent activity', mobileContent);
@@ -3064,28 +3073,33 @@ if (panel.tagName !== 'DETAILS' || panel.open || panel.children[0].tagName !== '
     panel.children[1] !== mobileContent) {
   throw new Error(`narrow secondary panel did not collapse safely: ${JSON.stringify(panel)}`);
 }
+
+// Direct regression for the reviewer's repro: render (and, in a real DOM,
+// discard) 1000 panels. The listener count must stay at exactly one -
+// nothing accumulates per panel.
+for (let i = 0; i < 1000; i++) {
+  hooks.responsiveSecondary('Recent activity', node('div'));
+}
 if (mq._listeners.length !== 1) {
-  throw new Error(`expected responsiveSecondary to register exactly one change listener, got ${mq._listeners.length}`);
+  throw new Error(`1000 rendered panels must not accumulate listeners, got ${mq._listeners.length}`);
 }
 
-// The SAME node crosses narrow -> wide (e.g. rotation, window resize) -
-// it must reopen without being recreated.
+// The fix is RENDER-TIME state (the reviewer's own suggested design), not a
+// live per-node listener: renderActiveView already rebuilds the whole view
+// every poll, so the NEXT panel rendered after a viewport crossing must
+// reflect it, in both directions.
 fireMediaChange(false);
-if (!panel.open) {
-  throw new Error('existing panel did not reopen when crossing narrow -> wide');
-}
+const wide = hooks.responsiveSecondary('Recent activity', node('div'));
+if (!wide.open) throw new Error('a panel rendered after crossing narrow -> wide was not open');
 
-// And back wide -> narrow: it must re-collapse (no user override recorded).
 fireMediaChange(true);
-if (panel.open) {
-  throw new Error('existing panel did not re-collapse when crossing wide -> narrow');
-}
+const narrowAgain = hooks.responsiveSecondary('Recent activity', node('div'));
+if (narrowAgain.open) throw new Error('a panel rendered after crossing wide -> narrow was not collapsed');
 
-// A second, freshly-created panel while wide must still open immediately
-// (the original creation-time contract is unchanged).
-fireMediaChange(false);
-const desktop = hooks.responsiveSecondary('Recent activity', node('div'));
-if (!desktop.open) throw new Error('desktop secondary panel was not open');
+// Still exactly one listener after all of the above.
+if (mq._listeners.length !== 1) {
+  throw new Error(`expected exactly one shared change listener at the end, got ${mq._listeners.length}`);
+}
 """, encoding="utf-8")
     subprocess.run(["node", str(runner), str(instrumented)], check=True,
                    capture_output=True, text=True)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3015,13 +3015,22 @@ def test_console_narrow_layout_collapses_secondary_panels(tmp_path: Path) -> Non
 const fs = require('node:fs');
 const vm = require('node:vm');
 
-let narrow = true;
 function node(tag) {
   return {
     tagName: String(tag).toUpperCase(), className: '', textContent: '', children: [], open: false,
     appendChild(child) { this.children.push(child); return child; },
     setAttribute() {}, addEventListener() {},
   };
+}
+// A live MediaQueryList mock: ONE shared object (like the real
+// `window.matchMedia(query)` returning an equivalent list for a repeated
+// query), so a listener registered against it can be fired later to
+// simulate an EXISTING node's viewport crossing the boundary - not just a
+// freshly created node reading a new snapshot (#207 residual, finding 1).
+const mq = { matches: true, _listeners: [] };
+function fireMediaChange(matches) {
+  mq.matches = matches;
+  for (const cb of mq._listeners) cb({ matches });
 }
 const document = {
   readyState: 'loading', addEventListener() {},
@@ -3033,7 +3042,12 @@ const ctx = {
   localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
   performance: { now() { return 0; } },
   setInterval() {}, clearInterval() {},
-  matchMedia() { return { matches: narrow }; },
+  matchMedia() {
+    return {
+      get matches() { return mq.matches; },
+      addEventListener(type, cb) { if (type === 'change') mq._listeners.push(cb); },
+    };
+  },
   fetch() { throw new Error('fetch should not run'); },
   __agenttalkConsoleTestHooks: null,
 };
@@ -3042,13 +3056,34 @@ ctx.window = ctx;
 vm.createContext(ctx);
 vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), ctx);
 const hooks = ctx.__agenttalkConsoleTestHooks;
+
+// Created narrow: closed, per the existing contract.
 const mobileContent = node('div');
-const mobile = hooks.responsiveSecondary('Recent activity', mobileContent);
-if (mobile.tagName !== 'DETAILS' || mobile.open || mobile.children[0].tagName !== 'SUMMARY' ||
-    mobile.children[1] !== mobileContent) {
-  throw new Error(`narrow secondary panel did not collapse safely: ${JSON.stringify(mobile)}`);
+const panel = hooks.responsiveSecondary('Recent activity', mobileContent);
+if (panel.tagName !== 'DETAILS' || panel.open || panel.children[0].tagName !== 'SUMMARY' ||
+    panel.children[1] !== mobileContent) {
+  throw new Error(`narrow secondary panel did not collapse safely: ${JSON.stringify(panel)}`);
 }
-narrow = false;
+if (mq._listeners.length !== 1) {
+  throw new Error(`expected responsiveSecondary to register exactly one change listener, got ${mq._listeners.length}`);
+}
+
+// The SAME node crosses narrow -> wide (e.g. rotation, window resize) -
+// it must reopen without being recreated.
+fireMediaChange(false);
+if (!panel.open) {
+  throw new Error('existing panel did not reopen when crossing narrow -> wide');
+}
+
+// And back wide -> narrow: it must re-collapse (no user override recorded).
+fireMediaChange(true);
+if (panel.open) {
+  throw new Error('existing panel did not re-collapse when crossing wide -> narrow');
+}
+
+// A second, freshly-created panel while wide must still open immediately
+// (the original creation-time contract is unchanged).
+fireMediaChange(false);
 const desktop = hooks.responsiveSecondary('Recent activity', node('div'));
 if (!desktop.open) throw new Error('desktop secondary panel was not open');
 """, encoding="utf-8")
@@ -3072,7 +3107,8 @@ def test_console_agent_state_info_uses_fresh_unwrapped_heartbeat(tmp_path: Path)
         "  globalThis.__agenttalkConsoleTestHooks = {\n"
         "    stateInfo: stateInfo,\n"
         "    agentStateInfo: agentStateInfo,\n"
-        "    freshHeartbeat: freshHeartbeat\n"
+        "    freshHeartbeat: freshHeartbeat,\n"
+        "    monotonicNow: monotonicNow\n"
         "  };\n\n" + marker,
         1,
     )
@@ -3127,6 +3163,17 @@ check({ health: { state: 'working_turn' }, last_seen_age_seconds: 5, wrapped: tr
 check({ health: { state: 'idle_waiting' }, last_seen_age_seconds: 5, wrapped: true },
   { key: 'idle_waiting', label: 'Idle \u00b7 waiting', color: 'warn', grp: 'idle' });
 assert(hooks.freshHeartbeat({ last_seen_age_seconds: -1 }) === false, 'negative heartbeat fails');
+
+// #207 residual, finding 3: this ctx has NO `performance` global, so
+// monotonicNow() must take its fallback branch. A frozen `0` fallback is
+// fail-open (every later delta reads permanently "just now"); the fix must
+// fall back to a real, advancing wall clock instead.
+const before = Date.now();
+const stamp = hooks.monotonicNow();
+const after = Date.now();
+assert(stamp !== 0, 'monotonicNow() fallback must not freeze at 0 when performance is unavailable');
+assert(stamp >= before && stamp <= after,
+  `monotonicNow() fallback should track Date.now(): ${stamp} not in [${before}, ${after}]`);
 """, encoding="utf-8")
     subprocess.run(["node", str(runner), str(instrumented)], check=True,
                    capture_output=True, text=True)


### PR DESCRIPTION
Two fully-reviewed console branches for v0.86.0.

## Quick wins (claude-agenttalk-developer-2)
Three new read-only console views: gate & evidence wall, risk register, ownership map (#208 direction, quick-win subset).
- Approved by codex-agenttalk-reviewer-1 (2 rounds) and claude-agenttalk-reviewer-3 unbriefed cold read + delta re-review (3 blockers found, fixed, verified — incl. a reproduced silent under-report in the risk register, now surfaced as partial/degraded state).

## #207 mechanical fixes (authored by codex-agenttalk-developer-4, carried by developer-2)
Mission-pill bound, server-timestamp trust, active-run default scope, serialized slow-endpoint polling, narrow-layout priority + review residuals (live media-query re-evaluation without listener leak, fail-closed freshness fallback).
- Approved by codex-agenttalk-reviewer-1 (2 rounds) and claude-agenttalk-reviewer-3 unbriefed cold read.

## Posture
Console posture verified unweakened by both reviewers on both branches: loopback-only, GET-only, read-only; zero innerHTML; the three new routes are covered by all five route-enumerating posture regressions.

Merged tree: tests/test_web.py 213 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)