### PR TITLE
docs+src: genericize a project identifier (confidentiality sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to agenttalk are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[2026-08-31: client references genericized; entries otherwise unchanged]
+
 ## [Unreleased]
 
 ## [0.86.0] - 2026-08-26
@@ -46,8 +48,8 @@ Theme: **the console tells the truth about risk — and the comprehension plane 
 
 Theme: **seat reliability — a wrapped seat fails loudly, recovers honestly.**
 
-Field basis: the v0.84.0 two-seat live smoke plus the JAWS retrospective's
-remaining seat-reliability findings (#202/#204/#205).
+Field basis: the v0.84.0 two-seat live smoke plus the dogfood migration's
+retrospective's remaining seat-reliability findings (#202/#204/#205).
 
 ### Added
 
@@ -93,7 +95,7 @@ remaining seat-reliability findings (#202/#204/#205).
 
 Theme: **every seat can answer — wrapper-owned reply delivery.**
 
-Field basis: the JAWS migration dry-run retrospective. A claude-wrapped seat
+Field basis: the dogfood migration's dry-run retrospective. A claude-wrapped seat
 could not deliver a bus reply in 5 of 5 work turns — its harness statically
 rejected the prescribed reply command and approval-gated every literal
 respelling, so finished answers dead-lettered into files indistinguishable on

--- a/docs/DESIGN-201-wrapper-owned-reply-delivery.md
+++ b/docs/DESIGN-201-wrapper-owned-reply-delivery.md
@@ -2,12 +2,13 @@
 
 Status: rev 2 — restructured after adversarial design review (approve-with-changes,
 3 blockers). Author: claude-agenttalk-lead · 2026-08-21.
-Field basis: JAWS dry-run retro (jaws-legacy `docs/dryrun/RETRO.md`, finding 1).
+Field basis: the dogfood migration's dry-run retrospective (the dogfood target
+repo's `docs/dryrun/RETRO.md`, finding 1).
 
 ## Problem
 
 A wrapped child delivers replies by running an `agenttalk reply` subprocess in
-its own shell. That channel fails as a class: the claude-wrapped JAWS seat
+its own shell. That channel fails as a class: the claude-wrapped dogfood seat
 could not deliver a bus reply in 5 of 5 work turns (static command validation
 + unanswerable interactive approvals), the codex seat's first reply died on
 missing `AGENTTALK_SELF`, and the claude adapter cannot even report that a
@@ -17,8 +18,8 @@ dead-letter into files that are indistinguishable on the bus from a dead agent.
 ## Review verdict that reshaped rev 1 → rev 2
 
 The rev 1 design put wrapper-owned delivery inside the commit-gate
-(owed-action) path. The adversarial review verified against the JAWS ledger
-that **the commit gate was inactive for the entire dry run** (no
+(owed-action) path. The adversarial review verified against the dogfood
+migration's ledger that **the commit gate was inactive for the entire dry run** (no
 `POLICY_ENV` policy file → `PolicySnapshot.inactive` → zero obligations
 admitted): every one of the motivating failures went through the FREEFORM
 branch rev 1 had scoped out. Rev 1 also had three blocker defects in its
@@ -138,8 +139,8 @@ explicitly.
 - A seat that can neither run bus commands NOR write files cannot reply;
   PR-3's preflight exists to catch that seat before work is dispatched.
   (The draft dir lives under the store's `.agenttalk/state/`, i.e. inside
-  the project root the wrapped child is normally granted — the JAWS claude
-  seat's `--add-dir <root>` covers it — but PR-3's write probe must verify
+  the project root the wrapped child is normally granted — the dogfood
+  claude seat's `--add-dir <root>` covers it — but PR-3's write probe must verify
   this per seat rather than assume it.)
 - Typed multi-field responses (review-result, proposal-response, consult
   replies needing `consult=true`+`round`, NA responses needing
@@ -191,5 +192,5 @@ explicitly.
 PR-1 changes child-visible instructions for every freeform turn (fleet-wide
 blast radius — review R4): the CLI channel remains fully supported, so a
 mixed fleet (old prompts cached in resumed sessions) is safe. Ship as a
-minor release; JAWS-pattern smoke (one wrapped claude seat, one codex seat)
+minor release; dogfood-pattern smoke (one wrapped claude seat, one codex seat)
 before tagging.

--- a/docs/DESIGN-202-interruption-aware-redelivery.md
+++ b/docs/DESIGN-202-interruption-aware-redelivery.md
@@ -4,8 +4,9 @@ Status: rev 3 — rev 1 REJECTED (3 blockers, all resolved in rev 2); rev 2
 re-verdict found 3 NEW defects in the rev-2 additions (NEW-1 blocker, NEW-2
 major, NEW-3 minor), fixed here per the reviewer's prescriptions; reviewer
 pre-cleared rev 3 as approve-implement with these deltas. Author:
-claude-agenttalk-lead · 2026-08-25. Field basis: JAWS retro finding 2;
-mechanism investigation 2026-08-25 (anchors verified at master a35297c).
+claude-agenttalk-lead · 2026-08-25. Field basis: the dogfood migration's
+retrospective, finding 2; mechanism investigation 2026-08-25 (anchors
+verified at master a35297c).
 
 ## Verified mechanism (unchanged from rev 1, review-confirmed)
 

--- a/docs/DESIGN-55-comprehension-plane.md
+++ b/docs/DESIGN-55-comprehension-plane.md
@@ -19,9 +19,10 @@ than implying that this design produces them. The reconciled companion baseline
 is commit `8b064acd0419813b1f28df34159e468a18f9fd4f` on
 `docs/55-priorart-requirements`.
 
-The original JAWS Plateau 1 retrospective is not present in this repository or
-its reachable history. This design therefore does not claim JAWS application,
-language, component, or business-flow coverage. It uses checked-in task and
+The original dogfood migration's Plateau 1 retrospective is not present in
+this repository or its reachable history. This design therefore does not
+claim coverage of the dogfood target's application, language, component, or
+business-flow. It uses checked-in task and
 agenttalk design evidence plus the companion requirements document. It also
 makes no Graphify compatibility or dependency decision; that belongs to the
 companion document and a separately reviewed spike.
@@ -570,7 +571,7 @@ measurement against a representative legacy corpus. That evidence pins the
 exact corpus revision/content fingerprint, platform and path policy, file-count
 and size distribution, cold and warm scan/freshness timings, peak memory, and
 cap-hit outcome. The implementation plan cannot present these unmeasured values
-as a proven JAWS-scale budget.
+as a proven dogfood-scale budget.
 
 Until that measurement is accepted, treat the provisional values as fail-closed
 guards. If a scan reaches an entry, per-file, or hashed-byte limit, narrow the

--- a/docs/DESIGN-55-priorart-and-requirements.md
+++ b/docs/DESIGN-55-priorart-and-requirements.md
@@ -231,25 +231,27 @@ spots.
 
 ## Evidence provenance and limits
 
-The original `jaws-legacy/docs/dryrun/RETRO.md` is referenced but is absent from
-this clone and its reachable history at the research cut. Rev 2 therefore separates
-four evidence categories instead of describing all requirements as JAWS field facts.
+The original dogfood target repo's `docs/dryrun/RETRO.md` is referenced but is
+absent from this clone and its reachable history at the research cut. Rev 2
+therefore separates four evidence categories instead of describing all
+requirements as dogfood-target field facts.
 
 | Provenance | What it supports | What it does not support |
 | --- | --- | --- |
 | Checked-in agenttalk code and policy at `abc1c6e` | Existing local-store, onboarding, wrapper, console, and reset contracts; product privacy and workflow constraints. | Claims about a client legacy repository's languages, components, or business flows. |
 | [DESIGN #201](DESIGN-201-wrapper-owned-reply-delivery.md) and [DESIGN #202](DESIGN-202-interruption-aware-redelivery.md) | A checked-in account of agenttalk wrapper delivery/redelivery failures and the mechanisms proposed to address them. | Direct evidence that a static client-code extractor needs runtime, state, or fleet entities in slice 1. Requirements extrapolated from these designs are later-slice target architecture. |
 | Pinned external prior art | Candidate schemas, adapters, and query shapes worth testing. | Evidence that an upstream tool satisfies agenttalk's privacy, correctness, scale, or platform contract. |
-| Missing JAWS Plateau 1 retrospective | Nothing normative yet. | Application-specific entity/relation sufficiency, language coverage, business-flow coverage, or a claim that the target architecture reconstructs the JAWS domain map. |
+| Missing dogfood migration Plateau 1 retrospective | Nothing normative yet. | Application-specific entity/relation sufficiency, language coverage, business-flow coverage, or a claim that the target architecture reconstructs the dogfood target's domain map. |
 
 The checked-in proxy evidence still motivates later work: the recorded failures crossed
 configuration, runtime mode, persisted state, retry/cleanup, test reachability, and
 fleet capability boundaries. That is an extrapolation from agenttalk's own runtime,
-not a finding from static analysis of JAWS client source. Rev 2 preserves those needs
-as slices 2–4 and does not use them to enlarge slice 1.
+not a finding from static analysis of the dogfood target's source. Rev 2 preserves
+those needs as slices 2–4 and does not use them to enlarge slice 1.
 
-Until the original retrospective is obtained, the design MUST describe any JAWS-
-specific language, framework, component, and business-flow coverage as unknown. The
+Until the original retrospective is obtained, the design MUST describe any
+dogfood-target-specific language, framework, component, and business-flow coverage
+as unknown. The
 later requirements below are hypotheses to validate against that record, not proof that
 the named vocabulary is sufficient.
 
@@ -258,7 +260,7 @@ the named vocabulary is sufficient.
 | Checked-in agenttalk product/workflow constraints | R-01 through R-09, R-21, R-22, and R-23a. |
 | Pinned prior-art mechanisms reconciled to the companion S1 design | R-10a, R-11a, R-12a, R-15a, R-17a, and R-24. |
 | Extrapolated from agenttalk's #201/#202 runtime failures; later target only | R-10b, R-11b/c, R-12b, R-13, R-14, R-15b, R-16, R-17b, R-18 through R-20, and R-23b. |
-| Deferred until the missing JAWS retrospective is obtained | Any assertion that the entity/relation vocabulary, adapter language set, or coverage criteria are sufficient for the JAWS application/domain. |
+| Deferred until the missing dogfood migration retrospective is obtained | Any assertion that the entity/relation vocabulary, adapter language set, or coverage criteria are sufficient for the dogfood target's application/domain. |
 
 ## Delivery slices and normative meaning
 
@@ -360,7 +362,7 @@ paths, available ranges/symbol pointers, and source digests.
 symbol/type/callable, configuration key, build target, test, and documentation/decision
 entities. S3 adds persisted record, runtime process instance, state, and event entities.
 There is no S1 producer for these types; S1 reports their absence as unsupported or
-unknown. JAWS-specific sufficiency remains deferred until its retrospective is obtained.
+unknown. Dogfood-target-specific sufficiency remains deferred until its retrospective is obtained.
 
 **R-11a — Static direct relations [S1, companion-design producer].** S1 MUST retain
 the companion design's closed direct relation set: `import`, `include`, `inherit`,
@@ -440,7 +442,7 @@ freshness. No S1 delta producer exists.
 **R-19 — Lifecycle/state-machine queries [S3 later, extrapolated].** For retrying or
 persisted workflows, S3 MUST answer how state is entered, recorded, observed, retried,
 cleaned, and exited; list cycles and terminal states; and identify states with no proven
-escape. This target comes from agenttalk's #202 failure class, not static JAWS evidence.
+escape. This target comes from agenttalk's #202 failure class, not static dogfood-target evidence.
 
 **R-20 — Counterexample evaluation [S4 later, extrapolated].** S4 SHOULD evaluate
 proposed conditions and invariants over checked-in defaults and captured S3
@@ -542,7 +544,7 @@ produces them.
 
 ## Residual risks and open questions
 
-1. **Original field record:** obtain the JAWS Plateau 1 retrospective before claiming
+1. **Original field record:** obtain the dogfood migration's Plateau 1 retrospective before claiming
    application-specific requirements. The S2–S4 extrapolations may change or be removed
    when that evidence is available.
 2. **Production network isolation:** S1 has a test-time network-deny harness and a

--- a/src/agenttalk/reply_transport.py
+++ b/src/agenttalk/reply_transport.py
@@ -1,6 +1,6 @@
 """Shared reply-construction rules for the CLI and the wrapper.
 
-#201 (JAWS retro finding 1): a wrapped child that cannot run shell commands
+#201 (the dogfood migration's retro finding 1): a wrapped child that cannot run shell commands
 cannot deliver `agenttalk reply`, so the wrapper delivers a child-written
 draft file itself. The CLI and the wrapper MUST apply byte-identical
 correlation-echo and digest rules or nonce dedupe silently forks (the

--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -160,7 +160,7 @@ def assemble_turn_prompt(record: dict, *, rules: str | None = None,
             anchor = "--to-request <request_id from the header above>"
         # #201: the wrapper-declared draft channel. Works in EVERY sandbox —
         # a child whose harness statically rejects or approval-gates shell
-        # commands (the JAWS claude seat: 5/5 turns undeliverable) can still
+        # commands (the dogfood claude seat: 5/5 turns undeliverable) can still
         # answer with nothing but its structured Write tool; the wrapper
         # validates and publishes the draft with exact thread correlation.
         reply_draft = record.get("reply_draft")

--- a/tests/test_reply_draft_delivery.py
+++ b/tests/test_reply_draft_delivery.py
@@ -1,7 +1,7 @@
 """#201 wrapper-owned reply delivery (freeform path).
 
 A wrapped child whose harness statically rejects or approval-gates shell
-commands (the JAWS claude seat: 5/5 turns undeliverable) answers by writing
+commands (the dogfood claude seat: 5/5 turns undeliverable) answers by writing
 the wrapper-declared draft file; the wrapper validates and publishes it with
 exact thread correlation. Fixture Store + injected drive — NO real CLI here
 (the real spawn path is covered by the stub canary's draft_only scenario).


### PR DESCRIPTION
## What

Genericizes an internal pilot-project identifier out of tracked content across 8 files (a changelog, four design docs, two source modules, one test module) - 23 occurrences, all traced to the same repeated field-basis citation. Neutral, sentence-preserving wording replaces it throughout; no other content or behavior changes.

## Why

Public repo hygiene (task #215). This is a forward-fix commit only - no git history is rewritten, per standing instruction.

## Verification

- `git grep -i` for the identifier across **all** tracked content at this branch's tip: zero matches.
- Targeted tests for the two touched Python modules and their existing test module: 192 passed.
- `ruff` clean on the touched source/test files.
- This PR's own title, body, and commit message were swept the same way before posting: zero matches.

No further identifying detail is included in this description, its title, or the commit message, per the confidentiality constraint this PR exists to close.
