### PR TITLE
fix(close): counter decide CLI vocabulary mismatch - every decision was refused (field bug, v0.86.0)

### DIFF
--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -3092,6 +3092,14 @@ def cmd_close(args: argparse.Namespace) -> int:
             return 2
         actor = _resolve_self(getattr(args, "actor", None), roster=roster)
         _check_close_authority(store, actor, "counter decide")
+        # args.decision is the operator-facing accept/reject CLI spelling;
+        # decide_counter requires the stored accepted/rejected vocabulary
+        # (close_mod.COUNTER_ACCEPTED/COUNTER_REJECTED). Map explicitly here,
+        # at the one call site, so the two spellings cannot silently drift
+        # apart again (v0.86.0 field bug: every counter decision was refused).
+        decision = (
+            close_mod.COUNTER_ACCEPTED if args.decision == "accept" else close_mod.COUNTER_REJECTED
+        )
         remediation = None
         if args.decision == "accept":
             remediation = {
@@ -3106,7 +3114,7 @@ def cmd_close(args: argparse.Namespace) -> int:
             with close_mod.close_transaction(store, args.id) as transaction:
                 record = transaction.record
                 close_mod.decide_counter(
-                    record, counter_id=args.counter, decision=args.decision, by=actor,
+                    record, counter_id=args.counter, decision=decision, by=actor,
                     at=_iso_now(), reason=args.reason, remediation=remediation)
                 transaction.commit()
         except (close_mod.CloseConflict, TimeoutError) as e:
@@ -3114,7 +3122,7 @@ def cmd_close(args: argparse.Namespace) -> int:
         except close_mod.CloseError as e:
             sys.stderr.write(f"agenttalk close counter decide: {e}\n")
             return 2
-        print(f"counter {args.counter} {args.decision}ed on {args.id} by {actor}")
+        print(f"counter {args.counter} {decision} on {args.id} by {actor}")
         return 0
 
     if action == "check":

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -2921,6 +2921,22 @@ def _close_worktree_eval(store, record: dict) -> dict | None:
     }
 
 
+def _counter_decision_from_cli_spelling(spelling: str, close_mod) -> str:
+    """Maps `close counter decide --decision`'s operator-facing accept/
+    reject CLI spelling to close.py's stored accepted/rejected
+    vocabulary. Hotfix round 2: an explicit dict lookup, not an
+    accept-or-else-reject ternary - argparse's own `choices` already
+    guarantees `spelling` is one of these two keys today, so a KeyError
+    here means that constraint and this mapping have drifted apart (e.g.
+    a future third --decision choice added to one but not the other) - a
+    programmer error that must be loud, never silently rendered as
+    `rejected`."""
+    return {
+        "accept": close_mod.COUNTER_ACCEPTED,
+        "reject": close_mod.COUNTER_REJECTED,
+    }[spelling]
+
+
 def cmd_close(args: argparse.Namespace) -> int:
     """Assurance P2 milestone/release close (advisory; see close.py)."""
     from agenttalk import close as close_mod
@@ -3094,12 +3110,10 @@ def cmd_close(args: argparse.Namespace) -> int:
         _check_close_authority(store, actor, "counter decide")
         # args.decision is the operator-facing accept/reject CLI spelling;
         # decide_counter requires the stored accepted/rejected vocabulary
-        # (close_mod.COUNTER_ACCEPTED/COUNTER_REJECTED). Map explicitly here,
+        # (close_mod.COUNTER_ACCEPTED/COUNTER_REJECTED). Mapped explicitly,
         # at the one call site, so the two spellings cannot silently drift
         # apart again (v0.86.0 field bug: every counter decision was refused).
-        decision = (
-            close_mod.COUNTER_ACCEPTED if args.decision == "accept" else close_mod.COUNTER_REJECTED
-        )
+        decision = _counter_decision_from_cli_spelling(args.decision, close_mod)
         remediation = None
         if args.decision == "accept":
             remediation = {
@@ -13780,10 +13794,17 @@ def build_parser() -> argparse.ArgumentParser:
     csov.set_defaults(func=cmd_close)
     csign.set_defaults(func=cmd_close, signoffs_cmd=None)
 
+    # Hotfix round 2 (v0.86.0 field bug): a hand-written choices list here
+    # agreed with close.py's own ACK_STATUSES by spelling coincidence
+    # only - the exact two-hand-written-lists shape the counter-decide
+    # vocabulary bug was. Derived from the frozenset itself so a future
+    # rename in close.py cannot silently reproduce that bug here.
+    from agenttalk import close as close_mod
+
     cack = csub.add_parser("ack", help="Record a lens ack (accept / counter / na).")
     cack.add_argument("--id", required=True)
     cack.add_argument("--lens", required=True, help="Lens id being acked.")
-    cack.add_argument("--status", required=True, choices=["accept", "counter", "na"])
+    cack.add_argument("--status", required=True, choices=sorted(close_mod.ACK_STATUSES))
     cack.add_argument("--from", dest="actor", help="Acking agent.")
     cack.add_argument("--reason", help="Reason (required for na).")
     cack.add_argument("--override", action="store_true",

--- a/src/agenttalk/close.py
+++ b/src/agenttalk/close.py
@@ -1682,7 +1682,8 @@ def decide_counter(record: dict, *, counter_id: str, decision: str, by: str,
     if not isinstance(counter, dict):
         raise CloseError(f"no counter {counter_id!r} on this close")
     if decision not in (COUNTER_ACCEPTED, COUNTER_REJECTED):
-        raise CloseError("counter decision must be accept or reject")
+        raise CloseError(
+            f"counter decision must be {COUNTER_ACCEPTED!r} or {COUNTER_REJECTED!r}")
     if not (reason and reason.strip()):
         raise CloseError("a counter decision requires a reason")
     counter["decision"] = decision

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -15,6 +15,7 @@ through to the pinned-SHA branch and `_worktree_clean` reports None -> clean.
 
 from __future__ import annotations
 
+import argparse
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -242,22 +243,84 @@ def test_apply_ack_rejects_duplicate_counter_id_without_mutating_ack() -> None:
 
 
 def test_decide_counter_accept_requires_remediation() -> None:
+    """Hotfix round 2: this test used to pass decision="accept" - the
+    CLI's operator-facing spelling, an INVALID value under close.py's own
+    stored vocabulary - so it was satisfied by the vocabulary refusal
+    (decide_counter's very first check) and never actually exercised the
+    missing-remediation behaviour its name claims; it would have kept
+    passing even with that check deleted. Now passes the stored spelling
+    and asserts the SPECIFIC remediation-required message."""
     rec = _satisfied()
     rec["counters"]["ctr-1"] = {"counter_id": "ctr-1", "decision": close.COUNTER_PENDING}
-    with pytest.raises(close.CloseError):
-        close.decide_counter(rec, counter_id="ctr-1", decision="accept", by="lead",
+    with pytest.raises(close.CloseError, match="accepting a counter requires a remediation item"):
+        close.decide_counter(rec, counter_id="ctr-1", decision=close.COUNTER_ACCEPTED, by="lead",
                              at="t", reason="ok", remediation=None)
 
 
 def test_decide_counter_blocker_remediation_requires_gate() -> None:
+    """Hotfix round 2: same masking as the test above - decision="accept"
+    was refused by the vocabulary check before the gate-requirement
+    check this test names ever ran."""
     rec = _satisfied()
     rec["counters"]["ctr-1"] = {"counter_id": "ctr-1", "decision": close.COUNTER_PENDING}
-    with pytest.raises(close.CloseError):
+    with pytest.raises(close.CloseError, match="a blocker remediation MUST name a gate id"):
         close.decide_counter(
-            rec, counter_id="ctr-1", decision="accept", by="lead", at="t",
+            rec, counter_id="ctr-1", decision=close.COUNTER_ACCEPTED, by="lead", at="t",
             reason="fix it", remediation={
                 "id": "rem-1", "owner": "dev", "fix": "patch",
                 "verification": "tests", "blocker": True})  # no gate
+
+
+def test_decide_counter_unknown_decision_names_the_actual_vocabulary() -> None:
+    """Hotfix round 2: the refusal message used to say 'must be accept or
+    reject' while the check actually required accepted/rejected - the
+    misleading diagnostic that made the v0.86.0 field bug undiagnosable
+    for every OTHER caller (any direct close.decide_counter caller, not
+    just the CLI). The message now names the real, stored constants."""
+    rec = _satisfied()
+    rec["counters"]["ctr-1"] = {"counter_id": "ctr-1", "decision": close.COUNTER_PENDING}
+    with pytest.raises(close.CloseError, match=r"'accepted'.*'rejected'"):
+        close.decide_counter(rec, counter_id="ctr-1", decision="accept", by="lead",
+                             at="t", reason="ok", remediation=None)
+
+
+def test_counter_decision_from_cli_spelling_maps_both_directions_and_rejects_unknown() -> None:
+    """Hotfix round 2 item 4: an explicit dict lookup, not a ternary whose
+    else-branch would silently render any future third --decision choice
+    as rejected."""
+    assert cli._counter_decision_from_cli_spelling("accept", close) == close.COUNTER_ACCEPTED
+    assert cli._counter_decision_from_cli_spelling("reject", close) == close.COUNTER_REJECTED
+    with pytest.raises(KeyError):
+        cli._counter_decision_from_cli_spelling("bogus", close)
+
+
+def _ack_status_choices(parser: argparse.ArgumentParser) -> list:
+    close_action = parser._subparsers._group_actions[0]
+    close_sub = close_action.choices["close"]
+    ack_sub = close_sub._subparsers._group_actions[0].choices["ack"]
+    status_action = next(a for a in ack_sub._actions if a.dest == "status")
+    return status_action.choices
+
+
+def test_ack_status_choices_are_derived_from_the_ack_statuses_frozenset() -> None:
+    """Hotfix round 2 item 2: `close ack --status`'s choices used to be a
+    hand-written list agreeing with close.py's ACK_STATUSES by spelling
+    coincidence only - the same two-hand-written-lists shape the counter-
+    decide vocabulary bug was. Derived from the frozenset now, so a
+    future rename in close.py cannot silently reproduce that bug here."""
+    parser = cli.build_parser()
+    assert set(_ack_status_choices(parser)) == close.ACK_STATUSES
+
+
+def test_ack_status_choices_track_a_change_to_the_ack_statuses_frozenset(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """Proves genuine derivation, not value coincidence: today's hardcoded
+    list and close.ACK_STATUSES happen to already agree, so a plain
+    before/after revert of the derivation would not, by itself, fail -
+    monkeypatching the frozenset and rebuilding the parser does."""
+    monkeypatch.setattr(close, "ACK_STATUSES", frozenset({"only-this-one"}))
+    parser = cli.build_parser()
+    assert set(_ack_status_choices(parser)) == {"only-this-one"}
 
 
 def test_reopen_clears_final_and_revision_change_stales_acks() -> None:

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -510,6 +510,43 @@ def test_cli_full_go_lifecycle(tmp_path: Path) -> None:
     assert rec["final"]["verdict"] == close.VERDICT_GO
 
 
+def test_cli_counter_decide_accepts_and_rejects_through_the_real_argv_path(
+        tmp_path: Path) -> None:
+    """Field bug (v0.86.0): `close counter decide --decision accept|reject`
+    was refused every time - the CLI's operator-facing accept/reject never
+    got mapped to close.py's stored accepted/rejected vocabulary before
+    reaching decide_counter. This exercises the real CLI entrypoint (real
+    argv, real store), not decide_counter() directly, so it would have
+    caught the mismatch between the two layers."""
+    root = _init(tmp_path)
+    assert _open(root) == 0
+
+    assert _run(["close", "ack", "--id", "rel", "--lens", "sec", "--status",
+                 "counter", "--from", "codex", "--counter", "ctr-accept",
+                 "--finding", "needs a closer look"], root) == 0
+    assert _run(["close", "counter", "decide", "--id", "rel",
+                 "--counter", "ctr-accept", "--decision", "accept",
+                 "--from", "lead", "--reason", "confirmed, fixing",
+                 "--rem-owner", "dev2", "--rem-fix", "patched the gap",
+                 "--rem-verification", "regression test added"], root) == 0
+
+    assert _run(["close", "ack", "--id", "rel", "--lens", "sec", "--status",
+                 "counter", "--from", "codex", "--counter", "ctr-reject",
+                 "--finding", "turned out to be a non-issue"], root) == 0
+    assert _run(["close", "counter", "decide", "--id", "rel",
+                 "--counter", "ctr-reject", "--decision", "reject",
+                 "--from", "lead", "--reason", "not applicable"], root) == 0
+
+    rec = close.load_close(Store(root), "rel")
+    accepted = rec["counters"]["ctr-accept"]
+    assert accepted["decision"] == close.COUNTER_ACCEPTED
+    remediation_id = accepted["remediation_id"]
+    assert rec["remediation_items"][remediation_id]["fix"] == "patched the gap"
+
+    rejected = rec["counters"]["ctr-reject"]
+    assert rejected["decision"] == close.COUNTER_REJECTED
+
+
 @pytest.mark.parametrize("mutation", ["ack", "counter"])
 def test_cli_publish_serializes_against_ack_and_counter(
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation: str) -> None:


### PR DESCRIPTION
## Field bug (reported from a v0.86.0 deployment)

'agenttalk close counter decide --decision accept|reject' passed the CLI spelling straight into close.decide_counter, which requires the stored vocabulary (accepted/rejected) - so EVERY counter decision, both directions, was refused with an error whose message named the exact words it refused. The counter-decide path had never been exercised end-to-end through the real CLI.

## Fix (single-sourced vocabulary)
- CLI maps explicitly to the imported close.COUNTER_ACCEPTED/COUNTER_REJECTED constants via an explicit dict lookup (raises on unknown key - unreachable by data, loud on contract drift). No literal of the stored vocabulary survives in the CLI close path; the success line prints the mapped value (removing an implicit third copy).
- decide_counter's refusal message now interpolates the real constants (was a fourth, prose copy telling callers to pass exactly what it refused - the diagnostic that made the field bug hard to debug).
- ack --status choices derived from close.ACK_STATUSES (same latent two-lists shape, hardened before it bites).
- The two decide_counter unit tests nearest the bug passed for the wrong reason (satisfied by the vocabulary refusal; proven they'd stay green if the remediation requirement were deleted) - now use the stored spelling + match= on the specific message.
- NEW end-to-end test through the real CLI argv path: open close -> counter -> decide accept AND reject -> assert stored vocabulary + remediation lands. Fails against pre-fix master (verified by reviewer independently).

## Review
reviewer-3: two APPROVED rounds (rq-a. initial + rq-4ac7e700072a round 2), including independently grafting the new test onto pre-fix master (fails on the genuine field symptom) and mutation-verifying the test-split and remediation-detector claims.

Rides v0.87.0 per operator decision (no patch release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)