### PR TITLE
feat(#148): per-seat scratch root + agenttalk janitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Per-seat scratch root + janitor (#148).** `agenttalk scratch root
-  --for <agent> [--task <id>]` resolves and creates
-  `<scratch_root>/<agent>/<task>` (configurable via `.agenttalk/config.json`'s
+  --for <agent>` resolves and creates the agent's own scratch root
+  `<scratch_root>/<agent>`; `--task <id>` scopes to a task subdirectory
+  instead. `scratch_root` is configurable via `.agenttalk/config.json`'s
   `"scratch"` key; default a sibling `atk-scratch/` next to the project
-  root - unconfigured projects get the default, nothing breaks). Wrapped
-  agents receive it pre-resolved as `$AGENTTALK_SCRATCH`, and the
-  dispatch envelope now states the rule. `agenttalk janitor [--apply]
+  root - unconfigured projects get the default, nothing breaks. Wrapped
+  agents receive the agent root pre-resolved as `$AGENTTALK_SCRATCH`
+  (never a task subdirectory - see `docs/ops/scratch-hygiene.md`), and
+  the dispatch envelope now states the rule. `agenttalk janitor [--apply]
   [--keep-days N]` is a cross-platform, config-driven port of the
   project's own validated `cleanup-scratch.ps1`: report mode (default)
-  lists scratch-family candidates and dirty registered worktrees;
-  `--apply` WIP-commits dirty worktrees on their own branch (never the
-  default branch), removes allow-listed paths, prunes stale worktree
-  registrations, and reports removals that fail (e.g. sandbox-restricted
-  ACLs on Windows) as `FAILED` with an elevated re-run hint rather than
-  silently skipping them. `agenttalk doctor` warns when registered
-  worktrees or scratch families exist outside the scratch root. See
+  lists scratch-family candidates and dirty registered worktrees (ANY
+  uncommitted change, tracked or untracked); `--apply` WIP-commits dirty
+  worktrees on their own branch, REFUSING outright (neither committed nor
+  removed) a worktree on a default branch or a detached `HEAD`; removes
+  allow-listed paths - a symlink/junction candidate is removed as the
+  link itself, never through it into its target; prunes stale worktree
+  registrations (scratch staleness measured from the newest mtime
+  anywhere in the tree, not the directory's own); and reports a removal
+  that fails, or a location it could not even list, as `FAILED` with an
+  elevated re-run hint, never silently skipped. The OS temp root gets a
+  narrower, case-sensitive, directories-only, age-windowed family list -
+  it is shared with every other program on the machine. `agenttalk
+  doctor` warns when registered worktrees, scratch families, or
+  unlistable locations exist outside the scratch root. See
   `docs/ops/scratch-hygiene.md`.
 
 ## [0.87.0] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anywhere in the tree, not the directory's own); and reports a removal
   that fails, or a location it could not even list, as `FAILED` with an
   elevated re-run hint, never silently skipped. The OS temp root gets a
-  narrower, case-sensitive, directories-only, age-windowed family list -
-  it is shared with every other program on the machine. `agenttalk
+  narrower, case-sensitive family list matching files and directories
+  alike, every entry individually gated by an age window - it is shared
+  with every other program on the machine. `agenttalk
   doctor` warns when registered worktrees, scratch families, or
   unlistable locations exist outside the scratch root. See
   `docs/ops/scratch-hygiene.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-seat scratch root + janitor (#148).** `agenttalk scratch root
+  --for <agent> [--task <id>]` resolves and creates
+  `<scratch_root>/<agent>/<task>` (configurable via `.agenttalk/config.json`'s
+  `"scratch"` key; default a sibling `atk-scratch/` next to the project
+  root - unconfigured projects get the default, nothing breaks). Wrapped
+  agents receive it pre-resolved as `$AGENTTALK_SCRATCH`, and the
+  dispatch envelope now states the rule. `agenttalk janitor [--apply]
+  [--keep-days N]` is a cross-platform, config-driven port of the
+  project's own validated `cleanup-scratch.ps1`: report mode (default)
+  lists scratch-family candidates and dirty registered worktrees;
+  `--apply` WIP-commits dirty worktrees on their own branch (never the
+  default branch), removes allow-listed paths, prunes stale worktree
+  registrations, and reports removals that fail (e.g. sandbox-restricted
+  ACLs on Windows) as `FAILED` with an elevated re-run hint rather than
+  silently skipping them. `agenttalk doctor` warns when registered
+  worktrees or scratch families exist outside the scratch root. See
+  `docs/ops/scratch-hygiene.md`.
+
 ## [0.87.0] - 2026-09-07
 
 Theme: **the comprehension producer ships — a static inventory plane for

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -102,14 +102,23 @@ In order:
    older than `keep_days` - a directory's mtime does not change when a
    file nested inside it is edited). Reports, for every registered git
    worktree, whether it has ANY uncommitted change (tracked or
-   untracked). A location the janitor could not even list (e.g. an
-   ACL-denied directory) is reported as `FAILED to list`, never silently
-   skipped or swallowed.
+   untracked - but NOT ignored: `git status --porcelain` never lists an
+   ignored file, so a worktree whose only content is gitignored files is
+   not "dirty" and can be removed without a WIP commit). A location the
+   janitor could not even list (e.g. an ACL-denied directory) is reported
+   as `FAILED to list`, never silently skipped or swallowed.
 2. **`--apply`**: for each dirty worktree, commits ALL changes (tracked
    and untracked) as a WIP commit on the worktree's OWN branch - REFUSED
    OUTRIGHT (neither committed nor removed) on a default branch
-   (`master`/`main` by default, configurable) or a detached `HEAD`. A
-   detached-HEAD WIP commit would be reachable from no ref and become
+   (`master`/`main` by default, configurable), a detached `HEAD`, or if
+   the commit itself fails for any reason - `git` unresolvable, `git add`
+   or `git commit` returning a non-zero exit code (a refusing pre-commit
+   hook, `commit.gpgsign` without a key, no configured user identity), or
+   the worktree still showing as dirty immediately after the commit. A
+   directory is only ever removed once its worktree is confirmed CLEAN,
+   never on the strength of "the commit command was run" - never
+   `--no-verify`: a refusing hook should keep the work, not be bypassed.
+   A detached-HEAD WIP commit would be reachable from no ref and become
    effectively lost the moment its directory is removed, so a detached
    worktree is refused the same way a default-branch one is, even though
    `git worktree add --detach` is Rule 2's own recommended form for a

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -1,0 +1,117 @@
+# Scratch hygiene: where temporary work goes, and how it gets cleaned up
+
+Applies to every seat (wrapped agents, subagents, the lead) and every batch
+of work (a slice, a PR round, a review sweep, a release) in any project run
+over agenttalk.
+
+## Why this exists
+
+Unmanaged scratch has the same shape everywhere agenttalk runs: pytest
+base-temps, review clones, git worktrees, service data directories, and
+reply-draft probes land in the repository root, in the OS temp root, or in
+`.worktrees/`, and nothing owns their removal. Left alone for long enough
+this produces hundreds of registered git worktrees nobody remembers,
+thousands of scratch entries in the shared temp root, worktrees holding
+uncommitted work, and directories created inside a sandboxed process whose
+ACLs deny even a listing until an elevated shell takes ownership. Nothing
+owned the cleanup, so it never ran - `agenttalk` owns it now, because every
+project has the same sprawl.
+
+## Rule 1: one scratch root per seat and task
+
+Every piece of temporary work lives under
+
+    <scratch_root>/<seat>/<task-id>/
+
+`<scratch_root>` defaults to a sibling `atk-scratch/` directory next to the
+project root (`<project>/../atk-scratch`), and is configurable in
+`.agenttalk/config.json`:
+
+```json
+{"scratch": "D:/custom/scratch/root"}
+```
+
+or the long form (any key may be omitted):
+
+```json
+{"scratch": {"root": "D:/custom/scratch/root", "keep_days": 3}}
+```
+
+Resolve and create the per-agent/per-task directory with:
+
+```
+agenttalk scratch root --for <agent> [--task <id>]
+```
+
+A wrapped agent also finds it pre-resolved in `$AGENTTALK_SCRATCH` (the
+wrapper exports the per-seat root at launch; a dispatch that predates this
+feature, or a project without a `"scratch"` config key, still works - the
+default root always resolves, config or not).
+
+Uses:
+- pytest: `--basetemp <scratch_root>/<seat>/<task-id>/pt`
+- review clones and worktrees: `.../<task-id>/wt-<sha>`
+- service data directories (databases, brokers): `.../<task-id>/data-<n>`
+- reply drafts and probe outputs: `.../<task-id>/`
+
+Never: the OS temp root directly, the repository root, `.worktrees/`, or
+another seat's root. A dispatch that asks for a build, gate, review, or
+probe names the scratch root explicitly; a close-out that created scratch
+reports "scratch removed" or lists what is left and why (a worktree kept
+for a follow-up, a preserved evidence tree).
+
+## Rule 2: worktrees are registered, short-lived, and never dirty at close
+
+- `git worktree add --detach <scratch>/wt-<sha> <sha>` for reviews; a
+  branch worktree only while the task is open.
+- Before a task closes: commit or stash anything worth keeping on the
+  task's own branch, then `git worktree remove <path>` and
+  `git worktree prune`.
+- Evidence that must outlive the worktree is copied OUT to wherever the
+  programme keeps evidence; the worktree itself is disposable.
+
+## Rule 3: `agenttalk janitor` runs at every batch close
+
+```
+agenttalk janitor                          # report only (default)
+agenttalk janitor --apply                  # clean up
+agenttalk janitor --apply --keep-days 7    # override the scratch-root staleness window
+```
+
+In order:
+
+1. **Report mode** (default): lists scratch candidates under the
+   repository root, `.worktrees/`, the OS temp root (allow-listed name
+   families only, configurable), and the scratch root (past its
+   `keep_days` window), with counts and the oldest entries - and, for
+   every registered git worktree, whether it has uncommitted changes to
+   TRACKED files (an all-untracked worktree is not "dirty" in this
+   sense).
+2. **`--apply`**: for each dirty worktree, commits the tracked changes as
+   a WIP commit on the worktree's OWN branch - refused outright on a
+   default branch (`master`/`main` by default, configurable), never
+   auto-committed there. Removes the allow-listed candidates. Runs
+   `git worktree prune`.
+3. **Directories that refuse removal** (e.g. sandbox-restricted ACLs on
+   Windows): printed as `FAILED`, never silently skipped, with an
+   elevated re-run hint (Windows only; the escalation itself - taking
+   ownership and re-granting access - also only runs on Windows, and only
+   in `--apply`). The command is idempotent: re-running after fixing
+   permissions removes what's left.
+
+The janitor never touches: `.agenttalk/` (the bus), tracked files, or a
+configured `"foreign"` folder under the temp root (`scratch.foreign` in
+config - reported and kept, never removed). It never removes a directory
+that doesn't match an allow-listed name family.
+
+`agenttalk doctor` warns when registered worktrees or scratch-family
+candidates exist outside the scratch root, so this doesn't need to be
+checked by hand.
+
+## Rule 4: cleanup is part of "done"
+
+A batch is not closed until the janitor report is empty (or its leftovers
+are named in the close record). A close-out checklist for a slice or
+release ends with: janitor run, worktree list short, `git status`
+warning-free, and the OS temp root and repository root free of agenttalk
+scratch.

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -133,10 +133,14 @@ In order:
    review worktree - commit it onto a real branch (or leave it) before
    closing the task if it must survive `--apply`. A CLEAN detached
    worktree is not automatically safe either: if its HEAD holds a commit
-   that no branch or tag contains (a reviewer's local fixup left on the
-   checkout, say), it is refused too, dirty or not - pruning a clean-
-   looking worktree like that would drop the only ref keeping that commit
-   reachable.
+   that no branch, tag, or remote-tracking ref contains, it is refused
+   too, dirty or not - pruning a clean-looking worktree like that would
+   drop the only ref keeping that commit reachable. Remote-tracking refs
+   count deliberately: Rule 2's own recommended review-worktree form is
+   routinely detached at a fetched PR head that lives only under
+   `refs/remotes/origin/*` until it lands on a local branch, and without
+   crediting that, an ordinary, disposable review checkout would be
+   refused on every single run for as long as it exists.
 
    A refusal applies in BOTH directions: a scratch task directory that
    itself looks stale by age but CONTAINS a refused worktree (exactly
@@ -147,17 +151,24 @@ In order:
    `.git` entry (a clone's own `.git` directory, or a worktree's gitdir
    FILE) that is not a registered worktree of THIS repository is refused
    outright - another seat's dirty worktree living under the shared
-   scratch root (Rule 1), or a standalone clone nobody registered
-   anywhere, is invisible to `git worktree list` here and gets exactly
-   the same protection as if it were. When git itself cannot be trusted
-   (unresolvable, or `worktree list` failing) the same refusal applies
-   even more broadly: any directory the janitor cannot ask git about at
-   all is refused if its own tree contains a `.git` entry anywhere, or
-   if any part of that tree could not even be listed - staleness age
-   never overrides either check. Removes the allow-listed candidates - a
-   symlink or junction candidate is removed AS THE LINK ITSELF; its
-   target (and anything behind it, `.git` or otherwise) is never
-   touched, entered, or overwritten. Runs `git worktree prune`.
+   scratch root (Rule 1), a standalone clone nobody registered anywhere,
+   or even this repository's OWN worktree if its `.git/worktrees/<name>`
+   admin entry has separately gone missing, is invisible to `git
+   worktree list` here and gets exactly the same protection as if it
+   were. This ownership check is NOT limited to the scratch root or the
+   repository root - it applies inside `.worktrees/` too: that location's
+   "every directory there is a candidate, regardless of name" design (see
+   Report mode, above) means the family filter is absent, not that
+   ownership stops mattering; an unregistered tree dropped there is
+   refused exactly like one found anywhere else. When git itself cannot
+   be trusted (unresolvable, or `worktree list` failing) the same
+   refusal applies even more broadly: any directory the janitor cannot
+   ask git about at all is refused if its own tree contains a `.git`
+   entry anywhere, or if any part of that tree could not even be listed
+   - staleness age never overrides either check. Removes the allow-listed
+   candidates - a symlink or junction candidate is removed AS THE LINK
+   ITSELF; its target (and anything behind it, `.git` or otherwise) is
+   never touched, entered, or overwritten. Runs `git worktree prune`.
 3. **Removals that fail** (e.g. sandbox-restricted ACLs on Windows, or a
    link that resists even a plain unlink): printed as `FAILED`, never
    silently skipped, with an elevated re-run hint (Windows only; the

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -123,10 +123,18 @@ In order:
    worktree is refused the same way a default-branch one is, even though
    `git worktree add --detach` is Rule 2's own recommended form for a
    review worktree - commit it onto a real branch (or leave it) before
-   closing the task if it must survive `--apply`. Removes the allow-listed
-   candidates - a symlink or junction candidate is removed AS THE LINK
-   ITSELF; its target is never touched, entered, or overwritten. Runs
-   `git worktree prune`.
+   closing the task if it must survive `--apply`. A refusal applies in
+   BOTH directions: a scratch task directory that itself looks stale by
+   age but CONTAINS a refused worktree (exactly Rule 2's own recommended
+   `<scratch>/wt-<sha>` layout, nested a level or two under a task
+   directory) is refused right along with it, not removed out from under
+   the worktree the moment the refusal line prints. When git itself
+   cannot be trusted (unresolvable, or `worktree list` failing) even a
+   directory the janitor cannot ask git about is refused if its own tree
+   contains a `.git` entry anywhere - staleness age never overrides that.
+   Removes the allow-listed candidates - a symlink or junction candidate
+   is removed AS THE LINK ITSELF; its target is never touched, entered,
+   or overwritten. Runs `git worktree prune`.
 3. **Removals that fail** (e.g. sandbox-restricted ACLs on Windows, or a
    link that resists even a plain unlink): printed as `FAILED`, never
    silently skipped, with an elevated re-run hint (Windows only; the

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -37,16 +37,24 @@ or the long form (any key may be omitted):
 {"scratch": {"root": "D:/custom/scratch/root", "keep_days": 3}}
 ```
 
-Resolve and create the per-agent/per-task directory with:
+Resolve and create it with:
 
 ```
-agenttalk scratch root --for <agent> [--task <id>]
+agenttalk scratch root --for <agent>              # the agent's OWN root: <scratch_root>/<agent>
+agenttalk scratch root --for <agent> --task <id>  # a task-scoped subdirectory: .../<agent>/<task>
 ```
 
-A wrapped agent also finds it pre-resolved in `$AGENTTALK_SCRATCH` (the
-wrapper exports the per-seat root at launch; a dispatch that predates this
-feature, or a project without a `"scratch"` config key, still works - the
-default root always resolves, config or not).
+A wrapped agent also finds the agent's own root pre-resolved in
+`$AGENTTALK_SCRATCH` (the wrapper exports it at launch; a dispatch that
+predates this feature, or a project without a `"scratch"` config key,
+still works - the default root always resolves, config or not). It is
+deliberately the AGENT root, not a task subdirectory: `$AGENTTALK_SCRATCH`
+lives for the whole supervised session, so pinning it to one task
+directory would make everything written there subject to that task's
+staleness window even while the seat is still actively using it (a real
+data-loss path measured during review - see the janitor's own staleness
+rule below). Scope further with `--task <id>` explicitly for anything
+that should age out on its own.
 
 Uses:
 - pytest: `--basetemp <scratch_root>/<seat>/<task-id>/pt`
@@ -81,28 +89,47 @@ agenttalk janitor --apply --keep-days 7    # override the scratch-root staleness
 In order:
 
 1. **Report mode** (default): lists scratch candidates under the
-   repository root, `.worktrees/`, the OS temp root (allow-listed name
-   families only, configurable), and the scratch root (past its
-   `keep_days` window), with counts and the oldest entries - and, for
-   every registered git worktree, whether it has uncommitted changes to
-   TRACKED files (an all-untracked worktree is not "dirty" in this
-   sense).
-2. **`--apply`**: for each dirty worktree, commits the tracked changes as
-   a WIP commit on the worktree's OWN branch - refused outright on a
-   default branch (`master`/`main` by default, configurable), never
-   auto-committed there. Removes the allow-listed candidates. Runs
+   repository root (allow-listed name families only, configurable),
+   `.worktrees/` (**every** directory there is a candidate, regardless of
+   name - that location IS the family, unlike the repository root), the
+   OS temp root (a narrower, case-SENSITIVE, directories-only,
+   age-windowed family list - the temp root is shared with every other
+   program on the machine, so it is treated far more conservatively than
+   the repository root), and the scratch root (a task directory whose
+   NEWEST file anywhere in its tree, not the directory's own mtime, is
+   older than `keep_days` - a directory's mtime does not change when a
+   file nested inside it is edited). Reports, for every registered git
+   worktree, whether it has ANY uncommitted change (tracked or
+   untracked). A location the janitor could not even list (e.g. an
+   ACL-denied directory) is reported as `FAILED to list`, never silently
+   skipped or swallowed.
+2. **`--apply`**: for each dirty worktree, commits ALL changes (tracked
+   and untracked) as a WIP commit on the worktree's OWN branch - REFUSED
+   OUTRIGHT (neither committed nor removed) on a default branch
+   (`master`/`main` by default, configurable) or a detached `HEAD`. A
+   detached-HEAD WIP commit would be reachable from no ref and become
+   effectively lost the moment its directory is removed, so a detached
+   worktree is refused the same way a default-branch one is, even though
+   `git worktree add --detach` is Rule 2's own recommended form for a
+   review worktree - commit it onto a real branch (or leave it) before
+   closing the task if it must survive `--apply`. Removes the allow-listed
+   candidates - a symlink or junction candidate is removed AS THE LINK
+   ITSELF; its target is never touched, entered, or overwritten. Runs
    `git worktree prune`.
-3. **Directories that refuse removal** (e.g. sandbox-restricted ACLs on
-   Windows): printed as `FAILED`, never silently skipped, with an
-   elevated re-run hint (Windows only; the escalation itself - taking
-   ownership and re-granting access - also only runs on Windows, and only
-   in `--apply`). The command is idempotent: re-running after fixing
+3. **Removals that fail** (e.g. sandbox-restricted ACLs on Windows, or a
+   link that resists even a plain unlink): printed as `FAILED`, never
+   silently skipped, with an elevated re-run hint (Windows only; the
+   escalation itself - taking ownership and re-granting access - also
+   only runs on Windows, only in `--apply`, and never against a
+   symlink/junction). The command is idempotent: re-running after fixing
    permissions removes what's left.
 
-The janitor never touches: `.agenttalk/` (the bus), tracked files, or a
+The janitor never touches: `.agenttalk/` (the bus), tracked files, a
 configured `"foreign"` folder under the temp root (`scratch.foreign` in
-config - reported and kept, never removed). It never removes a directory
-that doesn't match an allow-listed name family.
+config - reported and kept, never removed), or the target behind a
+symlink/junction candidate. Outside `.worktrees/` (where every directory
+is in scope), it never removes something that doesn't match an
+allow-listed name family.
 
 `agenttalk doctor` warns when registered worktrees or scratch-family
 candidates exist outside the scratch root, so this doesn't need to be

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -188,6 +188,27 @@ allow-listed name family.
 candidates exist outside the scratch root, so this doesn't need to be
 checked by hand.
 
+**Cost.** The ownership check (the `.git`-in-tree walk above) runs for
+every directory candidate, including every registered worktree under
+`.worktrees/` - a full checkout, not just its metadata - on every
+`agenttalk janitor` run and therefore every `agenttalk doctor` run too.
+Measured at roughly 1.8x the walk time of a build without it, on a
+20,000-file stale task in one synthetic benchmark. Fine for ordinary
+task/scratch sizes; worth revisiting (e.g. one shared walk instead of a
+separate one per check) if `doctor` latency becomes noticeable on a
+much larger tree.
+
+**`refs/remotes` breadth.** A remote-tracking ref added from a
+LOCAL-PATH remote (another seat's clone, added as a `git remote`) counts
+toward reachability too. That local remote's own object store can later
+be pruned or deleted, and a subsequent `fetch --prune` would drop the
+only pointer keeping such a commit "reachable" as far as this check is
+concerned. In the ordinary case - a real server remote (GitHub, etc.) -
+the commit still exists upstream regardless of what happens locally, so
+this is not a local data-loss path; it is called out here as a known
+edge case of a local-only setup, not because it needs a different
+default today.
+
 ## Rule 4: cleanup is part of "done"
 
 A batch is not closed until the janitor report is empty (or its leftovers

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -92,10 +92,12 @@ In order:
    repository root (allow-listed name families only, configurable),
    `.worktrees/` (**every** directory there is a candidate, regardless of
    name - that location IS the family, unlike the repository root), the
-   OS temp root (a narrower, case-SENSITIVE, directories-only,
-   age-windowed family list - the temp root is shared with every other
-   program on the machine, so it is treated far more conservatively than
-   the repository root), and the scratch root (a task directory whose
+   OS temp root (a narrower, case-SENSITIVE family list, matching files
+   and directories alike, every entry individually gated by an age window
+   - `tmp_keep_days`, comfortably longer than a normal task/gate duration
+   - the temp root is shared with every other program on the machine, so
+   it is treated far more conservatively than the repository root), and
+   the scratch root (a task directory whose
    NEWEST file anywhere in its tree, not the directory's own mtime, is
    older than `keep_days` - a directory's mtime does not change when a
    file nested inside it is edited). Reports, for every registered git

--- a/docs/ops/scratch-hygiene.md
+++ b/docs/ops/scratch-hygiene.md
@@ -68,6 +68,14 @@ probe names the scratch root explicitly; a close-out that created scratch
 reports "scratch removed" or lists what is left and why (a worktree kept
 for a follow-up, a preserved evidence tree).
 
+`<scratch_root>` is SHARED: every seat's clone writes under the same
+root (one directory per seat, per Rule 1 above), so a batch `--apply`
+pointed at any one seat's repository walks every OTHER seat's task
+directories too, as plain filesystem trees. The janitor accounts for
+this - see Rule 3's ownership check - but it means "my scratch root" is
+really "everyone's scratch root"; never assume a stale-looking task
+directory under it belongs to nobody just because it isn't yours.
+
 ## Rule 2: worktrees are registered, short-lived, and never dirty at close
 
 - `git worktree add --detach <scratch>/wt-<sha> <sha>` for reviews; a
@@ -123,18 +131,33 @@ In order:
    worktree is refused the same way a default-branch one is, even though
    `git worktree add --detach` is Rule 2's own recommended form for a
    review worktree - commit it onto a real branch (or leave it) before
-   closing the task if it must survive `--apply`. A refusal applies in
-   BOTH directions: a scratch task directory that itself looks stale by
-   age but CONTAINS a refused worktree (exactly Rule 2's own recommended
-   `<scratch>/wt-<sha>` layout, nested a level or two under a task
-   directory) is refused right along with it, not removed out from under
-   the worktree the moment the refusal line prints. When git itself
-   cannot be trusted (unresolvable, or `worktree list` failing) even a
-   directory the janitor cannot ask git about is refused if its own tree
-   contains a `.git` entry anywhere - staleness age never overrides that.
-   Removes the allow-listed candidates - a symlink or junction candidate
-   is removed AS THE LINK ITSELF; its target is never touched, entered,
-   or overwritten. Runs `git worktree prune`.
+   closing the task if it must survive `--apply`. A CLEAN detached
+   worktree is not automatically safe either: if its HEAD holds a commit
+   that no branch or tag contains (a reviewer's local fixup left on the
+   checkout, say), it is refused too, dirty or not - pruning a clean-
+   looking worktree like that would drop the only ref keeping that commit
+   reachable.
+
+   A refusal applies in BOTH directions: a scratch task directory that
+   itself looks stale by age but CONTAINS a refused worktree (exactly
+   Rule 2's own recommended `<scratch>/wt-<sha>` layout, nested a level
+   or two under a task directory) is refused right along with it, not
+   removed out from under the worktree the moment the refusal line
+   prints. Ownership matters too, not just discovery: ANY tree holding a
+   `.git` entry (a clone's own `.git` directory, or a worktree's gitdir
+   FILE) that is not a registered worktree of THIS repository is refused
+   outright - another seat's dirty worktree living under the shared
+   scratch root (Rule 1), or a standalone clone nobody registered
+   anywhere, is invisible to `git worktree list` here and gets exactly
+   the same protection as if it were. When git itself cannot be trusted
+   (unresolvable, or `worktree list` failing) the same refusal applies
+   even more broadly: any directory the janitor cannot ask git about at
+   all is refused if its own tree contains a `.git` entry anywhere, or
+   if any part of that tree could not even be listed - staleness age
+   never overrides either check. Removes the allow-listed candidates - a
+   symlink or junction candidate is removed AS THE LINK ITSELF; its
+   target (and anything behind it, `.git` or otherwise) is never
+   touched, entered, or overwritten. Runs `git worktree prune`.
 3. **Removals that fail** (e.g. sandbox-restricted ACLs on Windows, or a
    link that resists even a plain unlink): printed as `FAILED`, never
    silently skipped, with an elevated re-run hint (Windows only; the

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -50,6 +50,8 @@ from agenttalk import checkpoint as checkpoint_mod
 from agenttalk import deadman as deadman_mod
 from agenttalk import ephemeral as eph
 from agenttalk import domains as dom
+from agenttalk import janitor as janitormod
+from agenttalk import scratch as scratchmod
 from agenttalk import transcript as tx
 from agenttalk import codex_config as cxc
 from agenttalk import doctor as dr
@@ -9423,6 +9425,36 @@ def cmd_capacity(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_scratch(args: argparse.Namespace) -> int:
+    """Resolve (and create) a seat's per-task scratch directory (#148)."""
+    root = Path(args.root).resolve() if getattr(args, "root", None) else find_root()
+    if args.scratch_cmd == "root":
+        agent = _resolve_self(args.agent, roster=None)
+        try:
+            path = scratchmod.task_scratch_dir(root, agent, args.task)
+        except ValueError as e:
+            sys.stderr.write(f"agenttalk: {e}\n")
+            return 2
+        print(str(path))
+        return 0
+    sys.stderr.write("agenttalk: scratch: choose a subcommand (root)\n")
+    return 2
+
+
+def cmd_janitor(args: argparse.Namespace) -> int:
+    """Report (default) or clean up (--apply) scratch sprawl (#148)."""
+    root = Path(args.root).resolve() if getattr(args, "root", None) else find_root()
+    cfg = janitormod.JanitorConfig.load(root)
+    if args.keep_days is not None:
+        cfg.keep_days = args.keep_days
+    report = janitormod.build_report(cfg)
+    if args.apply:
+        print(janitormod.apply(cfg, report))
+    else:
+        print(janitormod.format_report(report, cfg, apply=False))
+    return 0
+
+
 def cmd_install_skills(args: argparse.Namespace) -> int:
     if args.devkit_only:
         claude = codex = False
@@ -15908,6 +15940,39 @@ def build_parser() -> argparse.ArgumentParser:
     gw_clear_hold.set_defaults(func=cmd_gateway)
     gw_run = gwsub.add_parser("run", help=argparse.SUPPRESS)
     gw_run.set_defaults(func=cmd_gateway)
+
+    pscratch = sub.add_parser(
+        "scratch",
+        help="Per-seat scratch root (#148): where temporary work goes so it "
+             "never sprawls into the repo root, .worktrees/, or the OS temp dir.",
+    )
+    scratchsub = pscratch.add_subparsers(dest="scratch_cmd")
+    pscratch_root = scratchsub.add_parser(
+        "root",
+        help="Resolve (and create) <scratch_root>/<agent>/<task>; prints the path. "
+             "scratch_root is .agenttalk/config.json's \"scratch\" key, or a sibling "
+             "atk-scratch/ next to the project root by default.",
+    )
+    pscratch_root.add_argument("--for", dest="agent",
+                               help="Agent name (default: $AGENTTALK_SELF)")
+    pscratch_root.add_argument("--task", help="Task id (default: \"default\")")
+    pscratch_root.set_defaults(func=cmd_scratch)
+
+    pjanitor = sub.add_parser(
+        "janitor",
+        help="Report (default) or clean up (--apply) scratch sprawl: config-driven "
+             "allow-listed name families in the repo root, .worktrees/, the OS temp "
+             "root, and stale per-agent scratch directories (#148).",
+    )
+    pjanitor.add_argument("--apply", action="store_true",
+                          help="WIP-commit dirty registered worktrees on their own "
+                               "branch (never the default branch), remove allow-listed "
+                               "paths, and prune stale worktree registrations. Default "
+                               "is report-only.")
+    pjanitor.add_argument("--keep-days", type=int, default=None,
+                          help="Override the scratch-root staleness window "
+                               "(default: config's scratch.keep_days, else 3)")
+    pjanitor.set_defaults(func=cmd_janitor)
 
     ph = sub.add_parser(
         "hmac-init",

--- a/src/agenttalk/cli.py
+++ b/src/agenttalk/cli.py
@@ -9426,12 +9426,18 @@ def cmd_capacity(args: argparse.Namespace) -> int:
 
 
 def cmd_scratch(args: argparse.Namespace) -> int:
-    """Resolve (and create) a seat's per-task scratch directory (#148)."""
+    """Resolve (and create) a seat's scratch directory (#148). With --task,
+    the task-scoped subdirectory; without it, the agent's own root (NOT a
+    "default" task subdirectory - a seat's long-lived scratch export must
+    not itself be subject to the task-level staleness window)."""
     root = Path(args.root).resolve() if getattr(args, "root", None) else find_root()
     if args.scratch_cmd == "root":
         agent = _resolve_self(args.agent, roster=None)
         try:
-            path = scratchmod.task_scratch_dir(root, agent, args.task)
+            if args.task:
+                path = scratchmod.task_scratch_dir(root, agent, args.task)
+            else:
+                path = scratchmod.agent_scratch_dir(root, agent)
         except ValueError as e:
             sys.stderr.write(f"agenttalk: {e}\n")
             return 2
@@ -15949,13 +15955,16 @@ def build_parser() -> argparse.ArgumentParser:
     scratchsub = pscratch.add_subparsers(dest="scratch_cmd")
     pscratch_root = scratchsub.add_parser(
         "root",
-        help="Resolve (and create) <scratch_root>/<agent>/<task>; prints the path. "
-             "scratch_root is .agenttalk/config.json's \"scratch\" key, or a sibling "
-             "atk-scratch/ next to the project root by default.",
+        help="Resolve (and create) the agent's scratch root <scratch_root>/<agent>, "
+             "or with --task the task-scoped <scratch_root>/<agent>/<task>; prints "
+             "the path. scratch_root is .agenttalk/config.json's \"scratch\" key, "
+             "or a sibling atk-scratch/ next to the project root by default.",
     )
     pscratch_root.add_argument("--for", dest="agent",
                                help="Agent name (default: $AGENTTALK_SELF)")
-    pscratch_root.add_argument("--task", help="Task id (default: \"default\")")
+    pscratch_root.add_argument("--task",
+                               help="Task id; scopes to <scratch_root>/<agent>/<task> "
+                                    "instead of the agent's own root")
     pscratch_root.set_defaults(func=cmd_scratch)
 
     pjanitor = sub.add_parser(

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1398,7 +1398,7 @@ def _check_scratch_hygiene(project_root: Path) -> Check | None:
     """
     try:
         cfg = janitormod.JanitorConfig.load(project_root)
-        candidates = janitormod.find_candidates(cfg)
+        candidates, access_errors = janitormod.find_candidates(cfg)
         registered = janitormod.get_registered_worktrees(project_root)
     except OSError:
         return None
@@ -1409,13 +1409,18 @@ def _check_scratch_hygiene(project_root: Path) -> Check | None:
     # "scratch-stale" candidates already live under the scratch root (just
     # past keep_days) - not sprawl outside it, so they don't count here.
     outside_candidates = [c for c in candidates if c.reason != "scratch-stale"]
-    if not outside_worktrees and not outside_candidates:
+    if not outside_worktrees and not outside_candidates and not access_errors:
         return None
     parts = []
     if outside_worktrees:
         parts.append(f"{len(outside_worktrees)} registered worktree(s) outside the scratch root")
     if outside_candidates:
         parts.append(f"{len(outside_candidates)} scratch-family candidate(s) outside the scratch root")
+    # #148 acceptance: a directory the janitor can't even list is reported
+    # as FAILED, never silently skipped - doctor must not swallow it either.
+    if access_errors:
+        parts.append(f"{len(access_errors)} location(s) could not be listed (permissions?): "
+                      + ", ".join(str(p) for p in access_errors))
     return Check(
         name="scratch_hygiene",
         status="warn",

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -1419,8 +1419,8 @@ def _check_scratch_hygiene(project_root: Path) -> Check | None:
     # #148 acceptance: a directory the janitor can't even list is reported
     # as FAILED, never silently skipped - doctor must not swallow it either.
     if access_errors:
-        parts.append(f"{len(access_errors)} location(s) could not be listed (permissions?): "
-                      + ", ".join(str(p) for p in access_errors))
+        parts.append(f"{len(access_errors)} location(s) could not be listed or trusted: "
+                      + ", ".join(f"{p} ({reason})" for p, reason in access_errors))
     return Check(
         name="scratch_hygiene",
         status="warn",

--- a/src/agenttalk/doctor.py
+++ b/src/agenttalk/doctor.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from agenttalk import __version__
 from agenttalk import codex_config as cxc
 from agenttalk import install_skills as iskl
+from agenttalk import janitor as janitormod
 from agenttalk import signing as _signing
 from agenttalk import supervisor as sup
 from agenttalk import powershell_host as psh
@@ -136,6 +137,12 @@ def run(project_root: Path | None = None) -> Report:
     artifact_check = _check_powershell_artifacts(store)
     if artifact_check is not None:
         report.checks.append(artifact_check)
+    # Scratch hygiene (#148) runs UNCONDITIONALLY, like multi-store detection:
+    # scratch root resolution works without an initialized store, so the
+    # warning should too.
+    scratch_check = _check_scratch_hygiene(root)
+    if scratch_check is not None:
+        report.checks.append(scratch_check)
     # Config-dependent checks are gated on a LOADABLE config: `_check_init`
     # already reports a corrupt config as an `error` (e.g. an active∩retired
     # overlap, #19), so running these would just re-raise the same
@@ -1383,6 +1390,41 @@ def _check_identity_registry(store: Store) -> Check:
         details=(f"{len(active)} active, {len(retired)} retired "
                  f"(tombstones permanent; history stays valid)"),
         data=data)
+
+
+def _check_scratch_hygiene(project_root: Path) -> Check | None:
+    """Registered worktrees or scratch-family sprawl outside the scratch
+    root (#148). Runs unconditionally - scratch resolution needs no init.
+    """
+    try:
+        cfg = janitormod.JanitorConfig.load(project_root)
+        candidates = janitormod.find_candidates(cfg)
+        registered = janitormod.get_registered_worktrees(project_root)
+    except OSError:
+        return None
+    outside_worktrees = [
+        w for w in registered
+        if w != project_root and cfg.scratch_root not in w.parents
+    ]
+    # "scratch-stale" candidates already live under the scratch root (just
+    # past keep_days) - not sprawl outside it, so they don't count here.
+    outside_candidates = [c for c in candidates if c.reason != "scratch-stale"]
+    if not outside_worktrees and not outside_candidates:
+        return None
+    parts = []
+    if outside_worktrees:
+        parts.append(f"{len(outside_worktrees)} registered worktree(s) outside the scratch root")
+    if outside_candidates:
+        parts.append(f"{len(outside_candidates)} scratch-family candidate(s) outside the scratch root")
+    return Check(
+        name="scratch_hygiene",
+        status="warn",
+        details="; ".join(parts) + f" (scratch root: {cfg.scratch_root})",
+        fix="run `agenttalk janitor` to report, `agenttalk janitor --apply` to clean up",
+        data={"outside_worktrees": len(outside_worktrees),
+              "outside_candidates": len(outside_candidates),
+              "scratch_root": str(cfg.scratch_root)},
+    )
 
 
 def _check_store_hygiene(store: Store) -> Check:

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -3,10 +3,12 @@
 
 Report mode (default) lists scratch candidates and dirty registered
 worktrees without touching anything. Apply mode WIP-commits dirty
-worktrees on their own branch (never the default branch), removes the
-allow-listed candidates, and prunes stale worktree registrations. Never
-touches `.agenttalk/`, tracked files, or a configured "foreign" folder
-under the temp root - those are reported and kept.
+worktrees on their own branch (never a default branch, never a detached
+HEAD - both are refused outright, neither committed nor removed), removes
+the allow-listed candidates, and prunes stale worktree registrations.
+Never touches `.agenttalk/`, tracked files, a configured "foreign" folder
+under the temp root, or the CONTENTS behind a symlink/junction (the link
+itself is unlinked; its target is never touched).
 
 Config (optional, `.agenttalk/config.json`, key `"scratch"`, long form):
 
@@ -14,17 +16,20 @@ Config (optional, `.agenttalk/config.json`, key `"scratch"`, long form):
       "scratch": {
         "root": "...",                    # see scratch.py
         "keep_days": 3,
+        "tmp_keep_days": 1,
         "repo_dir_families": [...],       # fnmatch globs, repo root, directories
         "repo_file_families": [...],      # fnmatch globs, repo root, files
         "tmp_root": "...",                # default: the OS temp dir
-        "tmp_families": [...],            # fnmatch globs under tmp_root
+        "tmp_families": [...],            # fnmatch globs, temp root, DIRECTORIES only
         "foreign": [...],                 # exact names under tmp_root: report, never remove
         "default_branches": ["master", "main"]
       }
     }
 
 Every list has a built-in default (below) used when the key is absent, so
-an unconfigured project still gets sane behaviour.
+an unconfigured project still gets sane behaviour. Every family match is
+CASE-SENSITIVE (fnmatch.fnmatch is case-insensitive on Windows, which
+would over-match in the shared temp root - fnmatchcase is used instead).
 """
 
 from __future__ import annotations
@@ -32,9 +37,11 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import fnmatch
+import os
 import platform
 import shutil
-import subprocess
+import stat
+import subprocess  # nosec B404 - every call site below uses a resolved-path argv list, shell disabled
 import tempfile
 import uuid
 from pathlib import Path
@@ -50,15 +57,24 @@ DEFAULT_REPO_FILE_FAMILIES = [
     ".review-*.tar", ".review-*.zip", ".review-*.md", ".agenttalk-*.txt",
     ".agenttalk-*.md", ".coverage",
 ]
+# Narrower than the repo-root families on purpose: the OS temp root is
+# shared with every OTHER program on the machine, so a family here must be
+# specific enough not to collide with something real (reviewer-3 measured
+# 157 false-positive matches on the old, broader list, including a live
+# pytest run). Directories only - see find_candidates.
 DEFAULT_TMP_FAMILIES = [
-    "pytest-*", "review*", "reply-q*", "rq-*", "qa-*", "q-*", "race-*",
-    "adv-*", "run-*", "wt-*", "cold*", "mut*", "lane-*", "sub*", "probe-*",
-    "gate-*", "wf-*",
+    "pytest-of-*", "agenttalk-review-*", "agenttalk-reply-*",
+    "agenttalk-gate-*", "agenttalk-probe-*", "agenttalk-wf-*",
+    "mockitoboot*", "backend-request-test-*", "surefire*",
 ]
+DEFAULT_TMP_KEEP_DAYS = 1
 # Never removed regardless of family match, even if a candidate happens to
 # collide with one of these names.
 _ALWAYS_EXCLUDED_NAMES = {".agenttalk", ".claude", "docs", "tools"}
 _ALWAYS_EXCLUDED_PREFIXES = ("launch-", "MANUAL-", ".wt-")
+# A worktree on one of these, or a detached HEAD (git prints "HEAD" for
+# `rev-parse --abbrev-ref HEAD` when detached), is refused outright.
+_NEVER_AUTO_COMMIT_BRANCHES_SENTINELS = {None, "HEAD"}
 
 _ELEVATED_HINT_WINDOWS = (
     "re-run elevated: "
@@ -72,6 +88,7 @@ class JanitorConfig:
     repo: Path
     scratch_root: Path
     keep_days: int
+    tmp_keep_days: int
     tmp_root: Path
     repo_dir_families: list[str]
     repo_file_families: list[str]
@@ -84,10 +101,13 @@ class JanitorConfig:
         repo = Path(repo).resolve()
         cfg = _read_scratch_config(repo)
         tmp_root = cfg.get("tmp_root")
+        tmp_keep_days = cfg.get("tmp_keep_days")
         return cls(
             repo=repo,
             scratch_root=resolve_scratch_root(repo),
             keep_days=resolve_keep_days(repo),
+            tmp_keep_days=tmp_keep_days if isinstance(tmp_keep_days, int) and tmp_keep_days >= 0
+            else DEFAULT_TMP_KEEP_DAYS,
             tmp_root=Path(tmp_root).resolve() if tmp_root else Path(tempfile.gettempdir()),
             repo_dir_families=list(cfg.get("repo_dir_families") or DEFAULT_REPO_DIR_FAMILIES),
             repo_file_families=list(cfg.get("repo_file_families") or DEFAULT_REPO_FILE_FAMILIES),
@@ -110,6 +130,11 @@ class JanitorReport:
     registered_worktrees: list[Path]
     dirty_worktrees: list[Path]
     foreign_kept: list[Path]
+    # Discovery locations that could not even be LISTED (e.g. an ACL-denied
+    # directory) - #148's acceptance is "reported as FAILED, never silently
+    # skipped", so these surface exactly like a removal failure, not a
+    # crash and not a swallowed exception.
+    access_errors: list[Path]
 
 
 def _is_excluded_name(name: str) -> bool:
@@ -119,12 +144,64 @@ def _is_excluded_name(name: str) -> bool:
 
 
 def _matches_any(name: str, patterns: list[str]) -> bool:
-    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+    # fnmatchcase, NOT fnmatch: fnmatch normalizes case on Windows, which
+    # would over-match unrelated real files/dirs in a shared temp root.
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+def is_link_like(path: Path) -> bool:
+    """True for a symlink OR a Windows reparse point (junction/mount point).
+
+    `os.path.isjunction` only exists on Python 3.12+, so junctions are
+    detected the version-independent way: `os.stat(path, follow_symlinks=
+    False)` never follows a reparse point, and on Windows its
+    `st_file_attributes` carries `FILE_ATTRIBUTE_REPARSE_POINT` (0x400) for
+    BOTH symlinks and junctions. Candidates must NEVER be resolved through
+    this - a link is removed as the link itself, never followed into its
+    target (Codex xhigh finding P6A/P6B: `Path.resolve()` follows symlinks
+    on POSIX too, and un-guarded escalation mirrors an empty dir INTO a
+    junction's target instead of refusing it).
+    """
+    try:
+        st = os.stat(path, follow_symlinks=False)
+    except OSError:
+        return False
+    if stat.S_ISLNK(st.st_mode):
+        return True
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(getattr(st, "st_file_attributes", 0) & reparse_point)
+
+
+def _safe_iterdir(path: Path) -> tuple[list[Path], Path | None]:
+    """List `path`'s entries, or (on ANY OSError - permission denial,
+    a vanished directory mid-scan, etc.) return an empty list plus the
+    path that failed, instead of raising out of discovery or silently
+    returning nothing. The caller surfaces the failure path as FAILED."""
+    try:
+        return sorted(path.iterdir()), None
+    except OSError:
+        return [], path
+
+
+def _resolve_system_tool(name: str) -> str | None:
+    """Resolve an escalation tool to an absolute path (bandit B607 - never
+    start a process with a partial/PATH-searched name). Falls back to the
+    well-known System32 location since takeown/icacls/robocopy are core
+    Windows components that may not be on PATH in a restricted shell."""
+    found = shutil.which(name)
+    if found:
+        return found
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    candidate = Path(system_root) / "System32" / f"{name}.exe"
+    return str(candidate) if candidate.is_file() else None
 
 
 def _run_git(repo: Path, *args: str) -> str:
-    result = subprocess.run(
-        ["git", "-C", str(repo), *args],
+    git = shutil.which("git")
+    if git is None:
+        return ""
+    result = subprocess.run(  # nosec B603 - resolved executable, argv list
+        [git, "-C", str(repo), *args],
         capture_output=True, text=True, check=False,
     )
     return result.stdout
@@ -135,21 +212,19 @@ def get_registered_worktrees(repo: Path) -> list[Path]:
     worktrees = []
     for line in out.splitlines():
         if line.startswith("worktree "):
-            worktrees.append(Path(line[len("worktree "):]).resolve())
+            worktrees.append(Path(line[len("worktree "):]))
     return worktrees
 
 
 def is_dirty_worktree(path: Path) -> bool:
-    """True if the worktree has uncommitted changes to TRACKED files.
-    Untracked files (`??`) don't count - only tracked changes get a WIP
-    commit; an all-untracked worktree is not "dirty" in this sense."""
+    """True if the worktree has ANY uncommitted change - tracked or
+    untracked. An untracked file left behind by a `.worktrees/` removal is
+    real, unrecovered work (Codex xhigh finding P2); it is no longer
+    excluded from "dirty" the way a purely cosmetic ignored-file diff
+    would be."""
     if not (path / ".git").exists():
         return False
-    out = _run_git(path, "status", "--porcelain")
-    for line in out.splitlines():
-        if line and not line.startswith("??"):
-            return True
-    return False
+    return bool(_run_git(path, "status", "--porcelain").strip())
 
 
 def worktree_branch(path: Path) -> str | None:
@@ -157,23 +232,38 @@ def worktree_branch(path: Path) -> str | None:
     return out or None
 
 
-def find_candidates(cfg: JanitorConfig) -> list[Candidate]:
-    seen: set[Path] = set()
+def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
+    seen: set[str] = set()
     out: list[Candidate] = []
+    access_errors: list[Path] = []
 
     def add(path: Path, reason: str) -> None:
-        resolved = path.resolve()
-        if resolved in seen or _is_excluded_name(resolved.name):
+        # NEVER path.resolve() - that follows symlinks (POSIX) and would
+        # silently retarget a link candidate onto whatever it points at
+        # (P6A). normcase-of-the-given-path is dedup enough; identity, not
+        # canonicalization.
+        key = os.path.normcase(str(path))
+        if key in seen or _is_excluded_name(path.name):
             return
         try:
-            mtime = path.stat().st_mtime
+            entry_mtime = os.lstat(path).st_mtime
         except OSError:
             return
-        seen.add(resolved)
-        out.append(Candidate(path=resolved, mtime=mtime, reason=reason))
+        seen.add(key)
+        out.append(Candidate(path=path, mtime=entry_mtime, reason=reason))
 
     if cfg.repo.is_dir():
-        for entry in cfg.repo.iterdir():
+        entries, err = _safe_iterdir(cfg.repo)
+        if err is not None:
+            access_errors.append(err)
+        for entry in entries:
+            # A link is a candidate in its own right (removed as a link,
+            # never followed) - checked before is_dir()/is_file(), both of
+            # which FOLLOW symlinks/junctions and would misclassify it.
+            if is_link_like(entry):
+                if _matches_any(entry.name, cfg.repo_dir_families + cfg.repo_file_families):
+                    add(entry, "repo-dir")
+                continue
             if entry.is_dir() and _matches_any(entry.name, cfg.repo_dir_families):
                 add(entry, "repo-dir")
             elif entry.is_file() and _matches_any(entry.name, cfg.repo_file_families):
@@ -181,41 +271,114 @@ def find_candidates(cfg: JanitorConfig) -> list[Candidate]:
 
     worktrees_dir = cfg.repo / ".worktrees"
     if worktrees_dir.is_dir():
-        for entry in worktrees_dir.iterdir():
-            if entry.is_dir():
+        entries, err = _safe_iterdir(worktrees_dir)
+        if err is not None:
+            access_errors.append(err)
+        for entry in entries:
+            # Every directory (or dir-like link) under .worktrees/ is a
+            # candidate regardless of name - this location IS the family;
+            # no separate name-family filter applies here.
+            if is_link_like(entry) or entry.is_dir():
                 add(entry, "worktrees-dir")
 
     if cfg.tmp_root.is_dir():
-        for entry in cfg.tmp_root.iterdir():
+        cutoff = datetime.datetime.now().timestamp() - cfg.tmp_keep_days * 86400
+        entries, err = _safe_iterdir(cfg.tmp_root)
+        if err is not None:
+            access_errors.append(err)
+        for entry in entries:
             if entry.name in cfg.foreign:
                 continue
-            if _matches_any(entry.name, cfg.tmp_families):
-                add(entry, "tmp")
+            if not _matches_any(entry.name, cfg.tmp_families):
+                continue
+            # Directories only (P4): a matching FILE in the shared temp
+            # root (another program's log, e.g.) is not this janitor's to
+            # remove - and age-gated, since this root is shared machine-
+            # wide, not owned the way the repo root/scratch root are.
+            link = is_link_like(entry)
+            if not link and not entry.is_dir():
+                continue
+            try:
+                entry_mtime = os.lstat(entry).st_mtime
+            except OSError:
+                continue
+            if entry_mtime >= cutoff:
+                continue
+            add(entry, "tmp")
 
     if cfg.scratch_root.is_dir():
         cutoff = datetime.datetime.now().timestamp() - cfg.keep_days * 86400
-        for agent_dir in cfg.scratch_root.iterdir():
+        agent_entries, err = _safe_iterdir(cfg.scratch_root)
+        if err is not None:
+            access_errors.append(err)
+        for agent_dir in agent_entries:
             if not agent_dir.is_dir():
                 continue
-            for task_dir in agent_dir.iterdir():
-                if task_dir.is_dir() and task_dir.stat().st_mtime < cutoff:
+            task_entries, terr = _safe_iterdir(agent_dir)
+            if terr is not None:
+                access_errors.append(terr)
+            for task_dir in task_entries:
+                if not task_dir.is_dir():
+                    continue
+                # Staleness is the NEWEST mtime anywhere in the tree, not
+                # the task directory's own mtime (P3): a directory's mtime
+                # only changes when an entry is added/removed/renamed
+                # directly inside it, NOT when a file three levels down is
+                # edited - live work under an old task directory would
+                # otherwise be misclassified as stale and deleted.
+                newest, nerr = _newest_mtime_in_tree(task_dir)
+                if nerr:
+                    access_errors.append(nerr)
+                if newest is not None and newest < cutoff:
                     add(task_dir, "scratch-stale")
 
-    return out
+    return out, access_errors
+
+
+def _newest_mtime_in_tree(root: Path) -> tuple[float | None, Path | None]:
+    """The newest mtime of `root` itself or anything nested under it.
+    Returns (None, error_path) if any nested directory could not be
+    listed, rather than silently under-counting staleness."""
+    try:
+        newest = os.lstat(root).st_mtime
+    except OSError:
+        return None, root
+    entries, err = _safe_iterdir(root)
+    if err is not None:
+        return None, err
+    for entry in entries:
+        if is_link_like(entry):
+            try:
+                newest = max(newest, os.lstat(entry).st_mtime)
+            except OSError:
+                pass
+            continue
+        if entry.is_dir():
+            sub_newest, sub_err = _newest_mtime_in_tree(entry)
+            if sub_err is not None:
+                return None, sub_err
+            if sub_newest is not None:
+                newest = max(newest, sub_newest)
+        else:
+            try:
+                newest = max(newest, os.lstat(entry).st_mtime)
+            except OSError:
+                pass
+    return newest, None
 
 
 def find_foreign_kept(cfg: JanitorConfig) -> list[Path]:
     if not cfg.tmp_root.is_dir():
         return []
     return [
-        (cfg.tmp_root / name).resolve()
+        cfg.tmp_root / name
         for name in cfg.foreign
-        if (cfg.tmp_root / name).is_dir()
+        if (cfg.tmp_root / name).is_dir() or is_link_like(cfg.tmp_root / name)
     ]
 
 
 def build_report(cfg: JanitorConfig) -> JanitorReport:
-    candidates = find_candidates(cfg)
+    candidates, access_errors = find_candidates(cfg)
     registered = get_registered_worktrees(cfg.repo)
     dirty = [
         w for w in registered
@@ -224,7 +387,7 @@ def build_report(cfg: JanitorConfig) -> JanitorReport:
     foreign = find_foreign_kept(cfg)
     return JanitorReport(
         candidates=candidates, registered_worktrees=registered,
-        dirty_worktrees=dirty, foreign_kept=foreign,
+        dirty_worktrees=dirty, foreign_kept=foreign, access_errors=access_errors,
     )
 
 
@@ -240,6 +403,11 @@ def format_report(report: JanitorReport, cfg: JanitorConfig, *, apply: bool) -> 
         lines.append(f"  DIRTY {w}")
     for f in report.foreign_kept:
         lines.append(f"  FOREIGN (kept) {f}")
+    if report.access_errors:
+        lines.append(f"FAILED to list ({len(report.access_errors)}) - "
+                      "not silently skipped, permissions likely need fixing:")
+        for p in report.access_errors:
+            lines.append(f"  {p}")
     if not apply:
         oldest = sorted(report.candidates, key=lambda c: c.mtime)[:15]
         for c in oldest:
@@ -255,45 +423,94 @@ def format_report(report: JanitorReport, cfg: JanitorConfig, *, apply: bool) -> 
 @dataclasses.dataclass
 class WipCommitResult:
     message: str
-    refused: bool  # True: on a default branch - not committed AND not removed
+    refused: bool  # True: default branch or detached HEAD - not committed AND not removed
 
 
 def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> WipCommitResult:
-    """Commit tracked changes as a WIP commit on the worktree's own branch.
-    Refuses (no commit, and the caller must not remove the directory either
-    - uncommitted changes on a default branch are never destroyed) if the
-    worktree is on a default branch."""
+    """Commit ALL changes (tracked and untracked - P2) as a WIP commit on
+    the worktree's own branch. Refuses (no commit, and the caller must not
+    remove the directory either) if the worktree is on a default branch OR
+    is a detached HEAD (P1): a WIP commit made on a detached HEAD is
+    reachable from no ref and becomes an unreachable object the moment the
+    directory is removed - recoverable only until the next `git gc`, i.e.
+    not really preserved. `--detach` is the ops doc's OWN recommended form
+    for a review worktree, so this is not a corner case."""
     branch = worktree_branch(path)
-    if branch in default_branches:
+    if branch in default_branches or branch in _NEVER_AUTO_COMMIT_BRANCHES_SENTINELS:
+        label = branch or "an unresolvable HEAD"
         return WipCommitResult(
-            message=f"  REFUSED dirty worktree on {branch} (never auto-commit or remove "
-                     f"the default branch): {path}",
+            message=f"  REFUSED dirty worktree on {label} (never auto-commit or remove "
+                     f"a default branch or a detached HEAD): {path}",
             refused=True,
         )
-    _run_git(path, "add", "-u")
+    _run_git(path, "add", "-A")
     stamp = datetime.datetime.now().isoformat(timespec="seconds")
-    subprocess.run(
-        ["git", "-C", str(path), "commit", "-q", "-m",
-         f"wip: preserve uncommitted worktree state before scratch cleanup ({stamp})"],
-        capture_output=True, text=True, check=False,
-    )
+    git = shutil.which("git")
+    if git is not None:
+        subprocess.run(  # nosec B603 - resolved executable, argv list
+            [git, "-C", str(path), "commit", "-q", "-m",
+             f"wip: preserve uncommitted worktree state before scratch cleanup ({stamp})"],
+            capture_output=True, text=True, check=False,
+        )
     return WipCommitResult(message=f"  WIP committed on {branch}: {path}", refused=False)
 
 
+def _make_tree_writable(path: Path) -> None:
+    """Clear the read-only bit recursively before removal (Windows: git
+    marks its own `.git/objects/**` blobs read-only, so a plain
+    `shutil.rmtree` on a full clone hits PermissionError before it ever
+    reaches the escalation branch - reviewer-3's teardown observation).
+    Best-effort; a failure here just means the subsequent remove attempt
+    may also fail and fall through to escalation as before."""
+    try:
+        current = os.stat(path, follow_symlinks=False).st_mode
+        os.chmod(path, current | stat.S_IWRITE)
+    except OSError:
+        pass
+    if is_link_like(path) or not path.is_dir():
+        return
+    entries, _err = _safe_iterdir(path)
+    for entry in entries:
+        _make_tree_writable(entry)
+
+
 def _rmtree(path: Path) -> None:
-    if path.is_dir() and not path.is_symlink():
+    if is_link_like(path):
+        # The link itself, never its target - os.remove works for a file
+        # symlink; a directory symlink/junction needs rmdir on Windows.
+        try:
+            os.remove(path)
+        except OSError:
+            os.rmdir(path)
+        return
+    if path.is_dir():
+        _make_tree_writable(path)
         shutil.rmtree(path)
     else:
         path.unlink()
 
 
 def remove_stubborn(path: Path) -> str:
-    """Remove `path` (file or directory), escalating (Windows only) if a
-    plain remove fails. Returns one of: 'absent', 'removed',
-    'removed-after-acl', 'removed-after-robocopy', 'FAILED'. Never raises."""
-    if not path.exists():
+    """Remove `path` (file, directory, or - as the link itself, never its
+    target - a symlink/junction), escalating (Windows only) if a plain
+    remove fails. Returns one of: 'absent', 'removed', 'removed-after-acl',
+    'removed-after-robocopy', 'FAILED'. Never raises."""
+    link = is_link_like(path)
+    if not link and not path.exists():
         return "absent"
-    is_dir = path.is_dir() and not path.is_symlink()
+    if link:
+        try:
+            _rmtree(path)
+        except OSError:
+            pass
+        # A link is never escalated into: the takeover/robocopy branches
+        # below operate ON THE TARGET's contents, which is exactly the
+        # P6A/P6B mistake (deleting through the link, or mirroring an
+        # empty directory INTO the target). A link that resists a plain
+        # unlink is reported FAILED, full stop.
+        return "removed" if not path.exists() else "FAILED"
+
+    is_dir = path.is_dir()
     try:
         _rmtree(path)
     except OSError:
@@ -304,14 +521,21 @@ def remove_stubborn(path: Path) -> str:
         return "FAILED"
     # Windows-only escalation: the reference script's ACL-takeover path for
     # paths created inside a Codex sandbox whose session ACLs deny even a
-    # listing (#147 class).
-    takeown_args = ["takeown", "/F", str(path)] + (["/R", "/D", "Y"] if is_dir else [])
-    subprocess.run(takeown_args, capture_output=True, check=False)
-    icacls_args = ["icacls", str(path), "/grant", "*S-1-3-4:F" if not is_dir else "*S-1-3-4:(OI)(CI)F"]
-    if is_dir:
-        icacls_args += ["/T"]
-    icacls_args += ["/C", "/Q"]
-    subprocess.run(icacls_args, capture_output=True, check=False)
+    # listing (#147 class). Tools resolved to an absolute path (bandit
+    # B607); a missing tool just means escalation can't proceed - FAILED,
+    # not a crash.
+    takeown = _resolve_system_tool("takeown")
+    icacls = _resolve_system_tool("icacls")
+    if takeown is not None:
+        takeown_args = [takeown, "/F", str(path)] + (["/R", "/D", "Y"] if is_dir else [])
+        subprocess.run(takeown_args, capture_output=True, check=False)  # nosec B603
+    if icacls is not None:
+        icacls_args = [icacls, str(path), "/grant",
+                        "*S-1-3-4:(OI)(CI)F" if is_dir else "*S-1-3-4:F"]
+        if is_dir:
+            icacls_args += ["/T"]
+        icacls_args += ["/C", "/Q"]
+        subprocess.run(icacls_args, capture_output=True, check=False)  # nosec B603
     try:
         _rmtree(path)
     except OSError:
@@ -320,10 +544,13 @@ def remove_stubborn(path: Path) -> str:
         return "removed-after-acl"
     if not is_dir:
         return "FAILED"  # the robocopy-mirror trick below only applies to directories
+    robocopy = _resolve_system_tool("robocopy")
+    if robocopy is None:
+        return "FAILED"
     empty = Path(tempfile.gettempdir()) / f"empty-{uuid.uuid4().hex}"
     empty.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        ["robocopy", str(empty), str(path), "/MIR", "/NFL", "/NDL", "/NJH", "/NJS", "/NP",
+    subprocess.run(  # nosec B603 - resolved executable, argv list
+        [robocopy, str(empty), str(path), "/MIR", "/NFL", "/NDL", "/NJH", "/NJS", "/NP",
          "/R:0", "/W:0"],
         capture_output=True, check=False,
     )
@@ -349,7 +576,8 @@ def apply(cfg: JanitorConfig, report: JanitorReport) -> str:
 
     def is_refused(path: Path) -> bool:
         # A refused worktree's own directory, or anything under it, is never
-        # removed - uncommitted changes on a default branch must survive.
+        # removed - uncommitted changes on a default branch or a detached
+        # HEAD must survive.
         return any(path == r or r in path.parents for r in refused)
 
     summary: dict[str, int] = {}

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -135,11 +135,13 @@ class JanitorReport:
     registered_worktrees: list[Path]
     dirty_worktrees: list[Path]
     foreign_kept: list[Path]
-    # Discovery locations that could not even be LISTED (e.g. an ACL-denied
-    # directory) - #148's acceptance is "reported as FAILED, never silently
-    # skipped", so these surface exactly like a removal failure, not a
-    # crash and not a swallowed exception.
-    access_errors: list[Path]
+    # Discovery locations that could not even be LISTED or TRUSTED (an
+    # ACL-denied directory, or a .worktrees/ pass that had to fail closed
+    # because git itself was unresolvable or unreliable there) - #148's
+    # acceptance is "reported as FAILED, never silently skipped", so
+    # these surface exactly like a removal failure, not a crash and not
+    # a swallowed exception. Each entry names WHY, not just WHERE.
+    access_errors: list[tuple[Path, str]]
 
 
 def _is_excluded_name(name: str) -> bool:
@@ -177,15 +179,16 @@ def is_link_like(path: Path) -> bool:
     return bool(getattr(st, "st_file_attributes", 0) & reparse_point)
 
 
-def _safe_iterdir(path: Path) -> tuple[list[Path], Path | None]:
+def _safe_iterdir(path: Path) -> tuple[list[Path], tuple[Path, str] | None]:
     """List `path`'s entries, or (on ANY OSError - permission denial,
     a vanished directory mid-scan, etc.) return an empty list plus the
-    path that failed, instead of raising out of discovery or silently
-    returning nothing. The caller surfaces the failure path as FAILED."""
+    path and reason that failed, instead of raising out of discovery or
+    silently returning nothing. The caller surfaces the failure as
+    FAILED, with the reason quoted."""
     try:
         return sorted(path.iterdir()), None
-    except OSError:
-        return [], path
+    except OSError as exc:
+        return [], (path, str(exc))
 
 
 def _resolve_system_tool(name: str) -> str | None:
@@ -201,19 +204,43 @@ def _resolve_system_tool(name: str) -> str | None:
     return str(candidate) if candidate.is_file() else None
 
 
-def _run_git(repo: Path, *args: str) -> str:
+def _run_git_checked(repo: Path, *args: str) -> tuple[int | None, str, str]:
+    """Run git, returning (returncode, stdout, stderr). returncode is
+    `None` if git itself is unresolvable - callers that need to
+    distinguish "genuinely nothing to report" from "could not even run
+    git" must check this, not just parse stdout. A prior version of this
+    module returned "" for both cases from a single stdout-only helper,
+    and every caller (worktree discovery, dirty-status checks, the
+    post-commit clean confirmation) silently treated an unrunnable git
+    the same as a successful, empty answer - the exact mechanism that let
+    a live, dirty, untracked-file-holding worktree be removed with no
+    refusal printed anywhere."""
     git = shutil.which("git")
     if git is None:
-        return ""
+        return None, "", "git is not resolvable"
     result = subprocess.run(  # nosec B603 - resolved executable, argv list
         [git, "-C", str(repo), *args],
         capture_output=True, text=True, check=False,
     )
-    return result.stdout
+    return result.returncode, result.stdout, result.stderr
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    """Best-effort stdout only - for call sites where a failure is
+    genuinely harmless (e.g. the final `worktree prune`, or `git add`
+    before a commit whose own result is checked separately)."""
+    _rc, out, _err = _run_git_checked(repo, *args)
+    return out
 
 
 def get_registered_worktrees(repo: Path) -> list[Path]:
-    out = _run_git(repo, "worktree", "list", "--porcelain")
+    """Best-effort: returns `[]` if git is unresolvable or the command
+    fails, the same as "no worktrees registered" to THIS function's own
+    callers (a dirty-worktree count and doctor's outside-scratch-root
+    warning, neither of which removes anything on the strength of this
+    result alone). Candidate discovery under `.worktrees/` does NOT use
+    this function for that reason - see `_worktrees_discovery_ok`."""
+    _rc, out, _err = _run_git_checked(repo, "worktree", "list", "--porcelain")
     worktrees = []
     for line in out.splitlines():
         if line.startswith("worktree "):
@@ -221,15 +248,38 @@ def get_registered_worktrees(repo: Path) -> list[Path]:
     return worktrees
 
 
+def _worktrees_discovery_ok(repo: Path) -> tuple[bool, str]:
+    """Whether candidate discovery under `.worktrees/` can trust git's
+    account of what is registered there. False means git is unresolvable,
+    or `worktree list` itself failed (a damaged `.git`, "detected dubious
+    ownership", etc.) - in either case candidate discovery must leave
+    EVERYTHING under `.worktrees/` alone rather than reading the failure
+    as "zero worktrees registered" and removing every directory there as
+    an ordinary, unregistered candidate with no WIP-commit-or-refuse gate
+    ever applied to it."""
+    rc, _out, err = _run_git_checked(repo, "worktree", "list", "--porcelain")
+    if rc is None:
+        return False, "git is not resolvable"
+    if rc != 0:
+        return False, f"git worktree list failed, rc={rc}: {err.strip()}"
+    return True, ""
+
+
 def is_dirty_worktree(path: Path) -> bool:
     """True if the worktree has ANY uncommitted change - tracked or
-    untracked. An untracked file left behind by a `.worktrees/` removal is
-    real, unrecovered work (reviewer-3 finding P2); it is no longer
-    excluded from "dirty" the way a purely cosmetic ignored-file diff
-    would be."""
+    untracked - OR if `git status` itself could not be run/completed for
+    it. An untracked file left behind by a `.worktrees/` removal is real,
+    unrecovered work; it is no longer excluded from "dirty" the way a
+    purely cosmetic ignored-file diff would be. Failing to determine the
+    status at all is treated as dirty, not clean - it routes the worktree
+    through the WIP-commit-or-refuse gate instead of silently letting an
+    unconfirmed one through as "nothing to do here"."""
     if not (path / ".git").exists():
         return False
-    return bool(_run_git(path, "status", "--porcelain").strip())
+    rc, out, _err = _run_git_checked(path, "status", "--porcelain")
+    if rc != 0:
+        return True
+    return bool(out.strip())
 
 
 def worktree_branch(path: Path) -> str | None:
@@ -237,10 +287,10 @@ def worktree_branch(path: Path) -> str | None:
     return out or None
 
 
-def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
+def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Path, str]]]:
     seen: set[str] = set()
     out: list[Candidate] = []
-    access_errors: list[Path] = []
+    access_errors: list[tuple[Path, str]] = []
 
     def add(path: Path, reason: str) -> None:
         # NEVER path.resolve() - that follows symlinks (POSIX) and would
@@ -276,15 +326,28 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
 
     worktrees_dir = cfg.repo / ".worktrees"
     if worktrees_dir.is_dir():
-        entries, err = _safe_iterdir(worktrees_dir)
-        if err is not None:
-            access_errors.append(err)
-        for entry in entries:
-            # Every directory (or dir-like link) under .worktrees/ is a
-            # candidate regardless of name - this location IS the family;
-            # no separate name-family filter applies here.
-            if is_link_like(entry) or entry.is_dir():
-                add(entry, "worktrees-dir")
+        # FAIL CLOSED: candidate discovery here must be able to trust
+        # git's own account of what is registered under .worktrees/ - a
+        # directory this janitor cannot ask git about is NOT the same as
+        # "not a worktree", and reading it that way is exactly how a
+        # live, dirty, unregistered-in-its-own-eyes worktree used to be
+        # removed as a plain candidate with no WIP-commit-or-refuse gate
+        # ever applied to it (git unresolvable, or `worktree list` itself
+        # failing - a damaged `.git`, "detected dubious ownership").
+        # Nothing under .worktrees/ is touched until discovery is trusted.
+        discovery_ok, discovery_reason = _worktrees_discovery_ok(cfg.repo)
+        if not discovery_ok:
+            access_errors.append((worktrees_dir, discovery_reason))
+        else:
+            entries, err = _safe_iterdir(worktrees_dir)
+            if err is not None:
+                access_errors.append(err)
+            for entry in entries:
+                # Every directory (or dir-like link) under .worktrees/ is a
+                # candidate regardless of name - this location IS the
+                # family; no separate name-family filter applies here.
+                if is_link_like(entry) or entry.is_dir():
+                    add(entry, "worktrees-dir")
 
     if cfg.tmp_root.is_dir():
         cutoff = datetime.datetime.now().timestamp() - cfg.tmp_keep_days * 86400
@@ -303,11 +366,12 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
             # are, so age is the load-bearing safety check for EVERY
             # entry, not an extra filter on top of a type restriction.
             # A DIRECTORY entry is aged by the newest mtime anywhere in
-            # its tree, not its own top-level mtime (reviewer-3 R2 - the
-            # exact P3 flaw, recurring here): a directory's own mtime
-            # does not change when a file nested inside it is written. A
-            # link or a plain file has no nested tree, so lstat is
-            # already correct/complete for those.
+            # its tree, not its own top-level mtime: a directory's own
+            # mtime does not change when a file nested inside it is
+            # written, so a live file three levels down inside an
+            # apparently-old top-level directory would otherwise be
+            # deleted. A link or a plain file has no nested tree, so
+            # lstat is already correct/complete for those.
             if is_link_like(entry) or not entry.is_dir():
                 try:
                     entry_mtime = os.lstat(entry).st_mtime
@@ -330,12 +394,22 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
         if err is not None:
             access_errors.append(err)
         for agent_dir in agent_entries:
-            # reviewer-3 N1: a link ABOVE a candidate must not be walked
-            # through either - treat a link-like agent/task entry as a
-            # candidate in its own right (matching the repo-root pass),
-            # never recurse into what it points at.
+            # A link ABOVE a candidate must not be walked through either -
+            # a link-like agent/task entry is a candidate in its own
+            # right (matching the repo-root pass), never recursed into.
+            # It still needs its OWN age check against the same cutoff
+            # first, though: a fresh junction (an operator's scratch
+            # relocation, or a seat's live task link, age 0s) must not be
+            # removed just because it happens to be link-like - only
+            # once it is actually older than keep_days, exactly like
+            # every other scratch-root candidate.
             if is_link_like(agent_dir):
-                add(agent_dir, "scratch-stale")
+                try:
+                    link_mtime = os.lstat(agent_dir).st_mtime
+                except OSError:
+                    continue
+                if link_mtime < cutoff:
+                    add(agent_dir, "scratch-stale")
                 continue
             if not agent_dir.is_dir():
                 continue
@@ -344,7 +418,12 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
                 access_errors.append(terr)
             for task_dir in task_entries:
                 if is_link_like(task_dir):
-                    add(task_dir, "scratch-stale")
+                    try:
+                        link_mtime = os.lstat(task_dir).st_mtime
+                    except OSError:
+                        continue
+                    if link_mtime < cutoff:
+                        add(task_dir, "scratch-stale")
                     continue
                 if not task_dir.is_dir():
                     continue
@@ -365,20 +444,23 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
 
 def _newest_mtime_in_tree(
     root: Path, *, at_least: float | None = None
-) -> tuple[float | None, Path | None]:
+) -> tuple[float | None, tuple[Path, str] | None]:
     """The newest mtime of `root` itself or anything nested under it.
-    Returns (None, error_path) if any nested directory could not be
-    listed, rather than silently under-counting staleness.
+    Returns (None, (error_path, reason)) if any nested directory could
+    not be listed, rather than silently under-counting staleness.
 
     `at_least`: if given, the caller only cares whether the tree is AT
     LEAST this fresh (e.g. "not stale" - past some cutoff), not the exact
     maximum - the walk returns as soon as it finds an entry that alone
     already clears the threshold, capping cost on a very large tree
-    (reviewer-3 N4: doctor calls this on every scratch task on every run)."""
+    (this function runs once per scratch task on every `agenttalk
+    doctor`/`janitor` invocation, so an unbounded walk scales with the
+    total size of every task directory, not just the ones near the
+    staleness boundary)."""
     try:
         newest = os.lstat(root).st_mtime
-    except OSError:
-        return None, root
+    except OSError as exc:
+        return None, (root, str(exc))
     if at_least is not None and newest >= at_least:
         return newest, None
     entries, err = _safe_iterdir(root)
@@ -443,10 +525,9 @@ def format_report(report: JanitorReport, cfg: JanitorConfig, *, apply: bool) -> 
     for f in report.foreign_kept:
         lines.append(f"  FOREIGN (kept) {f}")
     if report.access_errors:
-        lines.append(f"FAILED to list ({len(report.access_errors)}) - "
-                      "not silently skipped, permissions likely need fixing:")
-        for p in report.access_errors:
-            lines.append(f"  {p}")
+        lines.append(f"FAILED to list ({len(report.access_errors)}) - not silently skipped:")
+        for p, reason in report.access_errors:
+            lines.append(f"  {p}: {reason}")
     if not apply:
         oldest = sorted(report.candidates, key=lambda c: c.mtime)[:15]
         for c in oldest:
@@ -477,8 +558,8 @@ def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> Wip
       worktree, so this is not a corner case.
     - `git` cannot be resolved, `git add -A` fails, `git commit` fails (a
       refusing pre-commit hook, `commit.gpgsign` without a key, no
-      configured user identity - reviewer-3 R1), or the worktree is STILL
-      dirty after the commit supposedly succeeded. Never `--no-verify`: a
+      configured user identity), or the worktree is STILL dirty after
+      the commit supposedly succeeded. Never `--no-verify`: a
       refusing hook should keep the work, not be bypassed. Every one of
       these previously fell through silently - `check=False` on both git
       calls, no return-code check, always reporting "WIP committed" while
@@ -519,7 +600,14 @@ def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> Wip
                      f"{commit_result.returncode}: {commit_result.stderr.strip()}): {path}",
             refused=True,
         )
-    if _run_git(path, "status", "--porcelain").strip():
+    status_rc, status_out, status_err = _run_git_checked(path, "status", "--porcelain")
+    if status_rc != 0:
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (could not confirm clean after "
+                     f"commit, git status rc={status_rc}: {status_err.strip()}): {path}",
+            refused=True,
+        )
+    if status_out.strip():
         return WipCommitResult(
             message=f"  REFUSED dirty worktree on {branch} (still dirty after commit - "
                      f"refusing to remove): {path}",
@@ -536,9 +624,9 @@ def _make_tree_writable(path: Path) -> None:
     Best-effort; a failure here just means the subsequent remove attempt
     may also fail and fall through to escalation as before.
 
-    A link entry is skipped ENTIRELY, not just left unrecursed into
-    (reviewer-3 N3): `os.chmod` follows symlinks by default on POSIX, so
-    chmod-ing a symlink candidate would silently change its TARGET's
+    A link entry is skipped ENTIRELY, not just left unrecursed into:
+    `os.chmod` follows symlinks by default on POSIX, so chmod-ing a
+    symlink candidate would silently change its TARGET's
     mode - exactly the kind of reach-through-the-link this module exists
     to prevent everywhere else."""
     if is_link_like(path):

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -265,6 +265,32 @@ def _worktrees_discovery_ok(repo: Path) -> tuple[bool, str]:
     return True, ""
 
 
+def _tree_contains_git_entry(root: Path) -> bool:
+    """True if `root`'s own tree contains a `.git` entry (a directory, for
+    an ordinary clone, or a file, for a worktree's gitdir pointer)
+    anywhere - an lstat-based walk, entirely independent of a runnable
+    git. Used when `_worktrees_discovery_ok` is False: git itself cannot
+    be trusted to say what is or isn't a worktree, so this is the
+    fallback signal that a directory candidate might be (or contain) one,
+    and must be refused rather than silently removed. NEVER follows a
+    symlink/junction - a link entry is checked for the name `.git` but
+    never descended into. Any entry this walk cannot itself list is
+    treated as "contains .git" too (conservative: an unreadable
+    subdirectory is exactly the kind of thing this fallback exists to
+    protect against, not a reason to assume it's safe)."""
+    entries, err = _safe_iterdir(root)
+    if err is not None:
+        return True
+    for entry in entries:
+        if entry.name == ".git":
+            return True
+        if is_link_like(entry):
+            continue
+        if entry.is_dir() and _tree_contains_git_entry(entry):
+            return True
+    return False
+
+
 def is_dirty_worktree(path: Path) -> bool:
     """True if the worktree has ANY uncommitted change - tracked or
     untracked - OR if `git status` itself could not be run/completed for
@@ -291,6 +317,11 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Pat
     seen: set[str] = set()
     out: list[Candidate] = []
     access_errors: list[tuple[Path, str]] = []
+    # Computed ONCE: whether git's account of registered worktrees can be
+    # trusted at all. When it cannot, EVERY pass (not just .worktrees/)
+    # must refuse a directory candidate that might itself be, or contain,
+    # a worktree git can no longer tell us about.
+    discovery_ok, discovery_reason = _worktrees_discovery_ok(cfg.repo)
 
     def add(path: Path, reason: str) -> None:
         # NEVER path.resolve() - that follows symlinks (POSIX) and would
@@ -304,6 +335,15 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Pat
             entry_mtime = os.lstat(path).st_mtime
         except OSError:
             return
+        if not discovery_ok and not is_link_like(path) and path.is_dir():
+            if _tree_contains_git_entry(path):
+                access_errors.append((
+                    path,
+                    "worktree discovery is not trusted (git unresolvable or "
+                    "`worktree list` failed) and this directory's tree contains "
+                    "a .git entry - refusing to remove",
+                ))
+                return
         seen.add(key)
         out.append(Candidate(path=path, mtime=entry_mtime, reason=reason))
 
@@ -335,7 +375,6 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Pat
         # ever applied to it (git unresolvable, or `worktree list` itself
         # failing - a damaged `.git`, "detected dubious ownership").
         # Nothing under .worktrees/ is touched until discovery is trusted.
-        discovery_ok, discovery_reason = _worktrees_discovery_ok(cfg.repo)
         if not discovery_ok:
             access_errors.append((worktrees_dir, discovery_reason))
         else:
@@ -744,10 +783,19 @@ def apply(cfg: JanitorConfig, report: JanitorReport) -> str:
             refused.add(w)
 
     def is_refused(path: Path) -> bool:
-        # A refused worktree's own directory, or anything under it, is never
-        # removed - uncommitted changes on a default branch or a detached
-        # HEAD must survive.
-        return any(path == r or r in path.parents for r in refused)
+        # A refused worktree's own directory, or anything under it, is
+        # never removed - uncommitted changes on a default branch or a
+        # detached HEAD must survive. The REVERSE direction matters just
+        # as much: a candidate that CONTAINS a refused worktree (a stale
+        # scratch task directory holding a `git worktree add --detach
+        # <scratch>/wt-<sha>` review checkout - the ops doc's own Rule 2
+        # layout) must also be refused, or the outer directory gets
+        # removed right after the REFUSED line prints, taking the
+        # supposedly-preserved worktree down with it.
+        for r in refused:
+            if path == r or r in path.parents or path in r.parents:
+                return True
+        return False
 
     summary: dict[str, int] = {}
     failed: list[Path] = []

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -20,7 +20,7 @@ Config (optional, `.agenttalk/config.json`, key `"scratch"`, long form):
         "repo_dir_families": [...],       # fnmatch globs, repo root, directories
         "repo_file_families": [...],      # fnmatch globs, repo root, files
         "tmp_root": "...",                # default: the OS temp dir
-        "tmp_families": [...],            # fnmatch globs, temp root, DIRECTORIES only
+        "tmp_families": [...],            # fnmatch globs, temp root, age-gated per entry
         "foreign": [...],                 # exact names under tmp_root: report, never remove
         "default_branches": ["master", "main"]
       }
@@ -61,11 +61,16 @@ DEFAULT_REPO_FILE_FAMILIES = [
 # shared with every OTHER program on the machine, so a family here must be
 # specific enough not to collide with something real (reviewer-3 measured
 # 157 false-positive matches on the old, broader list, including a live
-# pytest run). Directories only - see find_candidates.
+# pytest run), and every match - file or directory - is still gated by
+# tmp_keep_days below (see find_candidates). No estate/project-specific
+# name belongs here (#148 requires the shipped defaults stay
+# project-agnostic) - a project's own real-boot/integration-test scratch
+# families belong in ITS OWN .agenttalk/config.json under
+# scratch.tmp_families, never in this list.
 DEFAULT_TMP_FAMILIES = [
     "pytest-of-*", "agenttalk-review-*", "agenttalk-reply-*",
     "agenttalk-gate-*", "agenttalk-probe-*", "agenttalk-wf-*",
-    "mockitoboot*", "backend-request-test-*", "surefire*",
+    "mockitoboot*", "surefire*",
 ]
 DEFAULT_TMP_KEEP_DAYS = 1
 # Never removed regardless of family match, even if a candidate happens to
@@ -291,13 +296,12 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
                 continue
             if not _matches_any(entry.name, cfg.tmp_families):
                 continue
-            # Directories only (P4): a matching FILE in the shared temp
-            # root (another program's log, e.g.) is not this janitor's to
-            # remove - and age-gated, since this root is shared machine-
-            # wide, not owned the way the repo root/scratch root are.
-            link = is_link_like(entry)
-            if not link and not entry.is_dir():
-                continue
+            # A match here (file OR directory - some real families, like
+            # a Mockito boot log or a surefire report, are files) is only
+            # a candidate once past tmp_keep_days: this root is shared
+            # machine-wide, not owned the way the repo root/scratch root
+            # are, so age is the load-bearing safety check for EVERY
+            # entry, not an extra filter on top of a type restriction.
             try:
                 entry_mtime = os.lstat(entry).st_mtime
             except OSError:

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -341,17 +341,26 @@ def worktree_branch(path: Path) -> str | None:
 
 def worktree_head_reachable(path: Path) -> bool:
     """True if the worktree's HEAD commit is reachable from an existing
-    branch or tag (`git for-each-ref --contains HEAD refs/heads
-    refs/tags` is non-empty). False (unreachable) also if the check
-    itself could not be completed - fail closed: a detached HEAD whose
-    reachability this janitor cannot confirm is exactly the case that
-    must be protected, not assumed safe. Only meaningful for a DETACHED
-    worktree (`worktree_branch` returning `None` or the literal string
-    `"HEAD"` - git's own `rev-parse --abbrev-ref HEAD` prints "HEAD" for
-    a detached checkout, not an empty string) - a worktree checked out
-    onto a real branch is trivially reachable via that branch itself."""
+    branch, tag, or remote-tracking ref (`git for-each-ref --contains
+    HEAD refs/heads refs/tags refs/remotes` is non-empty). `refs/remotes`
+    is included deliberately: Rule 2's own recommended review-worktree
+    form (`git worktree add --detach <scratch>/wt-<sha> <sha>`) is
+    routinely detached at a fetched PR head that lives ONLY under
+    `refs/remotes/origin/*` until it lands on a local branch - without
+    it, that ordinary, disposable checkout would be refused on every
+    single run for as long as it exists (over-refusal, not data loss,
+    but it defeats the point of automated cleanup for the exact case the
+    docs recommend). False (unreachable) also if the check itself could
+    not be completed - fail closed: a detached HEAD whose reachability
+    this janitor cannot confirm is exactly the case that must be
+    protected, not assumed safe. Only meaningful for a DETACHED worktree
+    (`worktree_branch` returning `None` or the literal string `"HEAD"` -
+    git's own `rev-parse --abbrev-ref HEAD` prints "HEAD" for a detached
+    checkout, not an empty string) - a worktree checked out onto a real
+    branch is trivially reachable via that branch itself."""
     rc, out, _err = _run_git_checked(
-        path, "for-each-ref", "--contains", "HEAD", "refs/heads", "refs/tags",
+        path, "for-each-ref", "--contains", "HEAD",
+        "refs/heads", "refs/tags", "refs/remotes",
     )
     if rc != 0:
         return False
@@ -386,12 +395,16 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Pat
             entry_mtime = os.lstat(path).st_mtime
         except OSError:
             return
-        # .worktrees/ entries are exempt: that pass already gates on
-        # discovery_ok itself (nothing is added from it at all when
-        # discovery can't be trusted), and every entry it DOES add is,
-        # by construction, a worktree of cfg.repo - re-walking it here
-        # would be redundant, not protective.
-        if reason != "worktrees-dir" and not is_link_like(path) and path.is_dir():
+        # No exemption for .worktrees/ entries: that pass adds EVERY
+        # directory found there regardless of name (see below), not just
+        # ones git actually knows about - an unregistered tree living
+        # there (another clone's worktree dropped in by hand, a
+        # standalone clone, or this repo's OWN worktree whose
+        # `.git/worktrees/<name>` admin entry was separately lost) is
+        # exactly as invisible to `get_registered_worktrees` as one
+        # found anywhere else, and the dirty/refuse gate in apply() only
+        # ever runs for entries git DOES still recognize as registered.
+        if not is_link_like(path) and path.is_dir():
             git_entries, unlistable = _find_git_entries(path)
             if not discovery_ok:
                 if git_entries or unlistable:

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -163,7 +163,7 @@ def is_link_like(path: Path) -> bool:
     `st_file_attributes` carries `FILE_ATTRIBUTE_REPARSE_POINT` (0x400) for
     BOTH symlinks and junctions. Candidates must NEVER be resolved through
     this - a link is removed as the link itself, never followed into its
-    target (Codex xhigh finding P6A/P6B: `Path.resolve()` follows symlinks
+    target (reviewer-3 finding P6A/P6B: `Path.resolve()` follows symlinks
     on POSIX too, and un-guarded escalation mirrors an empty dir INTO a
     junction's target instead of refusing it).
     """
@@ -224,7 +224,7 @@ def get_registered_worktrees(repo: Path) -> list[Path]:
 def is_dirty_worktree(path: Path) -> bool:
     """True if the worktree has ANY uncommitted change - tracked or
     untracked. An untracked file left behind by a `.worktrees/` removal is
-    real, unrecovered work (Codex xhigh finding P2); it is no longer
+    real, unrecovered work (reviewer-3 finding P2); it is no longer
     excluded from "dirty" the way a purely cosmetic ignored-file diff
     would be."""
     if not (path / ".git").exists():
@@ -302,10 +302,24 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
             # machine-wide, not owned the way the repo root/scratch root
             # are, so age is the load-bearing safety check for EVERY
             # entry, not an extra filter on top of a type restriction.
-            try:
-                entry_mtime = os.lstat(entry).st_mtime
-            except OSError:
-                continue
+            # A DIRECTORY entry is aged by the newest mtime anywhere in
+            # its tree, not its own top-level mtime (reviewer-3 R2 - the
+            # exact P3 flaw, recurring here): a directory's own mtime
+            # does not change when a file nested inside it is written. A
+            # link or a plain file has no nested tree, so lstat is
+            # already correct/complete for those.
+            if is_link_like(entry) or not entry.is_dir():
+                try:
+                    entry_mtime = os.lstat(entry).st_mtime
+                except OSError:
+                    continue
+            else:
+                entry_mtime, terr = _newest_mtime_in_tree(entry, at_least=cutoff)
+                if terr is not None:
+                    access_errors.append(terr)
+                    continue
+                if entry_mtime is None:
+                    continue
             if entry_mtime >= cutoff:
                 continue
             add(entry, "tmp")
@@ -316,12 +330,22 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
         if err is not None:
             access_errors.append(err)
         for agent_dir in agent_entries:
+            # reviewer-3 N1: a link ABOVE a candidate must not be walked
+            # through either - treat a link-like agent/task entry as a
+            # candidate in its own right (matching the repo-root pass),
+            # never recurse into what it points at.
+            if is_link_like(agent_dir):
+                add(agent_dir, "scratch-stale")
+                continue
             if not agent_dir.is_dir():
                 continue
             task_entries, terr = _safe_iterdir(agent_dir)
             if terr is not None:
                 access_errors.append(terr)
             for task_dir in task_entries:
+                if is_link_like(task_dir):
+                    add(task_dir, "scratch-stale")
+                    continue
                 if not task_dir.is_dir():
                     continue
                 # Staleness is the NEWEST mtime anywhere in the tree, not
@@ -330,7 +354,7 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
                 # directly inside it, NOT when a file three levels down is
                 # edited - live work under an old task directory would
                 # otherwise be misclassified as stale and deleted.
-                newest, nerr = _newest_mtime_in_tree(task_dir)
+                newest, nerr = _newest_mtime_in_tree(task_dir, at_least=cutoff)
                 if nerr:
                     access_errors.append(nerr)
                 if newest is not None and newest < cutoff:
@@ -339,14 +363,24 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[Path]]:
     return out, access_errors
 
 
-def _newest_mtime_in_tree(root: Path) -> tuple[float | None, Path | None]:
+def _newest_mtime_in_tree(
+    root: Path, *, at_least: float | None = None
+) -> tuple[float | None, Path | None]:
     """The newest mtime of `root` itself or anything nested under it.
     Returns (None, error_path) if any nested directory could not be
-    listed, rather than silently under-counting staleness."""
+    listed, rather than silently under-counting staleness.
+
+    `at_least`: if given, the caller only cares whether the tree is AT
+    LEAST this fresh (e.g. "not stale" - past some cutoff), not the exact
+    maximum - the walk returns as soon as it finds an entry that alone
+    already clears the threshold, capping cost on a very large tree
+    (reviewer-3 N4: doctor calls this on every scratch task on every run)."""
     try:
         newest = os.lstat(root).st_mtime
     except OSError:
         return None, root
+    if at_least is not None and newest >= at_least:
+        return newest, None
     entries, err = _safe_iterdir(root)
     if err is not None:
         return None, err
@@ -356,9 +390,8 @@ def _newest_mtime_in_tree(root: Path) -> tuple[float | None, Path | None]:
                 newest = max(newest, os.lstat(entry).st_mtime)
             except OSError:
                 pass
-            continue
-        if entry.is_dir():
-            sub_newest, sub_err = _newest_mtime_in_tree(entry)
+        elif entry.is_dir():
+            sub_newest, sub_err = _newest_mtime_in_tree(entry, at_least=at_least)
             if sub_err is not None:
                 return None, sub_err
             if sub_newest is not None:
@@ -368,6 +401,8 @@ def _newest_mtime_in_tree(root: Path) -> tuple[float | None, Path | None]:
                 newest = max(newest, os.lstat(entry).st_mtime)
             except OSError:
                 pass
+        if at_least is not None and newest >= at_least:
+            return newest, None
     return newest, None
 
 
@@ -433,12 +468,21 @@ class WipCommitResult:
 def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> WipCommitResult:
     """Commit ALL changes (tracked and untracked - P2) as a WIP commit on
     the worktree's own branch. Refuses (no commit, and the caller must not
-    remove the directory either) if the worktree is on a default branch OR
-    is a detached HEAD (P1): a WIP commit made on a detached HEAD is
-    reachable from no ref and becomes an unreachable object the moment the
-    directory is removed - recoverable only until the next `git gc`, i.e.
-    not really preserved. `--detach` is the ops doc's OWN recommended form
-    for a review worktree, so this is not a corner case."""
+    remove the directory either) if:
+    - the worktree is on a default branch OR is a detached HEAD (P1): a WIP
+      commit made on a detached HEAD is reachable from no ref and becomes
+      an unreachable object the moment the directory is removed -
+      recoverable only until the next `git gc`, i.e. not really preserved.
+      `--detach` is the ops doc's OWN recommended form for a review
+      worktree, so this is not a corner case.
+    - `git` cannot be resolved, `git add -A` fails, `git commit` fails (a
+      refusing pre-commit hook, `commit.gpgsign` without a key, no
+      configured user identity - reviewer-3 R1), or the worktree is STILL
+      dirty after the commit supposedly succeeded. Never `--no-verify`: a
+      refusing hook should keep the work, not be bypassed. Every one of
+      these previously fell through silently - `check=False` on both git
+      calls, no return-code check, always reporting "WIP committed" while
+      apply() went on to remove the (still uncommitted) directory."""
     branch = worktree_branch(path)
     if branch in default_branches or branch in _NEVER_AUTO_COMMIT_BRANCHES_SENTINELS:
         label = branch or "an unresolvable HEAD"
@@ -447,14 +491,39 @@ def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> Wip
                      f"a default branch or a detached HEAD): {path}",
             refused=True,
         )
-    _run_git(path, "add", "-A")
-    stamp = datetime.datetime.now().isoformat(timespec="seconds")
     git = shutil.which("git")
-    if git is not None:
-        subprocess.run(  # nosec B603 - resolved executable, argv list
-            [git, "-C", str(path), "commit", "-q", "-m",
-             f"wip: preserve uncommitted worktree state before scratch cleanup ({stamp})"],
-            capture_output=True, text=True, check=False,
+    if git is None:
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (git not resolvable, cannot "
+                     f"commit): {path}",
+            refused=True,
+        )
+    add_result = subprocess.run(  # nosec B603 - resolved executable, argv list
+        [git, "-C", str(path), "add", "-A"], capture_output=True, text=True, check=False,
+    )
+    if add_result.returncode != 0:
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (git add -A failed, rc="
+                     f"{add_result.returncode}: {add_result.stderr.strip()}): {path}",
+            refused=True,
+        )
+    stamp = datetime.datetime.now().isoformat(timespec="seconds")
+    commit_result = subprocess.run(  # nosec B603 - resolved executable, argv list
+        [git, "-C", str(path), "commit", "-q", "-m",
+         f"wip: preserve uncommitted worktree state before scratch cleanup ({stamp})"],
+        capture_output=True, text=True, check=False,
+    )
+    if commit_result.returncode != 0:
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (git commit failed, rc="
+                     f"{commit_result.returncode}: {commit_result.stderr.strip()}): {path}",
+            refused=True,
+        )
+    if _run_git(path, "status", "--porcelain").strip():
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (still dirty after commit - "
+                     f"refusing to remove): {path}",
+            refused=True,
         )
     return WipCommitResult(message=f"  WIP committed on {branch}: {path}", refused=False)
 
@@ -465,13 +534,21 @@ def _make_tree_writable(path: Path) -> None:
     `shutil.rmtree` on a full clone hits PermissionError before it ever
     reaches the escalation branch - reviewer-3's teardown observation).
     Best-effort; a failure here just means the subsequent remove attempt
-    may also fail and fall through to escalation as before."""
+    may also fail and fall through to escalation as before.
+
+    A link entry is skipped ENTIRELY, not just left unrecursed into
+    (reviewer-3 N3): `os.chmod` follows symlinks by default on POSIX, so
+    chmod-ing a symlink candidate would silently change its TARGET's
+    mode - exactly the kind of reach-through-the-link this module exists
+    to prevent everywhere else."""
+    if is_link_like(path):
+        return
     try:
         current = os.stat(path, follow_symlinks=False).st_mode
         os.chmod(path, current | stat.S_IWRITE)
     except OSError:
         pass
-    if is_link_like(path) or not path.is_dir():
+    if not path.is_dir():
         return
     entries, _err = _safe_iterdir(path)
     for entry in entries:
@@ -500,7 +577,7 @@ def remove_stubborn(path: Path) -> str:
     remove fails. Returns one of: 'absent', 'removed', 'removed-after-acl',
     'removed-after-robocopy', 'FAILED'. Never raises."""
     link = is_link_like(path)
-    if not link and not path.exists():
+    if not link and not os.path.lexists(path):
         return "absent"
     if link:
         try:
@@ -512,14 +589,14 @@ def remove_stubborn(path: Path) -> str:
         # P6A/P6B mistake (deleting through the link, or mirroring an
         # empty directory INTO the target). A link that resists a plain
         # unlink is reported FAILED, full stop.
-        return "removed" if not path.exists() else "FAILED"
+        return "removed" if not os.path.lexists(path) else "FAILED"
 
     is_dir = path.is_dir()
     try:
         _rmtree(path)
     except OSError:
         pass
-    if not path.exists():
+    if not os.path.lexists(path):
         return "removed"
     if platform.system() != "Windows":
         return "FAILED"
@@ -544,7 +621,7 @@ def remove_stubborn(path: Path) -> str:
         _rmtree(path)
     except OSError:
         pass
-    if not path.exists():
+    if not os.path.lexists(path):
         return "removed-after-acl"
     if not is_dir:
         return "FAILED"  # the robocopy-mirror trick below only applies to directories
@@ -563,7 +640,7 @@ def remove_stubborn(path: Path) -> str:
         _rmtree(path)
     except OSError:
         pass
-    return "removed-after-robocopy" if not path.exists() else "FAILED"
+    return "removed-after-robocopy" if not os.path.lexists(path) else "FAILED"
 
 
 def apply(cfg: JanitorConfig, report: JanitorReport) -> str:

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -1,0 +1,378 @@
+"""Cross-platform scratch janitor (#148) - a Python port of the validated
+`tools/cleanup-scratch.ps1` reference implementation.
+
+Report mode (default) lists scratch candidates and dirty registered
+worktrees without touching anything. Apply mode WIP-commits dirty
+worktrees on their own branch (never the default branch), removes the
+allow-listed candidates, and prunes stale worktree registrations. Never
+touches `.agenttalk/`, tracked files, or a configured "foreign" folder
+under the temp root - those are reported and kept.
+
+Config (optional, `.agenttalk/config.json`, key `"scratch"`, long form):
+
+    {
+      "scratch": {
+        "root": "...",                    # see scratch.py
+        "keep_days": 3,
+        "repo_dir_families": [...],       # fnmatch globs, repo root, directories
+        "repo_file_families": [...],      # fnmatch globs, repo root, files
+        "tmp_root": "...",                # default: the OS temp dir
+        "tmp_families": [...],            # fnmatch globs under tmp_root
+        "foreign": [...],                 # exact names under tmp_root: report, never remove
+        "default_branches": ["master", "main"]
+      }
+    }
+
+Every list has a built-in default (below) used when the key is absent, so
+an unconfigured project still gets sane behaviour.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import fnmatch
+import platform
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+from .scratch import _read_scratch_config, resolve_keep_days, resolve_scratch_root
+
+DEFAULT_REPO_DIR_FAMILIES = [
+    ".review-*", ".pytest-*", ".pytest_cache", ".subreview-*", ".gw-*",
+    ".probe-*", "probe-*", "gateway-*", ".qa-*", ".codex-tmp-*",
+    ".codex-review-tmp", ".tmp_pytest*", ".task*-*",
+]
+DEFAULT_REPO_FILE_FAMILIES = [
+    ".review-*.tar", ".review-*.zip", ".review-*.md", ".agenttalk-*.txt",
+    ".agenttalk-*.md", ".coverage",
+]
+DEFAULT_TMP_FAMILIES = [
+    "pytest-*", "review*", "reply-q*", "rq-*", "qa-*", "q-*", "race-*",
+    "adv-*", "run-*", "wt-*", "cold*", "mut*", "lane-*", "sub*", "probe-*",
+    "gate-*", "wf-*",
+]
+# Never removed regardless of family match, even if a candidate happens to
+# collide with one of these names.
+_ALWAYS_EXCLUDED_NAMES = {".agenttalk", ".claude", "docs", "tools"}
+_ALWAYS_EXCLUDED_PREFIXES = ("launch-", "MANUAL-", ".wt-")
+
+_ELEVATED_HINT_WINDOWS = (
+    "re-run elevated: "
+    "pwsh -Command \"Start-Process pwsh -Verb RunAs -Wait -ArgumentList "
+    "'-NoProfile','-ExecutionPolicy','Bypass','-Command','agenttalk janitor --apply'\""
+)
+
+
+@dataclasses.dataclass
+class JanitorConfig:
+    repo: Path
+    scratch_root: Path
+    keep_days: int
+    tmp_root: Path
+    repo_dir_families: list[str]
+    repo_file_families: list[str]
+    tmp_families: list[str]
+    foreign: list[str]
+    default_branches: list[str]
+
+    @classmethod
+    def load(cls, repo: Path) -> "JanitorConfig":
+        repo = Path(repo).resolve()
+        cfg = _read_scratch_config(repo)
+        tmp_root = cfg.get("tmp_root")
+        return cls(
+            repo=repo,
+            scratch_root=resolve_scratch_root(repo),
+            keep_days=resolve_keep_days(repo),
+            tmp_root=Path(tmp_root).resolve() if tmp_root else Path(tempfile.gettempdir()),
+            repo_dir_families=list(cfg.get("repo_dir_families") or DEFAULT_REPO_DIR_FAMILIES),
+            repo_file_families=list(cfg.get("repo_file_families") or DEFAULT_REPO_FILE_FAMILIES),
+            tmp_families=list(cfg.get("tmp_families") or DEFAULT_TMP_FAMILIES),
+            foreign=list(cfg.get("foreign") or []),
+            default_branches=list(cfg.get("default_branches") or ["master", "main"]),
+        )
+
+
+@dataclasses.dataclass
+class Candidate:
+    path: Path
+    mtime: float
+    reason: str  # "repo-dir", "repo-file", "worktrees-dir", "tmp", "scratch-stale"
+
+
+@dataclasses.dataclass
+class JanitorReport:
+    candidates: list[Candidate]
+    registered_worktrees: list[Path]
+    dirty_worktrees: list[Path]
+    foreign_kept: list[Path]
+
+
+def _is_excluded_name(name: str) -> bool:
+    if name in _ALWAYS_EXCLUDED_NAMES:
+        return True
+    return any(name.startswith(p) for p in _ALWAYS_EXCLUDED_PREFIXES)
+
+
+def _matches_any(name: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=False,
+    )
+    return result.stdout
+
+
+def get_registered_worktrees(repo: Path) -> list[Path]:
+    out = _run_git(repo, "worktree", "list", "--porcelain")
+    worktrees = []
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            worktrees.append(Path(line[len("worktree "):]).resolve())
+    return worktrees
+
+
+def is_dirty_worktree(path: Path) -> bool:
+    """True if the worktree has uncommitted changes to TRACKED files.
+    Untracked files (`??`) don't count - only tracked changes get a WIP
+    commit; an all-untracked worktree is not "dirty" in this sense."""
+    if not (path / ".git").exists():
+        return False
+    out = _run_git(path, "status", "--porcelain")
+    for line in out.splitlines():
+        if line and not line.startswith("??"):
+            return True
+    return False
+
+
+def worktree_branch(path: Path) -> str | None:
+    out = _run_git(path, "rev-parse", "--abbrev-ref", "HEAD").strip()
+    return out or None
+
+
+def find_candidates(cfg: JanitorConfig) -> list[Candidate]:
+    seen: set[Path] = set()
+    out: list[Candidate] = []
+
+    def add(path: Path, reason: str) -> None:
+        resolved = path.resolve()
+        if resolved in seen or _is_excluded_name(resolved.name):
+            return
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return
+        seen.add(resolved)
+        out.append(Candidate(path=resolved, mtime=mtime, reason=reason))
+
+    if cfg.repo.is_dir():
+        for entry in cfg.repo.iterdir():
+            if entry.is_dir() and _matches_any(entry.name, cfg.repo_dir_families):
+                add(entry, "repo-dir")
+            elif entry.is_file() and _matches_any(entry.name, cfg.repo_file_families):
+                add(entry, "repo-file")
+
+    worktrees_dir = cfg.repo / ".worktrees"
+    if worktrees_dir.is_dir():
+        for entry in worktrees_dir.iterdir():
+            if entry.is_dir():
+                add(entry, "worktrees-dir")
+
+    if cfg.tmp_root.is_dir():
+        for entry in cfg.tmp_root.iterdir():
+            if entry.name in cfg.foreign:
+                continue
+            if _matches_any(entry.name, cfg.tmp_families):
+                add(entry, "tmp")
+
+    if cfg.scratch_root.is_dir():
+        cutoff = datetime.datetime.now().timestamp() - cfg.keep_days * 86400
+        for agent_dir in cfg.scratch_root.iterdir():
+            if not agent_dir.is_dir():
+                continue
+            for task_dir in agent_dir.iterdir():
+                if task_dir.is_dir() and task_dir.stat().st_mtime < cutoff:
+                    add(task_dir, "scratch-stale")
+
+    return out
+
+
+def find_foreign_kept(cfg: JanitorConfig) -> list[Path]:
+    if not cfg.tmp_root.is_dir():
+        return []
+    return [
+        (cfg.tmp_root / name).resolve()
+        for name in cfg.foreign
+        if (cfg.tmp_root / name).is_dir()
+    ]
+
+
+def build_report(cfg: JanitorConfig) -> JanitorReport:
+    candidates = find_candidates(cfg)
+    registered = get_registered_worktrees(cfg.repo)
+    dirty = [
+        w for w in registered
+        if w != cfg.repo and w.exists() and is_dirty_worktree(w)
+    ]
+    foreign = find_foreign_kept(cfg)
+    return JanitorReport(
+        candidates=candidates, registered_worktrees=registered,
+        dirty_worktrees=dirty, foreign_kept=foreign,
+    )
+
+
+def format_report(report: JanitorReport, cfg: JanitorConfig, *, apply: bool) -> str:
+    lines = [
+        f"agenttalk janitor  repo={cfg.repo}  tmp={cfg.tmp_root}  "
+        f"scratch={cfg.scratch_root}  mode={'APPLY' if apply else 'REPORT'}",
+        f"candidates: {len(report.candidates)}   "
+        f"registered worktrees: {len(report.registered_worktrees)}",
+        f"dirty registered worktrees: {len(report.dirty_worktrees)}",
+    ]
+    for w in report.dirty_worktrees:
+        lines.append(f"  DIRTY {w}")
+    for f in report.foreign_kept:
+        lines.append(f"  FOREIGN (kept) {f}")
+    if not apply:
+        oldest = sorted(report.candidates, key=lambda c: c.mtime)[:15]
+        for c in oldest:
+            when = datetime.datetime.fromtimestamp(c.mtime).strftime("%Y-%m-%d")
+            lines.append(f"  {when} {c.path}")
+        if len(report.candidates) > 15:
+            lines.append(f"  ... and {len(report.candidates) - 15} more")
+        lines.append("re-run with --apply to preserve dirty worktrees as WIP commits, "
+                      "delete, and prune.")
+    return "\n".join(lines)
+
+
+@dataclasses.dataclass
+class WipCommitResult:
+    message: str
+    refused: bool  # True: on a default branch - not committed AND not removed
+
+
+def wip_commit_dirty_worktree(path: Path, *, default_branches: list[str]) -> WipCommitResult:
+    """Commit tracked changes as a WIP commit on the worktree's own branch.
+    Refuses (no commit, and the caller must not remove the directory either
+    - uncommitted changes on a default branch are never destroyed) if the
+    worktree is on a default branch."""
+    branch = worktree_branch(path)
+    if branch in default_branches:
+        return WipCommitResult(
+            message=f"  REFUSED dirty worktree on {branch} (never auto-commit or remove "
+                     f"the default branch): {path}",
+            refused=True,
+        )
+    _run_git(path, "add", "-u")
+    stamp = datetime.datetime.now().isoformat(timespec="seconds")
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-q", "-m",
+         f"wip: preserve uncommitted worktree state before scratch cleanup ({stamp})"],
+        capture_output=True, text=True, check=False,
+    )
+    return WipCommitResult(message=f"  WIP committed on {branch}: {path}", refused=False)
+
+
+def _rmtree(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def remove_stubborn(path: Path) -> str:
+    """Remove `path` (file or directory), escalating (Windows only) if a
+    plain remove fails. Returns one of: 'absent', 'removed',
+    'removed-after-acl', 'removed-after-robocopy', 'FAILED'. Never raises."""
+    if not path.exists():
+        return "absent"
+    is_dir = path.is_dir() and not path.is_symlink()
+    try:
+        _rmtree(path)
+    except OSError:
+        pass
+    if not path.exists():
+        return "removed"
+    if platform.system() != "Windows":
+        return "FAILED"
+    # Windows-only escalation: the reference script's ACL-takeover path for
+    # paths created inside a Codex sandbox whose session ACLs deny even a
+    # listing (#147 class).
+    takeown_args = ["takeown", "/F", str(path)] + (["/R", "/D", "Y"] if is_dir else [])
+    subprocess.run(takeown_args, capture_output=True, check=False)
+    icacls_args = ["icacls", str(path), "/grant", "*S-1-3-4:F" if not is_dir else "*S-1-3-4:(OI)(CI)F"]
+    if is_dir:
+        icacls_args += ["/T"]
+    icacls_args += ["/C", "/Q"]
+    subprocess.run(icacls_args, capture_output=True, check=False)
+    try:
+        _rmtree(path)
+    except OSError:
+        pass
+    if not path.exists():
+        return "removed-after-acl"
+    if not is_dir:
+        return "FAILED"  # the robocopy-mirror trick below only applies to directories
+    empty = Path(tempfile.gettempdir()) / f"empty-{uuid.uuid4().hex}"
+    empty.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["robocopy", str(empty), str(path), "/MIR", "/NFL", "/NDL", "/NJH", "/NJS", "/NP",
+         "/R:0", "/W:0"],
+        capture_output=True, check=False,
+    )
+    shutil.rmtree(empty, ignore_errors=True)
+    try:
+        _rmtree(path)
+    except OSError:
+        pass
+    return "removed-after-robocopy" if not path.exists() else "FAILED"
+
+
+def apply(cfg: JanitorConfig, report: JanitorReport) -> str:
+    """Run apply mode: WIP-commit dirty worktrees, remove candidates, prune.
+    Returns the report text (same shape as report mode, plus the apply
+    summary)."""
+    lines = [format_report(report, cfg, apply=True)]
+    refused: set[Path] = set()
+    for w in report.dirty_worktrees:
+        result = wip_commit_dirty_worktree(w, default_branches=cfg.default_branches)
+        lines.append(result.message)
+        if result.refused:
+            refused.add(w)
+
+    def is_refused(path: Path) -> bool:
+        # A refused worktree's own directory, or anything under it, is never
+        # removed - uncommitted changes on a default branch must survive.
+        return any(path == r or r in path.parents for r in refused)
+
+    summary: dict[str, int] = {}
+    failed: list[Path] = []
+    for c in report.candidates:
+        if is_refused(c.path):
+            summary["refused"] = summary.get("refused", 0) + 1
+            continue
+        result = remove_stubborn(c.path)
+        summary[result] = summary.get(result, 0) + 1
+        if result == "FAILED":
+            failed.append(c.path)
+
+    _run_git(cfg.repo, "worktree", "prune")
+
+    lines.append("removed summary:")
+    for key, count in summary.items():
+        lines.append(f"  {key}: {count}")
+    lines.append(f"registered worktrees after prune: {len(get_registered_worktrees(cfg.repo))}")
+    if failed:
+        lines.append(f"FAILED ({len(failed)})" + (
+            " - " + _ELEVATED_HINT_WINDOWS if platform.system() == "Windows" else ""
+        ))
+        for f in failed:
+            lines.append(f"  {f}")
+    return "\n".join(lines)

--- a/src/agenttalk/janitor.py
+++ b/src/agenttalk/janitor.py
@@ -265,30 +265,56 @@ def _worktrees_discovery_ok(repo: Path) -> tuple[bool, str]:
     return True, ""
 
 
-def _tree_contains_git_entry(root: Path) -> bool:
-    """True if `root`'s own tree contains a `.git` entry (a directory, for
-    an ordinary clone, or a file, for a worktree's gitdir pointer)
-    anywhere - an lstat-based walk, entirely independent of a runnable
-    git. Used when `_worktrees_discovery_ok` is False: git itself cannot
-    be trusted to say what is or isn't a worktree, so this is the
-    fallback signal that a directory candidate might be (or contain) one,
-    and must be refused rather than silently removed. NEVER follows a
-    symlink/junction - a link entry is checked for the name `.git` but
-    never descended into. Any entry this walk cannot itself list is
-    treated as "contains .git" too (conservative: an unreadable
-    subdirectory is exactly the kind of thing this fallback exists to
-    protect against, not a reason to assume it's safe)."""
+def _find_git_entries(root: Path) -> tuple[list[Path], bool]:
+    """Every `.git` entry (a directory, for an ordinary clone, or a file,
+    for a worktree's gitdir pointer) anywhere in `root`'s own tree, plus
+    whether any nested subdirectory could not even be listed - an
+    lstat-based walk, entirely independent of a runnable git. NEVER
+    follows a symlink/junction - a link entry is checked for the name
+    `.git` but never descended into, so whatever it points at is
+    invisible to this walk either way. An unlistable subdirectory is
+    reported via the second return value rather than raising or being
+    silently read as "nothing here" (conservative: an unreadable
+    subdirectory is exactly the kind of thing this walk exists to guard
+    against, not a reason to assume it's safe)."""
+    found: list[Path] = []
     entries, err = _safe_iterdir(root)
     if err is not None:
-        return True
+        return found, True
+    unlistable = False
     for entry in entries:
         if entry.name == ".git":
-            return True
+            found.append(entry)
+            continue
         if is_link_like(entry):
             continue
-        if entry.is_dir() and _tree_contains_git_entry(entry):
-            return True
-    return False
+        if entry.is_dir():
+            sub_found, sub_unlistable = _find_git_entries(entry)
+            found.extend(sub_found)
+            unlistable = unlistable or sub_unlistable
+    return found, unlistable
+
+
+def _tree_contains_git_entry(root: Path) -> bool:
+    """True if `root`'s own tree contains a `.git` entry anywhere, OR a
+    nested subdirectory could not be listed - see `_find_git_entries`.
+    Used when `_worktrees_discovery_ok` is False: git itself cannot be
+    trusted to say what is or isn't a worktree, so this is the fallback
+    signal that a directory candidate might be (or contain) one, and must
+    be refused rather than silently removed."""
+    found, unlistable = _find_git_entries(root)
+    return bool(found) or unlistable
+
+
+def _git_entry_belongs_to_registered_worktree(git_entry: Path, registered: list[Path]) -> bool:
+    """True if `git_entry` (a `.git` file or directory found somewhere
+    inside a candidate's tree) is the `.git` of a worktree this janitor
+    already knows is registered to `cfg.repo` - the owning worktree root
+    is always `git_entry`'s parent, whether `.git` is a gitdir-pointer
+    FILE (a linked worktree) or a DIRECTORY (an ordinary clone/the main
+    worktree)."""
+    owner = git_entry.parent
+    return any(owner == r for r in registered)
 
 
 def is_dirty_worktree(path: Path) -> bool:
@@ -313,15 +339,40 @@ def worktree_branch(path: Path) -> str | None:
     return out or None
 
 
+def worktree_head_reachable(path: Path) -> bool:
+    """True if the worktree's HEAD commit is reachable from an existing
+    branch or tag (`git for-each-ref --contains HEAD refs/heads
+    refs/tags` is non-empty). False (unreachable) also if the check
+    itself could not be completed - fail closed: a detached HEAD whose
+    reachability this janitor cannot confirm is exactly the case that
+    must be protected, not assumed safe. Only meaningful for a DETACHED
+    worktree (`worktree_branch` returning `None` or the literal string
+    `"HEAD"` - git's own `rev-parse --abbrev-ref HEAD` prints "HEAD" for
+    a detached checkout, not an empty string) - a worktree checked out
+    onto a real branch is trivially reachable via that branch itself."""
+    rc, out, _err = _run_git_checked(
+        path, "for-each-ref", "--contains", "HEAD", "refs/heads", "refs/tags",
+    )
+    if rc != 0:
+        return False
+    return bool(out.strip())
+
+
 def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Path, str]]]:
     seen: set[str] = set()
     out: list[Candidate] = []
     access_errors: list[tuple[Path, str]] = []
     # Computed ONCE: whether git's account of registered worktrees can be
-    # trusted at all. When it cannot, EVERY pass (not just .worktrees/)
-    # must refuse a directory candidate that might itself be, or contain,
-    # a worktree git can no longer tell us about.
+    # trusted at all, and (when it can) what IS registered to cfg.repo.
+    # Every directory candidate outside .worktrees/ is checked against
+    # this regardless of discovery - the earlier version only ran the
+    # `.git`-in-tree guard when discovery was UNTRUSTED, which is
+    # backwards for a worktree registered to some OTHER clone (every seat
+    # shares one scratch root - Rule 1) or a standalone clone: git being
+    # perfectly resolvable for cfg.repo says nothing about whether a
+    # tree elsewhere under the shared root belongs to it.
     discovery_ok, discovery_reason = _worktrees_discovery_ok(cfg.repo)
+    registered_worktrees = get_registered_worktrees(cfg.repo) if discovery_ok else []
 
     def add(path: Path, reason: str) -> None:
         # NEVER path.resolve() - that follows symlinks (POSIX) and would
@@ -335,15 +386,36 @@ def find_candidates(cfg: JanitorConfig) -> tuple[list[Candidate], list[tuple[Pat
             entry_mtime = os.lstat(path).st_mtime
         except OSError:
             return
-        if not discovery_ok and not is_link_like(path) and path.is_dir():
-            if _tree_contains_git_entry(path):
-                access_errors.append((
-                    path,
-                    "worktree discovery is not trusted (git unresolvable or "
-                    "`worktree list` failed) and this directory's tree contains "
-                    "a .git entry - refusing to remove",
-                ))
-                return
+        # .worktrees/ entries are exempt: that pass already gates on
+        # discovery_ok itself (nothing is added from it at all when
+        # discovery can't be trusted), and every entry it DOES add is,
+        # by construction, a worktree of cfg.repo - re-walking it here
+        # would be redundant, not protective.
+        if reason != "worktrees-dir" and not is_link_like(path) and path.is_dir():
+            git_entries, unlistable = _find_git_entries(path)
+            if not discovery_ok:
+                if git_entries or unlistable:
+                    access_errors.append((
+                        path,
+                        "worktree discovery is not trusted (git unresolvable or "
+                        "`worktree list` failed) and this directory's tree contains "
+                        "a .git entry - refusing to remove",
+                    ))
+                    return
+            else:
+                foreign = [
+                    g for g in git_entries
+                    if not _git_entry_belongs_to_registered_worktree(g, registered_worktrees)
+                ]
+                if foreign or unlistable:
+                    access_errors.append((
+                        path,
+                        "this directory's tree contains a .git entry that is not a "
+                        "registered worktree of this repository (another clone's "
+                        "worktree, a standalone clone, or an unlistable "
+                        "subdirectory) - refusing to remove",
+                    ))
+                    return
         seen.add(key)
         out.append(Candidate(path=path, mtime=entry_mtime, reason=reason))
 
@@ -780,6 +852,24 @@ def apply(cfg: JanitorConfig, report: JanitorReport) -> str:
         result = wip_commit_dirty_worktree(w, default_branches=cfg.default_branches)
         lines.append(result.message)
         if result.refused:
+            refused.add(w)
+
+    # A worktree can be CLEAN and still hold a commit reachable from no
+    # branch or tag - a reviewer's local fixup, or a mutation-test commit,
+    # made on a `git worktree add --detach` checkout (Rule 2's own
+    # recommended form) with no further changes since. Only dirty
+    # worktrees reach the loop above; this one covers every registered
+    # worktree regardless of dirty state, so a clean-but-unreachable one
+    # is refused too - `worktree prune` below would otherwise drop its
+    # HEAD, turning that commit into unreachable garbage recoverable only
+    # until the next `git gc`, exactly the loss a detached WIP commit is
+    # already refused to avoid.
+    for w in report.registered_worktrees:
+        if w == cfg.repo or w in refused or not w.exists():
+            continue
+        if worktree_branch(w) in _NEVER_AUTO_COMMIT_BRANCHES_SENTINELS and not worktree_head_reachable(w):
+            lines.append(f"  REFUSED detached worktree with unreachable HEAD "
+                         f"(would become unreachable garbage on prune): {w}")
             refused.add(w)
 
     def is_refused(path: Path) -> bool:

--- a/src/agenttalk/scratch.py
+++ b/src/agenttalk/scratch.py
@@ -1,0 +1,105 @@
+"""Per-seat scratch root resolution (#148).
+
+Every piece of temporary work a seat creates (pytest base-temps, review
+worktrees, service data directories, reply-draft probes) should live under
+one predictable root instead of sprawling into the repository root, the OS
+temp dir, or `.worktrees/`. This module resolves that root; `janitor.py`
+cleans it (and the legacy locations) up.
+
+Config (optional, `.agenttalk/config.json`, key `"scratch"`):
+
+    {"scratch": "D:/custom/scratch/root"}
+
+or the long form (any key may be omitted; unset keys take the default):
+
+    {"scratch": {"root": "D:/custom/scratch/root", "keep_days": 3}}
+
+No config, or no `"scratch"` key, or a corrupt config file: silently use
+the default (a sibling `atk-scratch` directory next to the project root).
+This resolution never raises for a missing/malformed config - scratch
+hygiene must work in every project, initialized or not.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+DEFAULT_KEEP_DAYS = 3
+
+# A resolved agent/task path segment is used to build a filesystem path -
+# reject anything that could escape the scratch root (path separators,
+# `..`, empty) rather than silently sanitizing it into something else.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def _read_scratch_config(project_root: Path) -> dict:
+    """Best-effort read of the `"scratch"` config key. Never raises."""
+    config_path = project_root / ".agenttalk" / "config.json"
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    scratch = raw.get("scratch")
+    if isinstance(scratch, str) and scratch:
+        return {"root": scratch}
+    if isinstance(scratch, dict):
+        return scratch
+    return {}
+
+
+def default_scratch_root(project_root: Path) -> Path:
+    """The sibling `atk-scratch` directory next to the project root."""
+    return project_root.parent / "atk-scratch"
+
+
+def resolve_scratch_root(project_root: Path) -> Path:
+    """Resolve the scratch root for a project: configured `"scratch"."root"`,
+    else the default sibling directory. Does not create it."""
+    project_root = Path(project_root).resolve()
+    cfg = _read_scratch_config(project_root)
+    root = cfg.get("root")
+    if isinstance(root, str) and root.strip():
+        return Path(root).resolve()
+    return default_scratch_root(project_root)
+
+
+def resolve_keep_days(project_root: Path) -> int:
+    cfg = _read_scratch_config(project_root)
+    keep_days = cfg.get("keep_days")
+    if isinstance(keep_days, int) and keep_days >= 0:
+        return keep_days
+    return DEFAULT_KEEP_DAYS
+
+
+def validate_segment(name: str, *, label: str) -> str:
+    if not _SAFE_SEGMENT.match(name):
+        raise ValueError(
+            f"{label} {name!r} is not a safe scratch path segment "
+            f"(letters/digits/-._ only, must not start with one of -._)"
+        )
+    return name
+
+
+def agent_scratch_dir(project_root: Path, agent: str, *, create: bool = True) -> Path:
+    """`<scratch_root>/<agent>/`."""
+    validate_segment(agent, label="agent name")
+    path = resolve_scratch_root(project_root) / agent
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def task_scratch_dir(
+    project_root: Path, agent: str, task: str | None, *, create: bool = True
+) -> Path:
+    """`<scratch_root>/<agent>/<task>` (task defaults to `"default"`)."""
+    task = task if task else "default"
+    validate_segment(task, label="task id")
+    path = agent_scratch_dir(project_root, agent, create=create) / task
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -736,7 +736,7 @@ _AGENTTALK_SUBCOMMANDS = frozenset(
     "request-restart commit-gate request-launch wrap "
     "_internal-check-wrap-dispatch dead-letter managed-lead-loop supervise "
     "deadman reply tail start serve dashboard reset doctor gateway hmac-init "
-    "capacity install-skills codex-config comprehension".split()
+    "capacity install-skills codex-config comprehension scratch janitor".split()
 )
 _LAUNCHER_DERIVED_PRIOR_SOURCES = {"launch_child_provenance"}
 _DIAGNOSTIC_COUNTERS = (
@@ -12860,7 +12860,16 @@ function Resolve-AgenttalkScratchRoot($agentName) {
   if ($SrcOnPyPath) { $env:PYTHONPATH = (Join-Path $Root 'src') + ';' + $env:PYTHONPATH }
   try {
     $out = & $AgenttalkPython -m agenttalk --root $Root scratch root --for $agentName 2>$null
-    if ($LASTEXITCODE -eq 0 -and $out) { return ([string]$out).Trim() }
+    if ($LASTEXITCODE -ne 0 -or -not $out) { return $null }
+    # Reviewer-3 H5: $out can be an array of lines (multi-line stdout, e.g.
+    # stray output ahead of the real path) - take the LAST non-empty line,
+    # not the whole blob, and never trust it without confirming it is
+    # actually an existing directory before exporting it as an env var a
+    # child process will treat as a writable scratch root.
+    $lines = @($out) | Where-Object { $_ -and ([string]$_).Trim() }
+    if ($lines.Count -eq 0) { return $null }
+    $candidate = ([string]$lines[-1]).Trim()
+    if (Test-Path -LiteralPath $candidate -PathType Container) { return $candidate }
     return $null
   } catch {
     return $null

--- a/src/agenttalk/supervisor.py
+++ b/src/agenttalk/supervisor.py
@@ -12848,6 +12848,26 @@ function Set-AgenttalkEnvironmentMapEntry($entries, [string]$name, $value) {
   }
   $entries[$target] = $value
 }
+function Resolve-AgenttalkScratchRoot($agentName) {
+  # #148: the per-seat scratch root the wrapper exports as AGENTTALK_SCRATCH.
+  # Shells out to the already-tested `agenttalk scratch root` resolution
+  # (single source of truth with scratch.py's config-reading logic) rather
+  # than re-implementing it here. Best-effort: any failure - misconfigured
+  # config.json, an unexpected interpreter error - returns $null and the
+  # caller simply does not set the variable; a launch NEVER fails because
+  # this optional convenience lookup failed.
+  $savedPP = $env:PYTHONPATH
+  if ($SrcOnPyPath) { $env:PYTHONPATH = (Join-Path $Root 'src') + ';' + $env:PYTHONPATH }
+  try {
+    $out = & $AgenttalkPython -m agenttalk --root $Root scratch root --for $agentName 2>$null
+    if ($LASTEXITCODE -eq 0 -and $out) { return ([string]$out).Trim() }
+    return $null
+  } catch {
+    return $null
+  } finally {
+    if ($null -eq $savedPP) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $savedPP }
+  }
+}
 function Open-AgenttalkProcessHandle($procId) {
   if (-not $procId) { return $null }
   # SYNCHRONIZE | PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION. The
@@ -14439,6 +14459,8 @@ function Launch($name, $plan, $codexHome, $acceptedAdmission = $null) {
   $applied = [hashtable]::new([StringComparer]::Ordinal)
   $applied['AGENTTALK_ROOT'] = $Root
   $applied['AGENTTALK_PY'] = $AgenttalkPython
+  $scratchRoot = Resolve-AgenttalkScratchRoot $name
+  if ($scratchRoot) { $applied['AGENTTALK_SCRATCH'] = $scratchRoot }
   if ($SrcOnPyPath) { $applied['PYTHONPATH'] = (Join-Path $Root 'src') + ';' + $env:PYTHONPATH }
   if ($codexHome) { $applied['CODEX_HOME'] = $codexHome }  # per-agent isolated home
   # Deliberately case-insensitive - see Start-WrapperProcess's own $window
@@ -14564,6 +14586,8 @@ function Launch-Spec($name, $spec, $codexHome, $acceptedAdmission = $null) {
   $applied = [hashtable]::new([StringComparer]::Ordinal)
   $applied['AGENTTALK_ROOT'] = $Root
   $applied['AGENTTALK_PY'] = $AgenttalkPython
+  $scratchRoot = Resolve-AgenttalkScratchRoot $name
+  if ($scratchRoot) { $applied['AGENTTALK_SCRATCH'] = $scratchRoot }
   if ($SrcOnPyPath) {
     $applied['PYTHONPATH'] = (Join-Path $Root 'src') + ';' + $env:PYTHONPATH
   }

--- a/src/agenttalk/wrapper/prompt.py
+++ b/src/agenttalk/wrapper/prompt.py
@@ -52,6 +52,12 @@ _DEFAULT_RULES = (
     "\n"
     + _BUS_COMMAND_CONTRACT +
     "\n"
+    "SCRATCH: temporary work (pytest base-temps, review worktrees, service data "
+    "directories, probe outputs) goes under $AGENTTALK_SCRATCH (or "
+    "`agenttalk scratch root --for <you> --task <id>` if unset) and nowhere else - "
+    "never the repo root, .worktrees/, or the OS temp dir. A close-out that created "
+    "scratch reports \"scratch removed\" or names what is kept and why.\n"
+    "\n"
     "CLASSIFY by kind + meta and act, replying on the correct thread via the "
     "correlation_id (request_id or broadcast_id):\n"
     "- review-request: review READ-ONLY (do not modify the sender's files); reply "

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1847,3 +1847,45 @@ def test_check_codex_config_warns_on_duplicate_tables(tmp_path: Path, monkeypatc
     assert chk.status == "warn"
     assert "duplicate" in chk.details.lower()
     assert "codex-config --enable" in chk.fix
+
+
+def test_check_scratch_hygiene_uses_configured_tmp_root_never_the_real_one(tmp_path: Path) -> None:
+    """#148 fix round: the scratch-hygiene check must scan the CONFIGURED
+    tmp_root, not silently fall through to the real OS temp directory in a
+    project that pins one - proves the check completes correctly and fast
+    against a small, controlled tree rather than the real (potentially
+    huge, unbounded) system temp root."""
+    proj = tmp_path / "proj"
+    (proj / ".agenttalk").mkdir(parents=True)
+    fake_tmp_root = tmp_path / "fake-tmp"
+    fake_tmp_root.mkdir()
+    (proj / ".agenttalk" / "config.json").write_text(
+        json.dumps({"agents": ["a", "b"], "scratch": {"tmp_root": str(fake_tmp_root)}}),
+        encoding="utf-8",
+    )
+    check = doctor._check_scratch_hygiene(proj)
+    assert check is None  # nothing to warn about in an empty, controlled tree
+
+
+def test_check_scratch_hygiene_warns_and_names_access_errors(tmp_path: Path, monkeypatch) -> None:
+    """#148 fix round R2/P5: an unlistable location surfaces through the
+    doctor check as a named warning, never silently swallowed (the
+    original bug this check exists to prevent) and never a raised
+    exception out of doctor.run()."""
+    proj = tmp_path / "proj"
+    (proj / ".agenttalk").mkdir(parents=True)
+    fake_tmp_root = tmp_path / "fake-tmp"
+    fake_tmp_root.mkdir()
+    (proj / ".agenttalk" / "config.json").write_text(
+        json.dumps({"agents": ["a", "b"], "scratch": {"tmp_root": str(fake_tmp_root)}}),
+        encoding="utf-8",
+    )
+
+    def _raise_iterdir(self):
+        raise PermissionError("simulated access denied")
+
+    monkeypatch.setattr(Path, "iterdir", _raise_iterdir)
+    result = doctor._check_scratch_hygiene(proj)
+    assert result is not None
+    assert result.status == "warn"
+    assert "could not be listed" in result.details

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -87,9 +87,11 @@ def tree(tmp_path):
     _backdate(old_matching_dir, 5)
     fresh_matching_dir = tmp_root / "pytest-of-inuse"
     fresh_matching_dir.mkdir()  # fresh mtime - inside the age window, must survive
-    old_matching_file = tmp_root / "pytest-of-notadir.log"
-    old_matching_file.write_text("log", encoding="utf-8")
+    old_matching_file = tmp_root / "surefire-report.txt"
+    old_matching_file.write_text("report", encoding="utf-8")
     _backdate(old_matching_file, 5)
+    fresh_matching_file = tmp_root / "surefire-inuse.txt"
+    fresh_matching_file.write_text("in progress", encoding="utf-8")  # fresh - must survive
     wrong_case_dir = tmp_root / "PYTEST-OF-WRONGCASE"
     wrong_case_dir.mkdir()
     _backdate(wrong_case_dir, 5)
@@ -120,7 +122,7 @@ def tree(tmp_path):
         tmp_root=tmp_root,
         repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
         repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES,
-        tmp_families=["pytest-of-*", "agenttalk-review-*"],
+        tmp_families=["pytest-of-*", "agenttalk-review-*", "surefire-*"],
         foreign=["agenttalk-review-keepme"],
         default_branches=["master", "main"],
     )
@@ -130,8 +132,8 @@ def tree(tmp_path):
         "scratch_root": scratch_root, "stale": stale,
         "live_but_old_dir": live_but_old_dir, "fresh": fresh,
         "old_matching_dir": old_matching_dir, "fresh_matching_dir": fresh_matching_dir,
-        "old_matching_file": old_matching_file, "wrong_case_dir": wrong_case_dir,
-        "foreign": foreign,
+        "old_matching_file": old_matching_file, "fresh_matching_file": fresh_matching_file,
+        "wrong_case_dir": wrong_case_dir, "foreign": foreign,
     }
 
 
@@ -189,11 +191,19 @@ def test_p4_temp_root_fresh_matching_dir_survives_age_window(tree):
     assert tree["fresh_matching_dir"] not in paths
 
 
-def test_p4_temp_root_matching_file_is_never_a_candidate(tree):
-    """Files are excluded from the temp root entirely - only directories."""
+def test_p4_temp_root_old_matching_file_is_a_candidate(tree):
+    """Files ARE eligible temp-root candidates (some real families, like a
+    Mockito boot log or a surefire report, are files, not directories) -
+    gated by the same age window as directories, never excluded by type."""
     candidates, _ = janitor.find_candidates(tree["cfg"])
     paths = {c.path for c in candidates}
-    assert tree["old_matching_file"] not in paths
+    assert tree["old_matching_file"] in paths
+
+
+def test_p4_temp_root_fresh_matching_file_survives_age_window(tree):
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["fresh_matching_file"] not in paths
 
 
 def test_p4_temp_root_matching_is_case_sensitive(tree):
@@ -215,12 +225,13 @@ def test_apply_keeps_foreign_folder_that_matches_a_family(tree):
     assert (tree["foreign"] / "important.txt").exists()
 
 
-def test_apply_removes_matching_non_foreign_old_tmp_dir(tree):
+def test_apply_removes_matching_non_foreign_old_tmp_entries(tree):
     report = janitor.build_report(tree["cfg"])
     janitor.apply(tree["cfg"], report)
     assert not tree["old_matching_dir"].exists()
+    assert not tree["old_matching_file"].exists()
     assert tree["fresh_matching_dir"].exists()
-    assert tree["old_matching_file"].exists()
+    assert tree["fresh_matching_file"].exists()
 
 
 # --------------------------------------------------------------------- P3

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -455,3 +455,166 @@ def test_p6b_failed_junction_removal_never_escalates_into_the_target(tmp_path, m
     for call in calls:
         exe_name = Path(call[0]).stem.lower()
         assert exe_name not in escalation_tools
+
+
+# --------------------------------------------------------------- R1/R2/R3/N1
+
+
+def test_r1_refusing_precommit_hook_refuses_not_silently_loses_work(tmp_path):
+    """A pre-commit hook that exits non-zero must refuse the WIP commit,
+    not silently report success while the change is lost (reviewer-3 R1)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    wt = repo / ".worktrees" / "wt-hook"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-hook", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    result = janitor.wip_commit_dirty_worktree(wt, default_branches=["master", "main"])
+    assert result.refused is True
+    assert "REFUSED" in result.message
+    assert (wt / "precious.txt").exists()
+    assert (wt / "precious.txt").read_text(encoding="utf-8") == "do not lose me"
+
+
+def test_r1_refusing_precommit_hook_apply_preserves_the_worktree(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    wt = repo / ".worktrees" / "wt-hook"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-hook", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt in set(report.dirty_worktrees)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert (wt / "precious.txt").read_text(encoding="utf-8") == "do not lose me"
+
+
+def test_r2_temp_root_directory_aged_by_newest_nested_file_not_own_mtime(tree):
+    """The P3 flaw, recurring in the shared temp root: a directory whose
+    OWN mtime is old but whose nested file was written moments ago must
+    not be classified stale."""
+    live_old_dir = tree["tmp_root"] / "pytest-of-liveold"
+    nested = live_old_dir / "case0"
+    nested.mkdir(parents=True)
+    _backdate(live_old_dir, 5)
+    _backdate(nested, 5)
+    (nested / "live.txt").write_text("fresh", encoding="utf-8")
+
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert live_old_dir not in paths
+
+
+def test_r2_apply_preserves_live_nested_file_in_old_tmp_directory(tree):
+    live_old_dir = tree["tmp_root"] / "pytest-of-liveold2"
+    nested = live_old_dir / "case0"
+    nested.mkdir(parents=True)
+    _backdate(live_old_dir, 5)
+    _backdate(nested, 5)
+    (nested / "live.txt").write_text("fresh", encoding="utf-8")
+
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    assert (nested / "live.txt").exists()
+
+
+def test_r3_posix_symlink_directory_removes_link_not_target(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    real_target_dir = tmp_path / "real-target-dir"
+    real_target_dir.mkdir()
+    (real_target_dir / "precious.txt").write_text("do not delete", encoding="utf-8")
+    link_dir = repo / ".review-symlink"
+    try:
+        os.symlink(real_target_dir, link_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink privilege/support not available in this environment")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert (real_target_dir / "precious.txt").exists()
+    assert not os.path.lexists(link_dir)
+
+
+def test_r3_posix_symlink_file_removes_link_not_target(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    real_target_file = tmp_path / "real-target-file.txt"
+    real_target_file.write_text("do not delete", encoding="utf-8")
+    link_file = repo / ".review-symlink.md"
+    try:
+        os.symlink(real_target_file, link_file)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink privilege/support not available in this environment")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert real_target_file.exists()
+    assert not os.path.lexists(link_file)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_n1_link_above_candidate_is_itself_the_candidate_not_walked_through(tmp_path):
+    """scratch_root/<agent> as a junction: the agent entry itself must be
+    treated as a candidate (never entered) - matching the repo-root
+    pass's handling of a link, not silently walked through to whatever
+    is behind it."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    scratch_root.mkdir()
+    real_agent_dir = tmp_path / "real-agent-dir"
+    task_dir = real_agent_dir / "old-task"
+    task_dir.mkdir(parents=True)
+    _backdate(task_dir, 10)
+    (task_dir / "keep.txt").write_text("behind the link", encoding="utf-8")
+    agent_link = scratch_root / "dev-2"
+    if not _make_junction(agent_link, real_agent_dir):
+        pytest.skip("could not create a junction in this environment")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, _ = janitor.find_candidates(cfg)
+    paths = {c.path for c in candidates}
+    assert agent_link in paths  # the link itself is the candidate
+    assert task_dir not in paths  # never walked through it
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert not os.path.lexists(agent_link)  # the link is gone
+    assert task_dir.exists()  # the target behind it was never touched
+    assert (task_dir / "keep.txt").exists()

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -696,7 +696,7 @@ def test_n1_fresh_link_above_candidate_survives_the_age_window(tmp_path):
     assert os.path.lexists(agent_link)  # the fresh link survives
 
 
-# ------------------------------------------------------------- round 4: R1/N2
+# ------------------------------- fail-closed discovery / dangling-link lexists
 
 
 def test_r1_git_unresolvable_fails_closed_under_worktrees(tmp_path, monkeypatch):
@@ -789,3 +789,224 @@ def test_n2_dangling_link_removal_failure_reported_via_lexists_not_exists(tmp_pa
     result = janitor.remove_stubborn(link)
     assert result == "FAILED"
     assert os.path.lexists(link)  # the link itself is still there
+
+
+# --------------------------------- containment direction / fail-closed fallback
+
+
+def test_r1f_git_working_detached_worktree_nested_in_stale_task_survives(tmp_path):
+    """Round-5 containment fix: a scratch task directory that is itself
+    stale (by newest-mtime) but HOLDS a detached, dirty worktree (the ops
+    doc's own Rule 2 layout: `git worktree add --detach
+    <scratch>/wt-<sha>`) must not be removed out from under that worktree
+    just because the outer directory's own age check fires - staleness and
+    "protect uncommitted work" are separate signals, and a refusal on the
+    inner worktree must propagate to the outer candidate that contains
+    it."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-abc"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+    # Backdate the whole nested tree so the OUTER task directory reads as
+    # stale by newest-mtime, exactly like a review checkout nobody has
+    # touched in a while but that still carries uncommitted work.
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert task_dir in {c.path for c in report.candidates}
+    assert wt in set(report.dirty_worktrees)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert task_dir.exists()
+
+
+def test_r1g_git_unresolvable_branch_worktree_nested_in_stale_task_survives(tmp_path, monkeypatch):
+    """Round-5 fix, git-unresolvable side: even without git available to
+    identify what is or isn't a worktree, a stale-looking scratch task
+    directory whose tree contains a `.git` entry must be refused outright
+    (via the git-independent _tree_contains_git_entry fallback), not
+    removed as an ordinary stale candidate - the fallback substitutes for
+    the WIP-commit/refuse gate that discovery ordinarily provides."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review2"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-branch"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-nested", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert task_dir not in {c.path for c in candidates}
+    assert any(p == task_dir for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert task_dir.exists()
+
+
+def test_r1h_git_unresolvable_repo_root_family_match_that_is_actually_a_worktree_survives(
+    tmp_path, monkeypatch
+):
+    """Cheap round-5 pin: a repo-root directory that HAPPENS to match an
+    ordinary family name (`.review-*`) but is actually a git worktree
+    survives even when git is unresolvable - the .git-in-tree fallback
+    guard applies uniformly across every pass, not just the scratch-root
+    one."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".review-fakewt"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-fake", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert wt not in {c.path for c in candidates}
+    assert any(p == wt for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+
+
+def test_mb_git_status_failure_is_dirty_not_clean(tmp_path, monkeypatch):
+    """A worktree whose `git status --porcelain` itself fails (a corrupted
+    index, a lock file left behind by a crashed process) must be treated
+    as dirty, not clean - matching the module's fail-closed rule
+    everywhere else discovery can't be trusted (same style as the existing
+    rc=128 `worktree list` mutation, applied to the status call)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-statusfail"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-statusfail", str(wt), "master")
+
+    real_run = janitor.subprocess.run
+
+    def _fail_status(cmd, *args, **kwargs):
+        if "status" in cmd and "--porcelain" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, stdout="",
+                                                 stderr="fatal: simulated status failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.subprocess, "run", _fail_status)
+    assert janitor.is_dirty_worktree(wt) is True
+
+
+def test_mc_commit_succeeds_but_postcommit_status_fails_is_refused_and_kept(tmp_path, monkeypatch):
+    """A WIP commit whose `git commit` call itself succeeds but whose
+    immediate post-commit `git status --porcelain` confirmation fails must
+    still refuse - an unconfirmed "clean" is not a confirmed one, and
+    apply() must not remove (or report success for) a worktree on the
+    strength of an unverified commit."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-mc"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-mc", str(wt), "master")
+    (wt / "new-file.txt").write_text("new", encoding="utf-8")
+
+    real_run = janitor.subprocess.run
+
+    def _fail_status_for_wt(cmd, *args, **kwargs):
+        if "status" in cmd and "--porcelain" in cmd and str(wt) in cmd:
+            return subprocess.CompletedProcess(cmd, 128, stdout="",
+                                                 stderr="fatal: simulated status failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.subprocess, "run", _fail_status_for_wt)
+
+    result = janitor.wip_commit_dirty_worktree(wt, default_branches=["master", "main"])
+    assert result.refused is True
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt in set(report.dirty_worktrees)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "new-file.txt").exists()
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_me_fresh_task_level_link_survives_the_age_window(tmp_path):
+    """The agent-level fresh-junction protection (N1) has a task-level
+    sibling: scratch_root/<agent>/<task> can itself be a junction (a task
+    relocated onto another volume, or linked from a different clone) just
+    as much as scratch_root/<agent> can - the age gate must apply there
+    too, not just one level up."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    agent_dir = scratch_root / "dev-4"
+    agent_dir.mkdir(parents=True)
+    real_task_dir = tmp_path / "real-task-dir-fresh"
+    real_task_dir.mkdir()
+    task_link = agent_dir / "task-fresh"
+    if not _make_junction(task_link, real_task_dir):
+        pytest.skip("could not create a junction in this environment")
+    # Deliberately NOT backdated - this link is fresh.
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, _ = janitor.find_candidates(cfg)
+    paths = {c.path for c in candidates}
+    assert task_link not in paths
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert os.path.lexists(task_link)  # the fresh link survives

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1,15 +1,17 @@
 """Tests for janitor.py - the cross-platform scratch janitor (#148).
 
-Builds a synthetic tree per the issue's acceptance criteria: scratch
-families in the repo root, the temp root, and .worktrees/, one dirty
-registered worktree (on a non-default branch), one dirty worktree ON the
-default branch, and one foreign folder under the temp root. Every git
-operation runs inside tmp_path - nothing here touches a real project.
+Builds synthetic trees per the issue's acceptance criteria AND the
+reviewer-3 fix-round probes (P1-P6, MUT-A/B). Every git/filesystem
+operation runs inside tmp_path - nothing here touches a real project or
+the real OS temp root.
 """
 
 from __future__ import annotations
 
+import os
+import platform
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -32,6 +34,21 @@ def _init_repo(repo: Path) -> None:
     _git(repo, "commit", "-q", "-m", "initial")
 
 
+def _backdate(path: Path, days: float) -> None:
+    stamp = time.time() - days * 86400
+    os.utime(path, (stamp, stamp))
+
+
+def _make_junction(link: Path, target: Path) -> bool:
+    """Windows NTFS junction (no admin rights required, unlike a symlink).
+    Returns False (skip the test) if junction creation itself fails."""
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
 @pytest.fixture
 def tree(tmp_path):
     repo = tmp_path / "repo"
@@ -45,7 +62,7 @@ def tree(tmp_path):
     (repo / "docs").mkdir()
     (repo / "docs" / "keep.md").write_text("keep", encoding="utf-8")
 
-    # --- .worktrees/ -------------------------------------------------------
+    # --- .worktrees/: every dir is a candidate, no family filter -------
     worktrees_dir = repo / ".worktrees"
     worktrees_dir.mkdir()
 
@@ -62,116 +79,247 @@ def tree(tmp_path):
     _git(repo, "worktree", "add", "-q", str(wt_default_dirty), "master")
     (wt_default_dirty / "tracked.txt").write_text("three\n", encoding="utf-8")
 
-    # --- tmp root ------------------------------------------------------
+    # --- tmp root: narrower, case-sensitive, dirs-only, age-windowed ---
     tmp_root = tmp_path / "tmp"
     tmp_root.mkdir()
-    (tmp_root / "pytest-abc").mkdir()
-    (tmp_root / "review-xyz").mkdir()
-    (tmp_root / "reqforge").mkdir()  # foreign: kept, never a candidate
-    (tmp_root / "reqforge" / "important.txt").write_text("keep", encoding="utf-8")
+    old_matching_dir = tmp_root / "pytest-of-someone"
+    old_matching_dir.mkdir()
+    _backdate(old_matching_dir, 5)
+    fresh_matching_dir = tmp_root / "pytest-of-inuse"
+    fresh_matching_dir.mkdir()  # fresh mtime - inside the age window, must survive
+    old_matching_file = tmp_root / "pytest-of-notadir.log"
+    old_matching_file.write_text("log", encoding="utf-8")
+    _backdate(old_matching_file, 5)
+    wrong_case_dir = tmp_root / "PYTEST-OF-WRONGCASE"
+    wrong_case_dir.mkdir()
+    _backdate(wrong_case_dir, 5)
+    foreign = tmp_root / "agenttalk-review-keepme"  # matches a family - MUT-B fix
+    foreign.mkdir()
+    _backdate(foreign, 5)
+    (foreign / "important.txt").write_text("keep", encoding="utf-8")
 
-    # --- scratch root: one stale, one fresh -----------------------------
+    # --- scratch root: staleness from the newest mtime IN the tree -----
     scratch_root = tmp_path / "atk-scratch"
     stale = scratch_root / "dev-2" / "old-task"
-    fresh = scratch_root / "dev-2" / "new-task"
     stale.mkdir(parents=True)
+    _backdate(stale, 10)
+    live_but_old_dir = scratch_root / "dev-2" / "live-task"
+    live_nested = live_but_old_dir / "nested" / "deep"
+    live_nested.mkdir(parents=True)
+    _backdate(live_but_old_dir, 10)
+    _backdate(live_but_old_dir / "nested", 10)
+    (live_nested / "edited-now.txt").write_text("fresh", encoding="utf-8")
+    fresh = scratch_root / "dev-2" / "new-task"
     fresh.mkdir(parents=True)
-    import os
-    import time
-    old = time.time() - 10 * 86400
-    os.utime(stale, (old, old))
 
     cfg = janitor.JanitorConfig(
         repo=repo,
         scratch_root=scratch_root,
         keep_days=3,
+        tmp_keep_days=1,
         tmp_root=tmp_root,
         repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
         repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES,
-        tmp_families=janitor.DEFAULT_TMP_FAMILIES,
-        foreign=["reqforge"],
+        tmp_families=["pytest-of-*", "agenttalk-review-*"],
+        foreign=["agenttalk-review-keepme"],
         default_branches=["master", "main"],
     )
     return {
         "repo": repo, "cfg": cfg, "wt_dirty": wt_dirty,
         "wt_default_dirty": wt_default_dirty, "tmp_root": tmp_root,
-        "scratch_root": scratch_root, "stale": stale, "fresh": fresh,
+        "scratch_root": scratch_root, "stale": stale,
+        "live_but_old_dir": live_but_old_dir, "fresh": fresh,
+        "old_matching_dir": old_matching_dir, "fresh_matching_dir": fresh_matching_dir,
+        "old_matching_file": old_matching_file, "wrong_case_dir": wrong_case_dir,
+        "foreign": foreign,
     }
 
 
+# --------------------------------------------------------------------- report
+
+
 def test_report_finds_repo_root_candidates(tree):
-    report = janitor.build_report(tree["cfg"])
-    paths = {c.path for c in report.candidates}
-    assert (tree["repo"] / ".review-abc123").resolve() in paths
-    assert (tree["repo"] / ".review-notes.md").resolve() in paths
-    assert (tree["repo"] / "docs").resolve() not in paths
+    candidates, errors = janitor.find_candidates(tree["cfg"])
+    assert errors == []
+    paths = {c.path for c in candidates}
+    assert (tree["repo"] / ".review-abc123") in paths
+    assert (tree["repo"] / ".review-notes.md") in paths
+    assert (tree["repo"] / "docs") not in paths
 
 
 def test_report_finds_worktrees_dir_candidates(tree):
-    report = janitor.build_report(tree["cfg"])
-    paths = {c.path for c in report.candidates}
-    assert tree["wt_dirty"].resolve() in paths
-    assert tree["wt_default_dirty"].resolve() in paths
-
-
-def test_report_finds_tmp_family_candidates_and_excludes_foreign(tree):
-    report = janitor.build_report(tree["cfg"])
-    paths = {c.path for c in report.candidates}
-    assert (tree["tmp_root"] / "pytest-abc").resolve() in paths
-    assert (tree["tmp_root"] / "review-xyz").resolve() in paths
-    assert (tree["tmp_root"] / "reqforge").resolve() not in paths
-
-
-def test_report_finds_only_stale_scratch_dir(tree):
-    report = janitor.build_report(tree["cfg"])
-    paths = {c.path for c in report.candidates}
-    assert tree["stale"].resolve() in paths
-    assert tree["fresh"].resolve() not in paths
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["wt_dirty"] in paths
+    assert tree["wt_default_dirty"] in paths
 
 
 def test_report_lists_dirty_worktrees(tree):
     report = janitor.build_report(tree["cfg"])
-    dirty = {p.resolve() for p in report.dirty_worktrees}
-    assert tree["wt_dirty"].resolve() in dirty
-    assert tree["wt_default_dirty"].resolve() in dirty
+    dirty = set(report.dirty_worktrees)
+    assert tree["wt_dirty"] in dirty
+    assert tree["wt_default_dirty"] in dirty
 
 
 def test_report_lists_foreign_kept(tree):
     report = janitor.build_report(tree["cfg"])
-    kept = {p.resolve() for p in report.foreign_kept}
-    assert (tree["tmp_root"] / "reqforge").resolve() in kept
+    assert tree["foreign"] in set(report.foreign_kept)
 
 
 def test_report_mode_does_not_touch_anything(tree):
-    janitor.build_report(tree["cfg"])
-    janitor.format_report(janitor.build_report(tree["cfg"]), tree["cfg"], apply=False)
+    report = janitor.build_report(tree["cfg"])
+    janitor.format_report(report, tree["cfg"], apply=False)
     assert (tree["repo"] / ".review-abc123").exists()
     assert tree["wt_dirty"].exists()
     assert tree["stale"].exists()
 
 
-def test_apply_preserves_dirty_non_default_worktree_as_wip_commit(tree):
-    report = janitor.build_report(tree["cfg"])
-    janitor.apply(tree["cfg"], report)
-    log = subprocess.run(
-        ["git", "-C", str(tree["repo"]), "log", "--oneline", "feature-x"],
-        capture_output=True, text=True, check=True,
-    ).stdout
-    assert "wip: preserve uncommitted worktree state" in log
+# ------------------------------------------------------------------ P4/MUT-B
 
 
-def test_apply_refuses_default_branch_dirty_worktree(tree):
+def test_p4_temp_root_old_matching_dir_is_a_candidate(tree):
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["old_matching_dir"] in paths
+
+
+def test_p4_temp_root_fresh_matching_dir_survives_age_window(tree):
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["fresh_matching_dir"] not in paths
+
+
+def test_p4_temp_root_matching_file_is_never_a_candidate(tree):
+    """Files are excluded from the temp root entirely - only directories."""
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["old_matching_file"] not in paths
+
+
+def test_p4_temp_root_matching_is_case_sensitive(tree):
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["wrong_case_dir"] not in paths
+
+
+def test_mutb_foreign_name_matches_a_real_family(tree):
+    """The foreign fixture name must match a configured family - otherwise
+    the exclusion is never exercised (reviewer-3 MUT-B: the old fixture's
+    'reqforge' matched nothing, so this cell was vacuous)."""
+    assert janitor._matches_any(tree["foreign"].name, tree["cfg"].tmp_families)
+
+
+def test_apply_keeps_foreign_folder_that_matches_a_family(tree):
     report = janitor.build_report(tree["cfg"])
     janitor.apply(tree["cfg"], report)
-    # Never auto-committed on master.
-    log = subprocess.run(
-        ["git", "-C", str(tree["repo"]), "log", "--oneline", "master"],
-        capture_output=True, text=True, check=True,
-    ).stdout
-    assert "wip: preserve" not in log
-    # Never removed either - the uncommitted change must survive.
-    assert tree["wt_default_dirty"].exists()
-    assert (tree["wt_default_dirty"] / "tracked.txt").read_text(encoding="utf-8") == "three\n"
+    assert (tree["foreign"] / "important.txt").exists()
+
+
+def test_apply_removes_matching_non_foreign_old_tmp_dir(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    assert not tree["old_matching_dir"].exists()
+    assert tree["fresh_matching_dir"].exists()
+    assert tree["old_matching_file"].exists()
+
+
+# --------------------------------------------------------------------- P3
+
+
+def test_p3_staleness_uses_newest_mtime_in_tree_not_dir_mtime(tree):
+    """A task directory with an old top-level mtime but a file edited
+    seconds ago three levels down must NOT be classified stale."""
+    candidates, _ = janitor.find_candidates(tree["cfg"])
+    paths = {c.path for c in candidates}
+    assert tree["live_but_old_dir"] not in paths
+    assert tree["stale"] in paths
+
+
+def test_apply_preserves_live_scratch_work_despite_old_dir_mtime(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    assert tree["live_but_old_dir"].exists()
+    assert (tree["live_but_old_dir"] / "nested" / "deep" / "edited-now.txt").exists()
+    assert not tree["stale"].exists()
+    assert tree["fresh"].exists()
+
+
+# --------------------------------------------------------------------- P1/P2
+
+
+def test_p1_detached_worktree_dirty_is_reported(tree, tmp_path):
+    # The main repo (fixture) is already on a detached HEAD - master itself
+    # is held by wt_default_dirty, so a SECOND detached checkout at the same
+    # commit is fine (only a non-detached branch checkout is exclusive).
+    detached = tree["repo"] / ".worktrees" / "wt-detached"
+    _git(tree["repo"], "worktree", "add", "-q", "--detach", str(detached), "master")
+    (detached / "tracked.txt").write_text("detached-change\n", encoding="utf-8")
+    report = janitor.build_report(tree["cfg"])
+    assert detached in set(report.dirty_worktrees)
+
+
+def test_p1_detached_worktree_dirty_is_refused_not_orphan_committed(tree):
+    detached = tree["repo"] / ".worktrees" / "wt-detached"
+    _git(tree["repo"], "worktree", "add", "-q", "--detach", str(detached), "master")
+    (detached / "tracked.txt").write_text("detached-change\n", encoding="utf-8")
+    result = janitor.wip_commit_dirty_worktree(detached, default_branches=["master", "main"])
+    assert result.refused is True
+    # No commit was made: the file is still modified, not committed.
+    status = subprocess.run(["git", "-C", str(detached), "status", "--porcelain"],
+                             capture_output=True, text=True, check=True).stdout
+    assert "tracked.txt" in status
+
+
+def test_p2_untracked_only_worktree_is_dirty(tree):
+    wt_untracked = tree["repo"] / ".worktrees" / "wt-untracked"
+    _git(tree["repo"], "worktree", "add", "-q", "-b", "feature-untracked",
+         str(wt_untracked), "master")
+    (wt_untracked / "new-file.txt").write_text("new", encoding="utf-8")
+    assert janitor.is_dirty_worktree(wt_untracked) is True
+
+
+def test_p2_apply_stages_and_commits_untracked_files(tree):
+    wt_untracked = tree["repo"] / ".worktrees" / "wt-untracked"
+    _git(tree["repo"], "worktree", "add", "-q", "-b", "feature-untracked",
+         str(wt_untracked), "master")
+    (wt_untracked / "new-file.txt").write_text("new", encoding="utf-8")
+    result = janitor.wip_commit_dirty_worktree(wt_untracked, default_branches=["master", "main"])
+    assert result.refused is False
+    log = subprocess.run(["git", "-C", str(tree["repo"]), "show",
+                           "feature-untracked:new-file.txt"],
+                          capture_output=True, text=True, check=True).stdout
+    assert log == "new"
+
+
+# --------------------------------------------------------------------- P5
+
+
+def test_p5_unlistable_directory_reported_as_failed_not_raised(tree, monkeypatch):
+    real_safe_iterdir = janitor._safe_iterdir
+    blocked = tree["repo"]
+
+    def _blocked_iterdir(path):
+        if path == blocked:
+            return [], path
+        return real_safe_iterdir(path)
+
+    monkeypatch.setattr(janitor, "_safe_iterdir", _blocked_iterdir)
+    candidates, errors = janitor.find_candidates(tree["cfg"])
+    assert blocked in errors
+
+
+def test_p5_build_report_never_raises_and_surfaces_access_errors(tree, monkeypatch):
+    def _raise_iterdir(self):
+        raise PermissionError("simulated access denied")
+
+    monkeypatch.setattr(Path, "iterdir", _raise_iterdir)
+    report = janitor.build_report(tree["cfg"])  # must not raise
+    assert report.access_errors  # at least the repo root failed to list
+    text = janitor.format_report(report, tree["cfg"], apply=False)
+    assert "FAILED to list" in text
+
+
+# --------------------------------------------------------------------- MUT-A
 
 
 def test_apply_removes_only_allow_listed_paths(tree):
@@ -179,29 +327,28 @@ def test_apply_removes_only_allow_listed_paths(tree):
     janitor.apply(tree["cfg"], report)
     assert not (tree["repo"] / ".review-abc123").exists()
     assert not (tree["repo"] / ".review-notes.md").exists()
-    assert not (tree["tmp_root"] / "pytest-abc").exists()
-    assert not (tree["tmp_root"] / "review-xyz").exists()
-    assert not tree["stale"].exists()
-    # Never touched: tracked files, docs/, the fresh scratch dir.
     assert (tree["repo"] / "docs" / "keep.md").exists()
     assert (tree["repo"] / "tracked.txt").exists()
-    assert tree["fresh"].exists()
 
 
-def test_apply_keeps_foreign_folder(tree):
+def test_apply_refuses_default_branch_dirty_worktree(tree):
     report = janitor.build_report(tree["cfg"])
     janitor.apply(tree["cfg"], report)
-    assert (tree["tmp_root"] / "reqforge" / "important.txt").exists()
+    log = subprocess.run(
+        ["git", "-C", str(tree["repo"]), "log", "--oneline", "master"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "wip: preserve" not in log
+    assert tree["wt_default_dirty"].exists()
+    assert (tree["wt_default_dirty"] / "tracked.txt").read_text(encoding="utf-8") == "three\n"
 
 
 def test_apply_prunes_worktree_registrations(tree):
     report = janitor.build_report(tree["cfg"])
     janitor.apply(tree["cfg"], report)
     remaining = janitor.get_registered_worktrees(tree["repo"])
-    # wt_dirty's directory was removed after its WIP commit -> pruned away.
-    assert tree["wt_dirty"].resolve() not in remaining
-    # wt_default_dirty was refused (never removed) -> still registered.
-    assert tree["wt_default_dirty"].resolve() in remaining
+    assert tree["wt_dirty"] not in remaining
+    assert tree["wt_default_dirty"] in remaining
 
 
 def test_apply_is_idempotent(tree):
@@ -212,19 +359,20 @@ def test_apply_is_idempotent(tree):
     assert "FAILED" not in second
 
 
+# --------------------------------------------------------------- simulated permission failure
+
+
 def test_simulated_permission_failure_reported_as_failed_not_skipped(tree, monkeypatch):
     def _always_fail(path):
         raise OSError("simulated permission denied")
 
     monkeypatch.setattr(janitor, "_rmtree", _always_fail)
-    # No escalation path outside Windows: remove_stubborn returns FAILED
-    # directly once the plain remove fails and platform.system() != 'Windows'.
     monkeypatch.setattr(janitor.platform, "system", lambda: "Linux")
     target = tree["repo"] / ".review-abc123"
     assert target.exists()
     result = janitor.remove_stubborn(target)
     assert result == "FAILED"
-    assert target.exists()  # not silently removed either
+    assert target.exists()
 
 
 def test_simulated_permission_failure_surfaces_in_apply_report(tree, monkeypatch):
@@ -236,4 +384,63 @@ def test_simulated_permission_failure_surfaces_in_apply_report(tree, monkeypatch
     report = janitor.build_report(tree["cfg"])
     text = janitor.apply(tree["cfg"], report)
     assert "FAILED" in text
-    assert str((tree["repo"] / ".review-abc123").resolve()) in text
+    assert str(tree["repo"] / ".review-abc123") in text
+
+
+# ------------------------------------------------------------------- P6A/P6B
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_p6a_junction_candidate_removes_the_link_not_the_target(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    real_target = tmp_path / "real-target"
+    real_target.mkdir()
+    (real_target / "precious.txt").write_text("do not delete", encoding="utf-8")
+    link = repo / ".review-link"
+    if not _make_junction(link, real_target):
+        pytest.skip("could not create a junction in this environment")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert (real_target / "precious.txt").exists()
+    assert not link.exists()  # the link itself IS removed
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_p6b_failed_junction_removal_never_escalates_into_the_target(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    real_target = tmp_path / "real-target"
+    real_target.mkdir()
+    (real_target / "precious.txt").write_text("do not delete", encoding="utf-8")
+    link = repo / ".review-link"
+    if not _make_junction(link, real_target):
+        pytest.skip("could not create a junction in this environment")
+
+    calls = []
+    real_run = subprocess.run
+
+    def _spy_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    def _always_fail_rmtree(path):
+        raise OSError("simulated stubborn link")
+
+    monkeypatch.setattr(janitor, "_rmtree", _always_fail_rmtree)
+    monkeypatch.setattr(janitor.subprocess, "run", _spy_run)
+    result = janitor.remove_stubborn(link)
+    assert result == "FAILED"
+    assert (real_target / "precious.txt").exists()
+    # No escalation tool (takeown/icacls/robocopy) was ever invoked for a link.
+    escalation_tools = {"takeown", "icacls", "robocopy"}
+    for call in calls:
+        exe_name = Path(call[0]).stem.lower()
+        assert exe_name not in escalation_tools

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -30,6 +30,15 @@ def _init_repo(repo: Path) -> None:
     _git(repo, "init", "-q", "-b", "master")
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test")
+    # Repo-local, before the first commit: a modern git can start detached
+    # background maintenance on commit, which creates and deletes
+    # `.git/objects/maintenance.lock` - a file this fixture's own
+    # `task_dir.rglob("*")` + `_backdate` pattern can list and then fail to
+    # stamp (already gone), or whose creation/deletion can itself refresh
+    # mtimes inside a tree these tests are deliberately backdating to look
+    # stale. Disabled so every commit in this file is fully synchronous.
+    _git(repo, "config", "maintenance.auto", "false")
+    _git(repo, "config", "gc.auto", "0")
     (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
     _git(repo, "add", "tracked.txt")
     _git(repo, "commit", "-q", "-m", "initial")
@@ -80,6 +89,24 @@ def _win32_set_reparse_point_mtime(path: Path, unix_stamp: float) -> None:
             raise OSError(f"SetFileTime failed for {path}: {ctypes.get_last_error()}")
     finally:
         ctypes.windll.kernel32.CloseHandle(handle)
+
+
+def _backdate_tree(root: Path, days: float) -> None:
+    """Backdate every entry in `root`'s tree, then `root` itself. Skips a
+    path that no longer exists by the time its turn comes: git's own
+    background maintenance (started detached on a commit, on a modern
+    git) creates and deletes files like
+    `.git/objects/maintenance.lock` - one can be listed by `rglob` and
+    gone by the time this loop reaches it, which must not fail the
+    fixture (`maintenance.auto`/`gc.auto` are disabled in `_init_repo`
+    for the same reason; this is the defense-in-depth half of that
+    fix)."""
+    for p in sorted(root.rglob("*"), reverse=True):
+        try:
+            _backdate(p, days)
+        except FileNotFoundError:
+            continue
+    _backdate(root, days)
 
 
 def _make_junction(link: Path, target: Path) -> bool:
@@ -814,9 +841,7 @@ def test_r1f_git_working_detached_worktree_nested_in_stale_task_survives(tmp_pat
     # Backdate the whole nested tree so the OUTER task directory reads as
     # stale by newest-mtime, exactly like a review checkout nobody has
     # touched in a while but that still carries uncommitted work.
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -848,9 +873,7 @@ def test_r1g_git_unresolvable_branch_worktree_nested_in_stale_task_survives(tmp_
     wt = task_dir / "wt-branch"
     _git(repo, "worktree", "add", "-q", "-b", "feature-nested", str(wt), "master")
     (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     real_which = janitor.shutil.which
 
@@ -1032,9 +1055,7 @@ def test_p1_foreign_clones_worktree_nested_in_stale_task_survives(tmp_path):
     wt = task_dir / "wt-abc"
     _git(repo_b, "worktree", "add", "-q", "--detach", str(wt), "master")
     (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo_a, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -1067,9 +1088,7 @@ def test_p1c_own_clones_worktree_in_same_layout_goes_through_the_normal_gate(tmp
     wt = task_dir / "wt-abc"
     _git(repo_b, "worktree", "add", "-q", "--detach", str(wt), "master")
     (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo_b, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -1099,9 +1118,7 @@ def test_p2_standalone_clone_nested_in_stale_task_survives(tmp_path):
     clone = task_dir / "standalone-clone"
     _init_repo(clone)
     (clone / "uncommitted.txt").write_text("do not lose me", encoding="utf-8")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -1138,9 +1155,7 @@ def test_p3_clean_detached_worktree_with_unreachable_head_survives(tmp_path):
     (wt / "extra.txt").write_text("local commit content", encoding="utf-8")
     _git(wt, "add", "extra.txt")
     _git(wt, "commit", "-q", "-m", "local commit on no branch")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -1479,9 +1494,7 @@ def test_p8c_clean_detached_worktree_at_branch_tip_in_stale_task_is_removed(tmp_
     task_dir.mkdir(parents=True)
     wt = task_dir / "wt-clean-detached-reachable"
     _git(repo, "worktree", "add", "-q", "--detach", str(wt), "master")
-    for p in sorted(task_dir.rglob("*"), reverse=True):
-        _backdate(p, 10)
-    _backdate(task_dir, 10)
+    _backdate_tree(task_dir, 10)
 
     cfg = janitor.JanitorConfig(
         repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -1496,3 +1509,90 @@ def test_p8c_clean_detached_worktree_at_branch_tip_in_stale_task_is_removed(tmp_
 
     janitor.apply(cfg, report)
     assert not task_dir.exists()  # removed - nothing here needed protecting
+
+
+# ------------------------------------------------ refs/remotes crediting (round 8)
+
+
+def test_p8_worktree_at_remote_only_commit_is_removed(tmp_path):
+    """Round-8 R1: worktree_head_reachable credits refs/remotes on
+    purpose - a review worktree detached at a fetched PR head (Rule 2's
+    own recommended form) is routinely reachable ONLY via a remote-
+    tracking ref until it lands on a local branch. A clean detached
+    worktree of exactly such a commit must remain removable, not be
+    refused just because no LOCAL branch or tag contains it."""
+    origin = tmp_path / "origin"
+    _init_repo(origin)
+    (origin / "remote-only.txt").write_text("remote commit", encoding="utf-8")
+    _git(origin, "add", "remote-only.txt")
+    _git(origin, "commit", "-q", "-m", "remote-only commit")
+
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "fetch", "-q", "origin")
+
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-remote-only"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-remote-only"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "origin/master")
+    _backdate_tree(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt not in set(report.dirty_worktrees)  # clean
+    assert janitor.worktree_branch(wt) in janitor._NEVER_AUTO_COMMIT_BRANCHES_SENTINELS
+    assert janitor.worktree_head_reachable(wt) is True  # only refs/remotes/origin/* contains it
+
+    janitor.apply(cfg, report)
+    assert not task_dir.exists()  # removed - reachable via the remote-tracking ref
+
+
+def test_p8f_local_fixup_on_remote_only_worktree_is_refused(tmp_path):
+    """Companion to P8: a LOCAL fixup commit made on top of that same
+    detached checkout is reachable from NOTHING (not even refs/remotes,
+    since the fixup itself was never pushed anywhere) - the refs/remotes
+    crediting must not paper over a genuinely local-only commit. Guards
+    the dangerous direction if the credited ref set is ever widened
+    further."""
+    origin = tmp_path / "origin"
+    _init_repo(origin)
+    (origin / "remote-only.txt").write_text("remote commit", encoding="utf-8")
+    _git(origin, "add", "remote-only.txt")
+    _git(origin, "commit", "-q", "-m", "remote-only commit")
+
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "fetch", "-q", "origin")
+
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-remote-fixup"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-remote-fixup"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "origin/master")
+    (wt / "fixup.txt").write_text("local fixup", encoding="utf-8")
+    _git(wt, "add", "fixup.txt")
+    _git(wt, "commit", "-q", "-m", "local fixup on top of the remote-only commit")
+    _backdate_tree(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt not in set(report.dirty_worktrees)  # clean - the fixup IS committed
+    assert janitor.worktree_head_reachable(wt) is False  # the fixup itself is nowhere else
+
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "fixup.txt").exists()
+    assert task_dir.exists()

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1,0 +1,239 @@
+"""Tests for janitor.py - the cross-platform scratch janitor (#148).
+
+Builds a synthetic tree per the issue's acceptance criteria: scratch
+families in the repo root, the temp root, and .worktrees/, one dirty
+registered worktree (on a non-default branch), one dirty worktree ON the
+default branch, and one foreign folder under the temp root. Every git
+operation runs inside tmp_path - nothing here touches a real project.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agenttalk import janitor
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                    capture_output=True, text=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "master")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "initial")
+
+
+@pytest.fixture
+def tree(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    # --- repo-root scratch families -------------------------------------
+    (repo / ".review-abc123").mkdir()
+    (repo / ".review-abc123" / "x.txt").write_text("x", encoding="utf-8")
+    (repo / ".review-notes.md").write_text("notes", encoding="utf-8")
+    # Never removed regardless of family match.
+    (repo / "docs").mkdir()
+    (repo / "docs" / "keep.md").write_text("keep", encoding="utf-8")
+
+    # --- .worktrees/ -------------------------------------------------------
+    worktrees_dir = repo / ".worktrees"
+    worktrees_dir.mkdir()
+
+    wt_dirty = worktrees_dir / "wt-feature"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-x", str(wt_dirty), "master")
+    (wt_dirty / "tracked.txt").write_text("two\n", encoding="utf-8")
+
+    # A worktree literally ON the default branch: git refuses to have the
+    # same branch checked out twice, so detach the MAIN repo's own HEAD
+    # first, freeing "master" for the worktree to hold directly (not
+    # detached) - genuinely reproduces "a worktree on the default branch".
+    _git(repo, "checkout", "-q", "--detach", "master")
+    wt_default_dirty = worktrees_dir / "wt-default"
+    _git(repo, "worktree", "add", "-q", str(wt_default_dirty), "master")
+    (wt_default_dirty / "tracked.txt").write_text("three\n", encoding="utf-8")
+
+    # --- tmp root ------------------------------------------------------
+    tmp_root = tmp_path / "tmp"
+    tmp_root.mkdir()
+    (tmp_root / "pytest-abc").mkdir()
+    (tmp_root / "review-xyz").mkdir()
+    (tmp_root / "reqforge").mkdir()  # foreign: kept, never a candidate
+    (tmp_root / "reqforge" / "important.txt").write_text("keep", encoding="utf-8")
+
+    # --- scratch root: one stale, one fresh -----------------------------
+    scratch_root = tmp_path / "atk-scratch"
+    stale = scratch_root / "dev-2" / "old-task"
+    fresh = scratch_root / "dev-2" / "new-task"
+    stale.mkdir(parents=True)
+    fresh.mkdir(parents=True)
+    import os
+    import time
+    old = time.time() - 10 * 86400
+    os.utime(stale, (old, old))
+
+    cfg = janitor.JanitorConfig(
+        repo=repo,
+        scratch_root=scratch_root,
+        keep_days=3,
+        tmp_root=tmp_root,
+        repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES,
+        tmp_families=janitor.DEFAULT_TMP_FAMILIES,
+        foreign=["reqforge"],
+        default_branches=["master", "main"],
+    )
+    return {
+        "repo": repo, "cfg": cfg, "wt_dirty": wt_dirty,
+        "wt_default_dirty": wt_default_dirty, "tmp_root": tmp_root,
+        "scratch_root": scratch_root, "stale": stale, "fresh": fresh,
+    }
+
+
+def test_report_finds_repo_root_candidates(tree):
+    report = janitor.build_report(tree["cfg"])
+    paths = {c.path for c in report.candidates}
+    assert (tree["repo"] / ".review-abc123").resolve() in paths
+    assert (tree["repo"] / ".review-notes.md").resolve() in paths
+    assert (tree["repo"] / "docs").resolve() not in paths
+
+
+def test_report_finds_worktrees_dir_candidates(tree):
+    report = janitor.build_report(tree["cfg"])
+    paths = {c.path for c in report.candidates}
+    assert tree["wt_dirty"].resolve() in paths
+    assert tree["wt_default_dirty"].resolve() in paths
+
+
+def test_report_finds_tmp_family_candidates_and_excludes_foreign(tree):
+    report = janitor.build_report(tree["cfg"])
+    paths = {c.path for c in report.candidates}
+    assert (tree["tmp_root"] / "pytest-abc").resolve() in paths
+    assert (tree["tmp_root"] / "review-xyz").resolve() in paths
+    assert (tree["tmp_root"] / "reqforge").resolve() not in paths
+
+
+def test_report_finds_only_stale_scratch_dir(tree):
+    report = janitor.build_report(tree["cfg"])
+    paths = {c.path for c in report.candidates}
+    assert tree["stale"].resolve() in paths
+    assert tree["fresh"].resolve() not in paths
+
+
+def test_report_lists_dirty_worktrees(tree):
+    report = janitor.build_report(tree["cfg"])
+    dirty = {p.resolve() for p in report.dirty_worktrees}
+    assert tree["wt_dirty"].resolve() in dirty
+    assert tree["wt_default_dirty"].resolve() in dirty
+
+
+def test_report_lists_foreign_kept(tree):
+    report = janitor.build_report(tree["cfg"])
+    kept = {p.resolve() for p in report.foreign_kept}
+    assert (tree["tmp_root"] / "reqforge").resolve() in kept
+
+
+def test_report_mode_does_not_touch_anything(tree):
+    janitor.build_report(tree["cfg"])
+    janitor.format_report(janitor.build_report(tree["cfg"]), tree["cfg"], apply=False)
+    assert (tree["repo"] / ".review-abc123").exists()
+    assert tree["wt_dirty"].exists()
+    assert tree["stale"].exists()
+
+
+def test_apply_preserves_dirty_non_default_worktree_as_wip_commit(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    log = subprocess.run(
+        ["git", "-C", str(tree["repo"]), "log", "--oneline", "feature-x"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "wip: preserve uncommitted worktree state" in log
+
+
+def test_apply_refuses_default_branch_dirty_worktree(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    # Never auto-committed on master.
+    log = subprocess.run(
+        ["git", "-C", str(tree["repo"]), "log", "--oneline", "master"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "wip: preserve" not in log
+    # Never removed either - the uncommitted change must survive.
+    assert tree["wt_default_dirty"].exists()
+    assert (tree["wt_default_dirty"] / "tracked.txt").read_text(encoding="utf-8") == "three\n"
+
+
+def test_apply_removes_only_allow_listed_paths(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    assert not (tree["repo"] / ".review-abc123").exists()
+    assert not (tree["repo"] / ".review-notes.md").exists()
+    assert not (tree["tmp_root"] / "pytest-abc").exists()
+    assert not (tree["tmp_root"] / "review-xyz").exists()
+    assert not tree["stale"].exists()
+    # Never touched: tracked files, docs/, the fresh scratch dir.
+    assert (tree["repo"] / "docs" / "keep.md").exists()
+    assert (tree["repo"] / "tracked.txt").exists()
+    assert tree["fresh"].exists()
+
+
+def test_apply_keeps_foreign_folder(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    assert (tree["tmp_root"] / "reqforge" / "important.txt").exists()
+
+
+def test_apply_prunes_worktree_registrations(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    remaining = janitor.get_registered_worktrees(tree["repo"])
+    # wt_dirty's directory was removed after its WIP commit -> pruned away.
+    assert tree["wt_dirty"].resolve() not in remaining
+    # wt_default_dirty was refused (never removed) -> still registered.
+    assert tree["wt_default_dirty"].resolve() in remaining
+
+
+def test_apply_is_idempotent(tree):
+    report = janitor.build_report(tree["cfg"])
+    janitor.apply(tree["cfg"], report)
+    report2 = janitor.build_report(tree["cfg"])
+    second = janitor.apply(tree["cfg"], report2)
+    assert "FAILED" not in second
+
+
+def test_simulated_permission_failure_reported_as_failed_not_skipped(tree, monkeypatch):
+    def _always_fail(path):
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr(janitor, "_rmtree", _always_fail)
+    # No escalation path outside Windows: remove_stubborn returns FAILED
+    # directly once the plain remove fails and platform.system() != 'Windows'.
+    monkeypatch.setattr(janitor.platform, "system", lambda: "Linux")
+    target = tree["repo"] / ".review-abc123"
+    assert target.exists()
+    result = janitor.remove_stubborn(target)
+    assert result == "FAILED"
+    assert target.exists()  # not silently removed either
+
+
+def test_simulated_permission_failure_surfaces_in_apply_report(tree, monkeypatch):
+    def _always_fail(path):
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr(janitor, "_rmtree", _always_fail)
+    monkeypatch.setattr(janitor.platform, "system", lambda: "Linux")
+    report = janitor.build_report(tree["cfg"])
+    text = janitor.apply(tree["cfg"], report)
+    assert "FAILED" in text
+    assert str((tree["repo"] / ".review-abc123").resolve()) in text

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1310,3 +1310,189 @@ def test_r3_link_inside_candidate_is_never_descended_into(tmp_path, monkeypatch)
     assert not candidate.exists()  # the candidate itself IS removed
     assert other_wt.exists()  # but the link's target was never entered
     assert (other_wt / "precious.txt").exists()
+
+
+# ----------------------------------------------- .worktrees/ ownership (round 7)
+
+
+def test_p5_worktrees_dir_foreign_clones_dirty_worktree_survives(tmp_path):
+    """Round-7 R1: the ownership check must also apply to .worktrees/
+    entries - that pass adds EVERY directory found there regardless of
+    name, not just ones git actually recognizes. A worktree registered
+    to a DIFFERENT clone, dropped directly under repo A's own
+    .worktrees/, must not be removed just because repo A's own `worktree
+    list` has never heard of it."""
+    repo_a = tmp_path / "repo-a"
+    _init_repo(repo_a)
+    repo_b = tmp_path / "repo-b"
+    _init_repo(repo_b)
+
+    wt = repo_a / ".worktrees" / "wt-foreign"
+    _git(repo_b, "worktree", "add", "-q", "--detach", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo_a, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert wt not in {c.path for c in candidates}
+    assert any(p == wt for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+
+
+def test_p6_worktrees_dir_standalone_clone_survives(tmp_path):
+    """Round-7 R1: a standalone clone (not any worktree at all) dropped
+    directly under .worktrees/ must survive too - "every directory there
+    is a candidate" is about the family filter being absent, not about
+    ownership being irrelevant."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    clone = repo / ".worktrees" / "standalone"
+    _init_repo(clone)
+    (clone / "uncommitted.txt").write_text("do not lose me", encoding="utf-8")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert clone not in {c.path for c in candidates}
+    assert any(p == clone for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert clone.exists()
+    assert (clone / "uncommitted.txt").exists()
+
+
+def test_p7_own_worktree_with_missing_admin_entry_survives(tmp_path):
+    """Round-7 R1: this repo's OWN worktree, registered normally, whose
+    `.git/worktrees/<name>` admin entry has separately gone missing (git
+    no longer lists it at all) is exactly the "real, unrecovered work"
+    is_dirty_worktree's own docstring names - it must survive just like a
+    genuinely foreign tree, not be removed because git can no longer
+    vouch for it."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-orphaned-admin"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-orphaned", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    # Simulate the admin entry vanishing: `git worktree list` no longer
+    # knows about it, but the worktree's own directory (and its .git
+    # gitdir-pointer FILE) is untouched.
+    admin_line = (wt / ".git").read_text(encoding="utf-8").strip()
+    assert admin_line.startswith("gitdir: ")
+    admin_dir = Path(admin_line[len("gitdir: "):])
+    shutil.rmtree(admin_dir)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    assert wt not in set(janitor.get_registered_worktrees(repo))  # git no longer lists it
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert wt not in {c.path for c in candidates}
+    assert any(p == wt for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+
+
+def test_mo3_trusted_discovery_refuses_unlistable_subtree(tmp_path, monkeypatch):
+    """R2/MO3: the TRUSTED-discovery ownership branch must also refuse on
+    an unlistable subtree (`if foreign or unlistable`), not just a
+    foreign .git - every existing unlistable-subtree cell runs under
+    UNTRUSTED discovery, so dropping `or unlistable` from the trusted
+    branch alone would stay green against them."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    candidate = repo / ".review-unlistable-trusted"
+    blocked = candidate / "unlistable"
+    blocked.mkdir(parents=True)
+
+    real_safe_iterdir = janitor._safe_iterdir
+
+    def _blocked_iterdir(path):
+        if path == blocked:
+            return [], (path, "simulated access denied")
+        return real_safe_iterdir(path)
+
+    monkeypatch.setattr(janitor, "_safe_iterdir", _blocked_iterdir)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert candidate not in {c.path for c in candidates}
+    assert any(p == candidate for p, _reason in access_errors)
+
+
+def test_mh2_reachability_check_failure_is_treated_as_unreachable(tmp_path, monkeypatch):
+    """R2/MH2: a `for-each-ref --contains` call that itself fails must be
+    read as unreachable (fail closed), not reachable - no other cell
+    makes the reachability check itself fail, so flipping this branch
+    alone would stay green."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-mh2"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "master")
+
+    real_run = janitor.subprocess.run
+
+    def _fail_for_each_ref(cmd, *args, **kwargs):
+        if "for-each-ref" in cmd and str(wt) in cmd:
+            return subprocess.CompletedProcess(cmd, 128, stdout="",
+                                                 stderr="fatal: simulated failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.subprocess, "run", _fail_for_each_ref)
+    assert janitor.worktree_head_reachable(wt) is False
+
+
+def test_p8c_clean_detached_worktree_at_branch_tip_in_stale_task_is_removed(tmp_path):
+    """R2/MH3 control: a clean detached worktree whose HEAD IS reachable
+    (checked out exactly at a branch tip, no extra commits) must still be
+    removable - dropping refs/heads from the reachability check would
+    refuse every detached worktree unconditionally, and nothing else
+    would notice."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-reachable"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-clean-detached-reachable"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "master")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt not in set(report.dirty_worktrees)  # clean
+    assert janitor.worktree_branch(wt) in janitor._NEVER_AUTO_COMMIT_BRANCHES_SENTINELS
+    assert janitor.worktree_head_reachable(wt) is True  # exactly at master's tip
+
+    janitor.apply(cfg, report)
+    assert not task_dir.exists()  # removed - nothing here needed protecting

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1010,3 +1010,303 @@ def test_me_fresh_task_level_link_survives_the_age_window(tmp_path):
     report = janitor.build_report(cfg)
     janitor.apply(cfg, report)
     assert os.path.lexists(task_link)  # the fresh link survives
+
+
+# --------------------------------------------- shared-root ownership (round 6)
+
+
+def test_p1_foreign_clones_worktree_nested_in_stale_task_survives(tmp_path):
+    """Round-6 R1: every seat shares one scratch root (Rule 1), and each
+    seat's review worktree belongs to ITS OWN clone (Rule 2) - a worktree
+    registered to a DIFFERENT clone is, to cfg.repo's own `worktree list`,
+    invisible. A batch --apply pointed at repo A must not delete repo B's
+    dirty worktree just because repo A has never heard of it."""
+    repo_a = tmp_path / "repo-a"
+    _init_repo(repo_a)
+    repo_b = tmp_path / "repo-b"
+    _init_repo(repo_b)
+
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-abc"
+    _git(repo_b, "worktree", "add", "-q", "--detach", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo_a, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert task_dir not in {c.path for c in candidates}
+    assert any(p == task_dir for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert task_dir.exists()
+
+
+def test_p1c_own_clones_worktree_in_same_layout_goes_through_the_normal_gate(tmp_path):
+    """Control for P1: the identical layout, but the janitor is pointed at
+    the worktree's OWN clone this time - proves the ownership check does
+    not over-refuse a legitimate case; the existing detached-HEAD refusal
+    (not the new ownership check) is what keeps it."""
+    repo_b = tmp_path / "repo-b"
+    _init_repo(repo_b)
+
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-control"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-abc"
+    _git(repo_b, "worktree", "add", "-q", "--detach", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo_b, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert task_dir in {c.path for c in report.candidates}  # not refused at add()-time
+    assert wt in set(report.dirty_worktrees)  # it IS cfg.repo's own registered worktree
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert task_dir.exists()
+
+
+def test_p2_standalone_clone_nested_in_stale_task_survives(tmp_path):
+    """Round-6 R1: a standalone clone (its own `git init`, not any repo's
+    worktree) nested inside a stale scratch task must survive too - the
+    ownership check is "is this even a git tree this janitor knows about",
+    not just "is it registered to MY clone specifically"."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-standalone"
+    task_dir.mkdir(parents=True)
+    clone = task_dir / "standalone-clone"
+    _init_repo(clone)
+    (clone / "uncommitted.txt").write_text("do not lose me", encoding="utf-8")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert task_dir not in {c.path for c in candidates}
+    assert any(p == task_dir for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert clone.exists()
+    assert (clone / "uncommitted.txt").exists()
+    assert task_dir.exists()
+
+
+def test_p3_clean_detached_worktree_with_unreachable_head_survives(tmp_path):
+    """Round-6 R2: only DIRTY worktrees reached the refuse gate before - a
+    CLEAN detached worktree holding a local commit reachable from no
+    branch or tag (a reviewer's fixup, or a mutation-test commit, left on
+    a `git worktree add --detach` checkout with no further edits since) is
+    otherwise removed along with its task, and the final `worktree prune`
+    drops its HEAD - the commit becomes unreachable garbage, exactly the
+    loss a detached WIP commit is already refused to avoid."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    task_dir = scratch_root / "dev-9" / "old-review-unreachable"
+    task_dir.mkdir(parents=True)
+    wt = task_dir / "wt-clean-detached"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt), "master")
+    (wt / "extra.txt").write_text("local commit content", encoding="utf-8")
+    _git(wt, "add", "extra.txt")
+    _git(wt, "commit", "-q", "-m", "local commit on no branch")
+    for p in sorted(task_dir.rglob("*"), reverse=True):
+        _backdate(p, 10)
+    _backdate(task_dir, 10)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    report = janitor.build_report(cfg)
+    assert wt not in set(report.dirty_worktrees)  # clean - status --porcelain is empty
+    # git prints "HEAD" (not empty) for a detached rev-parse --abbrev-ref
+    assert janitor.worktree_branch(wt) in janitor._NEVER_AUTO_COMMIT_BRANCHES_SENTINELS
+    assert janitor.worktree_head_reachable(wt) is False  # on no branch or tag
+
+    janitor.apply(cfg, report)
+    assert wt.exists()
+    assert task_dir.exists()
+    unreachable_sha = subprocess.run(
+        ["git", "-C", str(wt), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    rev_list = subprocess.run(
+        ["git", "-C", str(repo), "rev-list", "--all"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert unreachable_sha in rev_list
+
+
+def test_r3_unlistable_subdirectory_counts_as_containing_git(tmp_path, monkeypatch):
+    """R3: an unlistable subdirectory inside a tree must count as
+    "contains .git" (conservative fail-closed), not "no .git found here" -
+    pins the exact branch of the walk a code-level mutation would leave
+    uncaught by every existing cell (none of which makes a nested
+    subdirectory unlistable)."""
+    root = tmp_path / "root"
+    blocked = root / "unlistable"
+    blocked.mkdir(parents=True)
+
+    real_safe_iterdir = janitor._safe_iterdir
+
+    def _blocked_iterdir(path):
+        if path == blocked:
+            return [], (path, "simulated access denied")
+        return real_safe_iterdir(path)
+
+    monkeypatch.setattr(janitor, "_safe_iterdir", _blocked_iterdir)
+    assert janitor._tree_contains_git_entry(root) is True
+    found, unlistable = janitor._find_git_entries(root)
+    assert found == []
+    assert unlistable is True
+
+
+def test_r3_unlistable_nested_subdir_at_repo_root_is_refused(tmp_path, monkeypatch):
+    """The same property, end to end through find_candidates() at the
+    repo-root pass (no age gate there, so this isolates the git-in-tree
+    check from the staleness walk's own, unrelated error handling)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    candidate = repo / ".review-deep"
+    blocked = candidate / "unlistable"
+    blocked.mkdir(parents=True)
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    real_safe_iterdir = janitor._safe_iterdir
+
+    def _blocked_iterdir(path):
+        if path == blocked:
+            return [], (path, "simulated access denied")
+        return real_safe_iterdir(path)
+
+    monkeypatch.setattr(janitor, "_safe_iterdir", _blocked_iterdir)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert candidate not in {c.path for c in candidates}
+    assert any(p == candidate for p, _reason in access_errors)
+
+
+def test_r3_clone_git_directory_under_untrusted_discovery_is_refused(tmp_path, monkeypatch):
+    """R3: `.git` as a DIRECTORY (an ordinary clone), not just a
+    worktree's gitdir FILE, must be recognized by the walk - every
+    existing untrusted-discovery cell used a worktree gitfile only,
+    leaving this branch uncaught."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    candidate = repo / ".review-clone"
+    _init_repo(candidate)  # a standalone clone - .git is a DIRECTORY here
+    (candidate / "extra.txt").write_text("do not lose me", encoding="utf-8")
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert candidate not in {c.path for c in candidates}
+    assert any(p == candidate for p, _reason in access_errors)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_r3_link_inside_candidate_is_never_descended_into(tmp_path, monkeypatch):
+    """R3: a link inside a candidate's tree pointing at something that
+    holds `.git` must never be descended into - the candidate proceeds
+    normally (removed, since it is otherwise an ordinary eligible
+    candidate) and whatever the link points at is left completely alone,
+    matching every other "never follow a link" guarantee in this
+    module."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    other_repo = tmp_path / "other-repo-with-dirty-wt"
+    _init_repo(other_repo)
+    other_wt = other_repo / ".worktrees" / "wt-elsewhere"
+    _git(other_repo, "worktree", "add", "-q", "--detach", str(other_wt), "master")
+    (other_wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    candidate = repo / ".review-withlink"
+    candidate.mkdir()
+    link = candidate / "elsewhere"
+    if not _make_junction(link, other_wt):
+        pytest.skip("could not create a junction in this environment")
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    # The candidate itself proceeds - the link inside it is never entered,
+    # so its tree does not "contain .git" as far as this janitor can see.
+    assert candidate in {c.path for c in candidates}
+    assert not any(p == candidate for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert not candidate.exists()  # the candidate itself IS removed
+    assert other_wt.exists()  # but the link's target was never entered
+    assert (other_wt / "precious.txt").exists()

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -34,9 +35,51 @@ def _init_repo(repo: Path) -> None:
     _git(repo, "commit", "-q", "-m", "initial")
 
 
-def _backdate(path: Path, days: float) -> None:
+def _backdate(path: Path, days: float, *, follow_symlinks: bool = True) -> None:
     stamp = time.time() - days * 86400
-    os.utime(path, (stamp, stamp))
+    if follow_symlinks or platform.system() != "Windows":
+        os.utime(path, (stamp, stamp), follow_symlinks=follow_symlinks)
+        return
+    # os.utime's follow_symlinks=False is unimplemented on this platform
+    # (NotImplementedError), and the default (follow_symlinks=True) sets
+    # a Windows junction's TARGET mtime, not the link's own - confirmed
+    # empirically. The reliable way to set a reparse point's OWN mtime is
+    # the Win32 API directly: open it WITHOUT following
+    # (FILE_FLAG_OPEN_REPARSE_POINT) and set its time via SetFileTime.
+    _win32_set_reparse_point_mtime(path, stamp)
+
+
+def _win32_set_reparse_point_mtime(path: Path, unix_stamp: float) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    class _FILETIME(ctypes.Structure):
+        _fields_ = [("dwLowDateTime", wintypes.DWORD), ("dwHighDateTime", wintypes.DWORD)]
+
+    GENERIC_WRITE = 0x40000000
+    FILE_SHARE_READ = 0x1
+    FILE_SHARE_WRITE = 0x2
+    OPEN_EXISTING = 3
+    FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+    FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+    EPOCH_AS_FILETIME = 116444736000000000  # 1601-01-01 -> 1970-01-01, in 100ns units
+    HUNDREDS_OF_NANOSECONDS = 10000000
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, None,
+        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, None,
+    )
+    if handle in (0, -1):
+        raise OSError(f"CreateFileW failed for {path}: {ctypes.get_last_error()}")
+    try:
+        ft_value = int(unix_stamp * HUNDREDS_OF_NANOSECONDS) + EPOCH_AS_FILETIME
+        filetime = _FILETIME(ft_value & 0xFFFFFFFF, ft_value >> 32)
+        if not ctypes.windll.kernel32.SetFileTime(handle, None, None, ctypes.byref(filetime)):
+            raise OSError(f"SetFileTime failed for {path}: {ctypes.get_last_error()}")
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)
 
 
 def _make_junction(link: Path, target: Path) -> bool:
@@ -311,12 +354,12 @@ def test_p5_unlistable_directory_reported_as_failed_not_raised(tree, monkeypatch
 
     def _blocked_iterdir(path):
         if path == blocked:
-            return [], path
+            return [], (path, "simulated access denied")
         return real_safe_iterdir(path)
 
     monkeypatch.setattr(janitor, "_safe_iterdir", _blocked_iterdir)
     candidates, errors = janitor.find_candidates(tree["cfg"])
-    assert blocked in errors
+    assert blocked in [p for p, _reason in errors]
 
 
 def test_p5_build_report_never_raises_and_surfaces_access_errors(tree, monkeypatch):
@@ -457,12 +500,12 @@ def test_p6b_failed_junction_removal_never_escalates_into_the_target(tmp_path, m
         assert exe_name not in escalation_tools
 
 
-# --------------------------------------------------------------- R1/R2/R3/N1
+# ---------------- unchecked commit failure / nested temp staleness / links ---
 
 
 def test_r1_refusing_precommit_hook_refuses_not_silently_loses_work(tmp_path):
     """A pre-commit hook that exits non-zero must refuse the WIP commit,
-    not silently report success while the change is lost (reviewer-3 R1)."""
+    not silently report success while the change is lost."""
     repo = tmp_path / "repo"
     _init_repo(repo)
     hooks_dir = repo / ".git" / "hooks"
@@ -584,11 +627,11 @@ def test_r3_posix_symlink_file_removes_link_not_target(tmp_path):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
-def test_n1_link_above_candidate_is_itself_the_candidate_not_walked_through(tmp_path):
-    """scratch_root/<agent> as a junction: the agent entry itself must be
-    treated as a candidate (never entered) - matching the repo-root
-    pass's handling of a link, not silently walked through to whatever
-    is behind it."""
+def test_n1_old_link_above_candidate_is_itself_the_candidate_not_walked_through(tmp_path):
+    """scratch_root/<agent> as a junction, older than keep_days: the agent
+    entry itself must be treated as a candidate (never entered) -
+    matching the repo-root pass's handling of a link, not silently
+    walked through to whatever is behind it."""
     repo = tmp_path / "repo"
     _init_repo(repo)
     scratch_root = tmp_path / "atk-scratch"
@@ -601,6 +644,7 @@ def test_n1_link_above_candidate_is_itself_the_candidate_not_walked_through(tmp_
     agent_link = scratch_root / "dev-2"
     if not _make_junction(agent_link, real_agent_dir):
         pytest.skip("could not create a junction in this environment")
+    _backdate(agent_link, 10, follow_symlinks=False)
 
     cfg = janitor.JanitorConfig(
         repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
@@ -618,3 +662,130 @@ def test_n1_link_above_candidate_is_itself_the_candidate_not_walked_through(tmp_
     assert not os.path.lexists(agent_link)  # the link is gone
     assert task_dir.exists()  # the target behind it was never touched
     assert (task_dir / "keep.txt").exists()
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_n1_fresh_link_above_candidate_survives_the_age_window(tmp_path):
+    """The same link-as-candidate handling above must still respect
+    keep_days: a junction created moments ago (an operator's scratch
+    relocation, or a seat's live task link) is not yet a candidate just
+    because it is link-like."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    scratch_root = tmp_path / "atk-scratch"
+    scratch_root.mkdir()
+    real_agent_dir = tmp_path / "real-agent-dir-fresh"
+    real_agent_dir.mkdir()
+    agent_link = scratch_root / "dev-3"
+    if not _make_junction(agent_link, real_agent_dir):
+        pytest.skip("could not create a junction in this environment")
+    # Deliberately NOT backdated - this link is fresh.
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=scratch_root, keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, _ = janitor.find_candidates(cfg)
+    paths = {c.path for c in candidates}
+    assert agent_link not in paths
+
+    report = janitor.build_report(cfg)
+    janitor.apply(cfg, report)
+    assert os.path.lexists(agent_link)  # the fresh link survives
+
+
+# ------------------------------------------------------------- round 4: R1/N2
+
+
+def test_r1_git_unresolvable_fails_closed_under_worktrees(tmp_path, monkeypatch):
+    """git missing must not be read as "zero worktrees registered" - a
+    dirty, unrecognized worktree under .worktrees/ would otherwise be
+    removed as a plain candidate, with no WIP-commit-or-refuse gate ever
+    applied to it."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-orphan"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-orphan", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    real_which = janitor.shutil.which
+
+    def _no_git(name, *args, **kwargs):
+        if name == "git":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.shutil, "which", _no_git)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert wt not in {c.path for c in candidates}
+    assert any(p == (repo / ".worktrees") for p, _reason in access_errors)
+
+    report = janitor.build_report(cfg)
+    text = janitor.apply(cfg, report)
+    assert wt.exists()
+    assert (wt / "precious.txt").exists()
+    assert "FAILED to list" in text
+
+
+def test_r1_worktree_list_failure_fails_closed_under_worktrees(tmp_path, monkeypatch):
+    """The same fail-closed behaviour when git IS resolvable but `worktree
+    list` itself exits non-zero (a damaged .git, "detected dubious
+    ownership", etc.) - discovery cannot tell that apart from "no
+    worktrees", so it must not treat it that way."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = repo / ".worktrees" / "wt-orphan2"
+    _git(repo, "worktree", "add", "-q", "-b", "feature-orphan2", str(wt), "master")
+    (wt / "precious.txt").write_text("do not lose me", encoding="utf-8")
+
+    real_run = janitor.subprocess.run
+
+    def _fail_worktree_list(cmd, *args, **kwargs):
+        if len(cmd) >= 3 and cmd[1] == "-C" and "worktree" in cmd and "list" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="fatal: simulated failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(janitor.subprocess, "run", _fail_worktree_list)
+
+    cfg = janitor.JanitorConfig(
+        repo=repo, scratch_root=tmp_path / "atk-scratch", keep_days=3, tmp_keep_days=1,
+        tmp_root=tmp_path / "tmp", repo_dir_families=janitor.DEFAULT_REPO_DIR_FAMILIES,
+        repo_file_families=janitor.DEFAULT_REPO_FILE_FAMILIES, tmp_families=[],
+        foreign=[], default_branches=["master", "main"],
+    )
+    candidates, access_errors = janitor.find_candidates(cfg)
+    assert wt not in {c.path for c in candidates}
+    assert any(p == (repo / ".worktrees") for p, _reason in access_errors)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="NTFS junctions are Windows-only")
+def test_n2_dangling_link_removal_failure_reported_via_lexists_not_exists(tmp_path, monkeypatch):
+    """A dangling link (its target deleted out from under it) whose own
+    unlink fails must be reported FAILED - `path.exists()` would follow
+    the (now-broken) link and read False, misreporting "removed" even
+    though the link itself is still on disk."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    target = tmp_path / "target-to-vanish"
+    target.mkdir()
+    link = repo / ".review-danglink"
+    if not _make_junction(link, target):
+        pytest.skip("could not create a junction in this environment")
+    shutil.rmtree(target)  # the link is now dangling
+
+    def _always_fail(path):
+        raise OSError("simulated stubborn dangling link")
+
+    monkeypatch.setattr(janitor, "_rmtree", _always_fail)
+    result = janitor.remove_stubborn(link)
+    assert result == "FAILED"
+    assert os.path.lexists(link)  # the link itself is still there

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -1,0 +1,88 @@
+"""Tests for scratch.py - per-seat scratch root resolution (#148)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agenttalk import scratch
+
+
+def _init_project(tmp_path: Path) -> Path:
+    project = tmp_path / "proj"
+    (project / ".agenttalk").mkdir(parents=True)
+    return project
+
+
+def test_default_root_is_sibling_atk_scratch(tmp_path):
+    project = _init_project(tmp_path)
+    assert scratch.resolve_scratch_root(project) == tmp_path / "atk-scratch"
+
+
+def test_no_config_file_uses_default(tmp_path):
+    # No .agenttalk/ at all - resolution must not raise.
+    project = tmp_path / "unconfigured"
+    project.mkdir()
+    assert scratch.resolve_scratch_root(project) == tmp_path / "atk-scratch"
+
+
+def test_corrupt_config_falls_back_to_default(tmp_path):
+    project = _init_project(tmp_path)
+    (project / ".agenttalk" / "config.json").write_text("{not json", encoding="utf-8")
+    assert scratch.resolve_scratch_root(project) == tmp_path / "atk-scratch"
+
+
+def test_short_form_string_config(tmp_path):
+    project = _init_project(tmp_path)
+    custom = tmp_path / "custom-scratch"
+    (project / ".agenttalk" / "config.json").write_text(
+        json.dumps({"scratch": str(custom)}), encoding="utf-8"
+    )
+    assert scratch.resolve_scratch_root(project) == custom.resolve()
+
+
+def test_long_form_dict_config(tmp_path):
+    project = _init_project(tmp_path)
+    custom = tmp_path / "custom-scratch"
+    (project / ".agenttalk" / "config.json").write_text(
+        json.dumps({"scratch": {"root": str(custom), "keep_days": 7}}), encoding="utf-8"
+    )
+    assert scratch.resolve_scratch_root(project) == custom.resolve()
+    assert scratch.resolve_keep_days(project) == 7
+
+
+def test_keep_days_defaults_when_absent(tmp_path):
+    project = _init_project(tmp_path)
+    assert scratch.resolve_keep_days(project) == scratch.DEFAULT_KEEP_DAYS
+
+
+def test_task_scratch_dir_creates_agent_and_task_dirs(tmp_path):
+    project = _init_project(tmp_path)
+    path = scratch.task_scratch_dir(project, "dev-2", "task148")
+    assert path == tmp_path / "atk-scratch" / "dev-2" / "task148"
+    assert path.is_dir()
+
+
+def test_task_scratch_dir_defaults_task_to_default(tmp_path):
+    project = _init_project(tmp_path)
+    path = scratch.task_scratch_dir(project, "dev-2", None)
+    assert path.name == "default"
+
+
+def test_agent_scratch_dir_without_create(tmp_path):
+    project = _init_project(tmp_path)
+    path = scratch.agent_scratch_dir(project, "dev-2", create=False)
+    assert not path.exists()
+    assert path == tmp_path / "atk-scratch" / "dev-2"
+
+
+@pytest.mark.parametrize("bad", ["", "..", "a/b", "a\\b", "-leading-dash", ".leading-dot"])
+def test_validate_segment_rejects_unsafe_names(bad):
+    with pytest.raises(ValueError):
+        scratch.validate_segment(bad, label="agent name")
+
+
+def test_validate_segment_accepts_safe_names():
+    assert scratch.validate_segment("dev-2_task.148", label="agent name") == "dev-2_task.148"


### PR DESCRIPTION
## Summary

Closes #148. Ports the project-local `tools/cleanup-scratch.ps1` (validated in report mode: 1480 candidates, 121 registered worktrees, 4 dirty) into the CLI itself, cross-platform and config-driven, so every project run over agenttalk gets scratch hygiene instead of re-solving the same sprawl per repo.

- `agenttalk scratch root --for <agent> [--task <id>]` resolves/creates `<scratch_root>/<agent>/<task>`. `scratch_root` comes from `.agenttalk/config.json`'s `"scratch"` key (string, or `{"root":..., "keep_days":...}`); default is a sibling `atk-scratch/` next to the project root. No config → default root, nothing breaks.
- `agenttalk janitor [--apply] [--keep-days N]`: report mode (default) lists config-driven allow-listed scratch-family candidates (repo root, `.worktrees/`, the OS temp root) and dirty registered worktrees (uncommitted changes to **tracked** files only). `--apply` WIP-commits dirty worktrees on their own branch; a worktree on a default branch (`master`/`main`, configurable) is **refused outright** — neither committed nor removed, so uncommitted default-branch work is never destroyed. Removes allow-listed candidates, prunes stale worktree registrations, and reports a removal that fails (e.g. sandbox-restricted ACLs) as `FAILED` with an elevated re-run hint — never silently skipped. The Windows-only `takeown`/`icacls`/`robocopy` escalation only runs in `--apply`. A configured `"foreign"` name under the temp root is reported and kept.
- `agenttalk doctor` gains a `scratch_hygiene` check: warns when registered worktrees or scratch-family candidates exist outside the scratch root.
- The wrapper's `_DEFAULT_RULES` envelope states the scratch rule; the supervisor's PS launcher exports `AGENTTALK_SCRATCH` for the child CLI at both launch sites, resolved by shelling out to the same `scratch root` command (single source of truth) and never blocking a launch on failure.
- `docs/ops/scratch-hygiene.md` ported project-agnostic (no repository-specific names); CHANGELOG entry.

## Flagging for extra scrutiny

`supervisor.py`'s `PS_TEMPLATE` change (the `AGENTTALK_SCRATCH` export at both `Launch-Agent`/`Launch-Spec` sites, plus the new `Resolve-AgenttalkScratchRoot` helper) is syntax-verified via PowerShell's own parser (`[System.Management.Automation.Language.Parser]::ParseFile`, zero errors) but **not** runtime-tested against a real supervised launch in this environment. It's purely additive (new env var only, wrapped in try/catch, never blocks a launch on failure), but a cold read here is worth extra attention.

## Test plan

- [x] `tests/test_scratch.py` — config resolution (default, short-form string, long-form dict), no-config/corrupt-config fallback, unsafe path-segment rejection. 
- [x] `tests/test_janitor.py` — synthetic tree fixture per the issue's acceptance list: families in the repo root/temp root/`.worktrees/`, one dirty non-default-branch worktree, one dirty default-branch worktree, one foreign folder. Covers: report correctness, `--apply` preserving the dirty worktree as a WIP commit, refusing (not just skipping the commit on) the default-branch worktree, allow-listed-only removal, foreign kept, worktree pruning, idempotency, and a monkeypatched simulated permission failure reported as `FAILED` not skipped.
- [x] 31/31 new tests passing.
- [x] Targeted regression (standing rule; CI is the full gate): `test_doctor.py` 115/115, `test_cli.py` 249/249, `test_wrapper_loop.py`+`test_reply_draft_delivery.py`+`test_turn_watchdog.py` 252/252, `test_supervisor_lifecycle.py`+`test_supervisor_spawn_seam.py` 36/36 (+2 xfail), and the `ps_template`/`env_apply`/`launch_spec` subset of `test_supervisor.py` 14/14.
- [x] Full-suite collection (6698 tests) clean, no import-time breakage.
- [x] `ruff check` clean on all touched/new files.
- [ ] Full `test_supervisor.py` (20k+ lines) and the hermetic `dev-gate` — left to CI per the standing "targeted tests only in-turn" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)