### PR TITLE
fix(#184): status reads the message store once, not 24 times

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -37,6 +37,7 @@ from agenttalk.store import (
     LEAD_LOOP_LEASE_ENV,
     LEAD_LOOP_REMINDER_AFTER_DEFAULT,
     OPENER_KINDS,
+    Message,
     Store,
     _owner_identity_gone,
     find_root,
@@ -524,8 +525,22 @@ def _gather_status(store: Store) -> dict:
     cfg = store.load_config()
     roles = cfg.get("roles", {}) or {}
     liaison = store.operator_facing()
-    msgs = store.all_messages()
     now = datetime.now(timezone.utc)
+    # #184: ONE full validated-message scan shared by every consumer below
+    # (message_count, invalid_messages, thread warnings, and every agent's
+    # unread count) instead of each independently re-walking and
+    # re-validating the whole message directory. `status` used to pay for
+    # this scan 20+ times over on a real project store (once per roster
+    # agent via unread_for, plus once each for all_messages/
+    # list_invalid_messages/_thread_warnings) - a 45x regression on the
+    # most-used command as both the store and the roster grew.
+    valid, _problems, _present_stems, scanned, scan_failures = (
+        store._validated_message_snapshot(since_id=None, collect_problems=True)
+    )
+    msgs = [m for m, _ in scanned]  # same shape/order as store.all_messages()
+    by_recipient: dict[str, list[Message]] = {}
+    for m in valid:
+        by_recipient.setdefault(m.recipient, []).append(m)
     # Resolve the lead-loop heartbeat window from supervisor.json (if present) so the
     # status view uses the SAME threshold as the steal path - never the 120s default
     # for a wrapped agent (WP1 contract; avoids armed/heartbeat_stale skew).
@@ -574,11 +589,18 @@ def _gather_status(store: Store) -> dict:
             ttl_seconds=health_timing["ttl_seconds"],
             heartbeat_skew_seconds=health_timing["heartbeat_skew_seconds"],
         )
+        cursor = store.cursor(a)
+        # Same exclusive-cursor semantics as Store.messages_for/unread_for
+        # (`since_id and m.id <= since_id` excluded), just computed against
+        # the ONE shared, already-validated `by_recipient` grouping instead
+        # of a fresh per-agent disk re-scan (#184).
+        agent_msgs = by_recipient.get(a, [])
+        unread = agent_msgs if not cursor else [m for m in agent_msgs if m.id > cursor]
         row = {
             "name": a,
             "role": roles.get(a),
-            "cursor": store.cursor(a) or None,
-            "unread": len(store.unread_for(a)),
+            "cursor": cursor or None,
+            "unread": len(unread),
             "heartbeat": heartbeat_iso,
             "last_seen_seconds": (round(last_seen_s, 3)
                                   if last_seen_s is not None else None),
@@ -610,7 +632,16 @@ def _gather_status(store: Store) -> dict:
                 store, a, supervisor_config=sup_cfg or None)["heartbeat_stale_after"]
             row["lead_loop"] = store.lead_loop_state(a, heartbeat_stale_after=hsa)
         agents.append(row)
-    invalid = store.list_invalid_messages()
+    # Same projection list_invalid_messages() applies, over the SAME raw
+    # scan result already paid for above instead of a second full walk
+    # (#184) - reason text is untouched (still the detailed, raw text
+    # list_invalid_messages() has always produced, not the stable codes
+    # `problems` above carries for its own, differently-documented contract).
+    invalid = [
+        (ident, reason)
+        for _, ident, reason in store._invalid_file_entries(
+            scan_result=(scanned, scan_failures))
+    ]
     quarantined = store.quarantined_count()
     dead_lettered = _unresolved_dead_letter_count(store)
     signing_enforced = store.signing_enforced()
@@ -623,12 +654,14 @@ def _gather_status(store: Store) -> dict:
         coordination = _coordination_stall.build_snapshot(
             store,
             supervisor_config=sup_cfg,
+            valid_messages=valid,
         )
     except Exception:  # noqa: BLE001 - status stays fail-safe
         coordination = {"items": [], "diagnostics": []}
     coordination_items = coordination.get("items") or []
     warnings = (
-        _status_warnings(agents) + _thread_warnings(store, cfg) + supervisor_warnings
+        _status_warnings(agents) + _thread_warnings(store, cfg, valid_msgs=valid)
+        + supervisor_warnings
     )
     for item in coordination_items:
         reason = item.get("reason") if isinstance(item, dict) else None
@@ -999,7 +1032,9 @@ def cmd_compact(args: argparse.Namespace) -> int:
     return 0
 
 
-def _thread_warnings(store: Store, cfg: dict) -> list[str]:
+def _thread_warnings(
+    store: Store, cfg: dict, *, valid_msgs: list | None = None,
+) -> list[str]:
     """Thread-correlation warnings shared with `agenttalk threads`.
 
     Derived from the SAME validated message set + derivation as the
@@ -1007,20 +1042,34 @@ def _thread_warnings(store: Store, cfg: dict) -> list[str]:
     "forgot to check if the reviewer replied" footguns per agent:
       1. a correlated response is sitting unread in the inbox; and
       2. an outbound request has gone unanswered past the stale window.
+
+    ``valid_msgs``, when given, is a caller-supplied ``store.valid_messages()``
+    result — skips this function's own call so a caller that already
+    computed one (e.g. `agenttalk status`, which needs the same snapshot
+    for several other things) doesn't pay for a second full scan (#184).
     """
     roster = cfg.get("agents", []) or []
-    try:
-        msgs = store.valid_messages()
-    except (ValueError, OSError, FileNotFoundError):
-        return []
+    if valid_msgs is not None:
+        msgs = valid_msgs
+    else:
+        try:
+            msgs = store.valid_messages()
+        except (ValueError, OSError, FileNotFoundError):
+            return []
     now = datetime.now(timezone.utc)
     liaison = store.operator_facing()
     out: list[str] = []
     pending_escalations_exist = False
+    # #184: grouping messages by request_id is agent-INDEPENDENT (only the
+    # per-thread role/state labeling below varies by `agent`), but
+    # derive_threads() used to redo that O(N) grouping fresh for every
+    # roster agent. Group once, hand every agent the same pre-grouped dict.
+    grouped = th.group_messages_by_request_id(msgs)
     for a in roster:
         rows = th.derive_threads(msgs, agent=a, cursor=store.cursor(a), now=now,
                                  closed_rids=_closed_rids(store, a),
-                                 retired=set(store.retired_agents()))
+                                 retired=set(store.retired_agents()),
+                                 grouped=grouped)
         waiting = [t for t in rows if t.state == "reply-waiting"]
         if waiting:
             ids = ", ".join(t.request_id for t in waiting[:3])

--- a/src/agenttalk/coordination_stall.py
+++ b/src/agenttalk/coordination_stall.py
@@ -419,8 +419,17 @@ def build_snapshot(
     supervisor_config: dict | None = None,
     supervisor_state: dict | None = None,
     process_snapshot: list[dict] | None = None,
+    valid_messages: list | None = None,
 ) -> dict:
-    """Build one read-only, fail-safe coordination snapshot."""
+    """Build one read-only, fail-safe coordination snapshot.
+
+    ``valid_messages``, when given, is a caller-supplied
+    ``store.valid_messages()`` result — skips this function's own call so
+    a caller that already computed one (e.g. `agenttalk status`) doesn't
+    pay for a second full store scan (#184). Tier 3
+    (``supervisor.build_report``'s own internal message reads) is
+    unchanged/out of scope for this fix.
+    """
     now = time.time() if now_epoch is None else float(now_epoch)
     config = supervisor_config if isinstance(supervisor_config, dict) else _load_supervisor_config(store)
     state = supervisor_state if isinstance(supervisor_state, dict) else _load_supervisor_state(store)
@@ -438,7 +447,7 @@ def build_snapshot(
             now_epoch=now,
             snapshot=process_snapshot,
         )
-        messages = store.valid_messages()
+        messages = valid_messages if valid_messages is not None else store.valid_messages()
         report_agents = report.get("agents") if isinstance(report.get("agents"), dict) else {}
         edges, diagnostics = _wait_edges(
             store,

--- a/src/agenttalk/store.py
+++ b/src/agenttalk/store.py
@@ -3761,7 +3761,11 @@ class Store:
         valid, _ = self._scan_messages()
         return valid
 
-    def _invalid_file_entries(self) -> list[tuple[Path, str, str]]:
+    def _invalid_file_entries(
+        self,
+        *,
+        scan_result: tuple[list[tuple[Message, Path]], list[tuple[Path, str, str]]] | None = None,
+    ) -> list[tuple[Path, str, str]]:
         """ONE path-aware walk over the FULL gate set (parse + schema +
         roster + signature). Returns ``[(path, ident, reason)]``.
 
@@ -3770,6 +3774,14 @@ class Store:
         projections of this list — FR-011 lockstep by construction, and
         every verdict is paired with its own source file at scan time
         (an ident can collide across files; a path cannot).
+
+        ``scan_result``, when given, is a caller-supplied
+        ``(valid_p, parse_failures)`` pair (the RAW ``_scan_messages_with_paths``
+        output, e.g. as returned by ``_validated_message_snapshot``) — skips
+        this method's own disk walk so a caller that already has one from the
+        SAME instant doesn't pay for a second (#184: `agenttalk status` was).
+        Reasons stay the same detailed, raw exception text this method has
+        always produced; only the disk walk is shared, not the verdict format.
         """
         try:
             cfg = self.load_config()
@@ -3787,7 +3799,10 @@ class Store:
                 key = _signing.load_key(project_id)
             except (FileNotFoundError, OSError, ValueError):
                 key = None
-        valid_p, parse_failures = self._scan_messages_with_paths()
+        if scan_result is not None:
+            valid_p, parse_failures = scan_result
+        else:
+            valid_p, parse_failures = self._scan_messages_with_paths()
         out: list[tuple[Path, str, str]] = list(parse_failures)
         for m, p in valid_p:
             try:
@@ -4357,6 +4372,8 @@ class Store:
         list[Message],
         list[dict[str, str | None]],
         set[str],
+        list[tuple[Message, Path]],
+        list[tuple[Path, str, str]],
     ]:
         """Run the shared full validation gate over one canonical disk walk.
 
@@ -4364,6 +4381,16 @@ class Store:
         that same walk.  The public completeness snapshot uses it to distinguish
         a present-but-rejected message from a publication-ordered message whose
         file is absent.
+
+        The fourth and fifth results are the RAW ``_scan_messages_with_paths``
+        output (parse+schema-valid entries with paths, and parse/schema
+        failures) this call already paid for — callers that need a second,
+        differently-filtered view of the SAME walk (e.g. the parse+schema-valid
+        count ``all_messages()`` reports, or ``_invalid_file_entries``'s
+        richer raw-reason report) pass it back in via their own
+        ``scan_result``/pre-scanned parameter instead of re-walking the
+        message directory (#184: a multi-agent caller like ``status`` was
+        paying for this walk 20+ times over).
 
         ``collect_problems=False`` is the delivery hot path.  In particular, it
         preserves the historical fail-closed early return when no usable roster
@@ -4380,7 +4407,7 @@ class Store:
             # Preserve _validated_messages' existing no-roster fast fail-closed
             # behavior.  The diagnostic API still scans so it can explain why
             # every otherwise-parseable file was rejected.
-            return [], [], set()
+            return [], [], set(), [], []
 
         require_sig = bool(roster) and self.signing_enforced()
         project_id = self.project_id() if require_sig else None
@@ -4449,7 +4476,7 @@ class Store:
                 continue
             seen_ids.add(message.id)
             deduped.append(message)
-        return deduped, problems, present_stems
+        return deduped, problems, present_stems, scanned, scan_failures
 
     def validated_messages_with_problems(
         self,
@@ -4475,7 +4502,7 @@ class Store:
         # Retirement uses the same outer lock ordering, so roster removal cannot
         # race the gate and manufacture a mixed-roster snapshot.
         with self._retirement_lock(), self._message_publication_lock():
-            valid, problems, present_stems = self._validated_message_snapshot(
+            valid, problems, present_stems, _scanned, _scan_failures = self._validated_message_snapshot(
                 since_id=since_id,
                 collect_problems=True,
             )
@@ -4513,7 +4540,7 @@ class Store:
         ``valid_messages`` MUST keep the default ``None`` (full log) —
         epoch / thread / rescind derivation reads the whole history.
         """
-        valid, _, _ = self._validated_message_snapshot(
+        valid, _, _, _, _ = self._validated_message_snapshot(
             since_id=since_id,
             collect_problems=False,
         )

--- a/src/agenttalk/threads.py
+++ b/src/agenttalk/threads.py
@@ -558,6 +558,26 @@ def _derive_broadcast(
     )
 
 
+def group_messages_by_request_id(messages: list[Message]) -> dict[str, list[Message]]:
+    """Group ``messages`` by ``meta.request_id``, each group sorted by id.
+
+    Messages without a request_id are untracked by design (you can't
+    correlate what was never tagged). This grouping is agent-INDEPENDENT —
+    ``derive_threads`` used to redo it fresh on every call, which is
+    wasteful for a caller deriving threads for every roster agent in a
+    loop (#184); compute it once and pass it to every call via
+    ``derive_threads(..., grouped=...)`` instead.
+    """
+    groups: dict[str, list[Message]] = {}
+    for m in messages:
+        rid = (m.meta or {}).get("request_id")
+        if isinstance(rid, str) and rid:
+            groups.setdefault(rid, []).append(m)
+    for group in groups.values():
+        group.sort(key=lambda m: m.id)
+    return groups
+
+
 def derive_threads(
     messages: list[Message],
     *,
@@ -566,6 +586,7 @@ def derive_threads(
     now: datetime | None = None,
     closed_rids: set[str] | None = None,
     retired: set[str] | None = None,
+    grouped: dict[str, list[Message]] | None = None,
 ) -> list[Thread]:
     """Return one :class:`Thread` per correlated request_id involving ``agent``.
 
@@ -577,23 +598,22 @@ def derive_threads(
     manual escape hatch for off-contract / already-handled threads.
     Threads where ``agent`` is neither the opener's sender nor recipient
     are omitted.
+
+    ``grouped``, when given, is a caller-supplied
+    ``group_messages_by_request_id(messages)`` result — skips this
+    function's own (agent-independent) grouping pass. Must be grouped from
+    the SAME ``messages`` list; passing a mismatched grouping silently
+    derives threads from the wrong message set.
     """
     now = now or datetime.now(timezone.utc)
     cursor = cursor or ""
     closed_rids = closed_rids or set()
     retired = retired or set()
 
-    # Group by correlation id. Messages without a request_id are
-    # untracked by design (you can't correlate what was never tagged).
-    groups: dict[str, list[Message]] = {}
-    for m in messages:
-        rid = (m.meta or {}).get("request_id")
-        if isinstance(rid, str) and rid:
-            groups.setdefault(rid, []).append(m)
+    groups = grouped if grouped is not None else group_messages_by_request_id(messages)
 
     threads: list[Thread] = []
     for rid, group in groups.items():
-        group.sort(key=lambda m: m.id)
         # Broadcast (multi-party) thread: question copies carrying a
         # broadcast_id. Gate PRECISELY — `agenttalk broadcast` only ever
         # fans out questions (message/note broadcasts aren't openers) and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1878,6 +1878,119 @@ def test_status_warns_about_unconsumed_reply(
     assert "pp-1" in warnings
 
 
+# ======================== #184: single-scan status regression fix =========
+
+def test_status_json_matches_expected_values_across_cursor_and_validity_edge_cases(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """Acceptance evidence for #184's fix: `_gather_status` now derives
+    message_count/invalid_messages/per-agent unread/thread warnings from
+    ONE shared `_validated_message_snapshot` call instead of each
+    independently re-scanning the message store. This asserts the exact
+    payload values for a fixture store that exercises every dimension the
+    refactor touches: a fresh cursor, a stale (non-head) cursor, no cursor
+    at all, a correlated thread with an unconsumed reply, and one invalid
+    (malformed JSON) message file. Any future change to the shared-scan
+    plumbing that alters these values breaks this test.
+    """
+    root = _team_root(tmp_path, agents="alpha,beta,gamma")
+    s = Store(root)
+
+    # A correlated thread: alpha proposes, beta replies - alpha has an
+    # unconsumed response sitting unread (same proven pattern as
+    # test_status_warns_about_unconsumed_reply above).
+    _run(["propose", "--from", "alpha", "--to", "beta",
+          "--meta", "request_id=pp-1", "-m", "do X", "--quiet"], root)
+    _run(["reply", "--from", "beta", "--kind", "proposal-response",
+          "--meta", "status=accepted", "-m", "ok"], root)
+    # A message to gamma with no cursor set at all - fully unread.
+    _run(["send", "--from", "alpha", "--to", "gamma", "-m", "task for gamma",
+          "--quiet"], root)
+    # Two messages to beta, in order; beta's cursor advances past only the
+    # FIRST, so beta's unread must be exactly the messages after it (the
+    # proposal-response beta itself sent doesn't address beta, so this is
+    # independent of the thread above).
+    _run(["send", "--from", "alpha", "--to", "beta", "-m", "beta msg 1",
+          "--quiet"], root)
+    _run(["send", "--from", "alpha", "--to", "beta", "-m", "beta msg 2",
+          "--quiet"], root)
+    # beta's inbox now has 3 messages: alpha's original propose (pp-1),
+    # "beta msg 1", "beta msg 2". Advance the cursor to "beta msg 1" - a
+    # stale-but-not-empty cursor that marks the propose AND msg 1 read,
+    # leaving only "beta msg 2" unread.
+    beta_msg_1 = next(
+        m for m in s.all_messages() if m.recipient == "beta" and m.body == "beta msg 1"
+    )
+    s.set_cursor("beta", beta_msg_1.id)
+
+    valid_before = len(s.all_messages())
+
+    # One malformed (unparseable) message file, injected directly - never
+    # produced by send(), but a real corrupt-file scenario the invalid-
+    # messages report must still surface.
+    (root / ".agenttalk" / "messages" / "20260101-000000-000000-ZZZZ.json").write_text(
+        "{not valid json", encoding="utf-8",
+    )
+
+    capsys.readouterr()
+    rc = _run(["status", "--json"], root)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    # message_count: parse+schema-valid files only - the malformed one is
+    # excluded (same definition as before the fix: all_messages()'s count).
+    assert payload["message_count"] == valid_before
+
+    # invalid_messages: exactly the one malformed file, with its RAW
+    # (not stable-coded) reason text preserved - list_invalid_messages()'s
+    # existing, documented contract.
+    assert len(payload["invalid_messages"]) == 1
+    entry = payload["invalid_messages"][0]
+    assert entry["id"] == "20260101-000000-000000-ZZZZ"
+    assert "invalid JSON" in entry["reason"]
+
+    agents = {a["name"]: a for a in payload["agents"]}
+    assert agents["alpha"]["unread"] == 1  # beta's proposal-response
+    assert agents["beta"]["unread"] == 1  # only "beta msg 2" (cursor skips msg 1)
+    assert agents["gamma"]["unread"] == 1  # "task for gamma", no cursor at all
+
+    warnings = " ".join(payload["warnings"])
+    assert "unconsumed response" in warnings
+    assert "pp-1" in warnings
+
+
+def test_status_scans_the_message_store_exactly_once(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#184 acceptance evidence: a wall-clock perf assertion on a fixture
+    store would flake (#160) since fixture stores are tiny regardless of
+    the bug. Assert the SCAN COUNT instead: exactly one
+    `Store._validated_message_snapshot` call per `status` invocation, via
+    a counting spy - this is what a fixture-sized store CAN prove, and it
+    is the actual mechanism of the fix (multiple roster agents no longer
+    trigger multiple re-scans).
+    """
+    root = _team_root(tmp_path, agents="alpha,beta,gamma,delta,epsilon")
+    _run(["send", "--from", "alpha", "--to", "beta", "-m", "hi", "--quiet"], root)
+
+    calls = {"n": 0}
+    real = Store._validated_message_snapshot
+
+    def counting_spy(self, *args, **kwargs):
+        calls["n"] += 1
+        return real(self, *args, **kwargs)
+
+    monkeypatch.setattr(Store, "_validated_message_snapshot", counting_spy)
+    capsys.readouterr()
+    rc = _run(["status", "--json"], root)
+    assert rc == 0
+    json.loads(capsys.readouterr().out)  # still well-formed
+    assert calls["n"] == 1, (
+        f"expected exactly one full-store scan per status call regardless of "
+        f"the 5-agent roster, got {calls['n']}"
+    )
+
+
 # ======================== 0.13.0: ergonomics (#6/#7/#8) ====================
 
 def test_reply_dry_run_resolves_without_sending(


### PR DESCRIPTION
Replaces the per-agent unread_for loop (one near-full store scan per roster agent) and four further independent full scans with ONE shared validated snapshot threaded through backward-compatible optional parameters.

Measured on the live 7,038-message store: ~8-9s -> ~1.4s (the reported 46s worst case scales with store size x stale-roster size).

Evidence: byte-identical `status --json` proven by running the same fixture test against pre-fix code; a scan-count spy asserting exactly one snapshot per invocation (which caught a fifth hidden scan pre-review); 486-540 targeted tests green untouched.

Review: approved by claude-agenttalk-reviewer-3 (rq-d2512b82c526) with ID-list equivalence probes, a disk-walk counting probe at a lower primitive, and full caller enumeration of the five signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)